### PR TITLE
Create python_venv param so that operators can be run in venv

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -42,11 +42,6 @@ install_requires =
     dbt-redshift==1.3.0
 zip_safe = false
 
-[options.extras_require]
-dbt =
-    dbt-core==1.3.1
-    dbt-postgres==1.3.1
-
 [options.packages.find]
 include =
     cosmos.*


### PR DESCRIPTION
Allows our users to build virtual envs in their Dockerfile and provide a path to that virtual env to separate dbt and airflow dependencies with ease.