### PR TITLE
Add cicd workflows and supporting tests

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -1,0 +1,19 @@
+name: Python Unit Tests
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+      run: |
+        make install_dev
+        pytest tests/validation_tests.py --package astronomer-cosmos

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,24 @@
+name: CI
+on: [push]
+jobs:
+  ship-package-to-pypi:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - name: Set up Python 3.8
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+
+    # run only if 'astronomer-cosmos' was changed
+    - name: astronomer-cosmos
+      if: startsWith(github.ref, 'refs/tags/astronomer-cosmos-v')
+      run: |
+        make install_dev
+        cd ${GITHUB_WORKSPACE}/astronomer-cosmos
+        make build
+        make ship
+      env:
+        TWINE_USER: "__token__"
+        TWINE_PASS: ${{ secrets.PYPI_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,47 @@
+ifneq (,$(wildcard ./.env))
+    include .env
+    export
+endif
+TWINE=$(shell which twine)
+PYTHON3=$(shell which python3)
+VERSION:=$(shell python3 gha_retrieve_version.py)
+TAG:= "astronomer-cosmos-v$(VERSION)"
+
+help:
+	@grep -h '\s##\s' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-20s\033[0m %s\n", $$1, $$2}'
+
+check: ## check doc formatting
+	$(PYTHON3) setup.py checkdocs
+
+package: ## create a new pypi dist
+	$(PYTHON3) setup.py sdist
+
+test-ship: ## ship to test pypi dist
+	$(TWINE) upload --repository testpypi dist/astronomer-cosmos-${VERSION}.tar.gz -u ${TWINE_USER} -p ${TWINE_TEST_PASS}
+
+ship: ## ship pypi dist
+ship: package
+	$(TWINE) upload dist/astronomer-cosmos-${VERSION}.tar.gz -u ${TWINE_USER} -p ${TWINE_PASS}
+
+.PHONY: delete-tag
+delete-tag:
+	- git tag -d $(TAG)
+	- git push origin --delete $(TAG)
+
+.PHONY: tag
+tag: delete-tag
+	git tag $(TAG)
+	git push origin $(TAG)
+
+.PHONY: build
+build:
+	python3 setup.py sdist
+
+.PHONY: install_dev
+install_dev:
+	python -m pip install --upgrade pip
+	python -m pip install -r dev-requirements.txt
+
+.PHONY: pre-commit-install
+pre-commit-install:
+	pre-commit install

--- a/gha_retrieve_version.py
+++ b/gha_retrieve_version.py
@@ -1,0 +1,10 @@
+def get_version():
+    import configparser
+    config = configparser.RawConfigParser()
+    config.read_file(open(r'setup.cfg'))
+    version = config.get('metadata', 'version')
+    return version
+
+if __name__ == '__main__':
+    version = get_version()
+    print(version)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = astronomer-cosmos
-version = 1.0.0
+version = 0.0.1
 url = https://github.com/astronomer/astronomer-cosmos/
 author = Astronomer
 author_email = humans@astronomer.io

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,11 @@
+import pytest
+
+def pytest_addoption(parser):
+    parser.addoption("--package", action="store")
+
+@pytest.fixture(scope='session')
+def package(request):
+    package_value = request.config.option.package
+    if package_value is None:
+        pytest.skip()
+    return package_value

--- a/tests/pytest.ini
+++ b/tests/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+python_files = validation_tests.py test_*.py

--- a/tests/validation_tests.py
+++ b/tests/validation_tests.py
@@ -1,0 +1,12 @@
+def test_version(package):
+    import configparser
+    import requests
+
+    config = configparser.RawConfigParser()
+    config.read_file(open(fr'{package}/setup.cfg'))
+    local_version = config.get('metadata', 'version')
+    releases = requests.get(f"https://pypi.org/pypi/{package}/json").json()['releases']
+    shipped_versions = []
+    [shipped_versions.append(version) for version, details in releases.items()]
+
+    assert local_version not in shipped_versions


### PR DESCRIPTION
When we tag a commit, and it gets pushed to the `main` branch, then this should package and ship to PyPi for us automatically