### PR TITLE
Fix cicd to only go off if a commit is tagged on main

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,12 @@
 name: CI
-on: [push]
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - astronomer-cosmos-v*
+
 jobs:
   ship-package-to-pypi:
     runs-on: ubuntu-latest


### PR DESCRIPTION
We have actions running unnecessarily for every push being made to main.