### PR TITLE
Include model tags in parsers as well as a list parameter to filter them

### DIFF
--- a/cosmos/providers/dbt/dag.py
+++ b/cosmos/providers/dbt/dag.py
@@ -8,6 +8,7 @@ def DbtDag(
     dbt_args: dict = None,
     emit_datasets: bool = True,
     dbt_root_path: str = "/usr/local/airflow/dbt",
+    include_tags: list = None,
     **kwargs,
 ):
     """
@@ -23,6 +24,8 @@ def DbtDag(
     :type emit_datasets: bool
     :param dbt_root_path: The path to the dbt root directory
     :type dbt_root_path: str
+    :param include_tags: A list of tags to filter the dbt project
+    :type include_tags: list
     :param kwargs: Additional kwargs to pass to the DAG
     :type kwargs: dict
     :return: The rendered DAG
@@ -35,6 +38,7 @@ def DbtDag(
         dbt_args=dbt_args,
         emit_datasets=emit_datasets,
         dbt_root_path=dbt_root_path,
+        include_tags=include_tags,
     )
     group = parser.parse()
 

--- a/cosmos/providers/dbt/parser/jinja.py
+++ b/cosmos/providers/dbt/parser/jinja.py
@@ -1,10 +1,13 @@
+from typing import Dict
+
 import os
-from typing import Dict, List
 from pathlib import Path
 
 import jinja2
+import yaml
 
-def extract_deps_from_models(project_path: str) -> Dict[str, List[str]]:
+
+def extract_model_data(project_path: str) -> Dict[str, Dict[str, list]]:
     """
     Takes a path to a dbt project and returns a list of all the
     models with their dependencies. Return value is a dictionary
@@ -30,23 +33,15 @@ def extract_deps_from_models(project_path: str) -> Dict[str, List[str]]:
         raise ValueError(f"models_path {models_path} is not a directory.")
 
     # get all the files recursively
-    all_files = [
-        os.path.join(root, f)
-        for root, _, files in os.walk(models_path)
-        for f in files
-    ]
+    all_files = [os.path.join(root, f) for root, _, files in os.walk(models_path) for f in files]
 
-    # get all the model files
-    model_files = [
-        path for path in all_files
-        if os.path.isfile(path) and path.endswith(".sql")
-    ]
+    model_data = {}
 
-
-    dependencies = {}
+    # MODELS (SQL Files)
+    model_files = [path for path in all_files if os.path.isfile(path) and path.endswith(".sql")]
 
     for model_file in model_files:
-        with open(model_file, "r", encoding="utf-8") as f:
+        with open(model_file, encoding="utf-8") as f:
             model = f.read()
 
         env = jinja2.Environment()
@@ -54,12 +49,44 @@ def extract_deps_from_models(project_path: str) -> Dict[str, List[str]]:
 
         # if there's a dependency, add it to the list
         model_deps = []
+        tags = []
         for base_node in ast.find_all(jinja2.nodes.Call):
             if hasattr(base_node.node, "name"):
                 if base_node.node.name == "ref":
                     model_deps.append(base_node.args[0].value)
+                if base_node.node.name == "config" and base_node.kwargs[0].key == "tags":
+                    lst = base_node.kwargs[0].value
+                    tags = [x.value for x in lst.items if lst.items]
 
         # add the dependencies to the dictionary, without the .sql extension
-        dependencies[Path(model_file).stem] = model_deps
+        # add the tags to the dictionary
+        model_data[Path(model_file).stem] = {"dependencies": model_deps, "tags": tags}
 
-    return dependencies
+    # PROPERTIES.YML
+    properties_files = [path for path in all_files if os.path.isfile(path) and path.endswith(".yml")]
+
+    # get tags for models from property files
+    for properties_file in properties_files:
+        with open(properties_file) as f:
+            properties = yaml.safe_load(f)
+
+        models = properties["models"]
+        for model in models:
+            properties_tags = []
+
+            if "config" in model:
+                config = model["config"]
+                [properties_tags.append(item) for item in config.get("tags", [])]
+                [properties_tags.append(item) for item in config.get("+tags", [])]
+
+            if model.get("name") in model_data:
+                # add tags to model_data without deleting the tags collected from models
+                exiting_tags = model_data[model.get("name")]["tags"]
+                model_data[model.get("name")]["tags"] = list(set(exiting_tags).union(set(properties_tags)))
+
+    # TODO: Decide if we want to include tags from the project file
+
+    # DBT_PROJECT.YML
+    # project_file = os.path.join(project_path, "dbt_project.yml")
+
+    return model_data

--- a/cosmos/providers/dbt/task_group.py
+++ b/cosmos/providers/dbt/task_group.py
@@ -11,6 +11,7 @@ def DbtTaskGroup(
     dbt_args: dict = None,
     emit_datasets: bool = True,
     dbt_root_path: str = "/usr/local/airflow/dbt",
+    include_tags: list = None,
     **kwargs,
 ):
     """
@@ -27,6 +28,8 @@ def DbtTaskGroup(
     :param kwargs: Additional kwargs to pass to the DAG
     :param dbt_root_path: The path to the dbt root directory
     :type dbt_root_path: str
+    :param include_tags: A list of tags to filter the dbt project
+    :type include_tags: list
     :type kwargs: dict
     :return: The rendered Task Group
     :rtype: airflow.utils.task_group.TaskGroup
@@ -38,6 +41,7 @@ def DbtTaskGroup(
         dbt_args=dbt_args,
         emit_datasets=emit_datasets,
         dbt_root_path=dbt_root_path,
+        include_tags=include_tags,
     )
     group = parser.parse()
 


### PR DESCRIPTION
Please take a look at the issue I've attached. This will be a doozie - tags are just one selector type, but they feel the most applicable to our parsers.

In a dbt project, tags can be set in 3 places (see more info [here](https://docs.getdbt.com/reference/resource-configs/tags)):

- [ ] a `properties.yml` file
- [ ] a `.sql` file in the `models` directory
- [ ] a `dbt_project.yml` file

(I've checked the ones that this PR would take care of) - the question is: **Do we want to do it this way?** This feels like the most natural, but we should talk about the following:

- the [other selector types](https://docs.getdbt.com/reference/node-selection/syntax#how-does-selection-work) besides tags (these may or may not apply to how the parsers are parsing)
    - `path:`
    - `config:`
    - `test_type:`
    - `test_name:`
- whether this will be too strenuous on the `DbtDag` and `DbtTaskGroup` process to do this in-memory