### PR TITLE
Convert cli commands to use dbt executable path

### DIFF
--- a/cosmos/providers/dbt/core/operators.py
+++ b/cosmos/providers/dbt/core/operators.py
@@ -70,8 +70,8 @@ class DbtBaseOperator(BaseOperator):
         in ``skipped`` state (default: 99). If set to ``None``, any non-zero
         exit code will be treated as a failure.
     :type skip_exit_code: int
-    :param python_venv: Path to venv for dbt command execution (i.e. /home/astro/.pyenv/versions/dbt_venv/bin/activate)
-    :type python_venv: str
+    :param dbt_executable_path: Path to dbt executable can be used with venv (i.e. /home/astro/.pyenv/versions/dbt_venv/bin/dbt)
+    :type dbt_executable_path: str
     """
 
     template_fields: Sequence[str] = ("env", "vars")
@@ -97,7 +97,7 @@ class DbtBaseOperator(BaseOperator):
         append_env: bool = False,
         output_encoding: str = "utf-8",
         skip_exit_code: int = 99,
-        python_venv: str = None,
+        dbt_executable_path: str = None,
         **kwargs,
     ) -> None:
         self.project_dir = project_dir
@@ -119,7 +119,7 @@ class DbtBaseOperator(BaseOperator):
         self.append_env = append_env
         self.output_encoding = output_encoding
         self.skip_exit_code = skip_exit_code
-        self.python_venv = python_venv
+        self.dbt_executable_path = dbt_executable_path
         super().__init__(**kwargs)
 
     @cached_property
@@ -150,8 +150,8 @@ class DbtBaseOperator(BaseOperator):
     def get_dbt_path(self):
         which_dbt = shutil.which("dbt-ol") or shutil.which("dbt") or "dbt"
 
-        if self.python_venv:
-            dbt_path = self.python_venv
+        if self.dbt_executable_path:
+            dbt_path = self.dbt_executable_path
         else:
             dbt_path = which_dbt
 

--- a/cosmos/providers/dbt/core/operators.py
+++ b/cosmos/providers/dbt/core/operators.py
@@ -148,10 +148,10 @@ class DbtBaseOperator(BaseOperator):
         return env
 
     def get_dbt_path(self):
-        which_dbt = shutil.which("dbt") or "dbt"
+        which_dbt = shutil.which("dbt-ol") or shutil.which("dbt") or "dbt"
 
         if self.python_venv:
-            dbt_path = f"{self.python_venv}/bin/dbt"
+            dbt_path = self.python_venv
         else:
             dbt_path = which_dbt
 

--- a/cosmos/providers/dbt/core/operators.py
+++ b/cosmos/providers/dbt/core/operators.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import os
 import shutil
 from typing import Sequence

--- a/cosmos/providers/dbt/render.py
+++ b/cosmos/providers/dbt/render.py
@@ -53,8 +53,8 @@ def render_project(
         if dbt_tags and not set(dbt_tags).intersection(model.config.tags):
             continue
 
-        run_args: dict[str, Any] = {**task_args, "models": [model_name]}
-        test_args: dict[str, Any] = {**task_args, "models": [model_name]}
+        run_args: dict[str, Any] = {**task_args, "models": model_name}
+        test_args: dict[str, Any] = {**task_args, "models": model_name}
 
         if emit_datasets:
             outlets = [

--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:7.0.0
+FROM quay.io/astronomer/astro-runtime:7.1.0
 
 # install dbt into a venv to avoid package dependency conflicts
 WORKDIR "/usr/local/airflow"

--- a/examples/dags/attribution-playbook.py
+++ b/examples/dags/attribution-playbook.py
@@ -15,7 +15,7 @@ from cosmos.providers.dbt.dag import DbtDag
 attribution_playbook = DbtDag(
     dbt_project_name="attribution-playbook",
     conn_id="airflow_db",
-    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv/bin/activate"},
+    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
     dag_id="attribution-playbook",
     start_date=datetime(2022, 11, 27),
     schedule=[Dataset("SEED://ATTRIBUTION_PLAYBOOK")],

--- a/examples/dags/attribution-playbook.py
+++ b/examples/dags/attribution-playbook.py
@@ -15,7 +15,10 @@ from cosmos.providers.dbt.dag import DbtDag
 attribution_playbook = DbtDag(
     dbt_project_name="attribution-playbook",
     conn_id="airflow_db",
-    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
+    dbt_args={
+        "schema": "public",
+        "dbt_executable_path": "/usr/local/airflow/dbt_venv/bin/dbt",
+    },
     dag_id="attribution-playbook",
     start_date=datetime(2022, 11, 27),
     schedule=[Dataset("SEED://ATTRIBUTION_PLAYBOOK")],

--- a/examples/dags/extract_dag.py
+++ b/examples/dags/extract_dag.py
@@ -50,7 +50,7 @@ with DAG(
                 task_id=f"{project['project']}_install_deps",
                 project_dir=f"/usr/local/airflow/dbt/{project['project']}",
                 schema="public",
-                python_venv="/usr/local/airflow/dbt_venv",
+                dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
                 conn_id="airflow_db",
             )
 
@@ -63,7 +63,7 @@ with DAG(
                     args={"table_name": seed},
                     project_dir=f"/usr/local/airflow/dbt/{project['project']}",
                     schema="public",
-                    python_venv="/usr/local/airflow/dbt_venv",
+                    dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
                     conn_id="airflow_db",
                 )
 
@@ -74,7 +74,7 @@ with DAG(
                 task_id=f"{name_underscores}_seed",
                 project_dir=f"/usr/local/airflow/dbt/{project}",
                 schema="public",
-                python_venv="/usr/local/airflow/dbt_venv",
+                dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
                 conn_id="airflow_db",
                 outlets=[Dataset(f"SEED://{name_underscores.upper()}")],
             )

--- a/examples/dags/extract_dag.py
+++ b/examples/dags/extract_dag.py
@@ -16,7 +16,11 @@ from airflow.datasets import Dataset
 from airflow.utils.task_group import TaskGroup
 from pendulum import datetime
 
-from cosmos.providers.dbt.core.operators import DbtRunOperationOperator, DbtSeedOperator
+from cosmos.providers.dbt.core.operators import (
+    DbtDepsOperator,
+    DbtRunOperationOperator,
+    DbtSeedOperator,
+)
 
 with DAG(
     dag_id="extract_dag",
@@ -29,10 +33,26 @@ with DAG(
 ) as dag:
 
     project_seeds = [
-        {"project": "jaffle_shop", "seeds": ["raw_customers", "raw_payments", "raw_orders"]},
-        {"project": "attribution-playbook", "seeds": ["customer_conversions", "ad_spend", "sessions"]},
+        {
+            "project": "jaffle_shop",
+            "seeds": ["raw_customers", "raw_payments", "raw_orders"],
+        },
+        {
+            "project": "attribution-playbook",
+            "seeds": ["customer_conversions", "ad_spend", "sessions"],
+        },
         {"project": "mrr-playbook", "seeds": ["subscription_periods"]},
     ]
+
+    with TaskGroup(group_id="install_project_deps") as deps_install:
+        for project in project_seeds:
+            DbtDepsOperator(
+                task_id=f"{project['project']}_install_deps",
+                project_dir=f"/usr/local/airflow/dbt/{project['project']}",
+                schema="public",
+                python_venv="/usr/local/airflow/dbt_venv",
+                conn_id="airflow_db",
+            )
 
     with TaskGroup(group_id="drop_seeds_if_exist") as drop_seeds:
         for project in project_seeds:
@@ -43,8 +63,8 @@ with DAG(
                     args={"table_name": seed},
                     project_dir=f"/usr/local/airflow/dbt/{project['project']}",
                     schema="public",
+                    python_venv="/usr/local/airflow/dbt_venv",
                     conn_id="airflow_db",
-                    python_venv="/usr/local/airflow/dbt_venv/bin/activate",
                 )
 
     with TaskGroup(group_id="all_seeds") as create_seeds:
@@ -54,9 +74,9 @@ with DAG(
                 task_id=f"{name_underscores}_seed",
                 project_dir=f"/usr/local/airflow/dbt/{project}",
                 schema="public",
+                python_venv="/usr/local/airflow/dbt_venv",
                 conn_id="airflow_db",
-                python_venv="/usr/local/airflow/dbt_venv/bin/activate",
                 outlets=[Dataset(f"SEED://{name_underscores.upper()}")],
             )
 
-    drop_seeds >> create_seeds
+    deps_install >> drop_seeds >> create_seeds

--- a/examples/dags/jaffle_shop.py
+++ b/examples/dags/jaffle_shop.py
@@ -26,7 +26,10 @@ with DAG(
     jaffle_shop = DbtTaskGroup(
         dbt_project_name="jaffle_shop",
         conn_id="airflow_db",
-        dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
+        dbt_args={
+            "schema": "public",
+            "dbt_executable_path": "/usr/local/airflow/dbt_venv/bin/dbt",
+        },
         test_behavior="after_all",
         dag=dag,
     )

--- a/examples/dags/jaffle_shop.py
+++ b/examples/dags/jaffle_shop.py
@@ -26,7 +26,8 @@ with DAG(
     jaffle_shop = DbtTaskGroup(
         dbt_project_name="jaffle_shop",
         conn_id="airflow_db",
-        dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv/bin/activate"},
+        dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
+        test_behavior="after_all",
         dag=dag,
     )
 

--- a/examples/dags/mrr-playbook.py
+++ b/examples/dags/mrr-playbook.py
@@ -14,7 +14,7 @@ from cosmos.providers.dbt.dag import DbtDag
 mrr_playbook = DbtDag(
     dbt_project_name="mrr-playbook",
     conn_id="airflow_db",
-    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv/bin/activate"},
+    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
     dag_id="mrr_playbook",
     start_date=datetime(2022, 11, 27),
     schedule=[Dataset("SEED://MRR_PLAYBOOK")],

--- a/examples/dags/mrr-playbook.py
+++ b/examples/dags/mrr-playbook.py
@@ -14,7 +14,10 @@ from cosmos.providers.dbt.dag import DbtDag
 mrr_playbook = DbtDag(
     dbt_project_name="mrr-playbook",
     conn_id="airflow_db",
-    dbt_args={"schema": "public", "python_venv": "/usr/local/airflow/dbt_venv"},
+    dbt_args={
+        "schema": "public",
+        "dbt_executable_path": "/usr/local/airflow/dbt_venv/bin/dbt",
+    },
     dag_id="mrr_playbook",
     start_date=datetime(2022, 11, 27),
     schedule=[Dataset("SEED://MRR_PLAYBOOK")],

--- a/examples/dbt/attribution-playbook/macros/drop_table.sql
+++ b/examples/dbt/attribution-playbook/macros/drop_table.sql
@@ -1,6 +1,6 @@
 {%- macro drop_table(table_name) -%}
     {%- set drop_query -%}
-        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }}
+        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }} CASCADE
     {%- endset -%}
     {% do run_query(drop_query) %}
 {%- endmacro -%}

--- a/examples/dbt/jaffle_shop/macros/drop_table.sql
+++ b/examples/dbt/jaffle_shop/macros/drop_table.sql
@@ -1,6 +1,6 @@
 {%- macro drop_table(table_name) -%}
     {%- set drop_query -%}
-        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }}
+        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }} CASCADE
     {%- endset -%}
     {% do run_query(drop_query) %}
 {%- endmacro -%}

--- a/examples/dbt/mrr-playbook/macros/drop_table.sql
+++ b/examples/dbt/mrr-playbook/macros/drop_table.sql
@@ -1,6 +1,6 @@
 {%- macro drop_table(table_name) -%}
     {%- set drop_query -%}
-        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }}
+        DROP TABLE IF EXISTS {{ target.schema }}.{{ table_name }} CASCADE
     {%- endset -%}
     {% do run_query(drop_query) %}
 {%- endmacro -%}


### PR DESCRIPTION
Currently, we are sourcing the venv [here](https://github.com/astronomer/astronomer-cosmos/blob/main/cosmos/providers/dbt/core/operators.py#L152). Instead, we should reference the dbt executable so that implementing the `dbt-ol` wrapper is easier.

Before:
```python
dbt_path = [bash_path, "-c", f"source {self.python_venv} && dbt {self.base_cmd} "]
```

After:
```python
{self.python_venv}/bin/dbt {self.base_cmd}
```