### PR TITLE
Update minor version for breaking changes

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -2,4 +2,4 @@
 Astronomer Cosmos is a library for rendering 3rd party workflows in Airflow.
 """
 
-__version__ = "0.1.2"
+__version__ = "0.2.0"


### PR DESCRIPTION
@jlaneve @iancmoritz I forgot to bump the minor version. We probably should do this after implementing [this](https://github.com/astronomer/astronomer-cosmos/pull/83) as it broke some stuff.