### PR TITLE
Make region optional in Snowflake connection

### DIFF
--- a/cosmos/providers/dbt/core/utils/profiles_generator.py
+++ b/cosmos/providers/dbt/core/utils/profiles_generator.py
@@ -79,7 +79,12 @@ def create_profile_vars(conn: Connection, database, schema):
 
     elif conn.conn_type == "snowflake":
         profile = "snowflake_profile"
-        extras = {"account": "account", "region": "region", "role": "role", "warehouse": "warehouse"}
+        extras = {
+            "account": "account",
+            "region": "region",
+            "role": "role",
+            "warehouse": "warehouse",
+        }
 
         # At some point the extras removed a prefix extra__snowflake__ when the provider got updated... handling that
         # here.
@@ -88,11 +93,13 @@ def create_profile_vars(conn: Connection, database, schema):
                 extras[key] = f"extra__snowflake__{value}"
 
         # Region is optional
-        region = conn.extra_dejson.get(extras['region'])
-        if region:
+        region = conn.extra_dejson.get(extras["region"])
+        account = conn.extra_dejson.get(extras["account"])
+
+        if region and region not in account:
             account = f"{conn.extra_dejson.get(extras['account'])}.{region}"
         else:
-            account = conn.extra_dejson.get(extras['account'])
+            account = conn.extra_dejson.get(extras["account"])
 
         profile_vars = {
             "SNOWFLAKE_USER": conn.login,
@@ -119,19 +126,37 @@ def create_profile_vars(conn: Connection, database, schema):
         profile = "bigquery_profile"
         profile_vars = {
             "BIGQUERY_DATASET": schema,
-            "BIGQUERY_PROJECT": json.loads(conn.extra_dejson.get("keyfile_dict"))["project_id"],
-            "BIGQUERY_TYPE": json.loads(conn.extra_dejson.get("keyfile_dict"))["type"],
-            "BIGQUERY_PROJECT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["project_id"],
-            "BIGQUERY_PRIVATE_KEY_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["private_key_id"],
-            "BIGQUERY_PRIVATE_KEY": json.loads(conn.extra_dejson.get("keyfile_dict"))["private_key"],
-            "BIGQUERY_CLIENT_EMAIL": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_email"],
-            "BIGQUERY_CLIENT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_id"],
-            "BIGQUERY_AUTH_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))["auth_uri"],
-            "BIGQUERY_TOKEN_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))["token_uri"],
-            "BIGQUERY_AUTH_PROVIDER_X509_CERT_URL": json.loads(conn.extra_dejson.get("keyfile_dict"))[
-                "auth_provider_x509_cert_url"
+            "BIGQUERY_PROJECT": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "project_id"
             ],
-            "BIGQUERY_CLIENT_X509_CERT_URL": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_x509_cert_url"],
+            "BIGQUERY_TYPE": json.loads(conn.extra_dejson.get("keyfile_dict"))["type"],
+            "BIGQUERY_PROJECT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "project_id"
+            ],
+            "BIGQUERY_PRIVATE_KEY_ID": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["private_key_id"],
+            "BIGQUERY_PRIVATE_KEY": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "private_key"
+            ],
+            "BIGQUERY_CLIENT_EMAIL": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "client_email"
+            ],
+            "BIGQUERY_CLIENT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "client_id"
+            ],
+            "BIGQUERY_AUTH_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "auth_uri"
+            ],
+            "BIGQUERY_TOKEN_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "token_uri"
+            ],
+            "BIGQUERY_AUTH_PROVIDER_X509_CERT_URL": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["auth_provider_x509_cert_url"],
+            "BIGQUERY_CLIENT_X509_CERT_URL": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["client_x509_cert_url"],
         }
 
     elif conn.conn_type == "databricks":
@@ -144,7 +169,9 @@ def create_profile_vars(conn: Connection, database, schema):
         }
 
     else:
-        logger.error(f"Connection type {conn.type} is not yet supported.", file=sys.stderr)
+        logger.error(
+            f"Connection type {conn.type} is not yet supported.", file=sys.stderr
+        )
         sys.exit(1)
 
     return profile, profile_vars

--- a/cosmos/providers/dbt/core/utils/profiles_generator.py
+++ b/cosmos/providers/dbt/core/utils/profiles_generator.py
@@ -87,10 +87,17 @@ def create_profile_vars(conn: Connection, database, schema):
             for key, value in extras.items():
                 extras[key] = f"extra__snowflake__{value}"
 
+        # Region is optional
+        region = conn.extra_dejson.get(extras['region'])
+        if region:
+            account = f"{conn.extra_dejson.get(extras['account'])}.{region}"
+        else:
+            account = conn.extra_dejson.get(extras['account'])
+
         profile_vars = {
             "SNOWFLAKE_USER": conn.login,
             "SNOWFLAKE_PASSWORD": conn.password,
-            "SNOWFLAKE_ACCOUNT": f"{conn.extra_dejson.get(extras['account'])}.{conn.extra_dejson.get(extras['region'])}",
+            "SNOWFLAKE_ACCOUNT": account,
             "SNOWFLAKE_ROLE": conn.extra_dejson.get(extras["role"]),
             "SNOWFLAKE_DATABASE": database,
             "SNOWFLAKE_WAREHOUSE": conn.extra_dejson.get(extras["warehouse"]),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,6 +82,11 @@ include = [
     "/cosmos",
 ]
 
+[tool.hatch.envs.test]
+dependencies = [
+  "pytest"
+]
+
 [tool.hatch.envs.docs]
 dependencies = [
     "sphinx",


### PR DESCRIPTION
Snowflake allows and if anything seems to encourage not adding in the `region` parameter to a Snowflake connection. The reason is because Snowflake recently [moved to a system](https://docs.snowflake.com/en/user-guide/admin-account-identifier.html#existing-accounts) where the "region" is no longer part of the URI.

Under the hood, Airflow just [passes to](https://github.com/apache/airflow/blob/d9cefcd0c50a1cce1c3c8e9ecb99cfacde5eafbf/airflow/providers/snowflake/hooks/snowflake.py#L285) the Snowflake SQLAlchemy `URL()`, and under the hood Snowflake's `URL()` [allows for](https://github.com/snowflakedb/snowflake-sqlalchemy/blob/7c8effdb8c38f37084d5165961df75cbbbc10ddf/src/snowflake/sqlalchemy/util.py#L49) `region` to be optional.

### Fix

`region` should be allowed to be optional, basically. I wanted to do an approach that did not rely on magically trimming a trailing `.`, so something that explicitly checks for when region is not specified.

There were two approaches I could go with that meets the requirement: either fix it in Python, or fix it in `profiles/snowflake.py`. I went with the former approach because doing lots of things in Jinja2 is usually harder to maintain than doing the equivalent in Python, but it would have looked like this:

```python
"account": "{{ env_var('SNOWFLAKE_ACCOUNT') ~ '.' ~ env_var('SNOWFLAKE_REGION')"
           " if env_var('SNOWFLAKE_REGION')"
           " else env_var('SNOWFLAKE_ACCOUNT') }}",
```

### Pyproject.toml change

I also added `pytest` to the project as it wasn't specified as a dependency, but the `tests/` folder uses it.