### PR TITLE
Use targeted database for BigQuery profile

### DIFF
--- a/cosmos/providers/dbt/core/utils/profiles_generator.py
+++ b/cosmos/providers/dbt/core/utils/profiles_generator.py
@@ -180,7 +180,10 @@ def map_profile(conn_id, db_override=None, schema_override=None):
         db = db_override
     else:
         if conn.conn_type != "snowflake":
-            db = conn.schema
+            if conn.conn_type == "google_cloud_platform":
+                db = json.loads(conn.extra_dejson.get("keyfile_dict"))["project_id"]
+            else:
+                db = conn.schema
         else:
             # At some point the extras removed a prefix extra__snowflake__ when the provider got updated... handling
             # that here.

--- a/cosmos/providers/dbt/core/utils/profiles_generator.py
+++ b/cosmos/providers/dbt/core/utils/profiles_generator.py
@@ -79,7 +79,12 @@ def create_profile_vars(conn: Connection, database, schema):
 
     elif conn.conn_type == "snowflake":
         profile = "snowflake_profile"
-        extras = {"account": "account", "region": "region", "role": "role", "warehouse": "warehouse"}
+        extras = {
+            "account": "account",
+            "region": "region",
+            "role": "role",
+            "warehouse": "warehouse",
+        }
 
         # At some point the extras removed a prefix extra__snowflake__ when the provider got updated... handling that
         # here.
@@ -112,19 +117,35 @@ def create_profile_vars(conn: Connection, database, schema):
         profile = "bigquery_profile"
         profile_vars = {
             "BIGQUERY_DATASET": schema,
-            "BIGQUERY_PROJECT": json.loads(conn.extra_dejson.get("keyfile_dict"))["project_id"],
+            "BIGQUERY_PROJECT": database,
             "BIGQUERY_TYPE": json.loads(conn.extra_dejson.get("keyfile_dict"))["type"],
-            "BIGQUERY_PROJECT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["project_id"],
-            "BIGQUERY_PRIVATE_KEY_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["private_key_id"],
-            "BIGQUERY_PRIVATE_KEY": json.loads(conn.extra_dejson.get("keyfile_dict"))["private_key"],
-            "BIGQUERY_CLIENT_EMAIL": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_email"],
-            "BIGQUERY_CLIENT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_id"],
-            "BIGQUERY_AUTH_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))["auth_uri"],
-            "BIGQUERY_TOKEN_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))["token_uri"],
-            "BIGQUERY_AUTH_PROVIDER_X509_CERT_URL": json.loads(conn.extra_dejson.get("keyfile_dict"))[
-                "auth_provider_x509_cert_url"
+            "BIGQUERY_PROJECT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "project_id"
             ],
-            "BIGQUERY_CLIENT_X509_CERT_URL": json.loads(conn.extra_dejson.get("keyfile_dict"))["client_x509_cert_url"],
+            "BIGQUERY_PRIVATE_KEY_ID": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["private_key_id"],
+            "BIGQUERY_PRIVATE_KEY": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "private_key"
+            ],
+            "BIGQUERY_CLIENT_EMAIL": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "client_email"
+            ],
+            "BIGQUERY_CLIENT_ID": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "client_id"
+            ],
+            "BIGQUERY_AUTH_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "auth_uri"
+            ],
+            "BIGQUERY_TOKEN_URI": json.loads(conn.extra_dejson.get("keyfile_dict"))[
+                "token_uri"
+            ],
+            "BIGQUERY_AUTH_PROVIDER_X509_CERT_URL": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["auth_provider_x509_cert_url"],
+            "BIGQUERY_CLIENT_X509_CERT_URL": json.loads(
+                conn.extra_dejson.get("keyfile_dict")
+            )["client_x509_cert_url"],
         }
 
     elif conn.conn_type == "databricks":
@@ -137,7 +158,9 @@ def create_profile_vars(conn: Connection, database, schema):
         }
 
     else:
-        logger.error(f"Connection type {conn.type} is not yet supported.", file=sys.stderr)
+        logger.error(
+            f"Connection type {conn.type} is not yet supported.", file=sys.stderr
+        )
         sys.exit(1)
 
     return profile, profile_vars


### PR DESCRIPTION
Fixes #102, the diffs in this PR are from the pre-commit black formatter, when it was actually only a single line update. I tested and it works as expected, though not sure if we want to default to the service-account project if `db_name` is None.