### PR TITLE
Add custom models directory argument

### DIFF
--- a/cosmos/providers/dbt/dag.py
+++ b/cosmos/providers/dbt/dag.py
@@ -20,6 +20,7 @@ class DbtDag(CosmosDag):
 
     :param dbt_project_name: The name of the dbt project
     :param dbt_root_path: The path to the dbt root directory
+    :param dbt_models_dir: The path to the dbt models directory within the project
     :param conn_id: The Airflow connection ID to use for the dbt profile
     :param dbt_args: Parameters to pass to the underlying dbt operators
     :param emit_datasets: If enabled test nodes emit Airflow Datasets for downstream cross-DAG dependencies

--- a/cosmos/providers/dbt/dag.py
+++ b/cosmos/providers/dbt/dag.py
@@ -36,6 +36,7 @@ class DbtDag(CosmosDag):
         dbt_args: Dict[str, Any] = {},
         emit_datasets: bool = True,
         dbt_root_path: str = "/usr/local/airflow/dbt",
+        dbt_models_dir: str = "models",
         test_behavior: Literal["none", "after_each", "after_all"] = "after_each",
         select: Dict[str, List[str]] = {},
         exclude: Dict[str, List[str]] = {},
@@ -52,6 +53,7 @@ class DbtDag(CosmosDag):
         group = render_project(
             dbt_project_name=dbt_project_name,
             dbt_root_path=dbt_root_path,
+            dbt_models_dir=dbt_models_dir,
             task_args=dbt_args,
             test_behavior=test_behavior,
             emit_datasets=emit_datasets,

--- a/cosmos/providers/dbt/parser/project.py
+++ b/cosmos/providers/dbt/parser/project.py
@@ -114,6 +114,7 @@ class DbtProject:
 
     # optional, user-specified instance variables
     dbt_root_path: str = "/usr/local/airflow/dbt"
+    dbt_models_dir: str = "models"
 
     # private instance variables for managing state
     models: Dict[str, DbtModel] = field(default_factory=dict)
@@ -126,7 +127,7 @@ class DbtProject:
         """
         # set the project and model dirs
         self.project_dir = Path(os.path.join(self.dbt_root_path, self.project_name))
-        self.models_dir = self.project_dir / "models"
+        self.models_dir = self.project_dir / self.dbt_models_dir
 
         # crawl the models in the project
         for file_name in self.models_dir.rglob("*.sql"):

--- a/cosmos/providers/dbt/render.py
+++ b/cosmos/providers/dbt/render.py
@@ -22,6 +22,7 @@ logger = logging.getLogger(__name__)
 def render_project(
     dbt_project_name: str,
     dbt_root_path: str = "/usr/local/airflow/dbt",
+    dbt_models_dir: str = "models",
     task_args: Dict[str, Any] = {},
     test_behavior: Literal["none", "after_each", "after_all"] = "after_each",
     emit_datasets: bool = True,
@@ -45,6 +46,7 @@ def render_project(
     # first, get the dbt project
     project = DbtProject(
         dbt_root_path=dbt_root_path,
+        dbt_models_dir=dbt_models_dir,
         project_name=dbt_project_name,
     )
 

--- a/cosmos/providers/dbt/task_group.py
+++ b/cosmos/providers/dbt/task_group.py
@@ -36,6 +36,7 @@ class DbtTaskGroup(CosmosTaskGroup):
         dbt_args: Dict[str, Any] = {},
         emit_datasets: bool = True,
         dbt_root_path: str = "/usr/local/airflow/dbt",
+        dbt_models_dir: str = "models",
         test_behavior: Literal["none", "after_each", "after_all"] = "after_each",
         select: Dict[str, List[str]] = {},
         exclude: Dict[str, List[str]] = {},
@@ -52,6 +53,7 @@ class DbtTaskGroup(CosmosTaskGroup):
         group = render_project(
             dbt_project_name=dbt_project_name,
             dbt_root_path=dbt_root_path,
+            dbt_models_dir=dbt_models_dir,
             task_args=dbt_args,
             test_behavior=test_behavior,
             emit_datasets=emit_datasets,

--- a/cosmos/providers/dbt/task_group.py
+++ b/cosmos/providers/dbt/task_group.py
@@ -20,6 +20,7 @@ class DbtTaskGroup(CosmosTaskGroup):
 
     :param dbt_project_name: The name of the dbt project
     :param dbt_root_path: The path to the dbt root directory
+    :param dbt_models_dir: The path to the dbt models directory within the project
     :param conn_id: The Airflow connection ID to use for the dbt profile
     :param dbt_args: Parameters to pass to the underlying dbt operators
     :param emit_datasets: If enabled test nodes emit Airflow Datasets for downstream cross-DAG dependencies

--- a/docs/dbt/usage.rst
+++ b/docs/dbt/usage.rst
@@ -3,7 +3,7 @@ Usage
 
 Cosmos supports two standard way of rendering dbt projects: either as a full DAG or as a Task Group.
 
-By default, Cosmos will look in the ``/usr/local/airflow/dbt`` directory (next to the ``dags`` folder if you're using the `Astro CLI <https://github.com/astronomer/astro-cli>`_). You can override this using the ``dbt_root_path`` argument in either :class:`cosmos.providers.dbt.DbtDag` or :class:`cosmos.providers.dbt.DbtTaskGroup`.
+By default, Cosmos will look in the ``/usr/local/airflow/dbt`` directory (next to the ``dags`` folder if you're using the `Astro CLI <https://github.com/astronomer/astro-cli>`_). You can override this using the ``dbt_root_path`` argument in either :class:`cosmos.providers.dbt.DbtDag` or :class:`cosmos.providers.dbt.DbtTaskGroup`. You can also override the default models directory, which is ``"models"`` by default, using the ``dbt_models_dir`` argument.
 
 Rendering
 +++++++++
@@ -88,4 +88,3 @@ Under the hood, this information gets translated to a profiles.yml file (using e
         dbt_args={"schema": "public"},
         # ...
     )
-


### PR DESCRIPTION
Hey,

I'm currently trying out the `DbtDag` and `DbtTaskGroup` classes for a project in the hope of replacing some bespoke `manifest.json` parsing code that we maintain, however I noticed the the dbt models directory is hard coded within the parser [here](https://github.com/astronomer/astronomer-cosmos/blob/e4abd7bbe043b46c7d66c18dca2d34d38cd03cc0/cosmos/providers/dbt/parser/project.py#L129). 

We use a custom models directory name and I'm sure others might too, so I thought I could contribute a small change upstream to enable a custom models directory to be specified.