### PR TITLE
Change cicd to use release branches instead of publishing from main

### DIFF
--- a/.github/workflows/astro-deploy.yml
+++ b/.github/workflows/astro-deploy.yml
@@ -3,7 +3,7 @@ name: Astronomer CI - Deploy code
 on:
   pull_request:
   push:
-    branches: main
+    branches: release-**
 
 env:
   ## Sets Deployment API key credentials as environment variables
@@ -12,7 +12,7 @@ env:
 
 jobs:
   tests:
-    if: github.head_ref == 'dev'
+    if: github.head_ref == 'main'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -30,7 +30,7 @@ jobs:
           pytest tests/validation_tests.py
 
   build:
-    if: github.head_ref == 'dev'
+    if: github.head_ref == 'main'
     needs: tests
     runs-on: ubuntu-latest
     steps:

--- a/astro_tests/Dockerfile
+++ b/astro_tests/Dockerfile
@@ -7,4 +7,4 @@ RUN python -m virtualenv dbt_venv && source dbt_venv/bin/activate && \
     pip install --no-cache-dir -r dbt-requirements.txt && deactivate
 
 # install cosmos from dev branch
-RUN pip install git+https://github.com/astronomer/astronomer-cosmos.git@dev#egg=astronomer-cosmos
+RUN pip install git+https://github.com/astronomer/astronomer-cosmos.git@main#egg=astronomer-cosmos


### PR DESCRIPTION
Setting up our CI/CD so that contributions follow this flow:

Contributor opens a PR and develops against `main` &rarr; Cosmos Admin opens a PR from `main` into appropriate `release-` branch &rarr; Changes are shipped to PyPI when GitHub release is published