### PR TITLE
Remove unneeded dependencies from the extras

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,6 @@ dependencies = [
 [project.optional-dependencies]
 dbt-all = [
     "dbt-bigquery",
-    "dbt-core",
     "dbt-databricks",
     "dbt-postgres",
     "dbt-redshift",
@@ -51,22 +50,17 @@ dbt-all = [
 ]
 dbt-bigquery = [
     "dbt-bigquery",
-    "dbt-core",
 ]
 dbt-databricks = [
-    "dbt-core",
     "dbt-databricks",
 ]
 dbt-postgres = [
-    "dbt-core",
     "dbt-postgres",
 ]
 dbt-redshift = [
-    "dbt-core",
     "dbt-redshift",
 ]
 dbt-snowflake = [
-    "dbt-core",
     "dbt-snowflake",
 ]
 


### PR DESCRIPTION
Specific adapters already contain `dbt-core`. For example, if you install `dbt-redshift`, `dbt-core` is a dependency for it already.