### PR TITLE
[Databricks] Fix issue for using single notebook task launch without taskgroup

### DIFF
--- a/cosmos/providers/databricks/constants.py
+++ b/cosmos/providers/databricks/constants.py
@@ -1,0 +1,3 @@
+import os
+
+JOBS_API_VERSION = os.getenv("JOBS_API_VERSION", "2.1")

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -128,9 +128,13 @@ class DatabricksNotebookOperator(BaseOperator):
         self._handle_final_state(final_state)
 
     def _get_current_databricks_task(self, runs_api):
-        print(self.databricks_run_id, runs_api.get_run(self.databricks_run_id))
+        print(
+            self.databricks_run_id,
+            runs_api.get_run(self.databricks_run_id, version="2.1"),
+        )
         return {
-            x["task_key"]: x for x in runs_api.get_run(self.databricks_run_id)["tasks"]
+            x["task_key"]: x
+            for x in runs_api.get_run(self.databricks_run_id, version="2.1")["tasks"]
         }[self.dag_id + "__" + self.task_id.replace(".", "__")]
 
     def _handle_final_state(self, final_state):

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -193,6 +193,7 @@ class DatabricksNotebookOperator(BaseOperator):
         runs_api = RunsApi(api_client)
         run = runs_api.submit_run(run_json)
         self.databricks_run_id = run["run_id"]
+        print(run)
         return run
 
     def execute(self, context: Context) -> Any:

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -179,6 +179,7 @@ class DatabricksNotebookOperator(BaseOperator):
         """Launch the notebook as a one-time job to Databricks."""
         api_client = self._get_api_client()
         run_json = {
+            "run_name": self.dag_id + "__" + self.task_id.replace(".", "__"),
             "notebook_task": {
                 "notebook_path": self.notebook_path,
                 "base_parameters": {"source": self.source},

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -11,6 +11,8 @@ from airflow.utils.context import Context
 from databricks_cli.runs.api import RunsApi
 from databricks_cli.sdk.api_client import ApiClient
 
+from cosmos.providers.databricks.constants import JOBS_API_VERSION
+
 
 class DatabricksNotebookOperator(BaseOperator):
     """
@@ -128,13 +130,11 @@ class DatabricksNotebookOperator(BaseOperator):
         self._handle_final_state(final_state)
 
     def _get_current_databricks_task(self, runs_api):
-        print(
-            self.databricks_run_id,
-            runs_api.get_run(self.databricks_run_id, version="2.1"),
-        )
         return {
             x["task_key"]: x
-            for x in runs_api.get_run(self.databricks_run_id, version="2.1")["tasks"]
+            for x in runs_api.get_run(self.databricks_run_id, version=JOBS_API_VERSION)[
+                "tasks"
+            ]
         }[self.dag_id + "__" + self.task_id.replace(".", "__")]
 
     def _handle_final_state(self, final_state):
@@ -199,7 +199,6 @@ class DatabricksNotebookOperator(BaseOperator):
         runs_api = RunsApi(api_client)
         run = runs_api.submit_run(run_json)
         self.databricks_run_id = run["run_id"]
-        print(run, self.databricks_run_id)
         return run
 
     def execute(self, context: Context) -> Any:

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -128,6 +128,7 @@ class DatabricksNotebookOperator(BaseOperator):
         self._handle_final_state(final_state)
 
     def _get_current_databricks_task(self, runs_api):
+        print(self.databricks_run_id, runs_api.get_run(self.databricks_run_id))
         return {
             x["task_key"]: x for x in runs_api.get_run(self.databricks_run_id)["tasks"]
         }[self.dag_id + "__" + self.task_id.replace(".", "__")]
@@ -193,7 +194,7 @@ class DatabricksNotebookOperator(BaseOperator):
         runs_api = RunsApi(api_client)
         run = runs_api.submit_run(run_json)
         self.databricks_run_id = run["run_id"]
-        print(run)
+        print(run, self.databricks_run_id)
         return run
 
     def execute(self, context: Context) -> Any:

--- a/docs/databricks/workflows.rst
+++ b/docs/databricks/workflows.rst
@@ -12,7 +12,7 @@ The DatabricksWorkflowTaskGroup is designed to look and function like a standard
 with the added ability to include specific Databricks arguments.
 An example of how to use the DatabricksWorkflowTaskGroup can be seen in the following code snippet:
 
-.. exampleinclude:: /../astronomer/providers/databricks/example_dags/example_databricks_workflow.py
+.. literalinclude:: /../examples/databricks/example_databricks_workflow.py
     :language: python
     :dedent: 4
     :start-after: [START howto_databricks_workflow_notebook]

--- a/examples/databricks/example_databricks_notebook.py
+++ b/examples/databricks/example_databricks_notebook.py
@@ -1,0 +1,61 @@
+"""Example DAG for using the DatabricksNotebookOperator."""
+import os
+from datetime import timedelta
+
+from airflow.models.dag import DAG
+from airflow.utils.timezone import datetime
+
+from cosmos.providers.databricks.notebook import DatabricksNotebookOperator
+
+EXECUTION_TIMEOUT = int(os.getenv("EXECUTION_TIMEOUT", 6))
+default_args = {
+    "execution_timeout": timedelta(hours=EXECUTION_TIMEOUT),
+    "retries": int(os.getenv("DEFAULT_TASK_RETRIES", 2)),
+    "retry_delay": timedelta(seconds=int(os.getenv("DEFAULT_RETRY_DELAY_SECONDS", 60))),
+}
+
+DATABRICKS_CONN_ID = os.getenv("ASTRO_DATABRICKS_CONN_ID", "databricks_conn")
+NEW_CLUSTER_SPEC = {
+    "cluster_name": "",
+    "spark_version": "11.3.x-scala2.12",
+    "aws_attributes": {
+        "first_on_demand": 1,
+        "availability": "SPOT_WITH_FALLBACK",
+        "zone_id": "us-east-2b",
+        "spot_bid_price_percent": 100,
+        "ebs_volume_count": 0,
+    },
+    "node_type_id": "i3.xlarge",
+    "spark_env_vars": {"PYSPARK_PYTHON": "/databricks/python3/bin/python3"},
+    "enable_elastic_disk": False,
+    "data_security_mode": "LEGACY_SINGLE_USER_STANDARD",
+    "runtime_engine": "STANDARD",
+    "num_workers": 8,
+}
+
+dag = DAG(
+    dag_id="example_databricks_notebook",
+    start_date=datetime(2022, 1, 1),
+    schedule_interval=None,
+    catchup=False,
+    default_args=default_args,
+    tags=["example", "async", "databricks"],
+)
+with dag:
+    notebook_1 = DatabricksNotebookOperator(
+        task_id="notebook_1",
+        databricks_conn_id=DATABRICKS_CONN_ID,
+        notebook_path="/Shared/Notebook_1",
+        notebook_packages=[
+            {
+                "pypi": {
+                    "package": "simplejson==3.18.0",
+                    "repo": "https://pypi.org/simple",
+                }
+            },
+            {"pypi": {"package": "Faker"}},
+        ],
+        source="WORKSPACE",
+        job_cluster_key="random_cluster_key",
+        new_cluster=NEW_CLUSTER_SPEC,
+    )


### PR DESCRIPTION
The latest Databricks Jobs API 2.1 offers a consistent response for
both single task and multi-task job run submit API which fixes the current 
issue mentioned in the ticket.

The PR also adds an example DAG for running the DatabricksNotebookOperator
alone without the DatabricksWorkflowTaskGroup operator.

closes: #160 