### PR TITLE
[Databricks] Link Airflow task timeout with Databricks Notebook task

### DIFF
--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -107,7 +107,7 @@ class DatabricksNotebookOperator(BaseOperator):
                 if t in relevant_upstreams
             ],
             "job_cluster_key": self.job_cluster_key,
-            "timeout_seconds": 0,
+            "timeout_seconds": int(self.execution_timeout.total_seconds()),
             "email_notifications": {},
             "notebook_task": {
                 "notebook_path": self.notebook_path,

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -107,7 +107,9 @@ class DatabricksNotebookOperator(BaseOperator):
                 if t in relevant_upstreams
             ],
             "job_cluster_key": self.job_cluster_key,
-            "timeout_seconds": int(self.execution_timeout.total_seconds()),
+            "timeout_seconds": int(self.execution_timeout.total_seconds())
+            if self.execution_timeout
+            else 0,
             "email_notifications": {},
             "notebook_task": {
                 "notebook_path": self.notebook_path,
@@ -193,7 +195,9 @@ class DatabricksNotebookOperator(BaseOperator):
                 "base_parameters": {"source": self.source},
             },
             "libraries": self.notebook_packages,
-            "timeout_seconds": int(self.execution_timeout.total_seconds()),
+            "timeout_seconds": int(self.execution_timeout.total_seconds())
+            if self.execution_timeout
+            else 0,
         }
         if self.new_cluster and self.existing_cluster_id:
             raise ValueError(

--- a/cosmos/providers/databricks/notebook.py
+++ b/cosmos/providers/databricks/notebook.py
@@ -193,6 +193,7 @@ class DatabricksNotebookOperator(BaseOperator):
                 "base_parameters": {"source": self.source},
             },
             "libraries": self.notebook_packages,
+            "timeout_seconds": int(self.execution_timeout.total_seconds()),
         }
         if self.new_cluster and self.existing_cluster_id:
             raise ValueError(

--- a/cosmos/providers/databricks/workflow.py
+++ b/cosmos/providers/databricks/workflow.py
@@ -88,7 +88,7 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
         full_json = {
             "name": self.databricks_job_name,
             "email_notifications": {"no_alert_for_skipped_runs": False},
-            "timeout_seconds": 0,
+            "timeout_seconds": int(self.execution_timeout.total_seconds()),
             "tasks": task_json,
             "format": "MULTI_TASK",
             "job_clusters": self.job_clusters,

--- a/cosmos/providers/databricks/workflow.py
+++ b/cosmos/providers/databricks/workflow.py
@@ -1,11 +1,8 @@
 """DatabricksWorkflowTaskGroup for submitting jobs to Databricks."""
 from __future__ import annotations
 
-from datetime import timedelta
 from logging import Logger
 from typing import TYPE_CHECKING
-
-from airflow.models.abstractoperator import DEFAULT_TASK_EXECUTION_TIMEOUT
 
 if TYPE_CHECKING:
     pass
@@ -275,7 +272,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         spark_submit_params: list = None,
         max_concurrent_runs: int = 1,
         extra_job_params: dict[str, Any] = None,
-        execution_timeout: timedelta | None = DEFAULT_TASK_EXECUTION_TIMEOUT,
         **kwargs,
     ):
         """
@@ -298,8 +294,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
          These parameters will be passed to all spark submit tasks
         :param max_concurrent_runs: The maximum number of concurrent runs for this workflow.
         :param extra_job_params: A dictionary containing properties which will override the default Databricks
-        :param execution_timeout: max time allowed for the execution of this task group job, if it goes beyond it will
-         raise Timeout exception, and it will fail both in Airflow and Databricks after this elapsed timeout duration.
         Workflow Job definitions.
         """
         self.databricks_conn_id = databricks_conn_id
@@ -312,7 +306,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         self.jar_params = jar_params or []
         self.max_concurrent_runs = max_concurrent_runs
         self.extra_job_params = extra_job_params or {}
-        self.execution_timeout = execution_timeout
         super().__init__(**kwargs)
 
     def __exit__(self, _type, _value, _tb):
@@ -326,7 +319,6 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
                 job_clusters=self.job_clusters,
                 existing_clusters=self.existing_clusters,
                 extra_job_params=self.extra_job_params,
-                execution_timeout=self.execution_timeout,
             )
         )
 

--- a/cosmos/providers/databricks/workflow.py
+++ b/cosmos/providers/databricks/workflow.py
@@ -88,7 +88,7 @@ class _CreateDatabricksWorkflowOperator(BaseOperator):
         full_json = {
             "name": self.databricks_job_name,
             "email_notifications": {"no_alert_for_skipped_runs": False},
-            "timeout_seconds": int(self.execution_timeout.total_seconds()),
+            "timeout_seconds": 0,
             "tasks": task_json,
             "format": "MULTI_TASK",
             "job_clusters": self.job_clusters,

--- a/cosmos/providers/databricks/workflow.py
+++ b/cosmos/providers/databricks/workflow.py
@@ -1,8 +1,11 @@
 """DatabricksWorkflowTaskGroup for submitting jobs to Databricks."""
 from __future__ import annotations
 
+from datetime import timedelta
 from logging import Logger
 from typing import TYPE_CHECKING
+
+from airflow.models.abstractoperator import DEFAULT_TASK_EXECUTION_TIMEOUT
 
 if TYPE_CHECKING:
     pass
@@ -272,6 +275,7 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         spark_submit_params: list = None,
         max_concurrent_runs: int = 1,
         extra_job_params: dict[str, Any] = None,
+        execution_timeout: timedelta | None = DEFAULT_TASK_EXECUTION_TIMEOUT,
         **kwargs,
     ):
         """
@@ -294,6 +298,8 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
          These parameters will be passed to all spark submit tasks
         :param max_concurrent_runs: The maximum number of concurrent runs for this workflow.
         :param extra_job_params: A dictionary containing properties which will override the default Databricks
+        :param execution_timeout: max time allowed for the execution of this task group job, if it goes beyond it will
+         raise Timeout exception, and it will fail both in Airflow and Databricks after this elapsed timeout duration.
         Workflow Job definitions.
         """
         self.databricks_conn_id = databricks_conn_id
@@ -306,6 +312,7 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
         self.jar_params = jar_params or []
         self.max_concurrent_runs = max_concurrent_runs
         self.extra_job_params = extra_job_params or {}
+        self.execution_timeout = execution_timeout
         super().__init__(**kwargs)
 
     def __exit__(self, _type, _value, _tb):
@@ -319,6 +326,7 @@ class DatabricksWorkflowTaskGroup(TaskGroup):
                 job_clusters=self.job_clusters,
                 existing_clusters=self.existing_clusters,
                 extra_job_params=self.extra_job_params,
+                execution_timeout=self.execution_timeout,
             )
         )
 

--- a/examples/databricks/example_databricks_workflow.py
+++ b/examples/databricks/example_databricks_workflow.py
@@ -70,6 +70,7 @@ with dag:
             notebook_packages=[{"pypi": {"package": "Faker"}}],
             source="WORKSPACE",
             job_cluster_key="Shared_job_cluster",
+            execution_timeout=timedelta(seconds=600),
         )
         notebook_2 = DatabricksNotebookOperator(
             task_id="notebook_2",

--- a/tests/databricks/test_notebook.py
+++ b/tests/databricks/test_notebook.py
@@ -139,11 +139,13 @@ def test_databricks_notebook_operator_without_taskgroup_new_cluster(
             "run_name": "1234",
             "notebook_task": {
                 "notebook_path": "/foo/bar",
-                "base_parameters": {"source": "WORKSPACE"},
+                "source": "WORKSPACE",
+                "base_parameters": {"foo": "bar"},
             },
             "new_cluster": {"foo": "bar"},
             "libraries": [{"nb_index": {"package": "nb_package"}}],
             "timeout_seconds": 0,
+            "email_notifications": {},
         }
     )
     mock_monitor.assert_called_once()
@@ -183,11 +185,13 @@ def test_databricks_notebook_operator_without_taskgroup_existing_cluster(
             "run_name": "1234",
             "notebook_task": {
                 "notebook_path": "/foo/bar",
-                "base_parameters": {"source": "WORKSPACE"},
+                "source": "WORKSPACE",
+                "base_parameters": {"foo": "bar"},
             },
             "existing_cluster_id": "123",
             "libraries": [{"nb_index": {"package": "nb_package"}}],
             "timeout_seconds": 0,
+            "email_notifications": {},
         }
     )
     mock_monitor.assert_called_once()

--- a/tests/databricks/test_notebook.py
+++ b/tests/databricks/test_notebook.py
@@ -143,6 +143,7 @@ def test_databricks_notebook_operator_without_taskgroup_new_cluster(
             },
             "new_cluster": {"foo": "bar"},
             "libraries": [{"nb_index": {"package": "nb_package"}}],
+            "timeout_seconds": 0,
         }
     )
     mock_monitor.assert_called_once()
@@ -186,6 +187,7 @@ def test_databricks_notebook_operator_without_taskgroup_existing_cluster(
             },
             "existing_cluster_id": "123",
             "libraries": [{"nb_index": {"package": "nb_package"}}],
+            "timeout_seconds": 0,
         }
     )
     mock_monitor.assert_called_once()


### PR DESCRIPTION
Based on the analysis and discussion comments on the issue https://github.com/astronomer/astronomer-cosmos/issues/145,
we pass the Airflow task's `execution_timeout` parameter value available with the `DatabricksNotebookOperator` as the `timeout_seconds` parameter for the Databricks Jobs Run API.

closes: #145 