### PR TITLE
Fix self-referential dependency in `all` for `dbt-openlineage`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dbt-all = [
     "dbt-postgres",
     "dbt-redshift",
     "dbt-snowflake",
-    "dbt-openlineage"
+    "astronomer-cosmos[dbt-openlineage]"
 ]
 dbt-bigquery = [
     "dbt-bigquery",


### PR DESCRIPTION
PR #86 was merged on 4th March 2023, but line
https://github.com/astronomer/astronomer-cosmos/pull/86/files#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711R50 is an incorrect way to specify self-referential dependency which causes a failure while installing the package as it cannot resolve that dependency. This PR fixes the issue by using the correct syntax to install the self-referential optional dependency for dbt-openlineage.

closes: #170 