### PR TITLE
Fix file lock check

### DIFF
--- a/cosmos/providers/dbt/core/operators.py
+++ b/cosmos/providers/dbt/core/operators.py
@@ -7,6 +7,7 @@ import shutil
 import signal
 import time
 from filecmp import dircmp
+from pathlib import Path
 from typing import Sequence
 
 import yaml
@@ -16,6 +17,7 @@ from airflow.hooks.subprocess import SubprocessHook, SubprocessResult
 from airflow.models.baseoperator import BaseOperator
 from airflow.utils.context import Context
 from airflow.utils.operator_helpers import context_to_airflow_vars
+from filelock import FileLock
 
 from cosmos.providers.dbt.constants import DBT_PROFILE_PATH
 from cosmos.providers.dbt.core.utils.file_syncing import (
@@ -251,27 +253,27 @@ class DbtBaseOperator(BaseOperator):
             # if there is already a lock file - then just wait for it to be released and continue without copying
             if os.path.exists(lock_file) and is_file_locked(lock_file):
                 while os.path.exists(lock_file):
-                    with open(lock_file, "w") as lock_file:
+                    with open(lock_file, "w") as lock_f:
                         try:
                             # Lock acquired, the lock file is available
-                            fcntl.flock(lock_file, fcntl.LOCK_SH | fcntl.LOCK_NB)
+                            fcntl.flock(lock_f, fcntl.LOCK_SH | fcntl.LOCK_NB)
                             break
                         except OSError:
                             # Lock is held by another process, wait and try again
                             time.sleep(1)
 
-                    # The lock file is available, release the shared lock
-                    fcntl.flock(lock_file, fcntl.LOCK_UN)
+                # The lock file is available, release the shared lock
+                with open(lock_file, "w") as lock_f:
+                    fcntl.flock(lock_f, fcntl.LOCK_UN)
 
             # otherwise create a lock file and copy the dbt directory
             else:
                 os.makedirs(os.path.dirname(lock_file), exist_ok=True)
-                with open(lock_file, "w") as f:
-                    fcntl.flock(f, fcntl.LOCK_EX)
+                lock_path = Path(target_dir) / ".lock"
+                with FileLock(str(lock_path), timeout=15):
                     shutil.copytree(
                         self.project_dir, target_dir, ignore=exclude, dirs_exist_ok=True
                     )
-                    fcntl.flock(f, fcntl.LOCK_UN)
         else:
             logging.info(
                 f"No differences detected between {self.project_dir} and {target_dir}"

--- a/cosmos/providers/dbt/core/utils/file_syncing.py
+++ b/cosmos/providers/dbt/core/utils/file_syncing.py
@@ -18,12 +18,15 @@ def has_differences(dcmp):
     return any([has_differences(subdcmp) for subdcmp in dcmp.subdirs.values()])
 
 
-def is_file_locked(file_path):
+def is_file_locked(filename):
     # checks a lock file to see if a lock is being held by another process
-    try:
-        with open(file_path, "w") as f:
+    with open(filename, "w") as f:
+        try:
             fcntl.flock(f, fcntl.LOCK_EX | fcntl.LOCK_NB)
-        fcntl.flock(f, fcntl.LOCK_UN)
-        return False
-    except OSError:
-        return True
+            fcntl.flock(f, fcntl.LOCK_UN)
+            return False
+        except OSError:
+            return True
+        finally:
+            if not f.closed:
+                f.close()


### PR DESCRIPTION
This should resolve the issue that caused us to yank release `0.5.0`. This was the error that I was getting previously. 

```text

  File "/usr/local/lib/python3.9/site-packages/cosmos/providers/dbt/core/utils/file_syncing.py", line 26, in is_file_locked
    fcntl.flock(f, fcntl.LOCK_UN)
ValueError: I/O operation on closed file

```

I was able to replicate the issue locally and resolve it with this change. 