### PR TITLE
Change the key of the GCP service account keyfile

### DIFF
--- a/cosmos/providers/dbt/core/profiles/bigquery.py
+++ b/cosmos/providers/dbt/core/profiles/bigquery.py
@@ -40,7 +40,7 @@ def create_profile_vars_google_cloud_platform(
     https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup
     https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
     """
-    bigquery_key_file = json.loads(conn.extra_dejson.get("keyfile_dict"))
+    bigquery_key_file = json.loads(conn.extra_dejson.get("extra__google_cloud_platform__keyfile_dict"))
 
     if not schema_override:
         raise ValueError(


### PR DESCRIPTION
Airflow version 2.4.2 connection generates a key_file with the key named "extra__google_cloud_platform__keyfile_dict" while the create_profile_vars_google_cloud_platform() function tries to access it with the keyword "keyfile_dict", which was used in older Airflow versions.