### PR TITLE
Make `shutil.copytree` call compatible with python3.7

### DIFF
--- a/cosmos/providers/dbt/core/operators.py
+++ b/cosmos/providers/dbt/core/operators.py
@@ -271,9 +271,9 @@ class DbtBaseOperator(BaseOperator):
                 os.makedirs(os.path.dirname(lock_file), exist_ok=True)
                 lock_path = Path(target_dir) / ".lock"
                 with FileLock(str(lock_path), timeout=15):
-                    shutil.copytree(
-                        self.project_dir, target_dir, ignore=exclude, dirs_exist_ok=True
-                    )
+                    if os.path.exists(target_dir):
+                        shutil.rmtree(target_dir)
+                    shutil.copytree(self.project_dir, target_dir, ignore=exclude)
         else:
             logging.info(
                 f"No differences detected between {self.project_dir} and {target_dir}"


### PR DESCRIPTION
This is another bug we ran into when trying to use v0.5.1 with astronomer-comos[dbt-bigquery]. The `dirs_exist_ok` arg for `shutil.copytree` was [added](https://docs.python.org/3/whatsnew/3.8.html#shutil) in python 3.8.

This PR has an update to support python 3.7