### PR TITLE
deprecate dbt deps operator

### DIFF
--- a/cosmos/providers/dbt/core/operators/local.py
+++ b/cosmos/providers/dbt/core/operators/local.py
@@ -241,9 +241,7 @@ class DbtDepsLocalOperator(DbtLocalBaseOperator):
     ui_color = "#8194E0"
 
     def __init__(self, **kwargs) -> None:
-        super().__init__(**kwargs)
-        self.base_cmd = "deps"
-
-    def execute(self, context: Context):
-        result = self.build_and_run_cmd(context=context)
-        return result.output
+        raise DeprecationWarning(
+            "The DbtDepsOperator has been deprecated. "
+            "Please use the `install_deps` flag in dbt_args instead."
+        )


### PR DESCRIPTION
This PR deprecates the dbt deps operator in favor of using the `install_deps` argument to the base operator.

<img width="816" alt="Screen Shot 2023-04-18 at 3 52 58 PM" src="https://user-images.githubusercontent.com/5252587/232895425-9df91d3b-2425-4d48-bf0d-ce11ccfdcf46.png">
