### PR TITLE
explicitly ignore user-supplied profiles file for now

### DIFF
--- a/cosmos/providers/dbt/core/operators/local.py
+++ b/cosmos/providers/dbt/core/operators/local.py
@@ -129,7 +129,9 @@ class DbtLocalBaseOperator(DbtBaseOperator):
             profiles_path = os.path.join(tmp_project_dir, "profiles.yml")
             if os.path.exists(profiles_path):
                 logger.warning(
-                    "Cosmos doesn't support user-supplied profiles.yml files. Removing..."
+                    "Cosmos doesn't support user-supplied profiles.yml files. \
+                    Please use Airflow connections instead. \
+                    Ignoring profiles.yml…"
                 )
                 os.remove(profiles_path)
 

--- a/cosmos/providers/dbt/core/operators/local.py
+++ b/cosmos/providers/dbt/core/operators/local.py
@@ -128,7 +128,9 @@ class DbtLocalBaseOperator(DbtBaseOperator):
             # ensure there's no profiles.yml file in the project dir
             profiles_path = os.path.join(tmp_project_dir, "profiles.yml")
             if os.path.exists(profiles_path):
-                logger.warning("Cosmos doesn't support user-supplied profiles.yml files. Removing...")
+                logger.warning(
+                    "Cosmos doesn't support user-supplied profiles.yml files. Removing..."
+                )
                 os.remove(profiles_path)
 
             # if we need to install deps, do so

--- a/cosmos/providers/dbt/core/operators/local.py
+++ b/cosmos/providers/dbt/core/operators/local.py
@@ -125,6 +125,12 @@ class DbtLocalBaseOperator(DbtBaseOperator):
                 tmp_project_dir,
             )
 
+            # ensure there's no profiles.yml file in the project dir
+            profiles_path = os.path.join(tmp_project_dir, "profiles.yml")
+            if os.path.exists(profiles_path):
+                logger.warning("Cosmos doesn't support user-supplied profiles.yml files. Removing...")
+                os.remove(profiles_path)
+
             # if we need to install deps, do so
             if self.install_deps:
                 self.subprocess_hook.run_command(

--- a/cosmos/providers/dbt/render.py
+++ b/cosmos/providers/dbt/render.py
@@ -174,6 +174,7 @@ def render_project(
         else:
             # TODO: coverme
             logger.error("Unknown DBT type.")
+            continue
 
         # if test_behavior isn't "after_each", we can just add the task to the
         # base group and do nothing else for now

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -1,0 +1,13 @@
+# WARNING: this gets ignored by cosmos
+jaffle_shop:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: localhost
+      user: alice
+      password: <password>
+      port: 5432
+      dbname: jaffle_shop
+      schema: dbt_alice
+      threads: 4


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
Previously, you could put a `profiles.yml` file in a dbt project, leading to unintended behaviors. For now, all profiles are autogenerated by Cosmos. https://github.com/astronomer/astronomer-cosmos/issues/269 deals with user-supplied profiles.yml files.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #257

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
There may be cases where a user did supply a `profiles.yml` file, and now this could potentially break that setup. But it's unlikely it would break things, because Cosmos enforces that you pass a connection.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
