### PR TITLE
Use hatch to run tests in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,13 +27,12 @@ jobs:
 
       - name: Install packages and dependencies
         run: |
-          python -m pip install .[tests,docker,kubernetes]
-          python -m pip install "apache-airflow==${{ matrix.airflow-version }}"
-          python -m pip list
+          python -m pip install hatch
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }} and Python ${{ matrix.python-version }}
         run: |
-          pytest --doctest-modules --durations=10 --pyargs --cov=cosmos/ cosmos/
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-cov
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3


### PR DESCRIPTION
Have a consistent way of installing dependencies when installing and running tests locally and in the CI, by using `hatch`.