### PR TITLE
add dbt docs operator with docs on uploading to s3

### DIFF
--- a/cosmos/providers/dbt/core/operators/__init__.py
+++ b/cosmos/providers/dbt/core/operators/__init__.py
@@ -5,6 +5,7 @@ from .local import DbtRunOperationLocalOperator as DbtRunOperationOperator
 from .local import DbtSeedLocalOperator as DbtSeedOperator
 from .local import DbtSnapshotLocalOperator as DbtSnapshotOperator
 from .local import DbtTestLocalOperator as DbtTestOperator
+from .local import DbtDocsLocalOperator as DbtDocsOperator
 
 __all__ = [
     "DbtLSOperator",
@@ -14,4 +15,5 @@ __all__ = [
     "DbtTestOperator",
     "DbtRunOperationOperator",
     "DbtDepsOperator",
+    "DbtDocsOperator",
 ]

--- a/cosmos/providers/dbt/core/operators/__init__.py
+++ b/cosmos/providers/dbt/core/operators/__init__.py
@@ -1,11 +1,11 @@
 from .local import DbtDepsLocalOperator as DbtDepsOperator
+from .local import DbtDocsLocalOperator as DbtDocsOperator
 from .local import DbtLSLocalOperator as DbtLSOperator
 from .local import DbtRunLocalOperator as DbtRunOperator
 from .local import DbtRunOperationLocalOperator as DbtRunOperationOperator
 from .local import DbtSeedLocalOperator as DbtSeedOperator
 from .local import DbtSnapshotLocalOperator as DbtSnapshotOperator
 from .local import DbtTestLocalOperator as DbtTestOperator
-from .local import DbtDocsLocalOperator as DbtDocsOperator
 
 __all__ = [
     "DbtLSOperator",

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -2,7 +2,7 @@
 ## Docs DAG
 
 This DAG illustrates how to run `dbt docs generate` and handle the output. In this example, we're using the
-`DbtDocsLocalOperator` to generate the docs, coupled with a callback. The callback will upload the docs to 
+`DbtDocsLocalOperator` to generate the docs, coupled with a callback. The callback will upload the docs to
 S3 (if you have the S3Hook installed) or to a local directory.
 
 """

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -1,0 +1,76 @@
+"""
+## Docs DAG
+
+This DAG illustrates how to run `dbt docs generate` and handle the output. In this example, we're using the
+`DbtDocsLocalOperator` to generate the docs, coupled with a callback. The callback will upload the docs to 
+S3 (if you have the S3Hook installed) or to a local directory.
+
+"""
+
+import os
+import shutil
+
+from airflow import DAG
+from pendulum import datetime
+
+from cosmos.providers.dbt.core.operators import DbtDocsOperator
+
+
+def docs_callback(project_dir: str) -> None:
+    """
+    Callback function to print the path to the generated docs.
+    """
+    target_dir = f"{project_dir}/target"
+
+    try:
+        from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+        hook = S3Hook(aws_conn_id="aws_default")
+
+        # iterate over the files in the target dir and upload them to S3
+        for dirpath, _, filenames in os.walk(target_dir):
+            for filename in filenames:
+                hook.load_file(
+                    filename=f"{dirpath}/{filename}",
+                    bucket_name="my-bucket",
+                    key=f"dbt-docs/{filename}",
+                    replace=True,
+                )
+
+        return
+
+    # if the S3Hook isn't installed, just copy the target dir to a local dir
+    except ImportError:
+        pass
+
+    # if there's a botocore.exceptions.NoCredentialsError, print a warning and just copy the docs locally
+    except Exception as exc:
+        if "NoCredentialsError" in str(exc):
+            print(
+                "WARNING: No AWS credentials found.\
+                To upload docs to S3, install the S3Hook and configure an S3 connection."
+            )
+
+    # copy the target dir to /usr/local/airflow/dbt-docs
+    if os.path.exists("/usr/local/airflow/dbt-docs"):
+        shutil.rmtree("/usr/local/airflow/dbt-docs")
+
+    shutil.copytree(target_dir, "/usr/local/airflow/dbt-docs")
+
+
+with DAG(
+    dag_id="docs_dag",
+    start_date=datetime(2023, 1, 1),
+    schedule="@daily",
+    doc_md=__doc__,
+    catchup=False,
+) as dag:
+    generate_dbt_docs = DbtDocsOperator(
+        task_id="generate_dbt_docs",
+        project_dir="/usr/local/airflow/dags/dbt/jaffle_shop",
+        schema="public",
+        conn_id="airflow_db",
+        callback=docs_callback,
+    )
+
+    generate_dbt_docs

--- a/docs/dbt/docs.rst
+++ b/docs/dbt/docs.rst
@@ -1,0 +1,44 @@
+Generating Docs
+================
+
+Cosmos offers a way to generate dbt docs (i.e. ``dbt docs generate``) via the :class:`~cosmos.providers.dbt.core.operators.DbtDocsOperator` class. This operator is a wrapper around the dbt CLI command ``dbt docs generate`` and exposes a ``callback`` parameter that allows you to run custom code after the docs are generated.
+
+The ``callback`` parameter is a function that takes in a single argument, ``project_dir``. You can use the ``callback`` to decide what to do with the generated docs. For example, you can upload the docs to a cloud storage bucket or commit them to a git repo.
+
+Examples
+----------------------
+
+Upload to S3
+~~~~~~~~~~~~~~~~~~~~~~~
+
+You can use the ``callback`` parameter to upload the generated docs to an S3 bucket. The following code snippet shows how to do this with the default jaffle_shop project:
+
+.. code-block:: python
+
+    import os
+
+    from cosmos.providers.dbt.core.operators import DbtDocsOperator
+    from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+
+    def upload_to_s3(project_dir: str):
+        # Upload the docs to S3
+        hook = S3Hook(aws_conn_id='aws_conn_id')
+
+        for dir, _, files in os.walk(project_dir):
+            for file in files:
+                hook.load_file(
+                    filename=os.path.join(dir, file),
+                    key=file,
+                    bucket_name='my-bucket',
+                    replace=True,
+                )
+
+
+    # then, in your DAG code:
+    generate_dbt_docs = DbtDocsOperator(
+        task_id="generate_dbt_docs",
+        project_dir="/usr/local/airflow/dags/dbt/jaffle_shop",
+        schema="public",
+        conn_id="airflow_db",
+        callback=upload_to_s3,
+    )

--- a/docs/dbt/index.rst
+++ b/docs/dbt/index.rst
@@ -12,6 +12,7 @@ Cosmos allows you to render your dbt models as Airflow DAGs and Task Groups.
     Scheduling <scheduling>
     Configuration <configuration>
     Connections <connections>
+    Generating Docs <docs>
     Lineage <lineage>
     Other execution options <other-execution-options>
 


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR does a few things related to the `dbt docs generate` command:
-  adds the `DbtDocsLocalOperator` and a `callback` argument to the base operator. This lets a user generate docs and take action with them - to, for example, upload them to be statically served on S3
- adds a new docs page with an example callback that uploads the docs to S3
- adds an example DAG in the `dev` directory with a callback that uploads docs to S3 (if a connection is configured). Otherwise, it copies the docs to a persistent local directory

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #239

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
No breaking changes.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
