### PR TITLE
Fix broken main CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,6 @@ dmypy.json
 
 # dbt
 logs/
+
+# integration tests
+dev/dags/.airflowignore

--- a/cosmos/providers/dbt/core/operators/tests/test_kubernetes.py
+++ b/cosmos/providers/dbt/core/operators/tests/test_kubernetes.py
@@ -142,7 +142,6 @@ def test_created_pod(test_hook):
             },
             "managed_fields": None,
             "name": pod_obj.metadata.name,
-            "namespace": "foo",
             "owner_references": None,
             "resource_version": None,
             "self_link": None,
@@ -224,4 +223,6 @@ def test_created_pod(test_hook):
         },
         "status": None,
     }
-    assert pod_obj.to_dict() == expected_result
+    computed_result = pod_obj.to_dict()
+    computed_result["metadata"].pop("namespace")
+    assert computed_result == expected_result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,9 +152,9 @@ matrix.airflow.dependencies = [
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
-test = 'pytest  -v . -m "not integration"'
-test-cov = 'pytest -v --cov=cosmos --cov-report=term-missing --cov-report=xml . -m "not integration"'
-test-integration = "pytest cosmos/tests/ --cov=cosmos --cov-report=term-missing --cov-report=xml -m integration"
+test = 'pytest  -vv . -m "not integration"'
+test-cov = 'pytest -vv --cov=cosmos --cov-report=term-missing --cov-report=xml . -m "not integration"'
+test-integration = "pytest -vv cosmos/tests/ --cov=cosmos --cov-report=term-missing --cov-report=xml -m integration"
 
 ######################################
 # DOCS


### PR DESCRIPTION
A unit test stopped working since the dependency `apache-airflow-providers-cncf-kubernetes` was upgraded from `6.1.0` to `7.0.0`. This test stopped working because we were mocking the hook, and the hook changed how it defines the namespace, resulting in the error:

```
E         -               'namespace': 'foo',
E         +               'namespace': <MagicMock name='hook.get_namespace().to_dict()' id='4666403472'>,
```

Example of failure in the CI:
https://github.com/astronomer/astronomer-cosmos/actions/runs/5048502884