### PR TITLE
fix select & exclude behavior to be and, not or

### DIFF
--- a/cosmos/providers/dbt/render.py
+++ b/cosmos/providers/dbt/render.py
@@ -111,7 +111,7 @@ def render_project(
 
         if "configs" in select:
             # TODO: coverme
-            if not set(select["configs"]).intersection(model.config.config_selectors):
+            if not set(select["configs"]).intersection(model.config.config_selectors) == set(select["configs"]):
                 continue
 
         if "configs" in exclude:

--- a/cosmos/providers/dbt/render.py
+++ b/cosmos/providers/dbt/render.py
@@ -116,7 +116,7 @@ def render_project(
 
         if "configs" in exclude:
             # TODO: coverme
-            if set(exclude["configs"]).intersection(model.config.config_selectors):
+            if set(exclude["configs"]).intersection(model.config.config_selectors) == set(exclude["configs"]):
                 continue
 
         run_args: Dict[str, Any] = {**task_args, **operator_args, "models": model_name}

--- a/dev/dags/cosmos_filtering_dag.py
+++ b/dev/dags/cosmos_filtering_dag.py
@@ -1,0 +1,26 @@
+"""
+An example DAG that uses Cosmos to render a dbt project. It selects a subset of models to run.
+"""
+import os
+from datetime import datetime
+from pathlib import Path
+
+from cosmos.providers.dbt.dag import DbtDag
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH)
+
+basic_cosmos_dag = DbtDag(
+    # dbt/cosmos-specific parameters
+    dbt_root_path=DBT_ROOT_PATH,
+    dbt_project_name="jaffle_shop",
+    conn_id="airflow_db",
+    dbt_args={"schema": "public"},
+    # explicitly select models to run
+    select={"configs": ["tags:customers", "materialized:view"]},
+    # normal dag parameters
+    schedule_interval="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="cosmos_filtering_dag",
+)

--- a/dev/dags/dbt/jaffle_shop/models/customers.sql
+++ b/dev/dags/dbt/jaffle_shop/models/customers.sql
@@ -1,3 +1,9 @@
+{{
+    config(
+        tags=["customers"],
+    )
+}}
+
 with customers as (
 
     select * from {{ ref('stg_customers') }}

--- a/dev/dags/dbt/jaffle_shop/models/staging/stg_customers.sql
+++ b/dev/dags/dbt/jaffle_shop/models/staging/stg_customers.sql
@@ -1,3 +1,10 @@
+{{
+    config(
+        tags=["customers"],
+    )
+}}
+
+
 with source as (
 
     {#-

--- a/docs/dbt/configuration.rst
+++ b/docs/dbt/configuration.rst
@@ -89,7 +89,9 @@ When at least one WARN message is present, the function passed to ``on_warning_c
 Selecting and Excluding
 ----------------------
 
-Cosmos allows you to filter by configs (e.g. ``materialized``, ``tags``) using the ``select`` and ``exclude`` parameters. If a model contains any of the configs in the ``select``, it gets included as part of the DAG/Task Group. Similarly, if a model contains any of the configs in the ``exclude``, it gets excluded from the DAG/Task Group.
+Cosmos allows you to filter by configs (e.g. ``materialized``, ``tags``) using the ``select`` and ``exclude`` parameters.
+
+If a model contains ALL of the configs in the ``select``, it gets included as part of the DAG/Task Group. Similarly, if a model contains ALL of the configs in the ``exclude``, it gets excluded from the DAG/Task Group.
 
 The ``select`` and ``exclude`` parameters are dictionaries with the following keys:
 


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR fixes an issue where the `select` logic would include any models that meet _any_ of the filters, which results in many more models selected than expected. Instead, this PR updates the logic to only include/exclude things where _all_ conditions are met.

Separately, we should revisit this in the future - the current behavior is pretty confusing, and I myself had to read through the source code to remember. Filed follow-up issue https://github.com/astronomer/astronomer-cosmos/issues/299.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

Yes, but this corrects previous incorrect behavior.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
