### PR TITLE
Add Kubernetes operators README regarding operator args for KubernetesPodOperator

### DIFF
--- a/docs/dbt/other-execution-options.rst
+++ b/docs/dbt/other-execution-options.rst
@@ -40,6 +40,28 @@ At the moment, the user is expected to add to the Docker image both:
 - The dbt Profile which contains the information for dbt to access the database
 - Handle secrets
 
+Additional KubernetesPodOperator parameters can be added on the operator_args parameter of the DbtKubernetesOperator.
+
+For instance,
+
+.. code-block:: text
+
+    DbtTaskGroup(
+        ...
+        operator_args={
+            "queue": "kubernetes",
+            "image": "dbt-jaffle-shop:1.0.0",
+            "image_pull_policy": "Always",
+            "get_logs": True,
+            "is_delete_operator_pod": False,
+            "namespace": "default",
+            "env_vars": {
+                ...
+            },
+        },
+        execution_mode="kubernetes",
+    )
+
 Step-by-step instructions
 +++++++++++++++++++++++++
 


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
There are no guides on the DBT Kubernetes Operator regarding the operator args, so this PR adds a guide and example for Kubernetes Operator users on where to add KubernetesPodOperator using the operator args.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
