### PR TITLE
Reduce the `virtualenv` unit test run time

### DIFF
--- a/cosmos/providers/dbt/core/operators/tests/test_virtualenv.py
+++ b/cosmos/providers/dbt/core/operators/tests/test_virtualenv.py
@@ -3,10 +3,11 @@ from unittest.mock import patch
 from cosmos.providers.dbt.core.operators.virtualenv import DbtVirtualenvBaseOperator
 
 
+@patch("airflow.utils.python_virtualenv.execute_in_subprocess")
 @patch("cosmos.providers.dbt.core.operators.virtualenv.DbtLocalBaseOperator.store_compiled_sql")
 @patch("cosmos.providers.dbt.core.operators.virtualenv.DbtLocalBaseOperator.exception_handling")
 @patch("cosmos.providers.dbt.core.operators.virtualenv.DbtLocalBaseOperator.subprocess_hook")
-def test_run_command(mock_subprocess_hook, mock_exception_handling, mock_store_compiled_sql):
+def test_run_command(mock_subprocess_hook, mock_exception_handling, mock_store_compiled_sql, mock_execute):
     venv_operator = DbtVirtualenvBaseOperator(
         conn_id="fake_conn",
         task_id="fake_task",
@@ -27,3 +28,4 @@ def test_run_command(mock_subprocess_hook, mock_exception_handling, mock_store_c
     assert dbt_deps[0][0][0].endswith("/bin/dbt")
     assert dbt_deps[0][0][0] == dbt_cmd[0][0][0]
     assert dbt_cmd[0][0][1] == "do-something"
+    assert mock_execute.call_count == 2


### PR DESCRIPTION
Reduce test call time from 7.51s to 0.01s.

Before:
```
7.51s call     cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
0.00s teardown cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
0.00s setup    cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
```

After:
```
0.01s call     cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
0.00s setup    cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
0.00s teardown cosmos/providers/dbt/core/operators/tests/test_virtualenv.py::test_run_command
```

Closes: #309
