### PR TITLE
Remove dbt sources from model config's upstream_models

### DIFF
--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -132,7 +132,7 @@ class DbtModel:
         for base_node in ast.find_all(jinja2.nodes.Call):
             if hasattr(base_node.node, "name"):
                 # check we have a ref - this indicates a dependency
-                if base_node.node.name == "ref" or base_node.node.name == "source":
+                if base_node.node.name == "ref":
                     # if it is, get the first argument
                     first_arg = base_node.args[0]
                     if isinstance(first_arg, jinja2.nodes.Const):

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -178,3 +178,13 @@ def test_dbtmodelconfig_extract_config_with_kwarg_str():
     computed = dbt_model._extract_config(kwarg, config_name)
     expected = ["some_conf:abc"]
     assert computed == expected
+
+
+def test_dbtmodelconfig_with_sources(tmp_path):
+    model_sql = SAMPLE_MODEL_SQL_PATH.read_text()
+    model_with_sources_sql = model_sql.replace("ref('stg_customers')", "source('sample_source', 'stg_customers')")
+    path_with_sources = tmp_path / "customers_with_sources.sql"
+    path_with_sources.write_text(model_with_sources_sql)
+
+    dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=path_with_sources)
+    assert "sample_source" not in dbt_model.config.upstream_models


### PR DESCRIPTION
## Description

Stops sources from being added to `DbtModelConfig.upstream_models` since they are not dbt models which was causing missing dependency errors in rendering the project's logs.

## Related Issue(s)

closes #337 
