### PR TITLE
ensure dbt_cmd_flags is used

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import os
 import shutil
-from typing import Any, Dict, Sequence, Tuple
+from typing import Any, Sequence, Tuple
 
 import yaml
 from airflow.models.baseoperator import BaseOperator

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -52,7 +52,7 @@ class DbtBaseOperator(BaseOperator):
         Otherwise, the query will keep running when the task is killed.
     :param dbt_executable_path: Path to dbt executable can be used with venv
         (i.e. /home/astro/.pyenv/versions/dbt_venv/bin/dbt)
-    :param dbt_cmd_flags: Flags passed to dbt command override those that are calculated.
+    :param dbt_cmd_flags: List of flags to pass to dbt command
     """
 
     template_fields: Sequence[str] = ("env", "vars")
@@ -97,7 +97,7 @@ class DbtBaseOperator(BaseOperator):
         skip_exit_code: int = 99,
         cancel_query_on_kill: bool = True,
         dbt_executable_path: str = "dbt",
-        dbt_cmd_flags: Dict[str, Any] = {},
+        dbt_cmd_flags: list[str] = None,
         **kwargs,
     ) -> None:
         self.project_dir = project_dir
@@ -207,14 +207,21 @@ class DbtBaseOperator(BaseOperator):
         cmd_flags: list[str] | None = None,
     ) -> Tuple[list[str], dict]:
         dbt_cmd = [self.dbt_executable_path]
+
         if isinstance(self.base_cmd, str):
             dbt_cmd.append(self.base_cmd)
         else:
             dbt_cmd.extend(self.base_cmd)
+
         dbt_cmd.extend(self.add_global_flags())
+
         # add command specific flags
         if cmd_flags:
             dbt_cmd.extend(cmd_flags)
+
+        # add user-supplied args
+        if self.dbt_cmd_flags:
+            dbt_cmd.extend(self.dbt_cmd_flags)
 
         env = self.get_env(context)
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -29,6 +29,21 @@ def test_dbt_base_operator_add_global_flags() -> None:
     ]
 
 
+def test_dbt_base_operator_add_user_supplied_flags() -> None:
+    dbt_base_operator = DbtLocalBaseOperator(
+        conn_id="my_airflow_connection",
+        task_id="my-task",
+        project_dir="my/dir",
+        base_cmd="run",
+        dbt_cmd_flags=["--full-refresh"],
+    )
+
+    cmd, _ = dbt_base_operator.build_cmd(
+        Context(execution_date=datetime(2023, 2, 15, 12, 30)),
+    )
+    assert "--full-refresh" in cmd
+
+
 @pytest.mark.parametrize(
     ["skip_exception", "exception_code_returned", "expected_exception"],
     [


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR ensures we're using the `dbt_cmd_flags` argument. It's documented, but not used in the code anywhere.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
