### PR TITLE
Add option to disable storing the compiled SQL

### DIFF
--- a/docs/dbt/configuration.rst
+++ b/docs/dbt/configuration.rst
@@ -127,3 +127,11 @@ Examples:
         # ...
         select={"paths": ["analytics/tables"]},
     )
+
+
+Viewing Compiled SQL
+----------------------
+
+When using the local execution mode, Cosmos will store the compiled SQL for each model in the ``compiled_sql`` field of the task's ``template_fields``. This allows you to view the compiled SQL in the Airflow UI.
+
+If you'd like to disable this feature, you can set ``should_store_compiled_sql=False`` on the local operator (or via the ``operator_args`` parameter on the DAG/Task Group).

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -162,3 +162,33 @@ def test_get_target_name() -> None:
     )
 
     assert dbt_base_operator.get_target_name() == "cosmos_target"
+
+
+def test_store_compiled_sql() -> None:
+    dbt_base_operator = DbtLocalBaseOperator(
+        conn_id="my_airflow_connection",
+        task_id="my-task",
+        project_dir="my/dir",
+        should_store_compiled_sql=False,
+    )
+
+    # here we just need to call the method to make sure it doesn't raise an exception
+    dbt_base_operator.store_compiled_sql(
+        tmp_project_dir="my/dir",
+        context=Context(execution_date=datetime(2023, 2, 15, 12, 30)),
+    )
+
+    dbt_base_operator = DbtLocalBaseOperator(
+        conn_id="my_airflow_connection",
+        task_id="my-task",
+        project_dir="my/dir",
+        should_store_compiled_sql=True,
+    )
+
+    # here we call the method and see if it tries to access the context["ti"]
+    # it should, and it should raise a KeyError because we didn't pass in a ti
+    with pytest.raises(KeyError):
+        dbt_base_operator.store_compiled_sql(
+            tmp_project_dir="my/dir",
+            context=Context(execution_date=datetime(2023, 2, 15, 12, 30)),
+        )


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR adds a new config option, `should_store_compiled_sql`, that configures the behavior of the local operator. When set to True (default), there's no change in behavior - Cosmos will write dbt's compiled SQL to Airflow's templated field. When set to False, nothing happens.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes https://github.com/astronomer/astronomer-cosmos/issues/328

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No breaking changes

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
