### PR TITLE
Add support to GCP connections that define `keyfile_dict` instead of `keyfile`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,8 +99,25 @@ jobs:
       matrix:
         python-version: ["3.10"]
         airflow-version: ["2.6"]
+    if: >-
+      github.event_name == 'push' ||
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.head.repo.fork == false
+      ) ||
+      (
+        github.event_name == 'pull_request_target' &&
+        contains(github.event.pull_request.labels.*.name, 'safe')
+      )
     steps:
       - uses: actions/checkout@v3
+        if: github.event_name != 'pull_request_target'
+
+      - name: Checkout pull/${{ github.event.number }}
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+        if: github.event_name == 'pull_request_target'
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -231,7 +231,6 @@ class DbtLocalBaseOperator(DbtBaseOperator):
                 output_encoding=self.output_encoding,
                 cwd=tmp_project_dir,
             )
-
             self.exception_handling(result)
             self.store_compiled_sql(tmp_project_dir, context)
             if self.callback:

--- a/cosmos/profiles/__init__.py
+++ b/cosmos/profiles/__init__.py
@@ -8,6 +8,7 @@ from airflow.hooks.base import BaseHook
 
 from .base import BaseProfileMapping
 from .bigquery.service_account_file import GoogleCloudServiceAccountFileProfileMapping
+from .bigquery.service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
 from .databricks.token import DatabricksTokenProfileMapping
 from .exasol.user_pass import ExasolUserPasswordProfileMapping
 from .postgres.user_pass import PostgresUserPasswordProfileMapping
@@ -21,6 +22,7 @@ from .trino.ldap import TrinoLDAPProfileMapping
 
 profile_mappings: list[Type[BaseProfileMapping]] = [
     GoogleCloudServiceAccountFileProfileMapping,
+    GoogleCloudServiceAccountDictProfileMapping,
     DatabricksTokenProfileMapping,
     PostgresUserPasswordProfileMapping,
     RedshiftUserPasswordProfileMapping,

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -79,7 +79,7 @@ class BaseProfileMapping(ABC):
             value = self.get_dbt_value(field)
             if isinstance(value, dict):
                 env_vars[env_var_name] = json.dumps(value)
-            if value is not None:
+            elif value is not None:
                 env_vars[env_var_name] = str(value)
 
         return env_vars
@@ -99,7 +99,6 @@ class BaseProfileMapping(ABC):
                 "outputs": {target_name: profile_vars},
             }
         }
-
         return str(yaml.dump(profile_contents, indent=4))
 
     def get_dbt_value(self, name: str) -> Any:

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -4,7 +4,6 @@ inherit from to ensure consistency.
 """
 from __future__ import annotations
 
-import json
 from abc import ABC, abstractmethod
 from logging import getLogger
 from typing import Any
@@ -80,9 +79,7 @@ class BaseProfileMapping(ABC):
         for field in self.secret_fields:
             env_var_name = self.get_env_var_name(field)
             value = self.get_dbt_value(field)
-            if isinstance(value, dict):
-                env_vars[env_var_name] = json.dumps(value)
-            elif value is not None:
+            if value is not None:
                 env_vars[env_var_name] = str(value)
 
         return env_vars

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -4,8 +4,8 @@ inherit from to ensure consistency.
 """
 from __future__ import annotations
 
+import json
 from abc import ABC, abstractmethod
-
 from logging import getLogger
 from typing import Any
 
@@ -77,6 +77,8 @@ class BaseProfileMapping(ABC):
         for field in self.secret_fields:
             env_var_name = self.get_env_var_name(field)
             value = self.get_dbt_value(field)
+            if isinstance(value, dict):
+                env_vars[env_var_name] = json.dumps(value)
             if value is not None:
                 env_vars[env_var_name] = str(value)
 

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -42,18 +42,21 @@ class BaseProfileMapping(ABC):
         if self.conn.conn_type != self.airflow_connection_type:
             return False
 
+        logger.info(dir(self.conn))
+        logger.info(self.conn.__dict__)
+
         for field in self.required_fields:
             try:
                 if not getattr(self, field):
                     logger.info(
-                        "Not using mapping %s because %s is not set",
+                        "1 Not using mapping %s because %s is not set",
                         self.__class__.__name__,
                         field,
                     )
                     return False
             except AttributeError:
                 logger.info(
-                    "Not using mapping %s because %s is not set",
+                    "2 Not using mapping %s because %s is not set",
                     self.__class__.__name__,
                     field,
                 )

--- a/cosmos/profiles/bigquery/__init__.py
+++ b/cosmos/profiles/bigquery/__init__.py
@@ -1,5 +1,9 @@
 "BigQuery Airflow connection -> dbt profile mappings"
 
 from .service_account_file import GoogleCloudServiceAccountFileProfileMapping
+from .service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
 
-__all__ = ["GoogleCloudServiceAccountFileProfileMapping"]
+__all__ = [
+    "GoogleCloudServiceAccountFileProfileMapping",
+    "GoogleCloudServiceAccountDictProfileMapping",
+]

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -37,7 +37,6 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         Even though the Airflow connection contains hard-coded Service account credentials,
         we generate a temporary file and the DBT profile uses it.
         """
-        # keyfile_path = self.dump_credentials_to_disk()
         return {
             "type": "bigquery",
             "method": "service-account-json",

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -22,6 +22,10 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         "keyfile_dict",
     ]
 
+    secret_fields = [
+        "keyfile_dict",
+    ]
+
     airflow_param_mapping = {
         "project": "extra.project",
         # multiple options for dataset because of older Airflow versions
@@ -39,6 +43,6 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
             "project": self.project,
             "dataset": self.dataset,
             "threads": self.profile_args.get("threads") or 1,
-            "keyfile_json": self.keyfile_dict,
+            "keyfile_json": self.get_env_var_format("keyfile_dict"),
             **self.profile_args,
         }

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -1,0 +1,43 @@
+"Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json."
+from __future__ import annotations
+
+from typing import Any
+
+from cosmos.profiles.base import BaseProfileMapping
+
+
+class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
+    """
+    Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json.
+
+    https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup#service-account-file
+    https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
+    """
+
+    airflow_connection_type: str = "google_cloud_platform"
+
+    required_fields = [
+        "project",
+        "dataset",
+        "keyfile_dict",
+    ]
+
+    airflow_param_mapping = {
+        "project": "extra.project",
+        "dataset": "dataset",
+        # multiple options for keyfile_dict param name because of older Airflow versions
+        "keyfile_dict": ["extra.keyfile_dict", "keyfile_dict", "extra__google_cloud_platform__keyfile_dict"],
+    }
+
+    @property
+    def profile(self) -> dict[str, Any | None]:
+        """Generates profile. Defaults `threads` to 1."""
+        return {
+            "type": "bigquery",
+            "method": "service-account-json",
+            "project": self.project,
+            "dataset": self.dataset,
+            "threads": self.profile_args.get("threads") or 1,
+            "keyfile_json": self.keyfile_dict,
+            **self.profile_args,
+        }

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -1,6 +1,8 @@
 "Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json."
 from __future__ import annotations
 
+import json
+import tempfile
 from typing import Any
 
 from cosmos.profiles.base import BaseProfileMapping
@@ -22,10 +24,6 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         "keyfile_dict",
     ]
 
-    secret_fields = [
-        "keyfile_dict",
-    ]
-
     airflow_param_mapping = {
         "project": "extra.project",
         # multiple options for dataset because of older Airflow versions
@@ -34,15 +32,30 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         "keyfile_dict": ["extra.keyfile_dict", "keyfile_dict", "extra__google_cloud_platform__keyfile_dict"],
     }
 
+    def dump_credentials_to_disk(self) -> str:
+        """
+        Store the GCP credentials into a file.
+        """
+        tmp_file = tempfile.NamedTemporaryFile("w")
+        json.dump(self.keyfile_dict, tmp_file)
+        tmp_file.flush()
+        return tmp_file.name
+
     @property
     def profile(self) -> dict[str, Any | None]:
-        """Generates profile. Defaults `threads` to 1."""
+        """
+        Generates a GCP profile.
+        Even though the Airflow connection contains hard-coded Service account credentials,
+        we generate a temporary file and the DBT profile uses it.
+        """
+        # keyfile_path = self.dump_credentials_to_disk()
         return {
             "type": "bigquery",
             "method": "service-account-json",
             "project": self.project,
             "dataset": self.dataset,
             "threads": self.profile_args.get("threads") or 1,
-            "keyfile_json": self.get_env_var_format("keyfile_dict"),
+            "keyfile_json": self.keyfile_dict,
+            # "keyfile": keyfile_path,
             **self.profile_args,
         }

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -1,8 +1,6 @@
 "Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json."
 from __future__ import annotations
 
-import json
-import tempfile
 from typing import Any
 
 from cosmos.profiles.base import BaseProfileMapping
@@ -32,15 +30,6 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         "keyfile_dict": ["extra.keyfile_dict", "keyfile_dict", "extra__google_cloud_platform__keyfile_dict"],
     }
 
-    def dump_credentials_to_disk(self) -> str:
-        """
-        Store the GCP credentials into a file.
-        """
-        tmp_file = tempfile.NamedTemporaryFile("w")
-        json.dump(self.keyfile_dict, tmp_file)
-        tmp_file.flush()
-        return tmp_file.name
-
     @property
     def profile(self) -> dict[str, Any | None]:
         """
@@ -56,6 +45,5 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
             "dataset": self.dataset,
             "threads": self.profile_args.get("threads") or 1,
             "keyfile_json": self.keyfile_dict,
-            # "keyfile": keyfile_path,
             **self.profile_args,
         }

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -24,7 +24,8 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
 
     airflow_param_mapping = {
         "project": "extra.project",
-        "dataset": "dataset",
+        # multiple options for dataset because of older Airflow versions
+        "dataset": ["extra.dataset", "dataset"],
         # multiple options for keyfile_dict param name because of older Airflow versions
         "keyfile_dict": ["extra.keyfile_dict", "keyfile_dict", "extra__google_cloud_platform__keyfile_dict"],
     }

--- a/docs/dbt/connections-profiles.rst
+++ b/docs/dbt/connections-profiles.rst
@@ -89,6 +89,14 @@ Service Account File
     :members:
 
 
+Service Account Dict
+~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: cosmos.profiles.bigquery.GoogleCloudServiceAccountDictProfileMapping
+    :undoc-members:
+    :members:
+
+
 Databricks
 ----------
 

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -46,19 +46,3 @@ def test_connection_claiming_fails(mock_bigquery_conn_with_dict: Connection):
     mock_bigquery_conn_with_dict.extra = json.dumps({"project": "my_project", "keyfile_dict": {"key": "value"}})
     profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
     assert not profile_mapping.can_claim_connection()
-
-
-def test_profile_env_vars(
-    mock_bigquery_conn_with_dict: Connection,
-) -> None:
-    """
-    Tests that the environment variables get set correctly.
-    """
-    profile_mapping = get_profile_mapping(
-        mock_bigquery_conn_with_dict.conn_id,
-    )
-    assert profile_mapping.env_vars == {
-        "COSMOS_CONN_GOOGLE_CLOUD_PLATFORM_KEYFILE_DICT": str(
-            mock_bigquery_conn_with_dict.extra_dejson["keyfile_dict"]
-        ),
-    }

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -1,0 +1,48 @@
+import json
+from unittest.mock import patch
+
+import pytest
+from airflow.models.connection import Connection
+
+from cosmos.profiles import get_profile_mapping
+from cosmos.profiles.bigquery.service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
+
+
+@pytest.fixture()
+def mock_bigquery_conn_with_dict():  # type: ignore
+    """
+    Mocks and returns an Airflow BigQuery connection.
+    """
+    extra = {
+        "project": "my_project",
+        "dataset": "my_dataset",
+        "keyfile_dict": {"key": "value"},
+    }
+    conn = Connection(
+        conn_id="my_bigquery_connection",
+        conn_type="google_cloud_platform",
+        extra=json.dumps(extra),
+    )
+
+    with patch("airflow.hooks.base.BaseHook.get_connection", return_value=conn):
+        yield conn
+
+
+def test_bigquery_mapping_selected(mock_bigquery_conn_with_dict: Connection):
+    profile_mapping = get_profile_mapping(
+        mock_bigquery_conn_with_dict.conn_id,
+        {"dataset": "my_dataset"},
+    )
+    assert isinstance(profile_mapping, GoogleCloudServiceAccountDictProfileMapping)
+
+
+def test_connection_claiming_succeeds(mock_bigquery_conn_with_dict: Connection):
+    profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
+    assert profile_mapping.can_claim_connection()
+
+
+def test_connection_claiming_fails(mock_bigquery_conn_with_dict: Connection):
+    # Remove the dataset key, which is mandatory
+    mock_bigquery_conn_with_dict.extra = json.dumps({"project": "my_project", "keyfile_dict": {"key": "value"}})
+    profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
+    assert not profile_mapping.can_claim_connection()

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -46,3 +46,16 @@ def test_connection_claiming_fails(mock_bigquery_conn_with_dict: Connection):
     mock_bigquery_conn_with_dict.extra = json.dumps({"project": "my_project", "keyfile_dict": {"key": "value"}})
     profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
     assert not profile_mapping.can_claim_connection()
+
+
+def test_profile(mock_bigquery_conn_with_dict: Connection):
+    profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
+    expected = {
+        "type": "bigquery",
+        "method": "service-account-json",
+        "project": "my_project",
+        "dataset": "my_dataset",
+        "threads": 1,
+        "keyfile_json": {"key": "value"},
+    }
+    assert profile_mapping.profile == expected

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -42,7 +42,23 @@ def test_connection_claiming_succeeds(mock_bigquery_conn_with_dict: Connection):
 
 
 def test_connection_claiming_fails(mock_bigquery_conn_with_dict: Connection):
-    # Remove the dataset key, which is mandatory
+    # Remove the `dataset` key, which is mandatory
     mock_bigquery_conn_with_dict.extra = json.dumps({"project": "my_project", "keyfile_dict": {"key": "value"}})
     profile_mapping = GoogleCloudServiceAccountDictProfileMapping(mock_bigquery_conn_with_dict, {})
     assert not profile_mapping.can_claim_connection()
+
+
+def test_profile_env_vars(
+    mock_bigquery_conn_with_dict: Connection,
+) -> None:
+    """
+    Tests that the environment variables get set correctly.
+    """
+    profile_mapping = get_profile_mapping(
+        mock_bigquery_conn_with_dict.conn_id,
+    )
+    assert profile_mapping.env_vars == {
+        "COSMOS_CONN_GOOGLE_CLOUD_PLATFORM_KEYFILE_DICT": str(
+            mock_bigquery_conn_with_dict.extra_dejson["keyfile_dict"]
+        ),
+    }


### PR DESCRIPTION
Add support to Google Cloud Platform connections that define `keyfile_dict` (actual value) instead of `keyfile` (path).

A design decision for this implementation was to not add `keyfile_json` to  `secret_fields`. This was not done because this property is originally a JSON. While storing it as an environment variable is simple, we'd need more significant changes to our profile parsing to correctly render this to the `profile.yml`  generated by Cosmos. 

This used to work in Cosmos 0.6.x and stopped working in 0.7.x as part of a previous profile refactors #271.

Closes: https://github.com/astronomer/astronomer-cosmos/issues/350

Co-authored-by:  Tatiana Al-Chueyr <tatiana.alchueyr@gmail.com>

**How to validate this change**

1. Have a GCP BQ service account with the `BigQuery Data Editor` role
2. Create a namespace that can be accessed by the service account (1)
3. Create an Airflow GCP connection that uses `keyfile` (path to the service account credentials saved locally). Example (replace `some-namespace` (2) and `key_path`(1)):
```
export AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT='{"conn_type": "google_cloud_platform", "extra": {"key_path": "/home/some-user/key.json", "scope": "https://www.googleapis.com/auth/cloud-platform", "project": "astronomer-dag-authoring", "dataset": "some-namespace" , "num_retries": 5}}'
```
4. Change the `basic_cosmos_dag.py` with the following lines, making sure it references the Airflow connection created in (3) and the dataset created in (2):
 ```
    conn_id="google_cloud_default",
    profile_args={
        "dataset": "some-namespace",
    },
```

5. Run the DAG, for instance:
```
 PYTHONPATH=`pwd` AIRFLOW_HOME=`pwd` AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT=20000 AIRFLOW__CORE__DAG_FILE_PROCESSOR_TIMEOUT=20000 airflow dags test basic_cosmos_dag `date -Iseconds`
```

6.  Change the Airflow GCP connection to use `keyfile_dict` (hard-code the `keyfile` content in the Airflow connection, replacing `<your keyfile content here>`)
```
export AIRFLOW_CONN_GOOGLE_CLOUD_DEFAULT='{"conn_type": "google_cloud_platform", "extra": {"keyfile_dict": <your keyfile content here>, "scope": "https://www.googleapis.com/auth/cloud-platform", "project": "astronomer-dag-authoring", "dataset": "cosmos" , "num_retries": 5}}'
```

7. Run the previously created Cosmos-powered DAG (5) that confirms (6) works
