### PR TITLE
Limit Pydantic < 2.0.0 until Airflow resolves incompatibilities

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
+    # Airflow & Pydantic issue: https://github.com/apache/airflow/issues/32311
+    "pydantic>=1.10.0,<2.0.0",
     "apache-airflow>=2.3.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",


### PR DESCRIPTION
Currently, the tests on our main branch are failing because of a recent Pydantic release, which has incompatibilities with Airflow. This PR solves it.

Relates to: https://github.com/apache/airflow/issues/32311
