### PR TITLE
Make sure there are no rendered SQL template conflicts

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -94,14 +94,16 @@ class DbtLocalBaseOperator(DbtBaseOperator):
 
         compiled_queries = {}
         # dbt compiles sql files and stores them in the target directory
-        for root, _, files in os.walk(os.path.join(tmp_project_dir, "target")):
-            for file in files:
-                if not file.endswith(".sql"):
+        for folder_path, _, file_paths in os.walk(os.path.join(tmp_project_dir, "target")):
+            for file_path in file_paths:
+                if not file_path.endswith(".sql"):
                     continue
 
-                compiled_sql_path = Path(os.path.join(root, file))
+                compiled_sql_path = Path(os.path.join(folder_path, file_path))
                 compiled_sql = compiled_sql_path.read_text(encoding="utf-8")
-                compiled_queries[file] = compiled_sql.strip()
+
+                relative_path = str(compiled_sql_path.relative_to(tmp_project_dir))
+                compiled_queries[relative_path] = compiled_sql.strip()
 
         for name, query in compiled_queries.items():
             self.compiled_sql += f"-- {name}\n{query}\n\n"


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

Currently, rendered SQL templates can overwrite each other because dbt writes rendered SQL with the same file name in different directories. This PR fixes the issue.

Context:
- https://github.com/astronomer/astronomer-cosmos/pull/268#issuecomment-1617530267
- https://github.com/astronomer/astronomer-cosmos/issues/364

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

fixes https://github.com/astronomer/astronomer-cosmos/issues/364

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No breaking change

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
