### PR TITLE
Snowflake private key

### DIFF
--- a/cosmos/profiles/__init__.py
+++ b/cosmos/profiles/__init__.py
@@ -13,6 +13,7 @@ from .exasol.user_pass import ExasolUserPasswordProfileMapping
 from .postgres.user_pass import PostgresUserPasswordProfileMapping
 from .redshift.user_pass import RedshiftUserPasswordProfileMapping
 from .snowflake.user_pass import SnowflakeUserPasswordProfileMapping
+from .snowflake.user_privatekey import SnowflakePrivateKeyPemProfileMapping
 from .spark.thrift import SparkThriftProfileMapping
 from .trino.certificate import TrinoCertificateProfileMapping
 from .trino.jwt import TrinoJWTProfileMapping
@@ -24,6 +25,7 @@ profile_mappings: list[Type[BaseProfileMapping]] = [
     PostgresUserPasswordProfileMapping,
     RedshiftUserPasswordProfileMapping,
     SnowflakeUserPasswordProfileMapping,
+    SnowflakePrivateKeyPemProfileMapping,
     SparkThriftProfileMapping,
     ExasolUserPasswordProfileMapping,
     TrinoLDAPProfileMapping,

--- a/cosmos/profiles/snowflake/__init__.py
+++ b/cosmos/profiles/snowflake/__init__.py
@@ -1,5 +1,6 @@
 "Snowflake Airflow connection -> dbt profile mapping."
 
 from .user_pass import SnowflakeUserPasswordProfileMapping
+from .user_privatekey import SnowflakePrivateKeyPemProfileMapping
 
-__all__ = ["SnowflakeUserPasswordProfileMapping"]
+__all__ = ["SnowflakeUserPasswordProfileMapping", "SnowflakePrivateKeyPemProfileMapping"]

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -1,0 +1,86 @@
+"Maps Airflow Snowflake connections to dbt profiles if they use a user/private key."
+from __future__ import annotations
+
+import json
+from typing import TYPE_CHECKING, Any
+
+from ..base import BaseProfileMapping
+
+if TYPE_CHECKING:
+    from airflow.models import Connection
+
+
+class SnowflakePrivateKeyPemProfileMapping(BaseProfileMapping):
+    """
+    Maps Airflow Snowflake connections to dbt profiles if they use a user/private key.
+    https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication
+    https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
+    """
+
+    airflow_connection_type: str = "snowflake"
+
+    required_fields = [
+        "account",
+        "user",
+        "database",
+        "warehouse",
+        "schema",
+        "private_key_content",
+    ]
+    secret_fields = [
+        "private_key_content",
+    ]
+    airflow_param_mapping = {
+        "account": "extra.account",
+        "user": "login",
+        "database": "extra.database",
+        "warehouse": "extra.warehouse",
+        "schema": "schema",
+        "role": "extra.role",
+        "private_key_content": "extra.private_key_content",
+    }
+
+    def __init__(self, conn: Connection, profile_args: dict[str, Any | None] | None = None) -> None:
+        """
+        Snowflake can be odd because the fields used to be stored with keys in the format
+        'extra__snowflake__account', but now are stored as 'account'.
+
+        This standardizes the keys to be 'account', 'database', etc.
+        """
+        conn_dejson = conn.extra_dejson
+
+        if conn_dejson.get("extra__snowflake__account"):
+            conn_dejson = {key.replace("extra__snowflake__", ""): value for key, value in conn_dejson.items()}
+
+        conn.extra = json.dumps(conn_dejson)
+
+        self.conn = conn
+        self.profile_args = profile_args or {}
+        super().__init__(conn, profile_args)
+
+    @property
+    def profile(self) -> dict[str, Any | None]:
+        "Gets profile."
+        profile_vars = {
+            "type": "snowflake",
+            "account": self.account,
+            "user": self.user,
+            "schema": self.schema,
+            "database": self.database,
+            "role": self.conn.extra_dejson.get("role"),
+            "warehouse": self.conn.extra_dejson.get("warehouse"),
+            **self.profile_args,
+            # private_key should always get set as env var
+            "private_key_content": self.get_env_var_format("private_key_content"),
+        }
+
+        # remove any null values
+        return self.filter_null(profile_vars)
+
+    def transform_account(self, account: str) -> str:
+        "Transform the account to the format <account>.<region> if it's not already."
+        region = self.conn.extra_dejson.get("region")
+        if region and region not in account:
+            account = f"{account}.{region}"
+
+        return str(account)

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -18,6 +18,7 @@ class SnowflakePrivateKeyPemProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "snowflake"
+    is_community: bool = True
 
     required_fields = [
         "account",

--- a/docs/dbt/connections-profiles.rst
+++ b/docs/dbt/connections-profiles.rst
@@ -144,6 +144,14 @@ Username and Password
     :members:
 
 
+Username and Private Key
+~~~~~~~~~~~~~~~~~~~~~~
+
+.. autoclass:: cosmos.profiles.snowflake.SnowflakePrivateKeyPemProfileMapping
+    :undoc-members:
+    :members:
+
+
 Spark
 -----
 

--- a/tests/profiles/snowflake/test_snowflake_user_privatekey.py
+++ b/tests/profiles/snowflake/test_snowflake_user_privatekey.py
@@ -22,7 +22,14 @@ def mock_snowflake_conn():  # type: ignore
         conn_type="snowflake",
         login="my_user",
         schema="my_schema",
-        extra='{"account": "my_account", "database": "my_database", "warehouse": "my_warehouse", "private_key_content": "my_private_key"}',
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
+            }
+        ),
     )
 
     with patch("airflow.hooks.base.BaseHook.get_connection", return_value=conn):
@@ -46,7 +53,14 @@ def test_connection_claiming() -> None:
         "conn_type": "snowflake",
         "login": "my_user",
         "schema": "my_database",
-        "extra": '{"account": "my_account", "database": "my_database", "warehouse": "my_warehouse", "private_key_content": "my_private_key"}',
+        "extra": json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
+            }
+        ),
     }
 
     # if we're missing any of the values, it shouldn't claim

--- a/tests/profiles/snowflake/test_snowflake_user_privatekey.py
+++ b/tests/profiles/snowflake/test_snowflake_user_privatekey.py
@@ -157,7 +157,7 @@ def test_profile_env_vars(
         mock_snowflake_conn.conn_id,
     )
     assert profile_mapping.env_vars == {
-        "COSMOS_CONN_SNOWFLAKE_PRIVATE_KEY_CONTENT": mock_snowflake_conn.password,
+        "COSMOS_CONN_SNOWFLAKE_PRIVATE_KEY_CONTENT": mock_snowflake_conn.extra_dejson.get("private_key_content"),
     }
 
 
@@ -169,13 +169,13 @@ def test_old_snowflake_format() -> None:
         conn_id="my_snowflake_connection",
         conn_type="snowflake",
         login="my_user",
-        password="my_password",
         schema="my_schema",
         extra=json.dumps(
             {
                 "extra__snowflake__account": "my_account",
                 "extra__snowflake__database": "my_database",
                 "extra__snowflake__warehouse": "my_warehouse",
+                "extra__snowflake__private_key_content": "my_private_key",
             }
         ),
     )
@@ -184,7 +184,7 @@ def test_old_snowflake_format() -> None:
     assert profile_mapping.profile == {
         "type": conn.conn_type,
         "user": conn.login,
-        "password": "{{ env_var('COSMOS_CONN_SNOWFLAKE_PRIVATE_KEY_CONTENT') }}",
+        "private_key_content": "{{ env_var('COSMOS_CONN_SNOWFLAKE_PRIVATE_KEY_CONTENT') }}",
         "schema": conn.schema,
         "account": conn.extra_dejson.get("account"),
         "database": conn.extra_dejson.get("database"),
@@ -200,7 +200,6 @@ def test_appends_region() -> None:
         conn_id="my_snowflake_connection",
         conn_type="snowflake",
         login="my_user",
-        password="my_password",
         schema="my_schema",
         extra=json.dumps(
             {
@@ -208,6 +207,7 @@ def test_appends_region() -> None:
                 "region": "my_region",
                 "database": "my_database",
                 "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
             }
         ),
     )
@@ -216,7 +216,7 @@ def test_appends_region() -> None:
     assert profile_mapping.profile == {
         "type": conn.conn_type,
         "user": conn.login,
-        "password": "{{ env_var('COSMOS_CONN_SNOWFLAKE_PASSWORD') }}",
+        "private_key_content": "{{ env_var('COSMOS_CONN_SNOWFLAKE_PRIVATE_KEY_CONTENT') }}",
         "schema": conn.schema,
         "account": f"{conn.extra_dejson.get('account')}.{conn.extra_dejson.get('region')}",
         "database": conn.extra_dejson.get("database"),


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
Added new profile mapping for Snowflake User/Private Key authentication. Currently only supports `private_key_content` from a Snowflake Airflow connection.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
Closes #267 

## Breaking Change?
N/A
<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
