### PR TITLE
Change `test_behavior` and `execution_mode` to use `Enum` as opposed to Literals

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,13 +6,12 @@ Contains dags, task groups, and operators.
 
 __version__ = "0.7.5"
 
-from cosmos.dataset import get_dbt_dataset
-
-# re-export the dag and task group
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
+from cosmos.constants import LoadMode, TestBehavior, ExecutionMode
+from cosmos.dataset import get_dbt_dataset
 
-# re-export the operators
+
 from cosmos.operators.local import (
     DbtDepsLocalOperator,
     DbtLSLocalOperator,
@@ -105,4 +104,7 @@ __all__ = [
     "DbtSeedKubernetesOperator",
     "DbtTestKubernetesOperator",
     "DbtSnapshotKubernetesOperator",
+    "ExecutionMode",
+    "LoadMode",
+    "TestBehavior",
 ]

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -41,7 +41,7 @@ class ExecutionMode(Enum):
 
 
 # Rename to DbtResourceType
-class DbtNodeType(Enum):
+class DbtResourceType(Enum):
     """
     Type of dbt node.
     """

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -1,6 +1,52 @@
 import os
+from enum import Enum
 from pathlib import Path
+
 
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
 DEFAULT_DBT_TARGET_NAME = "cosmos_target"
+
+
+class LoadMode(Enum):
+    """
+    Supported ways to load a `dbt` project into a `DbtGraph` instance.
+    """
+
+    AUTOMATIC = "automatic"
+    CUSTOM = "custom"
+    DBT_LS = "dbt_ls"
+    DBT_MANIFEST = "dbt_manifest"
+
+
+class TestBehavior(Enum):
+    """
+    Behavior of the tests.
+    """
+
+    NONE = "none"
+    AFTER_EACH = "after_each"
+    AFTER_ALL = "after_all"
+
+
+class ExecutionMode(Enum):
+    """
+    Where the Cosmos tasks should be executed.
+    """
+
+    LOCAL = "local"
+    DOCKER = "docker"
+    KUBERNETES = "kubernetes"
+    VIRTUALENV = "virtualenv"
+
+
+# Rename to DbtResourceType
+class DbtNodeType(Enum):
+    """
+    Type of dbt node.
+    """
+
+    MODEL = "model"
+    SNAPSHOT = "snapshot"
+    SEED = "seed"
+    TEST = "test"

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass, field
 from subprocess import Popen, PIPE
 from typing import Any
 
-from cosmos.constants import DbtNodeType, ExecutionMode, LoadMode
+from cosmos.constants import DbtResourceType, ExecutionMode, LoadMode
 from cosmos.dbt.executable import get_system_dbt
 from cosmos.dbt.parser.project import DbtProject as LegacyDbtProject
 from cosmos.dbt.project import DbtProject
@@ -150,7 +150,7 @@ class DbtGraph:
                 node = DbtNode(
                     name=node_dict["name"],
                     unique_id=node_dict["unique_id"],
-                    resource_type=DbtNodeType(node_dict["resource_type"]),
+                    resource_type=DbtResourceType(node_dict["resource_type"]),
                     depends_on=node_dict["depends_on"].get("nodes", []),
                     file_path=self.project.dir / node_dict["original_file_path"],
                     tags=node_dict["tags"],
@@ -188,7 +188,7 @@ class DbtGraph:
             node = DbtNode(
                 name=model_name,
                 unique_id=model_name,
-                resource_type=DbtNodeType(model.type.value),
+                resource_type=DbtResourceType(model.type.value),
                 depends_on=model.config.upstream_models,
                 file_path=model.path,
                 tags=[],
@@ -221,7 +221,7 @@ class DbtGraph:
                 node = DbtNode(
                     name=node_dict["name"],
                     unique_id=unique_id,
-                    resource_type=DbtNodeType(node_dict["resource_type"]),
+                    resource_type=DbtResourceType(node_dict["resource_type"]),
                     depends_on=node_dict["depends_on"].get("nodes", []),
                     file_path=self.project.dir / node_dict["original_file_path"],
                     tags=node_dict["tags"],

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -21,9 +21,9 @@ class DbtModelType(Enum):
     Represents type of dbt unit (model, snapshot, seed)
     """
 
-    DBT_MODEL = 1
-    DBT_SNAPSHOT = 2
-    DBT_SEED = 3
+    DBT_MODEL = "model"
+    DBT_SNAPSHOT = "snapshot"
+    DBT_SEED = "seed"
 
 
 @dataclass

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -5,7 +5,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag
+from cosmos import DbtDag, ExecutionMode
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
@@ -19,7 +19,7 @@ example_virtualenv = DbtDag(
     dbt_project_name=PROJECT_NAME,
     conn_id=CONNECTION_ID,
     dbt_args={"schema": "public"},
-    execution_mode="virtualenv",
+    execution_mode=ExecutionMode.VIRTUALENV,
     operator_args={
         "project_dir": DBT_ROOT_PATH / PROJECT_NAME,
         "py_system_site_packages": False,

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -13,7 +13,7 @@ from cosmos.airflow.graph import (
     create_test_task_metadata,
     calculate_operator_class,
 )
-from cosmos.constants import ExecutionMode, DbtResourceType
+from cosmos.constants import ExecutionMode, DbtResourceType, TestBehavior
 from cosmos.dbt.graph import DbtNode
 
 
@@ -75,7 +75,7 @@ def test_build_airflow_graph_with_after_each():
             dag=dag,
             execution_mode=ExecutionMode.LOCAL,
             task_args=task_args,
-            test_behavior="after_each",
+            test_behavior=TestBehavior.AFTER_EACH,
             dbt_project_name="astro_shop",
             conn_id="fake_conn",
         )
@@ -117,7 +117,7 @@ def test_build_airflow_graph_with_after_all():
             dag=dag,
             execution_mode=ExecutionMode.LOCAL,
             task_args=task_args,
-            test_behavior="after_all",
+            test_behavior=TestBehavior.AFTER_ALL,
             dbt_project_name="astro_shop",
             conn_id="fake_conn",
         )

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -22,26 +22,26 @@ SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
 parent_seed = DbtNode(
     name="seed_parent",
     unique_id="seed_parent",
-    resource_type="seed",
+    resource_type=DbtResourceType.SEED,
     depends_on=[],
     file_path="",
 )
 parent_node = DbtNode(
     name="parent",
     unique_id="parent",
-    resource_type="model",
+    resource_type=DbtResourceType.MODEL,
     depends_on=["seed_parent"],
     file_path=SAMPLE_PROJ_PATH / "gen2/models/parent.sql",
     tags=["has_child"],
     config={"materialized": "view"},
 )
 test_parent_node = DbtNode(
-    name="test_parent", unique_id="test_parent", resource_type="test", depends_on=["parent"], file_path=""
+    name="test_parent", unique_id="test_parent", resource_type=DbtResourceType.TEST, depends_on=["parent"], file_path=""
 )
 child_node = DbtNode(
     name="child",
     unique_id="child",
-    resource_type="model",
+    resource_type=DbtResourceType.MODEL,
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
     tags=["nightly"],
@@ -50,7 +50,7 @@ child_node = DbtNode(
 test_child_node = DbtNode(
     name="test_child",
     unique_id="test_child",
-    resource_type="test",
+    resource_type=DbtResourceType.TEST,
     depends_on=["child"],
     file_path="",
 )
@@ -73,7 +73,7 @@ def test_build_airflow_graph_with_after_each():
         build_airflow_graph(
             nodes=sample_nodes,
             dag=dag,
-            execution_mode="local",
+            execution_mode=ExecutionMode.LOCAL,
             task_args=task_args,
             test_behavior="after_each",
             dbt_project_name="astro_shop",
@@ -115,7 +115,7 @@ def test_build_airflow_graph_with_after_all():
         build_airflow_graph(
             nodes=sample_nodes,
             dag=dag,
-            execution_mode="local",
+            execution_mode=ExecutionMode.LOCAL,
             task_args=task_args,
             test_behavior="after_all",
             dbt_project_name="astro_shop",

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -13,7 +13,7 @@ from cosmos.airflow.graph import (
     create_test_task_metadata,
     calculate_operator_class,
 )
-from cosmos.constants import ExecutionMode, DbtNodeType
+from cosmos.constants import ExecutionMode, DbtResourceType
 from cosmos.dbt.graph import DbtNode
 
 
@@ -141,7 +141,7 @@ def test_calculate_leaves():
     grandparent_node = DbtNode(
         name="grandparent",
         unique_id="grandparent",
-        resource_type="model",
+        resource_type=DbtResourceType.MODEL,
         depends_on=[],
         file_path="",
         tags=[],
@@ -150,7 +150,7 @@ def test_calculate_leaves():
     parent1_node = DbtNode(
         name="parent1",
         unique_id="parent1",
-        resource_type="model",
+        resource_type=DbtResourceType.MODEL,
         depends_on=["grandparent"],
         file_path="",
         tags=[],
@@ -159,7 +159,7 @@ def test_calculate_leaves():
     parent2_node = DbtNode(
         name="parent2",
         unique_id="parent2",
-        resource_type="model",
+        resource_type=DbtResourceType.MODEL,
         depends_on=["grandparent"],
         file_path="",
         tags=[],
@@ -168,7 +168,7 @@ def test_calculate_leaves():
     child_node = DbtNode(
         name="child",
         unique_id="child",
-        resource_type="model",
+        resource_type=DbtResourceType.MODEL,
         depends_on=["parent1", "parent2"],
         file_path="",
         tags=[],
@@ -202,7 +202,7 @@ def test_create_task_metadata_model(caplog):
     child_node = DbtNode(
         name="my_model",
         unique_id="my_folder.my_model",
-        resource_type=DbtNodeType.MODEL,
+        resource_type=DbtResourceType.MODEL,
         depends_on=[],
         file_path="",
         tags=[],
@@ -218,7 +218,7 @@ def test_create_task_metadata_seed(caplog):
     sample_node = DbtNode(
         name="my_seed",
         unique_id="my_folder.my_seed",
-        resource_type=DbtNodeType.SEED,
+        resource_type=DbtResourceType.SEED,
         depends_on=[],
         file_path="",
         tags=[],
@@ -234,7 +234,7 @@ def test_create_task_metadata_snapshot(caplog):
     sample_node = DbtNode(
         name="my_snapshot",
         unique_id="my_folder.my_snapshot",
-        resource_type=DbtNodeType.SNAPSHOT,
+        resource_type=DbtResourceType.SNAPSHOT,
         depends_on=[],
         file_path="",
         tags=[],

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -3,6 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
+from cosmos.constants import ExecutionMode, DbtNodeType
 from cosmos.dbt.graph import DbtGraph, LoadMode, CosmosLoadDbtException
 from cosmos.dbt.project import DbtProject
 
@@ -22,7 +23,7 @@ def test_load_via_manifest_with_exclude():
     sample_node = dbt_graph.nodes["model.jaffle_shop.customers"]
     assert sample_node.name == "customers"
     assert sample_node.unique_id == "model.jaffle_shop.customers"
-    assert sample_node.resource_type == "model"
+    assert sample_node.resource_type == DbtNodeType.MODEL
     assert sample_node.depends_on == [
         "model.jaffle_shop.stg_customers",
         "model.jaffle_shop.stg_orders",
@@ -35,7 +36,7 @@ def test_load_via_manifest_with_exclude():
 def test_load_automatic_manifest_is_available(mock_load_from_dbt_manifest):
     dbt_project = DbtProject(name="jaffle_shop", root_dir=DBT_PROJECTS_ROOT_DIR, manifest_path=SAMPLE_MANIFEST)
     dbt_graph = DbtGraph(project=dbt_project)
-    dbt_graph.load(execution_mode="local")
+    dbt_graph.load(execution_mode=ExecutionMode.LOCAL)
     assert mock_load_from_dbt_manifest.called
 
 
@@ -44,7 +45,7 @@ def test_load_automatic_manifest_is_available(mock_load_from_dbt_manifest):
 def test_load_automatic_without_manifest(mock_load_via_dbt_ls, mock_load_via_custom_parser):
     dbt_project = DbtProject(name="jaffle_shop", root_dir=DBT_PROJECTS_ROOT_DIR, manifest_path="/tmp/manifest.json")
     dbt_graph = DbtGraph(project=dbt_project)
-    dbt_graph.load(execution_mode="local")
+    dbt_graph.load(execution_mode=ExecutionMode.LOCAL)
     assert mock_load_via_dbt_ls.called
     assert not mock_load_via_custom_parser.called
 
@@ -54,7 +55,7 @@ def test_load_automatic_without_manifest(mock_load_via_dbt_ls, mock_load_via_cus
 def test_load_automatic_without_manifest_and_without_dbt_cmd(mock_load_via_dbt_ls, mock_load_via_custom_parser):
     dbt_project = DbtProject(name="jaffle_shop", root_dir=DBT_PROJECTS_ROOT_DIR)
     dbt_graph = DbtGraph(project=dbt_project)
-    dbt_graph.load(execution_mode="local", method=LoadMode.AUTOMATIC)
+    dbt_graph.load(execution_mode=ExecutionMode.LOCAL, method=LoadMode.AUTOMATIC)
     assert mock_load_via_dbt_ls.called
     assert mock_load_via_custom_parser.called
 
@@ -63,7 +64,7 @@ def test_load_manifest_without_manifest():
     dbt_project = DbtProject(name="jaffle_shop", root_dir=DBT_PROJECTS_ROOT_DIR)
     dbt_graph = DbtGraph(project=dbt_project)
     with pytest.raises(CosmosLoadDbtException) as err_info:
-        dbt_graph.load(execution_mode="local", method=LoadMode.DBT_MANIFEST)
+        dbt_graph.load(execution_mode=ExecutionMode.LOCAL, method=LoadMode.DBT_MANIFEST)
     assert err_info.value.args[0] == "Unable to load manifest using None"
 
 
@@ -71,19 +72,19 @@ def test_load_manifest_without_manifest():
 def test_load_manifest_with_manifest(mock_load_from_dbt_manifest):
     dbt_project = DbtProject(name="jaffle_shop", root_dir=DBT_PROJECTS_ROOT_DIR, manifest_path=SAMPLE_MANIFEST)
     dbt_graph = DbtGraph(project=dbt_project)
-    dbt_graph.load(execution_mode="local", method=LoadMode.DBT_MANIFEST)
+    dbt_graph.load(execution_mode=ExecutionMode.LOCAL, method=LoadMode.DBT_MANIFEST)
     assert mock_load_from_dbt_manifest.called
 
 
 @pytest.mark.parametrize(
     "exec_mode,method,expected_function",
     [
-        ("local", LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
-        ("virtualenv", LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
-        ("kubernetes", LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
-        ("docker", LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
-        ("local", LoadMode.DBT_LS, "mock_load_via_dbt_ls"),
-        ("local", LoadMode.CUSTOM, "mock_load_via_custom_parser"),
+        (ExecutionMode.LOCAL, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
+        (ExecutionMode.VIRTUALENV, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
+        (ExecutionMode.KUBERNETES, LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
+        (ExecutionMode.DOCKER, LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
+        (ExecutionMode.LOCAL, LoadMode.DBT_LS, "mock_load_via_dbt_ls"),
+        (ExecutionMode.LOCAL, LoadMode.CUSTOM, "mock_load_via_custom_parser"),
     ],
 )
 @patch("cosmos.dbt.graph.DbtGraph.load_via_custom_parser", return_value=None)

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -3,7 +3,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cosmos.constants import ExecutionMode, DbtNodeType
+from cosmos.constants import ExecutionMode, DbtResourceType
 from cosmos.dbt.graph import DbtGraph, LoadMode, CosmosLoadDbtException
 from cosmos.dbt.project import DbtProject
 
@@ -23,7 +23,7 @@ def test_load_via_manifest_with_exclude():
     sample_node = dbt_graph.nodes["model.jaffle_shop.customers"]
     assert sample_node.name == "customers"
     assert sample_node.unique_id == "model.jaffle_shop.customers"
-    assert sample_node.resource_type == DbtNodeType.MODEL
+    assert sample_node.resource_type == DbtResourceType.MODEL
     assert sample_node.depends_on == [
         "model.jaffle_shop.stg_customers",
         "model.jaffle_shop.stg_orders",
@@ -122,7 +122,7 @@ def test_load_via_dbt_ls_with_exclude():
     sample_node = dbt_graph.nodes["model.jaffle_shop.customers"]
     assert sample_node.name == "customers"
     assert sample_node.unique_id == "model.jaffle_shop.customers"
-    assert sample_node.resource_type == "model"
+    assert sample_node.resource_type == DbtResourceType.MODEL
     assert sample_node.depends_on == [
         "model.jaffle_shop.stg_customers",
         "model.jaffle_shop.stg_orders",

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+from cosmos.constants import DbtResourceType
 from cosmos.dbt.graph import DbtNode
 from cosmos.dbt.selector import select_nodes
 
@@ -8,7 +9,7 @@ SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
 grandparent_node = DbtNode(
     name="grandparent",
     unique_id="grandparent",
-    resource_type="model",
+    resource_type=DbtResourceType.MODEL,
     depends_on=[],
     file_path=SAMPLE_PROJ_PATH / "gen1/models/grandparent.sql",
     tags=["has_child"],
@@ -17,7 +18,7 @@ grandparent_node = DbtNode(
 parent_node = DbtNode(
     name="parent",
     unique_id="parent",
-    resource_type="model",
+    resource_type=DbtResourceType.MODEL,
     depends_on=["grandparent"],
     file_path=SAMPLE_PROJ_PATH / "gen2/models/parent.sql",
     tags=["has_child"],
@@ -26,7 +27,7 @@ parent_node = DbtNode(
 child_node = DbtNode(
     name="child",
     unique_id="child",
-    resource_type="model",
+    resource_type=DbtResourceType.MODEL,
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
     tags=["nightly"],

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,18 @@
 import pytest
 from airflow.exceptions import AirflowException
 
-from cosmos.converter import validate_arguments
+
+from cosmos.constants import TestBehavior
+from cosmos.converter import convert_value_to_enum, validate_arguments, UserInputError
+
+
+def test_convert_value_to_enum():
+    assert convert_value_to_enum(TestBehavior.AFTER_ALL, TestBehavior) == TestBehavior.AFTER_ALL
+    assert convert_value_to_enum("none", TestBehavior) == TestBehavior.NONE
+    with pytest.raises(UserInputError) as err:
+        convert_value_to_enum("unavailable", TestBehavior)
+    expected = "The given value unavailable is not compatible with the type TestBehavior"
+    assert err.value.args[0] == expected
 
 
 @pytest.mark.parametrize("argument_key", ["tags", "paths"])


### PR DESCRIPTION
Change `DbtDag` and `DbtTaskGroup` so they use `Enum` as opposed to `Literal` strings to represent the arguments:
* `test_behavior`
* `execution_mode`

This is a breaking change. Before:
```
DbtDag(..., execution_mode="kubernetes", test_behavior="after_all")
```

Now:
```
from cosmos import ExecutionMode, TestBehavior

DbtDag(..., execution_mode=ExecutionMode.kubernetes, test_behavior=TestBehavior.AFTER_ALL)
```


Closes #371