### PR TITLE
Ignore `.user.yml` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,6 +141,7 @@ dmypy.json
 
 # dbt
 logs/
+*.user.yml
 
 # integration tests
 dev/dags/.airflowignore


### PR DESCRIPTION
When running `dbt ls`, it generates a few files, including a `.user.yml`. This change tells Git to ignore this file.