### PR TITLE
Fix bug where dbt_executable_path was not passed to operators

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -155,6 +155,9 @@ class DbtToAirflowConverter:
             "profile_config": profile_config,
         }
 
+        if dbt_executable_path:
+            task_args["dbt_executable_path"] = dbt_executable_path
+
         validate_arguments(select, exclude, profile_args, task_args)
 
         build_airflow_graph(


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR fixes a bug with Cosmos, where previously the `dbt_executable_path` didn't get passed all the way down to the underlying operators. This meant that the operators didn't have an executable, and would result in an error like so:


```
[2023-07-26, 22:21:06 UTC] {subprocess.py:70} INFO - Running command: [None, 'seed', '--models', 'raw_customers', '--profiles-dir', '/tmp/tmpde8e9703', '--profile', 'airflow_db', '--target', 'dev']
[2023-07-26, 22:21:06 UTC] {taskinstance.py:1824} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/cosmos/operators/local.py", line 242, in execute
    result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
  File "/usr/local/lib/python3.10/site-packages/cosmos/operators/local.py", line 188, in build_and_run_cmd
    return self.run_command(cmd=dbt_cmd, env=env, context=context)
  File "/usr/local/lib/python3.10/site-packages/cosmos/operators/local.py", line 172, in run_command
    result = self.run_subprocess(
  File "/usr/local/lib/python3.10/site-packages/cosmos/operators/local.py", line 125, in run_subprocess
    subprocess_result: FullOutputSubprocessResult = self.subprocess_hook.run_command(*args, **kwargs)
  File "/usr/local/lib/python3.10/site-packages/cosmos/hooks/subprocess.py", line 72, in run_command
    self.sub_process = Popen(
  File "/usr/local/lib/python3.10/subprocess.py", line 971, in __init__
    self._execute_child(args, executable, preexec_fn, close_fds,
  File "/usr/local/lib/python3.10/subprocess.py", line 1738, in _execute_child
    and os.path.dirname(executable)
  File "/usr/local/lib/python3.10/posixpath.py", line 152, in dirname
    p = os.fspath(p)
TypeError: expected str, bytes or os.PathLike object, not NoneType
```

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
Nope!

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
