### PR TITLE
Fix bug causing select and exclude filter issues

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -161,7 +161,7 @@ class DbtToAirflowConverter:
         validate_arguments(select, exclude, profile_args, task_args)
 
         build_airflow_graph(
-            nodes=dbt_graph.nodes,
+            nodes=dbt_graph.filtered_nodes,
             dag=dag or (task_group and task_group.dag),
             task_group=task_group,
             execution_mode=execution_mode,


### PR DESCRIPTION
## Description
When `load_method` was set to `LoadMode.CUSTOM`, any `select/exclude` parameters were ineffective. This is because the entire node list was being passed to the `build_airflow_graph` method instead of a filtered list of nodes.

## Related Issue(s)
closes #409 

## Breaking Change?
No breaking changes with this change

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
