### PR TITLE
Refactor `dbt ls` to run from a temporary directory

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
       - id: rst-backticks
       - id: python-check-mock-methods
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.3
+    rev: v1.5.1
     hooks:
       - id: remove-crlf
       - id: remove-tabs

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -6,6 +6,9 @@ from pathlib import Path
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
 DEFAULT_DBT_TARGET_NAME = "cosmos_target"
+DBT_LOG_PATH_ENVVAR = "DBT_LOG_PATH"
+DBT_TARGET_PATH_ENVVAR = "DBT_TARGET_PATH"
+DBT_LOG_FILENAME = "dbt.log"
 
 
 class LoadMode(Enum):

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -145,7 +145,10 @@ class DbtGraph:
             command.extend(["--select", *self.select])
 
         with tempfile.TemporaryDirectory() as tmpdir:
-            shutil.copytree(self.project.dir, tmpdir, dirs_exist_ok=True)
+            # when we drop support to Python 3.7, we can use:
+            # shutil.copytree(self.project.dir, tmpdir, dirs_exist_ok=True)
+            cwd = Path(tmpdir) / self.project.name
+            shutil.copytree(self.project.dir, cwd)
 
             with self.profile_config.ensure_profile() as (profile_path, env_vars):
                 command.extend(
@@ -168,7 +171,7 @@ class DbtGraph:
                     command,
                     stdout=PIPE,
                     stderr=PIPE,
-                    cwd=tmpdir,
+                    cwd=cwd,
                     universal_newlines=True,
                     env=env,
                 )

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -151,7 +151,6 @@ class DbtGraph:
 
         with self.profile_config.ensure_profile() as profile_values:
             (profile_path, env_vars) = profile_values
-            # TODO: check, it seems this is being called 5 times!!! :scream:
             command.extend(
                 [
                     "--project-dir",

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -108,6 +108,7 @@ def test_load(
     assert load_function.called
 
 
+@pytest.mark.integration
 @patch("cosmos.dbt.graph.Popen")
 def test_load_via_dbt_ls_uses_temp_dir(mock_popen):
     mock_popen().communicate.return_value = ("", "")


### PR DESCRIPTION
As of Cosmos 1.0.0, `LoadMode.DBT_LS` runs `dbt ls` from within the original dbt project directory.

The `dbt ls` outputs files to the directory it's running from unless the environment variables `DBT_LOG_PATH` and `DBT_TARGET_PATH` are specified (as of dbt 1.6). 

Depending on the deployment, the Airflow worker does not have write permissions to the dbt project directory. This can lead to an error message similar to the following:

```
20:43:06  Encountered an error:
[Errno 30] Read-only file system: '/usr/local/airflow/dags/dbt_grindr/logs/dbt.log'
```

This PR changes the behavior of `dbt ls` to try to make the `dbt ls` artifacts (logs and target directory) not be written to the original project directory.

In addition to the introduced test, this change was validated using airflow 2.6 and dbt 1.6, by following these steps:
(1) Delete folders `logs` and `target` from `astronomer-cosmos/dev/dags/dbt/jaffle_shop`
(2) Add a breakpoint after `stdout, stderr = process.communicate()` in `dbt/graph.py`
(3) Run a DAG that uses  `astronomer-cosmos/dev/dags/dbt/jaffle_shop`, e.g.:
```
airflow dags test basic_cosmos_dag `date -Iseconds`
```
(4) When the breakpoint happens, check that no `target` or `logs` folder was created after running `dbt ls` in `astronomer-cosmos/dev/dags/dbt/jaffle_shop`

A limitation with the current approach is that, although `dbt ls` is not creating these directories in the given circumstances, if the user is using the local executor or an earlier version of `dbt`, the files will still be written to the project directory.

Closes: #411