### PR TITLE
Ensure datasets are emitted from the right task

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -6,7 +6,7 @@ from typing import Any, Callable
 from airflow.models.dag import DAG
 from airflow.utils.task_group import TaskGroup
 
-from cosmos.constants import DbtResourceType, TestBehavior, ExecutionMode
+from cosmos.constants import DbtResourceType, TestBehavior, ExecutionMode, EmitDatasetsType
 from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dataset import get_dbt_dataset
@@ -127,7 +127,7 @@ def build_airflow_graph(
     conn_id: str,  # Cosmos, dataset URI
     task_group: TaskGroup | None = None,
     on_warning_callback: Callable[..., Any] | None = None,  # argument specific to the DBT test command
-    emit_datasets: bool = True,  # Cosmos
+    emit_datasets_from: EmitDatasetsType | None = None,  # Cosmos
 ) -> None:
     """
     Instantiate dbt `nodes` as Airflow tasks within the given `task_group` (optional) or `dag` (mandatory).
@@ -142,7 +142,7 @@ def build_airflow_graph(
     a single test task will be added after the Cosmos leave tasks, and it is named using `dbt_project_name`.
     Finally, if the `test_behaviour` is `after_each`, a test will be added after each model.
 
-    If `emit_datasets` is True, tasks will create outlets using:
+    If `emit_datasets_from` is defined, tasks will create outlets using:
     * `dbt_project_name`
     * `conn_id`
 
@@ -157,7 +157,8 @@ def build_airflow_graph(
     :param task_group: Airflow Task Group instance
     :param on_warning_callback: A callback function called on warnings with additional Context variables “test_names”
     and “test_results” of type List.
-    :param emit_datasets: Decides if Cosmos should add outlets to model classes or not.
+    :param emit_datasets_from: Model nodes emit Airflow Datasets for downstream cross-DAG dependencies
+    depending on whether they are run with tests or not.
     """
     tasks_map = {}
     task_or_group: TaskGroup | BaseOperator
@@ -167,10 +168,16 @@ def build_airflow_graph(
     # If test_behaviour=="after_each", each model task will be bundled with a test task, using TaskGroup
     for node_id, node in nodes.items():
         task_meta = create_task_metadata(node=node, execution_mode=execution_mode, args=task_args)
-        if emit_datasets:
+
+        if emit_datasets_from == EmitDatasetsType.MODELS:
             task_args["outlets"] = [get_dbt_dataset(conn_id, dbt_project_name, node.name)]
+
         if task_meta and node.resource_type != DbtResourceType.TEST:
-            if node.resource_type == DbtResourceType.MODEL and test_behavior == TestBehavior.AFTER_EACH:
+            if (
+                node.resource_type == DbtResourceType.MODEL
+                and test_behavior == TestBehavior.AFTER_EACH
+                and EmitDatasetsType.TESTS
+            ):
                 with TaskGroup(dag=dag, group_id=node.name, parent_group=task_group) as model_task_group:
                     task = create_airflow_task(task_meta, dag, task_group=model_task_group)
                     test_meta = create_test_task_metadata(
@@ -189,7 +196,7 @@ def build_airflow_graph(
 
     # If test_behaviour=="after_all", there will be one test task, run "by the end" of the DAG
     # The end of a DAG is defined by the DAG leaf tasks (tasks which do not have downstream tasks)
-    if test_behavior == TestBehavior.AFTER_ALL:
+    if emit_datasets_from == EmitDatasetsType.TESTS and test_behavior == TestBehavior.AFTER_ALL:
         task_args.pop("outlets", None)
         test_meta = create_test_task_metadata(
             f"{dbt_project_name}_test", execution_mode, task_args=task_args, on_warning_callback=on_warning_callback

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from logging import getLogger
 from typing import Iterator
 
-from cosmos.constants import TestBehavior, ExecutionMode, LoadMode
+from cosmos.constants import TestBehavior, ExecutionMode, LoadMode, EmitDatasetsType
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles import BaseProfileMapping
 
@@ -24,15 +24,15 @@ class RenderConfig:
     """
     Class for setting general Cosmos config.
 
-    :param emit_datasets: If enabled model nodes emit Airflow Datasets for downstream cross-DAG
-    dependencies. Defaults to True
+    :param emit_datasets_from: Model nodes emit Airflow Datasets for downstream cross-DAG
+    dependencies depending on whether they are run with tests or not. Defaults to None
     :param test_behavior: The behavior for running tests. Defaults to after each (model)
     :param load_method: The parsing method for loading the dbt model. Defaults to AUTOMATIC
     :param select: A list of dbt select arguments (e.g. 'config.materialized:incremental')
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
     """
 
-    emit_datasets: bool = True
+    emit_datasets_from: EmitDatasetsType | None = None
     test_behavior: TestBehavior = TestBehavior.AFTER_EACH
     load_method: LoadMode = LoadMode.AUTOMATIC
     select: list[str] = field(default_factory=list)

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -32,7 +32,7 @@ class RenderConfig:
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
     """
 
-    emit_datasets_from: EmitDatasetsType | None = None
+    emit_datasets_from: EmitDatasetsType | None = EmitDatasetsType.TESTS
     test_behavior: TestBehavior = TestBehavior.AFTER_EACH
     load_method: LoadMode = LoadMode.AUTOMATIC
     select: list[str] = field(default_factory=list)

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -51,3 +51,12 @@ class DbtResourceType(Enum):
     SEED = "seed"
     TEST = "test"
     SOURCE = "source"
+
+
+class EmitDatasetsType(Enum):
+    """
+    Type of dataset to emit.
+    """
+
+    MODELS = "models"
+    TESTS = "tests"

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -105,7 +105,7 @@ class DbtToAirflowConverter:
     ) -> None:
         project_config.validate_project()
 
-        emit_datasets = render_config.emit_datasets
+        emit_datasets_from = render_config.emit_datasets_from
         dbt_root_path = project_config.dbt_project_path.parent
         dbt_project_name = project_config.dbt_project_path.name
         dbt_models_dir = project_config.models_relative_path
@@ -170,5 +170,5 @@ class DbtToAirflowConverter:
             dbt_project_name=dbt_project.name,
             conn_id=conn_id,
             on_warning_callback=on_warning_callback,
-            emit_datasets=emit_datasets,
+            emit_datasets_from=emit_datasets_from,
         )

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True
+- ``emit_datasets_from``: whether or not to emit Airflow datasets to be used for data-aware scheduling based on if tests are run. Defaults to None
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``select`` and ``exclude``: which models to include or exclude from your DAGs. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.


### PR DESCRIPTION
## Description

Converts "emit_datasets" into the "emit_datasets_from" Enum, with corresponding support for emitting datasets from the model based on whether tests run.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
