### PR TITLE
Fix selector for config tags

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -89,8 +89,17 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
             continue
 
         supported_node_config = {key: value for key, value in node.config.items() if key in SUPPORTED_CONFIG}
-        if config.config and not (config.config.items() <= supported_node_config.items()):
-            continue
+        if config.config:
+            config_tag = config.config.get('tags')
+            if config_tag and not config_tag in supported_node_config.get("tags", []):
+                continue
+
+            # Remove 'tags' as we've already filtered for them
+            config.config.pop("tags", None)
+            supported_node_config.pop("tags", None)
+
+            if not (config.config.items() <= supported_node_config.items()):
+                continue
 
         if config.paths and not (set(config.paths).issubset(set(node.file_path.parents))):
             continue

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -94,7 +94,7 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
             if config_tag and config_tag not in supported_node_config.get("tags", []):
                 continue
 
-            # Remove 'tags' as we've already filtered for them
+            # Remove 'tags' as they've already been filtered for
             config.config.pop("tags", None)
             supported_node_config.pop("tags", None)
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -90,8 +90,8 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
 
         supported_node_config = {key: value for key, value in node.config.items() if key in SUPPORTED_CONFIG}
         if config.config:
-            config_tag = config.config.get('tags')
-            if config_tag and not config_tag in supported_node_config.get("tags", []):
+            config_tag = config.config.get("tags")
+            if config_tag and config_tag not in supported_node_config.get("tags", []):
                 continue
 
             # Remove 'tags' as we've already filtered for them

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -34,7 +34,7 @@ child_node = DbtNode(
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
     tags=["nightly"],
-    config={"materialized": "table", "tags": ["is_child"] },
+    config={"materialized": "table", "tags": ["is_child"]},
 )
 
 sample_nodes = {
@@ -55,13 +55,17 @@ def test_select_nodes_by_select_config():
     expected = {child_node.unique_id: child_node}
     assert selected == expected
 
+
 def test_select_nodes_by_select_config_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child"])
     expected = {child_node.unique_id: child_node}
     assert selected == expected
 
+
 def test_select_nodes_by_select_union_config_tag():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child" , "config.materialized:view"])
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child", "config.materialized:view"]
+    )
     expected = {
         grandparent_node.unique_id: grandparent_node,
         parent_node.unique_id: parent_node,
@@ -69,9 +73,13 @@ def test_select_nodes_by_select_union_config_tag():
     }
     assert selected == expected
 
+
 def test_select_nodes_by_select_intersection_config_tag():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child,config.materialized:view"])
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child,config.materialized:view"]
+    )
     assert selected == {}
+
 
 def test_select_nodes_by_select_path():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models"])

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -34,7 +34,7 @@ child_node = DbtNode(
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
     tags=["nightly"],
-    config={"materialized": "table"},
+    config={"materialized": "table", "tags": ["is_child"] },
 )
 
 sample_nodes = {
@@ -55,6 +55,23 @@ def test_select_nodes_by_select_config():
     expected = {child_node.unique_id: child_node}
     assert selected == expected
 
+def test_select_nodes_by_select_config_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child"])
+    expected = {child_node.unique_id: child_node}
+    assert selected == expected
+
+def test_select_nodes_by_select_union_config_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child" , "config.materialized:view"])
+    expected = {
+        grandparent_node.unique_id: grandparent_node,
+        parent_node.unique_id: parent_node,
+        child_node.unique_id: child_node,
+    }
+    assert selected == expected
+
+def test_select_nodes_by_select_intersection_config_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child,config.materialized:view"])
+    assert selected == {}
 
 def test_select_nodes_by_select_path():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models"])


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
Fixing an issue where the check in `selector.py`, specifically `select_nodes_ids_by_intersection`, didn't validate tags in the node's config. The function will now check if the tag specified in config is contained in the node's config and check all other configs to be filtered for are a subset of the node's config, as previously.  

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #440 
## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
