### PR TITLE
Fix BigQuery `keyfile_dict` mapping for connection created from webserver

### DIFF
--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -46,7 +46,7 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
             **self.profile_args,
         }
 
-    def transformer_keyfile_json(self, keyfile_json: str | dict[str, str]) -> dict[str, str]:
+    def transform_keyfile_json(self, keyfile_json: str | dict[str, str]) -> dict[str, str]:
         """
         Transforms the keyfile_json param to a dict if it is a string.
         """

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 from typing import Any
+import json
 
 from cosmos.profiles.base import BaseProfileMapping
 
@@ -44,3 +45,15 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
             "threads": 1,
             **self.profile_args,
         }
+
+    def transformer_keyfile_json(self, keyfile_json: str | dict[str, str]) -> dict[str, str]:
+        """
+        Transforms the keyfile_json param to a dict if it is a string.
+        """
+        if isinstance(keyfile_json, dict):
+            return keyfile_json
+        keyfile_json = json.loads(keyfile_json)
+        if isinstance(keyfile_json, dict):
+            return keyfile_json
+        else:
+            raise ValueError("keyfile_json cannot be loaded as a dict.")

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -8,15 +8,15 @@ from cosmos.profiles import get_automatic_profile_mapping
 from cosmos.profiles.bigquery.service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
 
 
-@pytest.fixture()
-def mock_bigquery_conn_with_dict():  # type: ignore
+@pytest.fixture(params=[{"key": "value"}, '{"key": "value"}'])
+def mock_bigquery_conn_with_dict(request):  # type: ignore
     """
     Mocks and returns an Airflow BigQuery connection.
     """
     extra = {
         "project": "my_project",
         "dataset": "my_dataset",
-        "keyfile_dict": {"key": "value"},
+        "keyfile_dict": request.param,
     }
     conn = Connection(
         conn_id="my_bigquery_connection",


### PR DESCRIPTION
## Description

GCP connections created with a keyfile json from the webserver UI were not previously working as documented in the related issues below. The keyfile_dict created in the webserver UI is stored as a string and is the reason why in the GoogleBaseHook [here](https://github.com/apache/airflow/blob/a752c902861d9a829d7451cc69d1343cbe5b54dc/airflow/providers/google/common/hooks/base_google.py#L250-L254) it uses `json.loads` if the keyfile_dict isn't a dict.

## Related Issue(s)

#436 #443

## Breaking Change?

None
## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
