### PR TITLE
Fix doc dead link and restore dbt/airflow conflicts page

### DIFF
--- a/docs/getting_started/execution-modes-local-conflicts.rst
+++ b/docs/getting_started/execution-modes-local-conflicts.rst
@@ -1,0 +1,70 @@
+.. _execution-modes-local-conflicts:
+
+Airflow and DBT dependencies conflicts
+======================================
+
+When using the `Local Execution Mode <execution-modes.html#local>`__, users may face dependency conflicts between
+Apache Airflow and DBT. The amount of conflicts may increase depending on the Airflow providers and DBT plugins being used.
+
+If you find errors, we recommend users look into using `alternative execution modes <execution-modes.html>`__.
+
+In the following table, ``x`` represents combinations that lead to conflicts (vanilla ``apache-airflow`` and ``dbt-core`` packages):
+
++---------------+-----+-----+-----+-----+-----+-----+---------+
+| Airflow \ DBT | 1.0 | 1.1 | 1.2 | 1.3 | 1.4 | 1.5 | 1.6.0b6 |
++===============+=====+=====+=====+=====+=====+=====+=========+
+| 2.2           |     |     |     | x   | x   | x   | x       |
++---------------+-----+-----+-----+-----+-----+-----+---------+
+| 2.3           | x   | x   |     | x   | x   | x   | x       |
++---------------+-----+-----+-----+-----+-----+-----+---------+
+| 2.4           | x   | x   | x   |     |     |     |         |
++---------------+-----+-----+-----+-----+-----+-----+---------+
+| 2.5           | x   | x   | x   |     |     |     |         |
++---------------+-----+-----+-----+-----+-----+-----+---------+
+| 2.6           | x   | x   | x   | x   | x   |     | x       |
++---------------+-----+-----+-----+-----+-----+-----+---------+
+
+Examples of errors
+-----------------------------------
+
+.. code-block:: bash
+
+  ERROR: Cannot install apache-airflow==2.2.4 and dbt-core==1.5.0 because these package versions have conflicting dependencies.
+  The conflict is caused by:
+    apache-airflow 2.2.4 depends on jinja2<3.1 and >=2.10.1
+    dbt-core 1.5.0 depends on Jinja2==3.1.2
+
+.. code-block:: bash
+
+  ERROR: Cannot install apache-airflow==2.6.0 and dbt-core because these package versions have conflicting dependencies.
+  The conflict is caused by:
+    apache-airflow 2.6.0 depends on importlib-metadata<5.0.0 and >=1.7; python_version < "3.9"
+    dbt-semantic-interfaces 0.1.0.dev7 depends on importlib-metadata==6.6.0
+
+
+How to reproduce
+----------------
+
+The table was created by running  `nox <https://nox.thea.codes/en/stable/>`__ with the following ``noxfile.py``:
+
+.. code-block:: python
+
+  import nox
+
+
+  nox.options.sessions = ["compatibility"]
+  nox.options.reuse_existing_virtualenvs = True
+
+
+  @nox.session(python=["3.10"])
+  @nox.parametrize("dbt_version", ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6.0b6"])
+  @nox.parametrize("airflow_version", ["2.2.4", "2.3", "2.4", "2.5", "2.6"])
+  def compatibility(session: nox.Session, airflow_version, dbt_version) -> None:
+      """Run both unit and integration tests."""
+      session.run(
+          "pip3",
+          "install",
+          "--pre",
+          f"apache-airflow=={airflow_version}",
+          f"dbt-core=={dbt_version}",
+      )

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -46,11 +46,9 @@ By default, Cosmos uses the ``local`` execution mode.
 The ``local`` execution mode is the fastest way to run Cosmos operators since they don't install ``dbt`` nor build docker containers. However, it may not be an option for users using managed Airflow services such as
 Google Cloud Composer, since Airflow and ``dbt`` dependencies can conflict (:ref:`execution-modes-local-conflicts`), the user may not be able to install ``dbt`` in a custom path.
 
- `Local Execution Mode <execution-modes.html#local>`_
-
 The ``local`` execution mode assumes a ``dbt`` binary is reachable within the Airflow worker node.
 
-If ``dbt`` was not `installed as part of the Cosmos package <install-options.html#local>`__,
+If ``dbt`` was not installed as part of the Cosmos packages,
 users can define a custom path to ``dbt`` by declaring the argument ``dbt_executable_path``.
 
 When using the ``local`` execution mode, Cosmos converts Airflow Connections into a native ``dbt`` profiles file (``profiles.yml``).
@@ -94,7 +92,7 @@ The other challenge with the ``docker`` approach is if the Airflow worker is alr
 
 This approach can be significantly slower than ``virtualenv`` since it may have to build the ``Docker`` container, which is slower than creating a Virtualenv with ``dbt-core``.
 
-Check the step-by-step guide on using the ``docker`` execution mode at `Docker Operators <docker.html>`_.
+Check the step-by-step guide on using the ``docker`` execution mode at :ref:`docker`.
 
 Example DAG:
 
@@ -121,7 +119,7 @@ It assumes the user has a Kubernetes cluster. It also expects the user to ensure
 
 The ``Kubernetes`` deployment may be slower than ``Docker`` and ``Virtualenv`` assuming that the container image is built (which is slower than creating a Python ``virtualenv`` and installing ``dbt-core``) and the Airflow task needs to spin up a new ``Pod`` in Kubernetes.
 
-Check the step-by-step guide on using the ``kubernetes`` execution mode at `Kubernetes Operators <kubernetes.html>`_.
+Check the step-by-step guide on using the ``kubernetes`` execution mode at :ref:`kubernetes`.
 
 Example DAG:
 

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -44,7 +44,9 @@ Local
 By default, Cosmos uses the ``local`` execution mode.
 
 The ``local`` execution mode is the fastest way to run Cosmos operators since they don't install ``dbt`` nor build docker containers. However, it may not be an option for users using managed Airflow services such as
-Google Cloud Composer, since Airflow and ``dbt`` dependencies can `conflict <execution-mode-local-conflicts.html>`__, the user may not be able to install ``dbt`` in a custom path.
+Google Cloud Composer, since Airflow and ``dbt`` dependencies can conflict (:ref:`execution-modes-local-conflicts`), the user may not be able to install ``dbt`` in a custom path.
+
+ `Local Execution Mode <execution-modes.html#local>`_
 
 The ``local`` execution mode assumes a ``dbt`` binary is reachable within the Airflow worker node.
 


### PR DESCRIPTION
Fix dead links in the live docs:

* Source: https://astronomer.github.io/astronomer-cosmos/getting_started/execution-modes.html
* Previous target: https://astronomer.github.io/astronomer-cosmos/getting_started/execution-mode-local-conflicts.html

Restore the compatibility matrix between Airflow and dbt, originally introduced in:
https://github.com/astronomer/astronomer-cosmos/pull/347

This change was validated using the following steps:
* Locally, using ` hatch run docs:build` and confirming using Chrome that the generated HTML `file:///<path>/astronomer-cosmos/docs/_build/dbt/execution-modes.html` resolved correctly the path to the conflicts page
* Remotely, confirming that https://deploy-preview-452--amazing-pothos-a3bca0.netlify.app/getting_started/execution-modes/ conflict link is associated to https://deploy-preview-452--amazing-pothos-a3bca0.netlify.app/getting_started/execution-modes-local-conflicts/#execution-modes-local-conflicts

<img width="1280" alt="Screenshot 2023-08-09 at 23 12 53" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/6b6da81e-4d88-48b4-a712-9bed95ae93a4">

