### PR TITLE
Fix outdated import statement

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -48,7 +48,8 @@ You can render an Airflow Task Group using the ``DbtTaskGroup`` class. Here's an
 
     from airflow import DAG
     from airflow.operators.empty import EmptyOperator
-    from cosmos.task_group import DbtTaskGroup
+    from cosmos import DbtTaskGroup
+
 
     profile_config = ProfileConfig(
         profile_name="default",


### PR DESCRIPTION
Before 1.0 this was valid:

```
    from cosmos.task_group import DbtTaskGroup
```

Now we expect users to do:
```
    from cosmos import DbtTaskGroup
```
