### PR TITLE
Improve CI tests runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -174,32 +174,3 @@ jobs:
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       DATABRICKS_WAREHOUSE_ID: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
       DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
-
-  Code-Coverage:
-    if: github.event.action != 'labeled'
-    needs:
-      - Run-Unit-Tests
-      - Run-Integration-Tests
-      - Run-Integration-Tests-Expensive
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - name: Set up Python 3.10
-        uses: actions/setup-python@v3
-        with:
-          python-version: '3.10'
-      - name: Install coverage
-        run: |
-          pip3 install coverage
-      - name: Download all artifacts
-        uses: actions/download-artifact@v2
-      - name: Run coverage
-        run: |
-          coverage combine ./coverage/coverage*/.coverage
-          coverage report
-          coverage xml
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v3
-        with:
-          fail_ci_if_error: true
-          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,11 +54,9 @@ jobs:
         airflow-version: ["2.3", "2.4", "2.5", "2.6"]
     services:
       postgres:
-        # Docker Hub image
         image: postgres
         env:
           POSTGRES_PASSWORD: postgres
-        # Set health checks to wait until postgres has started
         options: >-
           --health-cmd pg_isready
           --health-interval 10s
@@ -110,6 +108,18 @@ jobs:
       matrix:
         python-version: ["3.10"]
         airflow-version: ["2.6"]
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     if: >-
       github.event_name == 'push' ||
       (
@@ -164,3 +174,32 @@ jobs:
       DATABRICKS_TOKEN: ${{ secrets.DATABRICKS_TOKEN }}
       DATABRICKS_WAREHOUSE_ID: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
       DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
+
+  Code-Coverage:
+    if: github.event.action != 'labeled'
+    needs:
+      - Run-Unit-Tests
+      - Run-Integration-Tests
+      - Run-Integration-Tests-Expensive
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: '3.10'
+      - name: Install coverage
+        run: |
+          pip3 install coverage
+      - name: Download all artifacts
+        uses: actions/download-artifact@v2
+      - name: Run coverage
+        run: |
+          coverage combine ./coverage/coverage*/.coverage
+          coverage report
+          coverage xml
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v3
+        with:
+          fail_ci_if_error: true
+          token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
             ~/.cache/pip
             .nox
           key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-          
+
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,12 @@ jobs:
         airflow-version: ["2.3", "2.4", "2.5", "2.6"]
     steps:
       - uses: actions/checkout@v3
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -62,7 +68,12 @@ jobs:
           - 5432:5432
     steps:
       - uses: actions/checkout@v3
-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
         with:
@@ -112,7 +123,12 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         if: github.event_name != 'pull_request_target'
-
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .nox
+          key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
       - name: Checkout pull/${{ github.event.number }}
         uses: actions/checkout@v3
         with:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,7 +162,7 @@ test-integration = """pytest -vv \
 --cov-report=xml \
 --durations=0 \
 -m integration  \
--k 'not test_example_dag[example_cosmos_python_models]'
+-k 'not (test_example_dag[example_cosmos_python_models] or test_example_dag[example_virtualenv])'
 """
 test-integration-expensive = """pytest -vv \
 --cov=cosmos \
@@ -170,7 +170,7 @@ test-integration-expensive = """pytest -vv \
 --cov-report=xml \
 --durations=0 \
 -m integration  \
--k 'test_example_dag[example_cosmos_python_models]'"""
+-k 'test_example_dag[example_cosmos_python_models] or test_example_dag[example_virtualenv])'"""
 
 [tool.pytest.ini_options]
 filterwarnings = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,7 +170,7 @@ test-integration-expensive = """pytest -vv \
 --cov-report=xml \
 --durations=0 \
 -m integration  \
--k 'test_example_dag[example_cosmos_python_models] or test_example_dag[example_virtualenv])'"""
+-k 'test_example_dag[example_cosmos_python_models] or test_example_dag[example_virtualenv]'"""
 
 [tool.pytest.ini_options]
 filterwarnings = [


### PR DESCRIPTION
Before, Cosmos CI took approximately [18m 7s](https://github.com/astronomer/astronomer-cosmos/actions/runs/5823294146/usage) to run its tests since it did not cache the dependencies.

Configure cache so the CI workers do not have to install all pip dependencies at each CI job run.

Reduces test runtime to approximately [12m-14m](https://github.com/astronomer/astronomer-cosmos/actions/runs/5854886292), resulting in ~ 20-30% time savings to run tests in the CI.
