### PR TITLE
Fix bug on select node add exclude selector subset ids logic 

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -42,6 +42,10 @@ class SelectorConfig:
         self.config: dict[str, str] = {}
         self.other: list[str] = []
         self.load_from_statement(statement)
+        self.is_config_empty: bool = False
+
+        if not self.paths and not self.tags and not self.config and not self.other:
+            self.is_config_empty = True
 
     def load_from_statement(self, statement: str) -> None:
         """
@@ -85,7 +89,7 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     """
     selected_nodes = set()
     for node_id, node in nodes.items():
-        if not config.paths and not config.tags and not config.config:
+        if config.is_config_empty:
             continue
 
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -88,10 +88,8 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     https://docs.getdbt.com/reference/node-selection/yaml-selectors
     """
     selected_nodes = set()
-    for node_id, node in nodes.items():
-        if config.is_empty_config:
-            continue
-
+    if not config.is_empty_config:    
+        for node_id, node in nodes.items():
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):
             continue
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -88,8 +88,8 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     https://docs.getdbt.com/reference/node-selection/yaml-selectors
     """
     selected_nodes = set()
-    if not config.is_empty:
-        for node_id, node in nodes.items():
+    for node_id, node in nodes.items():
+        if not config.is_empty:
             if config.tags and not (sorted(node.tags) == sorted(config.tags)):
                 continue
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 from pathlib import Path
+import copy
 
 from typing import TYPE_CHECKING
 
@@ -88,22 +89,24 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     https://docs.getdbt.com/reference/node-selection/yaml-selectors
     """
     selected_nodes = set()
-    for node_id, node in nodes.items():
-        if not config.is_empty:
+
+    if not config.is_empty:
+        for node_id, node in nodes.items():
             if config.tags and not (sorted(node.tags) == sorted(config.tags)):
                 continue
 
             supported_node_config = {key: value for key, value in node.config.items() if key in SUPPORTED_CONFIG}
+            config_tag = config.config.get("tags")
             if config.config:
-                config_tag = config.config.get("tags")
                 if config_tag and config_tag not in supported_node_config.get("tags", []):
                     continue
 
                 # Remove 'tags' as they've already been filtered for
-                config.config.pop("tags", None)
+                config_copy = copy.deepcopy(config.config)
+                config_copy.pop("tags", None)
                 supported_node_config.pop("tags", None)
 
-                if not (config.config.items() <= supported_node_config.items()):
+                if not (config_copy.items() <= supported_node_config.items()):
                     continue
 
             if config.paths and not (set(config.paths).issubset(set(node.file_path.parents))):

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -42,10 +42,6 @@ class SelectorConfig:
         self.config: dict[str, str] = {}
         self.other: list[str] = []
         self.load_from_statement(statement)
-        self.is_config_empty: bool = False
-
-        if not self.paths and not self.tags and not self.config and not self.other:
-            self.is_config_empty = True
 
     def load_from_statement(self, statement: str) -> None:
         """
@@ -89,9 +85,6 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     """
     selected_nodes = set()
     for node_id, node in nodes.items():
-        if config.is_config_empty:
-            continue
-
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):
             continue
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -88,7 +88,7 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     https://docs.getdbt.com/reference/node-selection/yaml-selectors
     """
     selected_nodes = set()
-    if not config.is_empty_config:    
+    if not config.is_empty_config:
         for node_id, node in nodes.items():
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):
             continue

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -85,6 +85,9 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     """
     selected_nodes = set()
     for node_id, node in nodes.items():
+        if not config.paths and not config.tags and not config.config:
+            continue
+
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):
             continue
 
@@ -166,9 +169,10 @@ def select_nodes(
 
     nodes_ids = set(nodes.keys())
 
+    exclude_ids: set[str] = set()
     for statement in exclude:
         config = SelectorConfig(project_dir, statement)
-        exclude_ids = select_nodes_ids_by_intersection(nodes, config)
+        exclude_ids = exclude_ids.union(set(select_nodes_ids_by_intersection(nodes, config)))
         subset_ids = set(nodes_ids) - set(exclude_ids)
 
     return {id_: nodes[id_] for id_ in subset_ids}

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -43,6 +43,10 @@ class SelectorConfig:
         self.other: list[str] = []
         self.load_from_statement(statement)
 
+    @property
+    def is_empty_config(self) -> bool:
+        return not self.paths and not self.tags and not self.config and not self.other
+
     def load_from_statement(self, statement: str) -> None:
         """
         Load in-place select parameters.
@@ -85,6 +89,9 @@ def select_nodes_ids_by_intersection(nodes: dict[str, DbtNode], config: Selector
     """
     selected_nodes = set()
     for node_id, node in nodes.items():
+        if config.is_empty_config:
+            continue
+
         if config.tags and not (sorted(node.tags) == sorted(config.tags)):
             continue
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -35,7 +35,7 @@ def test_is_empty_config(selector_config, paths, tags, config, other, expected):
     selector_config.config = config
     selector_config.other = other
 
-    assert selector_config.is_empty_config == expected
+    assert selector_config.is_empty == expected
 
 
 grandparent_node = DbtNode(

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -86,8 +86,6 @@ def test_select_nodes_by_select_config_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child"])
     expected = {
         child_node.unique_id: child_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
     }
     assert selected == expected
 
@@ -140,6 +138,8 @@ def test_select_nodes_by_select_union():
         grandparent_node.unique_id: grandparent_node,
         parent_node.unique_id: parent_node,
         child_node.unique_id: child_node,
+        grandchild_1_test_node.unique_id: grandchild_1_test_node,
+        grandchild_2_test_node.unique_id: grandchild_2_test_node,
     }
     assert selected == expected
 
@@ -152,6 +152,7 @@ def test_select_nodes_by_select_intersection():
 def test_select_nodes_by_exclude_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["tag:has_child"])
     expected = {
+        child_node.unique_id: child_node,
         grandchild_1_test_node.unique_id: grandchild_1_test_node,
         grandchild_2_test_node.unique_id: grandchild_2_test_node,
     }

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -37,10 +37,32 @@ child_node = DbtNode(
     config={"materialized": "table", "tags": ["is_child"]},
 )
 
+grandchild_1_test_node = DbtNode(
+    name="grandchild_1",
+    unique_id="grandchild_1",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=["parent"],
+    file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_1.sql",
+    tags=["nightly"],
+    config={"materialized": "table", "tags": ["deprecated", "test"]},
+)
+
+grandchild_2_test_node = DbtNode(
+    name="grandchild_2",
+    unique_id="grandchild_2",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=["parent"],
+    file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_2.sql",
+    tags=["nightly"],
+    config={"materialized": "table", "tags": ["deprecated", "test2"]},
+)
+
 sample_nodes = {
     grandparent_node.unique_id: grandparent_node,
     parent_node.unique_id: parent_node,
     child_node.unique_id: child_node,
+    grandchild_1_test_node.unique_id: grandchild_1_test_node,
+    grandchild_2_test_node.unique_id: grandchild_2_test_node,
 }
 
 
@@ -52,13 +74,21 @@ def test_select_nodes_by_select_tag():
 
 def test_select_nodes_by_select_config():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.materialized:table"])
-    expected = {child_node.unique_id: child_node}
+    expected = {
+        child_node.unique_id: child_node,
+        grandchild_1_test_node.unique_id: grandchild_1_test_node,
+        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+    }
     assert selected == expected
 
 
 def test_select_nodes_by_select_config_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child"])
-    expected = {child_node.unique_id: child_node}
+    expected = {
+        child_node.unique_id: child_node,
+        grandchild_1_test_node.unique_id: grandchild_1_test_node,
+        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+    }
     assert selected == expected
 
 
@@ -70,6 +100,21 @@ def test_select_nodes_by_select_union_config_tag():
         grandparent_node.unique_id: grandparent_node,
         parent_node.unique_id: parent_node,
         child_node.unique_id: child_node,
+    }
+    assert selected == expected
+
+
+def test_select_nodes_by_select_union_config_test_tags():
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH,
+        nodes=sample_nodes,
+        select=["config.tags:test", "config.tags:test2", "config.materialized:view"],
+    )
+    expected = {
+        grandparent_node.unique_id: grandparent_node,
+        parent_node.unique_id: parent_node,
+        grandchild_1_test_node.unique_id: grandchild_1_test_node,
+        grandchild_2_test_node.unique_id: grandchild_2_test_node,
     }
     assert selected == expected
 
@@ -106,7 +151,10 @@ def test_select_nodes_by_select_intersection():
 
 def test_select_nodes_by_exclude_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["tag:has_child"])
-    expected = {child_node.unique_id: child_node}
+    expected = {
+        grandchild_1_test_node.unique_id: grandchild_1_test_node,
+        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+    }
     assert selected == expected
 
 
@@ -121,4 +169,16 @@ def test_select_nodes_by_select_union_exclude_tags():
         project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.materialized:view"], exclude=["tag:has_child"]
     )
     expected = {}
+    assert selected == expected
+
+
+def test_select_nodes_by_exclude_union_config_test_tags():
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["config.tags:test", "config.tags:test2"]
+    )
+    expected = {
+        grandparent_node.unique_id: grandparent_node,
+        parent_node.unique_id: parent_node,
+        child_node.unique_id: child_node,
+    }
     assert selected == expected

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -2,12 +2,41 @@ from pathlib import Path
 
 import pytest
 
+from cosmos.dbt.selector import SelectorConfig
 from cosmos.constants import DbtResourceType
 from cosmos.dbt.graph import DbtNode
 from cosmos.dbt.selector import select_nodes
 from cosmos.exceptions import CosmosValueError
 
 SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
+
+
+@pytest.fixture
+def selector_config():
+    project_dir = Path("/path/to/project")
+    statement = ""
+    return SelectorConfig(project_dir, statement)
+
+
+@pytest.mark.parametrize(
+    "paths, tags, config, other, expected",
+    [
+        ([], [], {}, [], True),
+        ([Path("path1")], [], {}, [], False),
+        ([], ["tag:has_child"], {}, [], False),
+        ([], [], {"config.tags:test"}, [], False),
+        ([], [], {}, ["other"], False),
+        ([Path("path1")], ["tag:has_child"], {"config.tags:test"}, ["other"], False),
+    ],
+)
+def test_is_empty_config(selector_config, paths, tags, config, other, expected):
+    selector_config.paths = paths
+    selector_config.tags = tags
+    selector_config.config = config
+    selector_config.other = other
+
+    assert selector_config.is_empty_config == expected
+
 
 grandparent_node = DbtNode(
     name="grandparent",


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

1. Add Skip case if all configs are None
2. Exclude subset id to not be overwrite as it iterates
3. Add more test cases

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
It closes: https://github.com/astronomer/astronomer-cosmos/issues/464

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
