### PR TITLE
Docs: fix RenderConfig load argument

### DIFF
--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -48,7 +48,7 @@ To use this:
             manifest_path="/path/to/manifest.json",
         ),
         render_config=RenderConfig(
-            load_mode=LoadMode.DBT_MANIFEST,
+            load_method=LoadMode.DBT_MANIFEST,
         )
         # ...,
     )
@@ -70,7 +70,7 @@ To use this:
 
     DbtDag(
         render_config=RenderConfig(
-            load_mode=LoadMode.DBT_LS,
+            load_method=LoadMode.DBT_LS,
         )
         # ...,
     )
@@ -92,7 +92,7 @@ To use this:
 
     DbtDag(
         render_config=RenderConfig(
-            load_mode=LoadMode.CUSTOM,
+            load_method=LoadMode.CUSTOM,
         )
         # ...,
     )


### PR DESCRIPTION
## Description

The docs currently reference `load_mode` for `RenderConfig` when it should be [load_method](https://github.com/astronomer/astronomer-cosmos/blob/c238a0b3d23688172495d5c391cdb51cf296e2d7/cosmos/config.py#L37).

## Related Issue(s)
 None
<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?
No
<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
