### PR TITLE
Fix forks code revision in code coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -206,6 +206,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
The code coverage report was being shown incorrectly for PRs derived from forks, as seen in the PR https://github.com/astronomer/astronomer-cosmos/pull/471

Incorrect parts of the code were highlighted:

![Screenshot 2023-08-16 at 11 25 27](https://github.com/astronomer/astronomer-cosmos/assets/272048/b657e7a2-4c35-4869-a99d-56d4ddc3c823)

Reference:
https://app.codecov.io/gh/astronomer/astronomer-cosmos/pull/471?src=pr&el=tree&utm_medium=referral&utm_source=github&utm_content=comment&utm_campaign=pr+comments&utm_term=astronomer#diff-Y29zbW9zL3Byb2ZpbGVzL2JpZ3F1ZXJ5L3NlcnZpY2VfYWNjb3VudF9rZXlmaWxlX2RpY3QucHk=
