### PR TITLE
Add Airflow 2.7 to the testing matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -67,7 +67,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.7", "3.8", "3.9", "3.10"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
     services:
       postgres:
         image: postgres

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -136,7 +136,7 @@ dependencies = [
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.7", "3.8", "3.9", "3.10"]
-airflow = ["2.3", "2.4", "2.5", "2.6"]
+airflow = ["2.3", "2.4", "2.5", "2.6", "2.7"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [
@@ -144,6 +144,7 @@ matrix.airflow.dependencies = [
     { value = "apache-airflow==2.4", if = ["2.4"] },
     { value = "apache-airflow==2.5", if = ["2.5"] },
     { value = "apache-airflow==2.6", if = ["2.6"] },
+    { value = "apache-airflow==2.7", if = ["2.7"] },
 ]
 
 [tool.hatch.envs.tests.scripts]


### PR DESCRIPTION
Make sure Cosmos is compliant with the recently released Apache Airflow 2.7.