### PR TITLE
Refactor dbt ls to run from tempdir with symbolic links

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -115,14 +115,18 @@ jobs:
           DATABRICKS_WAREHOUSE_ID: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
           DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: public
+          POSTGRES_SCHEMA: dbt_example
+          POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v2
         with:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
-
-
 
   Run-Integration-Tests-Expensive:
     needs: Authorize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -118,8 +118,8 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: public
-          POSTGRES_SCHEMA: dbt_example
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
@@ -187,8 +187,8 @@ jobs:
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: public
-          POSTGRES_SCHEMA: dbt_example
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -184,6 +184,12 @@ jobs:
           DATABRICKS_WAREHOUSE_ID: ${{ secrets.DATABRICKS_WAREHOUSE_ID }}
           DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: public
+          POSTGRES_SCHEMA: dbt_example
+          POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v2

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -7,7 +7,9 @@ DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
 DEFAULT_DBT_TARGET_NAME = "cosmos_target"
 DBT_LOG_PATH_ENVVAR = "DBT_LOG_PATH"
+DBT_LOG_DIR_NAME = "logs"
 DBT_TARGET_PATH_ENVVAR = "DBT_TARGET_PATH"
+DBT_TARGET_DIR_NAME = "target"
 DBT_LOG_FILENAME = "dbt.log"
 
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -205,7 +205,7 @@ class DbtGraph:
                         for line in logfile:
                             logger.debug(line.strip())
 
-                if stderr or "error" in stdout.lower():
+                if stderr or "Error" in stdout:
                     details = stderr or stdout
                     raise CosmosLoadDbtException(f"Unable to run the command due to the error:\n{details}")
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -16,6 +16,9 @@ from cosmos.constants import (
     LoadMode,
     DBT_LOG_FILENAME,
     DBT_LOG_PATH_ENVVAR,
+    DBT_TARGET_PATH_ENVVAR,
+    DBT_LOG_DIR_NAME,
+    DBT_TARGET_DIR_NAME,
 )
 from cosmos.dbt.executable import get_system_dbt
 from cosmos.dbt.parser.project import DbtProject as LegacyDbtProject
@@ -159,7 +162,7 @@ class DbtGraph:
                 # This allows us to run the dbt command from within the temporary directory, outputting any necessary
                 # artifact and also allow us to run `dbt deps`
                 tmpdir_path = Path(tmpdir)
-                ignore_paths = ("target", "logs")
+                ignore_paths = (DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME)
                 for child_name in os.listdir(self.project.dir):
                     if child_name not in ignore_paths:
                         os.symlink(self.project.dir / child_name, tmpdir_path / child_name)
@@ -178,7 +181,10 @@ class DbtGraph:
                 )
                 logger.info("Running command: `%s`", " ".join(command))
                 logger.info("Environment variable keys: %s", env.keys())
-                log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir)
+                log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir_path / DBT_LOG_DIR_NAME)
+                target_dir = Path(env.get(DBT_TARGET_PATH_ENVVAR) or tmpdir_path / DBT_TARGET_DIR_NAME)
+                env[DBT_LOG_PATH_ENVVAR] = str(log_dir)
+                env[DBT_TARGET_PATH_ENVVAR] = str(target_dir)
 
                 process = Popen(
                     command,

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -162,7 +162,7 @@ class DbtGraph:
                 # This allows us to run the dbt command from within the temporary directory, outputting any necessary
                 # artifact and also allow us to run `dbt deps`
                 tmpdir_path = Path(tmpdir)
-                ignore_paths = (DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME)
+                ignore_paths = (DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, "profiles.yml")
                 for child_name in os.listdir(self.project.dir):
                     if child_name not in ignore_paths:
                         os.symlink(self.project.dir / child_name, tmpdir_path / child_name)

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -205,7 +205,7 @@ class DbtGraph:
                         for line in logfile:
                             logger.debug(line.strip())
 
-                if stderr or "Error" in stdout:
+                if stderr or "error" in stdout.lower():
                     details = stderr or stdout
                     raise CosmosLoadDbtException(f"Unable to run the command due to the error:\n{details}")
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -157,7 +157,7 @@ class DbtGraph:
             env.update(env_vars)
 
             with tempfile.TemporaryDirectory() as tmpdir:
-                logger.info("Creating symlinks to the project from: `%s`", tmpdir)
+                logger.info("Creating symlinks from %s to `%s`", self.project.dir, tmpdir)
                 # We create symbolic links to the original directory files and directories.
                 # This allows us to run the dbt command from within the temporary directory, outputting any necessary
                 # artifact and also allow us to run `dbt deps`

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -172,6 +172,7 @@ def test_load_via_dbt_ls_with_exclude():
             ),
         ),
     )
+
     dbt_graph.load_via_dbt_ls()
     assert dbt_graph.nodes == dbt_graph.filtered_nodes
     assert len(dbt_graph.nodes) == 7


### PR DESCRIPTION
Since Cosmos 1.0, `load_method.DBT_LS` is the default dbt project parsing method, unless the user gives a manifest.

Using the original dbt project path has been a source of issues when that path is Read-Only. This issue was faced when running commands that generate `{project-dir}/target/` and `{project-dir}/logs/`, which was solved as part of #414.

This issue is particularly problematic if we want to run `dbt deps` from the original project directory since dbt 1.6 saves adaptors to `{project_dir}/dbt_packages` unless specified in the user's `dbt_project.yml`. To our knowledge, dbt currently does not allow users to define this directory via flags or environment variables, as discussed in #481.

This change aims to solve these issues, by creating a temporary directory and creating symbolic links to the original directory.

Finally, during the development of this task, it was observed that when running dbt ls in a project with `packages.yml`,  dbt raises a 'Compilation Error'. Since dbt may raise other errors in stdout, this PR captures "Errors" more generically - making it more evident potential issues to the end-users.
