### PR TITLE
Parse DAGs with no connections (offline)

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -149,7 +149,7 @@ class DbtGraph:
         if self.select:
             command.extend(["--select", *self.select])
 
-        with self.profile_config.ensure_profile() as profile_values:
+        with self.profile_config.ensure_profile(use_mock_values=True) as profile_values:
             (profile_path, env_vars) = profile_values
             command.extend(
                 [

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -144,7 +144,7 @@ class BaseProfileMapping(ABC):
             logger.info("Using mock values for profile %s")
         else:
             profile_vars = self.profile
-            logger.info("Using real values for profile %s")
+            logger.info("Using real values for profile %s", profile_name)
 
         # filter out any null values
         profile_vars = {k: v for k, v in profile_vars.items() if v is not None}

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -141,7 +141,7 @@ class BaseProfileMapping(ABC):
         """
         if use_mock_values:
             profile_vars = self.mock_profile
-            logger.info("Using mock values for profile %s")
+            logger.info("Using mock values for profile %s", profile_name)
         else:
             profile_vars = self.profile
             logger.info("Using real values for profile %s", profile_name)

--- a/cosmos/profiles/bigquery/oauth.py
+++ b/cosmos/profiles/bigquery/oauth.py
@@ -16,6 +16,8 @@ class GoogleCloudOauthProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "google_cloud_platform"
+    dbt_profile_type: str = "bigquery"
+    dbt_profile_method: str = "oauth"
 
     required_fields = [
         "project",
@@ -32,8 +34,17 @@ class GoogleCloudOauthProfileMapping(BaseProfileMapping):
         "Generates profile. Defaults `threads` to 1."
         return {
             **self.mapped_params,
-            "type": "bigquery",
             "method": "oauth",
             "threads": 1,
             **self.profile_args,
+        }
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        "Generates mock profile. Defaults `threads` to 1."
+        parent_mock_profile = super().mock_profile
+
+        return {
+            **parent_mock_profile,
+            "threads": 1,
         }

--- a/cosmos/profiles/bigquery/service_account_file.py
+++ b/cosmos/profiles/bigquery/service_account_file.py
@@ -15,6 +15,8 @@ class GoogleCloudServiceAccountFileProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "google_cloud_platform"
+    dbt_profile_type: str = "bigquery"
+    dbt_profile_method: str = "service-account"
 
     required_fields = [
         "project",
@@ -33,8 +35,16 @@ class GoogleCloudServiceAccountFileProfileMapping(BaseProfileMapping):
         "Generates profile. Defaults `threads` to 1."
         return {
             **self.mapped_params,
-            "type": "bigquery",
-            "method": "service-account",
             "threads": 1,
             **self.profile_args,
+        }
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        "Generates mock profile. Defaults `threads` to 1."
+        parent_mock_profile = super().mock_profile
+
+        return {
+            **parent_mock_profile,
+            "threads": 1,
         }

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -17,6 +17,8 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "google_cloud_platform"
+    dbt_profile_type: str = "bigquery"
+    dbt_profile_method: str = "service-account-json"
 
     required_fields = [
         "project",
@@ -45,10 +47,18 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         """
         return {
             **self.mapped_params,
-            "type": "bigquery",
-            "method": "service-account-json",
             "threads": 1,
             **self.profile_args,
+        }
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        "Generates mock profile. Defaults `threads` to 1."
+        parent_mock_profile = super().mock_profile
+
+        return {
+            **parent_mock_profile,
+            "threads": 1,
         }
 
     def transform_keyfile_json(self, keyfile_json: str | dict[str, str]) -> dict[str, str]:

--- a/cosmos/profiles/databricks/token.py
+++ b/cosmos/profiles/databricks/token.py
@@ -15,6 +15,7 @@ class DatabricksTokenProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "databricks"
+    dbt_profile_type: str = "databricks"
 
     required_fields = [
         "host",
@@ -39,7 +40,6 @@ class DatabricksTokenProfileMapping(BaseProfileMapping):
         "Generates profile. The token is stored in an environment variable."
         return {
             **self.mapped_params,
-            "type": "databricks",
             **self.profile_args,
             # token should always get set as env var
             "token": self.get_env_var_format("token"),

--- a/cosmos/profiles/exasol/user_pass.py
+++ b/cosmos/profiles/exasol/user_pass.py
@@ -13,6 +13,7 @@ class ExasolUserPasswordProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "exasol"
+    dbt_profile_type: str = "exasol"
     is_community: bool = True
 
     default_port: int = 8563
@@ -47,7 +48,6 @@ class ExasolUserPasswordProfileMapping(BaseProfileMapping):
         "Gets profile. The password is stored in an environment variable."
         profile_vars = {
             **self.mapped_params,
-            "type": "exasol",
             **self.profile_args,
             # password should always get set as env var
             "password": self.get_env_var_format("password"),

--- a/cosmos/profiles/postgres/user_pass.py
+++ b/cosmos/profiles/postgres/user_pass.py
@@ -14,6 +14,7 @@ class PostgresUserPasswordProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "postgres"
+    dbt_profile_type: str = "postgres"
 
     required_fields = [
         "host",
@@ -40,7 +41,6 @@ class PostgresUserPasswordProfileMapping(BaseProfileMapping):
         "Gets profile. The password is stored in an environment variable."
         profile = {
             **self.mapped_params,
-            "type": "postgres",
             "port": 5432,
             **self.profile_args,
             # password should always get set as env var
@@ -48,3 +48,13 @@ class PostgresUserPasswordProfileMapping(BaseProfileMapping):
         }
 
         return self.filter_null(profile)
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        "Gets mock profile. Defaults port to 5432."
+        parent_mock = super().mock_profile
+
+        return {
+            **parent_mock,
+            "port": 5432,
+        }

--- a/cosmos/profiles/redshift/user_pass.py
+++ b/cosmos/profiles/redshift/user_pass.py
@@ -14,6 +14,7 @@ class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "redshift"
+    dbt_profile_type: str = "redshift"
 
     required_fields = [
         "host",
@@ -41,7 +42,6 @@ class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
         "Gets profile."
         profile = {
             **self.mapped_params,
-            "type": "redshift",
             "port": 5439,
             **self.profile_args,
             # password should always get set as env var
@@ -49,3 +49,13 @@ class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
         }
 
         return self.filter_null(profile)
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        "Gets mock profile. Defaults port to 5439."
+        parent_mock = super().mock_profile
+
+        return {
+            **parent_mock,
+            "port": 5439,
+        }

--- a/cosmos/profiles/snowflake/user_pass.py
+++ b/cosmos/profiles/snowflake/user_pass.py
@@ -18,6 +18,7 @@ class SnowflakeUserPasswordProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "snowflake"
+    dbt_profile_type: str = "snowflake"
 
     required_fields = [
         "account",
@@ -64,7 +65,6 @@ class SnowflakeUserPasswordProfileMapping(BaseProfileMapping):
         "Gets profile."
         profile_vars = {
             **self.mapped_params,
-            "type": "snowflake",
             **self.profile_args,
             # password should always get set as env var
             "password": self.get_env_var_format("password"),

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -18,6 +18,7 @@ class SnowflakePrivateKeyPemProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "snowflake"
+    dbt_profile_type: str = "snowflake"
     is_community: bool = True
 
     required_fields = [
@@ -65,7 +66,6 @@ class SnowflakePrivateKeyPemProfileMapping(BaseProfileMapping):
         "Gets profile."
         profile_vars = {
             **self.mapped_params,
-            "type": "snowflake",
             **self.profile_args,
             # private_key should always get set as env var
             "private_key_content": self.get_env_var_format("private_key_content"),

--- a/cosmos/profiles/spark/thrift.py
+++ b/cosmos/profiles/spark/thrift.py
@@ -14,6 +14,8 @@ class SparkThriftProfileMapping(BaseProfileMapping):
     """
 
     airflow_connection_type: str = "spark"
+    dbt_profile_type: str = "spark"
+    dbt_profile_method: str = "thrift"
     is_community: bool = True
 
     required_fields = [
@@ -33,8 +35,6 @@ class SparkThriftProfileMapping(BaseProfileMapping):
         """
         profile_vars = {
             **self.mapped_params,
-            "type": "spark",
-            "method": "thrift",
             **self.profile_args,
         }
 

--- a/cosmos/profiles/trino/base.py
+++ b/cosmos/profiles/trino/base.py
@@ -10,6 +10,7 @@ class TrinoBaseProfileMapping(BaseProfileMapping):
     "Maps common fields for Airflow Trino connections to dbt profiles."
 
     airflow_connection_type: str = "trino"
+    dbt_profile_type: str = "trino"
     is_community: bool = True
 
     required_fields = [
@@ -30,7 +31,6 @@ class TrinoBaseProfileMapping(BaseProfileMapping):
         "Gets profile."
         profile_vars = {
             **self.mapped_params,
-            "type": "trino",
             **self.profile_args,
         }
 

--- a/cosmos/profiles/trino/certificate.py
+++ b/cosmos/profiles/trino/certificate.py
@@ -13,6 +13,8 @@ class TrinoCertificateProfileMapping(TrinoBaseProfileMapping):
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 
+    dbt_profile_method: str = "certificate"
+
     required_fields = TrinoBaseProfileMapping.required_fields + [
         "client_certificate",
         "client_private_key",
@@ -31,7 +33,6 @@ class TrinoCertificateProfileMapping(TrinoBaseProfileMapping):
         profile_vars = {
             **self.mapped_params,
             **common_profile_vars,
-            "method": "certificate",
             **self.profile_args,
         }
 

--- a/cosmos/profiles/trino/jwt.py
+++ b/cosmos/profiles/trino/jwt.py
@@ -14,6 +14,8 @@ class TrinoJWTProfileMapping(TrinoBaseProfileMapping):
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 
+    dbt_profile_method: str = "jwt"
+
     required_fields = TrinoBaseProfileMapping.required_fields + [
         "jwt_token",
     ]
@@ -36,7 +38,6 @@ class TrinoJWTProfileMapping(TrinoBaseProfileMapping):
 
         profile_vars = {
             **common_profile_vars,
-            "method": "jwt",
             **profile_args,
             # jwt_token should always get set as env var
             "jwt_token": self.get_env_var_format("jwt_token"),

--- a/cosmos/profiles/trino/ldap.py
+++ b/cosmos/profiles/trino/ldap.py
@@ -14,6 +14,8 @@ class TrinoLDAPProfileMapping(TrinoBaseProfileMapping):
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 
+    dbt_profile_method: str = "ldap"
+
     required_fields = TrinoBaseProfileMapping.required_fields + [
         "user",
         "password",
@@ -36,7 +38,6 @@ class TrinoLDAPProfileMapping(TrinoBaseProfileMapping):
         profile_vars = {
             **self.mapped_params,
             **common_profile_vars,
-            "method": "ldap",
             **self.profile_args,
             # password should always get set as env var
             "password": self.get_env_var_format("password"),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -148,8 +148,8 @@ matrix.airflow.dependencies = [
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"
-test = 'pytest -vv --durations=0 . -m "not integration" --ignore=tests/test_example_dags.py'
-test-cov = 'pytest -vv --cov=cosmos --cov-report=term-missing --cov-report=xml --durations=0 -m "not integration" --ignore=tests/test_example_dags.py'
+test = 'pytest -vv --durations=0 . -m "not integration" --ignore=tests/test_example_dags.py --ignore=tests/test_example_dags_no_connections.py'
+test-cov = 'pytest -vv --cov=cosmos --cov-report=term-missing --cov-report=xml --durations=0 -m "not integration" --ignore=tests/test_example_dags.py --ignore=tests/test_example_dags_no_connections.py'
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
 test-integration-setup = """pip uninstall dbt-postgres; \

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -5,11 +5,8 @@ from pathlib import Path
 import airflow
 import pytest
 from airflow.models.dagbag import DagBag
-from airflow.utils.db import create_default_connections
-from airflow.utils.session import provide_session
 from packaging.version import Version
 
-from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -48,6 +48,7 @@ def get_dag_ids() -> list[str]:
     return dag_bag.dag_ids
 
 
+@pytest.mark.integration
 @pytest.mark.parametrize("dag_id", get_dag_ids())
 def test_parse_dags_without_connections(dag_id: str):
     dag_bag = get_dag_bag()

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+import airflow
+import pytest
+from airflow.models.dagbag import DagBag
+from airflow.utils.db import create_default_connections
+from airflow.utils.session import provide_session
+from packaging.version import Version
+
+from . import utils as test_utils
+
+EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
+AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
+
+MIN_VER_DAG_FILE: dict[str, list[str]] = {
+    "2.4": ["cosmos_seed_dag.py"],
+}
+
+# Sort descending based on Versions and convert string to an actual version
+MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
+    Version(version): MIN_VER_DAG_FILE[version] for version in sorted(MIN_VER_DAG_FILE, key=Version, reverse=True)
+}
+
+
+def get_dag_bag() -> DagBag:
+    """Create a DagBag by adding the files that are not supported to .airflowignore"""
+    with open(AIRFLOW_IGNORE_FILE, "w+") as file:
+        for min_version, files in MIN_VER_DAG_FILE_VER.items():
+            if Version(airflow.__version__) < min_version:
+                print(f"Adding {files} to .airflowignore")
+                file.writelines([f"{file_name}\n" for file_name in files])
+
+        # cosmos_profile_mapping uses the automatic profile rendering from an Airflow connection.
+        # so we can't parse that without live connections
+        for file_name in ["cosmos_profile_mapping.py"]:
+            print(f"Adding {file_name} to .airflowignore")
+            file.write(f"{file_name}\n")
+
+    print(".airflowignore contents: ")
+    print(AIRFLOW_IGNORE_FILE.read_text())
+    db = DagBag(EXAMPLE_DAGS_DIR, include_examples=False)
+    assert db.dags
+    assert not db.import_errors
+    return db
+
+
+def get_dag_ids() -> list[str]:
+    dag_bag = get_dag_bag()
+    return dag_bag.dag_ids
+
+
+@pytest.mark.parametrize("dag_id", get_dag_ids())
+def test_parse_dags_without_connections(dag_id: str):
+    dag_bag = get_dag_bag()
+
+    assert dag_bag.dags
+    assert not dag_bag.import_errors
+
+    dag = dag_bag.get_dag(dag_id)
+    assert dag is not None


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

Cosmos requires connections to be defined when using the `dbt_ls` parsing method. This is not ideal for 2 reasons:
1. Requiring connections for parsing DAGs is generally bad Airflow practice, as it requires reaching out to a secrets backend/Airflow metadata DB on every parse
2. Connections aren't set up in all environments, i.e. CI/CD

This PR fixes the issue by generating a mock profile when Cosmos is parsing (not executing) the DAG. This works for all but the automatic_profile_mapping, which requires a live connection.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
