### PR TITLE
update cosmos log color to purple

### DIFF
--- a/cosmos/log.py
+++ b/cosmos/log.py
@@ -8,7 +8,7 @@ LOG_FORMAT: str = (
     "[%(blue)s%(asctime)s%(reset)s] "
     "{%(blue)s%(filename)s:%(reset)s%(lineno)d} "
     "%(log_color)s%(levelname)s%(reset)s - "
-    "%(yellow)s(astronomer-cosmos)%(reset)s - "
+    "%(purple)s(astronomer-cosmos)%(reset)s - "
     "%(log_color)s%(message)s%(reset)s"
 )
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -4,7 +4,7 @@ from cosmos.log import get_logger
 
 
 def test_get_logger():
-    custom_string = "%(yellow)s(astronomer-cosmos)%(reset)s"
+    custom_string = "%(purple)s(astronomer-cosmos)%(reset)s"
     standard_logger = logging.getLogger()
     assert custom_string not in standard_logger.handlers[0].formatter._fmt
 


### PR DESCRIPTION
## Description

The previous color was the same as error messages and confusing to read the logs. Updating to purple.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

no, purely cosmetic.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
