### PR TITLE
Remove duplicate CI workflow when pushing changes to a PR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,7 @@ name: test
 on:
   push: # Run on pushes to the default branch
     branches: [main]
-  pull_request: # Run on pull requests targeting the default branch
-    branches: [main]
-  pull_request_target: # Run on pull requests originated from forks
+  pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 
 concurrency:


### PR DESCRIPTION
At the moment, whenever we push changes to a pull request, two Github Action workflows are created:
<img width="1092" alt="Screenshot 2023-08-30 at 16 04 39" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/d0cb5b4f-581b-4895-856b-3783834d05db">

This pull request aims to keep only one of them. 

Example of how the Github actions workflows look after this change:
<img width="567" alt="Screenshot 2023-08-30 at 16 08 45" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/aabe04e0-adb5-423a-8505-7bbde9f2f533">
