### PR TITLE
Fix incorrect temporary directory creation in VirtualenvOperator init

### DIFF
--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -50,7 +50,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         self.py_requirements = py_requirements or []
         self.py_system_site_packages = py_system_site_packages
         super().__init__(**kwargs)
-        self._venv_tmp_dir = TemporaryDirectory()
+        self._venv_tmp_dir: None | TemporaryDirectory[str] = None
 
     @cached_property
     def venv_dbt_path(

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -46,6 +46,8 @@ def test_run_command(
         py_system_site_packages=False,
         py_requirements=["dbt-postgres==1.6.0b1"],
     )
+    assert venv_operator._venv_tmp_dir is None  # Otherwise we are creating empty directories during DAG parsing time
+    # and not deleting them
     venv_operator.run_command(cmd=["fake-dbt", "do-something"], env={}, context={})
     run_command_args = mock_subprocess_hook.run_command.call_args_list
     assert len(run_command_args) == 3


### PR DESCRIPTION
As part of adding MyPy checks, we introduced an issue of creating temporary directories during the VirtualenvOperator initialization. This leads to Cosmos creating unnecessary empty temporary directories in the user scheduler during parse time.

Fixes: #484 