### PR TITLE
Update selector.py closes #506

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -160,7 +160,7 @@ def select_nodes(
             elif any([filter_parameter.startswith(CONFIG_SELECTOR + config + ":") for config in SUPPORTED_CONFIG]):
                 continue
             else:
-                raise CosmosValueError(f"Invalid {filter_type} filter: {filter_parameter}")
+                logger.warning(f"Invalid {filter_type} filter: {filter_parameter}")
 
     subset_ids: set[str] = set()
 


### PR DESCRIPTION

## Description

Only log from not supported filter, utill you figure how you would like to validate incomming selectors.
This PR at least allows selectors that are not taken into account by a validator like in case of LS LoadMode

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #506" -->

## Checklist

- [-] I have made corresponding changes to the documentation (if required)
- [-] I have added tests that prove my fix is effective or that my feature works - tested on my own airflow instance
