### PR TITLE
Fetch port from connection

### DIFF
--- a/cosmos/profiles/postgres/user_pass.py
+++ b/cosmos/profiles/postgres/user_pass.py
@@ -40,8 +40,8 @@ class PostgresUserPasswordProfileMapping(BaseProfileMapping):
     def profile(self) -> dict[str, Any | None]:
         "Gets profile. The password is stored in an environment variable."
         profile = {
-            **self.mapped_params,
             "port": 5432,
+            **self.mapped_params,
             **self.profile_args,
             # password should always get set as env var
             "password": self.get_env_var_format("password"),
@@ -55,6 +55,6 @@ class PostgresUserPasswordProfileMapping(BaseProfileMapping):
         parent_mock = super().mock_profile
 
         return {
-            **parent_mock,
             "port": 5432,
+            **parent_mock,
         }

--- a/cosmos/profiles/redshift/user_pass.py
+++ b/cosmos/profiles/redshift/user_pass.py
@@ -41,8 +41,8 @@ class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
     def profile(self) -> dict[str, Any | None]:
         "Gets profile."
         profile = {
-            **self.mapped_params,
             "port": 5439,
+            **self.mapped_params,
             **self.profile_args,
             # password should always get set as env var
             "password": self.get_env_var_format("password"),
@@ -56,6 +56,6 @@ class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
         parent_mock = super().mock_profile
 
         return {
-            **parent_mock,
             "port": 5439,
+            **parent_mock,
         }


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR fixes a bug that was introduced in Cosmos 1.0: the port was misplaced in the dictionary, causing the port to _always_ be fixed.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes #508

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
