### PR TITLE
Change operators to log ``dbt`` commands output as opposed to recording to XCom

### DIFF
--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -52,6 +52,10 @@ class DbtDockerBaseOperator(DockerOperator, DbtBaseOperator):  # type: ignore[mi
         self.environment = {**env_vars, **self.environment}  # type: ignore[has-type]
         self.command = dbt_cmd
 
+    def execute(self, context: Context) -> None:
+        result = self.build_and_run_cmd(context=context)
+        logger.info(result.output)
+
 
 class DbtLSDockerOperator(DbtDockerBaseOperator):
     """
@@ -63,9 +67,6 @@ class DbtLSDockerOperator(DbtDockerBaseOperator):
     def __init__(self, **kwargs: str) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["ls"]
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtSeedDockerOperator(DbtDockerBaseOperator):
@@ -89,9 +90,10 @@ class DbtSeedDockerOperator(DbtDockerBaseOperator):
 
         return flags
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        return self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        logger.info(result.output)
 
 
 class DbtSnapshotDockerOperator(DbtDockerBaseOperator):
@@ -106,9 +108,6 @@ class DbtSnapshotDockerOperator(DbtDockerBaseOperator):
         super().__init__(**kwargs)
         self.base_cmd = ["snapshot"]
 
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
-
 
 class DbtRunDockerOperator(DbtDockerBaseOperator):
     """
@@ -121,9 +120,6 @@ class DbtRunDockerOperator(DbtDockerBaseOperator):
     def __init__(self, **kwargs: str) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["run"]
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtTestDockerOperator(DbtDockerBaseOperator):
@@ -138,9 +134,6 @@ class DbtTestDockerOperator(DbtDockerBaseOperator):
         self.base_cmd = ["test"]
         # as of now, on_warning_callback in docker executor does nothing
         self.on_warning_callback = on_warning_callback
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtRunOperationDockerOperator(DbtDockerBaseOperator):
@@ -168,6 +161,7 @@ class DbtRunOperationDockerOperator(DbtDockerBaseOperator):
             flags.append(yaml.dump(self.args))
         return flags
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        return self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        logger.info(result.output)

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -40,7 +40,8 @@ class DbtDockerBaseOperator(DockerOperator, DbtBaseOperator):  # type: ignore[mi
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")  # type: ignore[has-type]
-        return super().execute(context)
+        result = super().execute(context)
+        logger.info(result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt
@@ -53,8 +54,7 @@ class DbtDockerBaseOperator(DockerOperator, DbtBaseOperator):  # type: ignore[mi
         self.command = dbt_cmd
 
     def execute(self, context: Context) -> None:
-        result = self.build_and_run_cmd(context=context)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context)
 
 
 class DbtLSDockerOperator(DbtDockerBaseOperator):
@@ -92,8 +92,7 @@ class DbtSeedDockerOperator(DbtDockerBaseOperator):
 
     def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
 
 
 class DbtSnapshotDockerOperator(DbtDockerBaseOperator):
@@ -163,5 +162,4 @@ class DbtRunOperationDockerOperator(DbtDockerBaseOperator):
 
     def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -71,6 +71,10 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type
         self.build_env_args(env_vars)
         self.arguments = dbt_cmd
 
+    def execute(self, context: Context) -> None:
+        result = self.build_and_run_cmd(context=context)
+        logger.info(result.output)
+
 
 class DbtLSKubernetesOperator(DbtKubernetesBaseOperator):
     """
@@ -82,9 +86,6 @@ class DbtLSKubernetesOperator(DbtKubernetesBaseOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["ls"]
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtSeedKubernetesOperator(DbtKubernetesBaseOperator):
@@ -108,9 +109,10 @@ class DbtSeedKubernetesOperator(DbtKubernetesBaseOperator):
 
         return flags
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        return self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        logger.info(result.output)
 
 
 class DbtSnapshotKubernetesOperator(DbtKubernetesBaseOperator):
@@ -125,9 +127,6 @@ class DbtSnapshotKubernetesOperator(DbtKubernetesBaseOperator):
         super().__init__(**kwargs)
         self.base_cmd = ["snapshot"]
 
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
-
 
 class DbtRunKubernetesOperator(DbtKubernetesBaseOperator):
     """
@@ -140,9 +139,6 @@ class DbtRunKubernetesOperator(DbtKubernetesBaseOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["run"]
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtTestKubernetesOperator(DbtKubernetesBaseOperator):
@@ -157,9 +153,6 @@ class DbtTestKubernetesOperator(DbtKubernetesBaseOperator):
         self.base_cmd = ["test"]
         # as of now, on_warning_callback in kubernetes executor does nothing
         self.on_warning_callback = on_warning_callback
-
-    def execute(self, context: Context) -> Any:
-        return self.build_and_run_cmd(context=context)
 
 
 class DbtRunOperationKubernetesOperator(DbtKubernetesBaseOperator):
@@ -187,6 +180,7 @@ class DbtRunOperationKubernetesOperator(DbtKubernetesBaseOperator):
             flags.append(yaml.dump(self.args))
         return flags
 
-    def execute(self, context: Context) -> Any:
+    def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        return self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
+        logger.info(result.output)

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -51,7 +51,8 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_kube_args(context, cmd_flags)
         self.log.info(f"Running command: {self.arguments}")
-        return super().execute(context)
+        result = super().execute(context)
+        logger.info(result)
 
     def build_kube_args(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt
@@ -72,8 +73,7 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type
         self.arguments = dbt_cmd
 
     def execute(self, context: Context) -> None:
-        result = self.build_and_run_cmd(context=context)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context)
 
 
 class DbtLSKubernetesOperator(DbtKubernetesBaseOperator):
@@ -111,8 +111,7 @@ class DbtSeedKubernetesOperator(DbtKubernetesBaseOperator):
 
     def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
 
 
 class DbtSnapshotKubernetesOperator(DbtKubernetesBaseOperator):
@@ -182,5 +181,4 @@ class DbtRunOperationKubernetesOperator(DbtKubernetesBaseOperator):
 
     def execute(self, context: Context) -> None:
         cmd_flags = self.add_cmd_flags()
-        result = self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)
-        logger.info(result.output)
+        self.build_and_run_cmd(context=context, cmd_flags=cmd_flags)

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -91,11 +91,11 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         subprocess_result: FullOutputSubprocessResult = self.subprocess_hook.run_command(command, *args, **kwargs)
         return subprocess_result
 
-    def execute(self, context: Context) -> str:
+    def execute(self, context: Context) -> None:
         output = super().execute(context)
         if self._venv_tmp_dir:
             self._venv_tmp_dir.cleanup()
-        return output
+        logger.info(output)
 
 
 class DbtLSVirtualenvOperator(DbtVirtualenvBaseOperator, DbtLSLocalOperator):


### PR DESCRIPTION
All Cosmos operators were dumping unnecessary data to XCom.
Change the behavior to log the information as opposed to polluting XCom.

Closes: #304