### PR TITLE
Fix CI type check Python version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v3
         with:
-          python-version: '3.10'
+          python-version: '3.9'
           architecture: 'x64'
       - uses: actions/cache@v3
         with:


### PR DESCRIPTION
Fix an issue introduced by #510, which only surfaced in the CI after the PR was merged.