### PR TITLE
Remove prefix of run and test tasks if test_behavior = TestBehavior.AFTER_EACH

### DIFF
--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -272,25 +272,6 @@ def test_create_task_metadata_seed(caplog, use_name_as_task_id_prefix):
     assert metadata.arguments == {"models": "my_seed"}
 
 
-@pytest.mark.parametrize("use_name_as_task_id_prefix", (True, False))
-def test_create_task_metadata_seed_use_name_as_task_id_prefix(caplog, use_name_as_task_id_prefix):
-    sample_node = DbtNode(
-        name="my_seed",
-        unique_id="my_folder.my_seed",
-        resource_type=DbtResourceType.SEED,
-        depends_on=[],
-        file_path="",
-        tags=[],
-        config={},
-    )
-    metadata = create_task_metadata(
-        sample_node, execution_mode=ExecutionMode.DOCKER, args={}, use_name_as_task_id_prefix=use_name_as_task_id_prefix
-    )
-    assert metadata.id == "my_seed_seed"
-    assert metadata.operator_class == "cosmos.operators.docker.DbtSeedDockerOperator"
-    assert metadata.arguments == {"models": "my_seed"}
-
-
 def test_create_task_metadata_snapshot(caplog):
     sample_node = DbtNode(
         name="my_snapshot",

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -261,7 +261,12 @@ def test_create_task_metadata_seed(caplog, use_name_as_task_id_prefix):
     if use_name_as_task_id_prefix is None:
         metadata = create_task_metadata(sample_node, execution_mode=ExecutionMode.DOCKER, args={})
     else:
-        metadata = create_task_metadata(sample_node, execution_mode=ExecutionMode.DOCKER, args={})
+        metadata = create_task_metadata(
+            sample_node,
+            execution_mode=ExecutionMode.DOCKER,
+            args={},
+            use_name_as_task_id_prefix=use_name_as_task_id_prefix,
+        )
     assert metadata.id == "my_seed_seed"
     assert metadata.operator_class == "cosmos.operators.docker.DbtSeedDockerOperator"
     assert metadata.arguments == {"models": "my_seed"}

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -1,5 +1,5 @@
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -10,15 +10,14 @@ from packaging import version
 from cosmos.airflow.graph import (
     build_airflow_graph,
     calculate_leaves,
+    calculate_operator_class,
     create_task_metadata,
     create_test_task_metadata,
-    calculate_operator_class,
 )
 from cosmos.config import ProfileConfig
-from cosmos.profiles import PostgresUserPasswordProfileMapping
-from cosmos.constants import ExecutionMode, DbtResourceType, TestBehavior
+from cosmos.constants import DbtResourceType, ExecutionMode, TestBehavior
 from cosmos.dbt.graph import DbtNode
-
+from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
 
@@ -92,23 +91,23 @@ def test_build_airflow_graph_with_after_each():
     topological_sort = [task.task_id for task in dag.topological_sort()]
     expected_sort = [
         "seed_parent_seed",
-        "parent.parent_run",
-        "parent.parent_test",
-        "child.child_run",
-        "child.child_test",
+        "parent.run",
+        "parent.test",
+        "child.run",
+        "child.test",
     ]
     assert topological_sort == expected_sort
     task_groups = dag.task_group_dict
     assert len(task_groups) == 2
 
     assert task_groups["parent"].upstream_task_ids == {"seed_parent_seed"}
-    assert list(task_groups["parent"].children.keys()) == ["parent.parent_run", "parent.parent_test"]
+    assert list(task_groups["parent"].children.keys()) == ["parent.run", "parent.test"]
 
-    assert task_groups["child"].upstream_task_ids == {"parent.parent_test"}
-    assert list(task_groups["child"].children.keys()) == ["child.child_run", "child.child_test"]
+    assert task_groups["child"].upstream_task_ids == {"parent.test"}
+    assert list(task_groups["child"].children.keys()) == ["child.run", "child.test"]
 
     assert len(dag.leaves) == 1
-    assert dag.leaves[0].task_id == "child.child_test"
+    assert dag.leaves[0].task_id == "child.test"
 
 
 @pytest.mark.skipif(
@@ -232,7 +231,23 @@ def test_create_task_metadata_model(caplog):
     assert metadata.arguments == {"models": "my_model"}
 
 
-def test_create_task_metadata_seed(caplog):
+def test_create_task_metadata_model_use_name_as_task_id_prefix(caplog):
+    child_node = DbtNode(
+        name="my_model",
+        unique_id="my_folder.my_model",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path=Path(""),
+        tags=[],
+        config={},
+    )
+    metadata = create_task_metadata(
+        child_node, execution_mode=ExecutionMode.LOCAL, args={}, use_name_as_task_id_prefix=False
+    )
+    assert metadata.id == "run"
+
+@pytest.mark.parametrize("use_name_as_task_id_prefix", (None, True, False))
+def test_create_task_metadata_seed(caplog, use_name_as_task_id_prefix):
     sample_node = DbtNode(
         name="my_seed",
         unique_id="my_folder.my_seed",
@@ -242,7 +257,29 @@ def test_create_task_metadata_seed(caplog):
         tags=[],
         config={},
     )
-    metadata = create_task_metadata(sample_node, execution_mode=ExecutionMode.DOCKER, args={})
+    if use_name_as_task_id_prefix is None:
+        metadata = create_task_metadata(sample_node, execution_mode=ExecutionMode.DOCKER, args={})
+    else:
+        metadata = create_task_metadata(sample_node, execution_mode=ExecutionMode.DOCKER, args={})
+    assert metadata.id == "my_seed_seed"
+    assert metadata.operator_class == "cosmos.operators.docker.DbtSeedDockerOperator"
+    assert metadata.arguments == {"models": "my_seed"}
+
+
+@pytest.mark.parametrize("use_name_as_task_id_prefix", (True, False))
+def test_create_task_metadata_seed_use_name_as_task_id_prefix(caplog, use_name_as_task_id_prefix):
+    sample_node = DbtNode(
+        name="my_seed",
+        unique_id="my_folder.my_seed",
+        resource_type=DbtResourceType.SEED,
+        depends_on=[],
+        file_path="",
+        tags=[],
+        config={},
+    )
+    metadata = create_task_metadata(
+        sample_node, execution_mode=ExecutionMode.DOCKER, args={}, use_name_as_task_id_prefix=use_name_as_task_id_prefix
+    )
     assert metadata.id == "my_seed_seed"
     assert metadata.operator_class == "cosmos.operators.docker.DbtSeedDockerOperator"
     assert metadata.arguments == {"models": "my_seed"}

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -246,6 +246,7 @@ def test_create_task_metadata_model_use_name_as_task_id_prefix(caplog):
     )
     assert metadata.id == "run"
 
+
 @pytest.mark.parametrize("use_name_as_task_id_prefix", (None, True, False))
 def test_create_task_metadata_seed(caplog, use_name_as_task_id_prefix):
     sample_node = DbtNode(


### PR DESCRIPTION
## Description

If test_behavior = TestBehavior.AFTER_EACH, DbtNode.name in task_id is not necessary because the parent task group is named as `DbtNode.name`

## Related Issue(s)

[Slack thread](https://apache-airflow.slack.com/archives/C059CC42E9W/p1692776042134929)

## Breaking Change?

Remove prefix of run and test tasks if test_behavior = TestBehavior.AFTER_EACH.

Olds rendered tasks before this PR:
![image](https://github.com/astronomer/astronomer-cosmos/assets/8995895/d7b55ad8-1c3a-4355-a5ce-04bf3037fd90)


New rendered tasks:
![image](https://github.com/astronomer/astronomer-cosmos/assets/8995895/a8b933f6-7990-4f4f-9fa8-d590dd63f8b2)


## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
