### PR TITLE
Use Airflow task logger

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -5,7 +5,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 
 Contains dags, task groups, and operators.
 """
-__version__ = "1.1.1"
+__version__ = "1.1.1a1"
 
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -9,10 +9,6 @@ from airflow.utils.context import Context
 from airflow.utils.operator_helpers import context_to_airflow_vars
 
 from cosmos.dbt.executable import get_system_dbt
-from cosmos.log import get_logger
-
-
-logger = get_logger(__name__)
 
 
 class DbtBaseOperator(BaseOperator):
@@ -163,14 +159,14 @@ class DbtBaseOperator(BaseOperator):
                 filtered_env[key] = val
             else:
                 if isinstance(key, accepted_types):
-                    logger.warning(
+                    self.log.warning(
                         "Env var %s was ignored because its key is not a valid type. Must be one of %s",
                         key,
                         accepted_types,
                     )
 
                 if isinstance(val, accepted_types):
-                    logger.warning(
+                    self.log.warning(
                         "Env var %s was ignored because its value is not a valid type. Must be one of %s",
                         key,
                         accepted_types,

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -5,10 +5,7 @@ from typing import Any, Callable, Sequence
 import yaml
 from airflow.utils.context import Context
 
-from cosmos.log import get_logger
 from cosmos.operators.base import DbtBaseOperator
-
-logger = get_logger(__name__)
 
 # docker is an optional dependency, so we need to check if it's installed
 try:
@@ -41,7 +38,7 @@ class DbtDockerBaseOperator(DockerOperator, DbtBaseOperator):  # type: ignore
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")
         result = super().execute(context)
-        logger.info(result)
+        self.log.info(result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -6,12 +6,9 @@ from typing import Any, Callable, Sequence
 import yaml
 from airflow.utils.context import Context
 
-from cosmos.log import get_logger
 from cosmos.config import ProfileConfig
 from cosmos.operators.base import DbtBaseOperator
 
-
-logger = get_logger(__name__)
 
 # kubernetes is an optional dependency, so we need to check if it's installed
 try:
@@ -54,7 +51,7 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type
         self.build_kube_args(context, cmd_flags)
         self.log.info(f"Running command: {self.arguments}")
         result = super().execute(context)
-        logger.info(result)
+        self.log.info(result)
 
     def build_kube_args(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -8,7 +8,6 @@ from airflow.compat.functools import cached_property
 from airflow.utils.python_virtualenv import prepare_virtualenv
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
-from cosmos.log import get_logger
 from cosmos.operators.local import (
     DbtDocsLocalOperator,
     DbtLocalBaseOperator,
@@ -22,8 +21,6 @@ from cosmos.operators.local import (
 
 if TYPE_CHECKING:
     from airflow.utils.context import Context
-
-logger = get_logger(__name__)
 
 
 PY_INTERPRETER = "python3"
@@ -95,7 +92,8 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         output = super().execute(context)
         if self._venv_tmp_dir:
             self._venv_tmp_dir.cleanup()
-        logger.info(output)
+
+        self.log.info(output)
 
 
 class DbtLSVirtualenvOperator(DbtVirtualenvBaseOperator, DbtLSLocalOperator):


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR updates the code within the Cosmos operators to use Airflow's `self.log` that gets exposed via the BaseOperator instead of the custom Cosmos logger. This ensures the task execution logs always show up properly in Airflow's task logs.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
