### PR TITLE
Adding emit_datasets param to DbtBaseOperator

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -56,6 +56,8 @@ class DbtBaseOperator(BaseOperator):
         (i.e. /home/astro/.pyenv/versions/dbt_venv/bin/dbt)
     :param dbt_cmd_flags: List of flags to pass to dbt command
     :param dbt_cmd_global_flags: List of dbt global flags to be passed to the dbt command
+    :param emit_datasets: If enabled model nodes emit Airflow Datasets for downstream cross-DAG dependencies.
+        Defaults to True
     """
 
     template_fields: Sequence[str] = ("env", "vars")
@@ -102,6 +104,7 @@ class DbtBaseOperator(BaseOperator):
         dbt_executable_path: str = get_system_dbt(),
         dbt_cmd_flags: list[str] | None = None,
         dbt_cmd_global_flags: list[str] | None = None,
+        emit_datasets: bool = True,
         **kwargs: Any,
     ) -> None:
         self.project_dir = project_dir
@@ -127,6 +130,7 @@ class DbtBaseOperator(BaseOperator):
         self.dbt_executable_path = dbt_executable_path
         self.dbt_cmd_flags = dbt_cmd_flags
         self.dbt_cmd_global_flags = dbt_cmd_global_flags or []
+        self.emit_datasets = emit_datasets
         super().__init__(**kwargs)
 
     def get_env(self, context: Context) -> dict[str, str | bytes | os.PathLike[Any]]:


### PR DESCRIPTION
## Description

When using the kubernetes execution mode I get this error:
![image](https://github.com/astronomer/astronomer-cosmos/assets/14027534/7e7039b1-5a0e-44c8-97a0-f84a3928116e)

This can be reproduced by following the README [here](https://github.com/pgoslatara/dynamic_task_mapping_for_dbt/blob/cosmos-to-k8s/README.md), the relevant DAG file is [here](https://github.com/pgoslatara/dynamic_task_mapping_for_dbt/blob/cosmos-to-k8s/dags/astronomer_cosmos_dag.py).

It appears that `emit_datasets` is not set in `DbtBaseOperator`, only in `DbtLocalBaseOperator`.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
