### PR TITLE
Add support to apache-airflow-providers-cncf-kubernetes < 7.4.0

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -9,15 +9,15 @@ __version__ = "1.1.1"
 
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
-from cosmos.constants import LoadMode, TestBehavior, ExecutionMode
-from cosmos.operators.lazy_load import MissingPackage
 from cosmos.config import (
     ProjectConfig,
     ProfileConfig,
     ExecutionConfig,
     RenderConfig,
 )
-
+from cosmos.constants import LoadMode, TestBehavior, ExecutionMode
+from cosmos.log import get_logger
+from cosmos.operators.lazy_load import MissingPackage
 from cosmos.operators.local import (
     DbtDepsLocalOperator,
     DbtLSLocalOperator,
@@ -27,6 +27,8 @@ from cosmos.operators.local import (
     DbtSnapshotLocalOperator,
     DbtTestLocalOperator,
 )
+
+logger = get_logger()
 
 try:
     from cosmos.operators.docker import (
@@ -57,7 +59,8 @@ try:
         DbtSnapshotKubernetesOperator,
         DbtTestKubernetesOperator,
     )
-except ImportError:
+except ImportError as error:
+    logger.exception(error)
     DbtLSKubernetesOperator = MissingPackage(
         "cosmos.operators.kubernetes.DbtLSKubernetesOperator",
         "kubernetes",

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -13,17 +13,22 @@ from cosmos.operators.base import DbtBaseOperator
 
 logger = get_logger(__name__)
 
-# kubernetes is an optional dependency, so we need to check if it's installed
 try:
+    # apache-airflow-providers-cncf-kubernetes >= 7.4.0
     from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import (
         convert_env_vars,
     )
     from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
 except ImportError:
-    raise ImportError(
-        "Could not import KubernetesPodOperator. Ensure you've installed the Kubernetes provider "
-        "separately or with with `pip install astronomer-cosmos[...,kubernetes]`."
-    )
+    try:
+        # apache-airflow-providers-cncf-kubernetes < 7.4.0
+        from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
+    except ImportError as error:
+        logger.info(
+            "Could not import KubernetesPodOperator. Ensure you've installed the Kubernetes provider "
+            "separately or with with `pip install astronomer-cosmos[...,kubernetes]`."
+        )
+        logger.exception(error)
 
 
 class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type: ignore

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -24,11 +24,11 @@ except ImportError:
         # apache-airflow-providers-cncf-kubernetes < 7.4.0
         from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
     except ImportError as error:
-        logger.info(
+        logger.exception(error)
+        raise ImportError(
             "Could not import KubernetesPodOperator. Ensure you've installed the Kubernetes provider "
             "separately or with with `pip install astronomer-cosmos[...,kubernetes]`."
         )
-        logger.exception(error)
 
 
 class DbtKubernetesBaseOperator(KubernetesPodOperator, DbtBaseOperator):  # type: ignore


### PR DESCRIPTION
Try to import `KubernetesPodOperator` from `airflow.providers.cncf.kubernetes.operators.kubernetes_pod` (`apache-airflow-providers-cncf-kubernetes` < 7.4.0), if it is not available in `airflow.providers.cncf.kubernetes.operators.pod` (`apache-airflow-providers-cncf-kubernetes` >= 7.4.0).

Users using `apache-airflow-providers-cncf-kubernetes < 7.4.0` would get the error message:
```
Could not import KubernetesPodOperator. Ensure you've installed the Kubernetes provider 
separately or with with `pip install astronomer-cosmos[...,kubernetes]`.
```

As reported in the #airflow-dbt channel in the Apache Airflow Slack, by Aditya Sharma:
https://apache-airflow.slack.com/archives/C059CC42E9W/p1695076622562159


 