### PR TITLE
fixing existing issues with DbtTestLocalOperator on_warning_callback

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -348,7 +348,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
             job_facets=job_facets,
         )
 
-    def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> None:
+    def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> FullOutputSubprocessResult:
         dbt_cmd, env = self.build_cmd(context=context, cmd_flags=cmd_flags)
         dbt_cmd = dbt_cmd or []
         result = self.run_command(cmd=dbt_cmd, env=env, context=context)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -40,10 +40,7 @@ from cosmos.hooks.subprocess import (
     FullOutputSubprocessHook,
     FullOutputSubprocessResult,
 )
-from cosmos.dbt.parser.output import (
-    extract_log_issues,
-    parse_output
-)
+from cosmos.dbt.parser.output import extract_log_issues
 
 logger = get_logger(__name__)
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -303,6 +303,7 @@ def test_operator_execute_without_flags(mock_build_and_run_cmd, operator_class):
     task.execute(context={})
     mock_build_and_run_cmd.assert_called_once_with(context={})
 
+
 @pytest.mark.integration
 def test_dbt_test_local_operator_on_warning_callback():
     on_warning_callback_mock = MagicMock()
@@ -314,12 +315,13 @@ def test_dbt_test_local_operator_on_warning_callback():
             task_id="my-task",
             install_deps=True,
             dbt_cmd_flags=["--models", "stg_customers"],
-            on_warning_callback=on_warning_callback_mock
+            on_warning_callback=on_warning_callback_mock,
         )
         test_operator
 
     run_test_dag(dag)
     on_warning_callback_mock.assert_called_once()
+
 
 @pytest.mark.integration
 def test_on_warning_callback_not_triggered():

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -302,3 +302,38 @@ def test_operator_execute_without_flags(mock_build_and_run_cmd, operator_class):
     )
     task.execute(context={})
     mock_build_and_run_cmd.assert_called_once_with(context={})
+
+@pytest.mark.integration
+def test_dbt_test_local_operator_on_warning_callback():
+    on_warning_callback_mock = MagicMock()
+
+    with DAG("my-test-dag", start_date=datetime(2022, 1, 1)) as dag:
+        test_operator = DbtTestLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="my-task",
+            install_deps=True,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            on_warning_callback=on_warning_callback_mock
+        )
+        test_operator
+
+    run_test_dag(dag)
+    on_warning_callback_mock.assert_called_once()
+
+@pytest.mark.integration
+def test_on_warning_callback_not_triggered():
+    on_warning_callback_mock = MagicMock()
+
+    with DAG("my-test-dag", start_date=datetime(2022, 1, 1)) as dag:
+        test_operator = DbtTestLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            install_deps=True,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            task_id="my-task",
+        )
+        test_operator
+
+    run_test_dag(dag)
+    on_warning_callback_mock.assert_not_called()


### PR DESCRIPTION
…method

## Description

Due to changes in https://github.com/astronomer/astronomer-cosmos/commit/c7a203a0f2125c784d55db87843d7958496242b4 DbtTestLocalOperator _handle_warnings was never triggered.

## Related Issue(s)

Closes https://github.com/astronomer/astronomer-cosmos/issues/549

## Breaking Change?

I had made a minor change to the DbtLocalBaseOperator - result.output is logged in the execute() method instead of build_and_run_cmd(), shouldn't be a breaking change though.

## Checklist

- [x ] I have made corresponding changes to the documentation (if required)
- [x ] I have added tests that prove my fix is effective or that my feature works
