### PR TITLE
Fix on warning callback

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -494,17 +494,15 @@ class DbtTestLocalOperator(DbtLocalBaseOperator):
         if self.on_warning_callback:
             self.on_warning_callback(warning_context)
 
-    def execute(self, context: Context) -> str:
+    def execute(self, context: Context) -> None:
         result = self.build_and_run_cmd(context=context)
 
         if not self._should_run_tests(result):
-            return result.output
+            return
 
         warnings = parse_output(result, "WARN")
         if warnings > 0:
             self._handle_warnings(result, context)
-
-        return result.output
 
 
 class DbtRunOperationLocalOperator(DbtLocalBaseOperator):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -313,10 +313,7 @@ def test_test_operator_execute_with_on_warning_callback(mock_build_and_run_cmd, 
     warning_handler = MagicMock()
 
     test_operator = DbtTestLocalOperator(
-        profile_config=profile_config,
-        project_dir="my/dir",
-        task_id="test",
-        on_warning_callback=warning_handler
+        profile_config=profile_config, project_dir="my/dir", task_id="test", on_warning_callback=warning_handler
     )
     test_operator.execute(context={})
     mock_build_and_run_cmd.assert_called_once()
@@ -332,10 +329,7 @@ def test_test_operator_execute_without_on_warning_callback(mock_build_and_run_cm
     warning_handler = MagicMock()
 
     test_operator = DbtTestLocalOperator(
-        profile_config=profile_config,
-        project_dir="my/dir",
-        task_id="test",
-        on_warning_callback=warning_handler
+        profile_config=profile_config, project_dir="my/dir", task_id="test", on_warning_callback=warning_handler
     )
     test_operator.execute(context={})
     mock_build_and_run_cmd.assert_called_once()

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -302,3 +302,41 @@ def test_operator_execute_without_flags(mock_build_and_run_cmd, operator_class):
     )
     task.execute(context={})
     mock_build_and_run_cmd.assert_called_once_with(context={})
+
+
+@patch("cosmos.operators.local.parse_output")
+@patch("cosmos.operators.local.DbtLocalBaseOperator.build_and_run_cmd")
+def test_test_operator_execute_with_on_warning_callback(mock_build_and_run_cmd, mock_parse_output):
+    # simulate when there is warning
+    mock_parse_output.return_value = 1
+
+    warning_handler = MagicMock()
+
+    test_operator = DbtTestLocalOperator(
+        profile_config=profile_config,
+        project_dir="my/dir",
+        task_id="test",
+        on_warning_callback=warning_handler
+    )
+    test_operator.execute(context={})
+    mock_build_and_run_cmd.assert_called_once()
+    warning_handler.assert_called_once()
+
+
+@patch("cosmos.operators.local.parse_output")
+@patch("cosmos.operators.local.DbtLocalBaseOperator.build_and_run_cmd")
+def test_test_operator_execute_without_on_warning_callback(mock_build_and_run_cmd, mock_parse_output):
+    # simulate when there is no warning
+    mock_parse_output.return_value = 0
+
+    warning_handler = MagicMock()
+
+    test_operator = DbtTestLocalOperator(
+        profile_config=profile_config,
+        project_dir="my/dir",
+        task_id="test",
+        on_warning_callback=warning_handler
+    )
+    test_operator.execute(context={})
+    mock_build_and_run_cmd.assert_called_once()
+    warning_handler.assert_not_called()


### PR DESCRIPTION
## Description

- Added back the on_warning_callback feature to DbtTestLocalOperator caused by accidentally removal in [https://github.com/astronomer/astronomer-cosmos/commit/c7a203a0f2125c784d55db87843d7958496242b4](https://github.com/astronomer/astronomer-cosmos/commit/c7a203a0f2125c784d55db87843d7958496242b4)

- Added two test cases for when the on_warning_callback should be called and should not be called

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)
closes #549 
<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
None, just added back what should be there

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
