### PR TITLE
Release 1.1.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+1.1.2 (2023-09-27)
+------------------
+
+Bug fixes
+
+* Fix using ``ExecutionMode.KUBERNETES`` by @pgoslatara and @tatiana in #554
+* Add support to ``apache-airflow-providers-cncf-kubernetes < 7.4.0`` by @tatiana in #553
+* Fix ``on_warning_callback`` behaviour on ``DbtTestLocalOperator`` by @edgga, @marco9663 and @tatiana in #558
+* Use ``returncode`` instead of ``stderr`` to determine dbt graph loading errors by @cliff-lau-cloverhealth in #547
+* Improve error message in ``config.py`` by @meyobagero in #532
+* Fix ``DbtTestOperator`` when test does not have ``test_metadata`` by @tatiana in #558
+* Fix ``target-path`` not specified issue in ``dbt-project.yml`` by @tatiana in #533
+
+Others
+
+* Docs: add reference links to dbt and Airflow columns by @TJaniF in #542
+* pre-commit updates #552 and #546
+
+
+
 1.1.1 (2023-09-14)
 ------------------
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -5,7 +5,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 
 Contains dags, task groups, and operators.
 """
-__version__ = "1.1.1"
+__version__ = "1.1.2"
 
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup


### PR DESCRIPTION
This PR is a subset of the actual Release 1.1.2 (#560), since - for this release - we had to revert a [commit](https://github.com/astronomer/astronomer-cosmos/pull/560#issuecomment-1737659616) which we don't intend to revert on the project's main branch.

Bug fixes

* Fix using `ExecutionMode.KUBERNETES` by @pgoslatara and @tatiana in #554
* Add support to `apache-airflow-providers-cncf-kubernetes < 7.4.0` by @tatiana in #553
* Fix `on_warning_callback` behaviour on `DbtTestLocalOperator` by @edgga, @marco9663 and @tatiana in #558
* Use `returncode` instead of `stderr` to determine dbt graph loading errors by @cliff-lau-cloverhealth in #547
* Improve error message in `config.py` by @meyobagero in #532
* Fix `DbtTestOperator` when test does not have `test_metadata` by @tatiana in #558
* Fix `target-path` not specified issue in `dbt-project.yml` by @tatiana in #533

Others

* Docs: add reference links to dbt and Airflow columns by @TJaniF in #542
* pre-commit updates #552 and #546

