### PR TITLE
Fix parsing test nodes when using the custom load method (LoadMethod.CUSTOM)

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -292,7 +292,9 @@ class DbtGraph:
             operator_args=self.operator_args,
         )
         nodes = {}
-        models = itertools.chain(project.models.items(), project.snapshots.items(), project.seeds.items())
+        models = itertools.chain(
+            project.models.items(), project.snapshots.items(), project.seeds.items(), project.tests.items()
+        )
         for model_name, model in models:
             config = {item.split(":")[0]: item.split(":")[-1] for item in model.config.config_selectors}
             node = DbtNode(

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -16,6 +16,7 @@ DBT_PROJECT_PATH = Path(__name__).parent.parent.parent.parent.parent / "dev/dags
 SAMPLE_CSV_PATH = DBT_PROJECT_PATH / "jaffle_shop/seeds/raw_customers.csv"
 SAMPLE_MODEL_SQL_PATH = DBT_PROJECT_PATH / "jaffle_shop/models/customers.sql"
 SAMPLE_SNAPSHOT_SQL_PATH = DBT_PROJECT_PATH / "jaffle_shop/models/orders.sql"
+SAMPLE_YML_PATH = DBT_PROJECT_PATH / "jaffle_shop/models/schema.yml"
 
 
 def test_dbtproject__handle_csv_file():
@@ -62,6 +63,22 @@ def test_dbtproject__handle_sql_file_snapshot():
     assert raw_customers.name == "orders"
     assert raw_customers.type == DbtModelType.DBT_MODEL
     assert raw_customers.path == SAMPLE_SNAPSHOT_SQL_PATH
+
+
+def test_dbtproject__handle_config_file():
+    dbt_project = DbtProject(
+        project_name="jaffle_shop",
+        dbt_root_path=DBT_PROJECT_PATH,
+    )
+    dbt_project.tests = {}
+
+    dbt_project._handle_config_file(SAMPLE_YML_PATH)
+
+    assert len(dbt_project.tests) == 12
+    assert "not_null_customer_id_customers" in dbt_project.tests
+    sample_test = dbt_project.tests["not_null_customer_id_customers"]
+    assert sample_test.type == DbtModelType.DBT_TEST
+    assert sample_test.path == SAMPLE_YML_PATH
 
 
 def test_dbtproject__handle_config_file_empty_file():

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -359,8 +359,7 @@ def test_load_via_load_via_custom_parser(pipeline_name):
     dbt_graph.load_via_custom_parser()
 
     assert dbt_graph.nodes == dbt_graph.filtered_nodes
-    # the custom parser does not add dbt test nodes
-    assert len(dbt_graph.nodes) == 8
+    assert len(dbt_graph.nodes) == 28
 
 
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency", return_value=None)


### PR DESCRIPTION
## Description

This PR Added a functionality to parse Test on the custom parser. After implementing #543, there's an issue using `load_via_custom_parser` which doesn't load the test node. That's happen because the implementation in #543 is assume all node doesn't has test. After debugging, i found that the `load_via_custom_parser` not return any tests node.

## Related Issue(s)

closes #561

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
