### PR TITLE
add KeyError to openlineage except list

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -274,7 +274,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
         try:
             events = openlineage_processor.parse()
             self.openlineage_events_completes = events.completes
-        except (FileNotFoundError, NotImplementedError, ValueError):
+        except (FileNotFoundError, KeyError, NotImplementedError, ValueError):
             logger.debug("Unable to parse OpenLineage events", stack_info=True)
 
     def get_datasets(self, source: Literal["inputs", "outputs"]) -> list[Dataset]:


### PR DESCRIPTION
## Description
Adding `KeyError` to except list when parsing OpenLineage events.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #545 

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
