### PR TITLE
Release 1.1.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,18 @@
 Changelog
 =========
 
+1.1.3 (2023-09-28)
+------------------
+
+Bug fixes
+
+* Only create task group and test task only if the model has a test by @raffifu in #543
+* Fix parsing test nodes when using the custom load method (LoadMethod.CUSTOM) by @raffifu in #563
+* Fix ``DbtTestOperator`` when test does not have ``test_metadata`` by @javihernovoa and @tatiana in #565
+* Support dbt 1.6 and apache-airflow-providers-cncf-kubernetes 7.3.0  by @tatiana in #564
+
+
+
 1.1.2 (2023-09-27)
 ------------------
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -5,7 +5,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 
 Contains dags, task groups, and operators.
 """
-__version__ = "1.1.2"
+__version__ = "1.1.3"
 
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup


### PR DESCRIPTION
Bug fixes
    
* Only create task group and test task only if the model has a test by @raffifu in #543
* Fix parsing test nodes when using the custom load method (`LoadMethod.CUSTOM`) by @raffifu in #563
* Fix `DbtTestOperator` when test does not have ``test_metadata`` by @javihernovoa and @tatiana in #565
* Support dbt 1.6 and `apache-airflow-providers-cncf-kubernetes` 7.3.0  by @tatiana in #564

