### PR TITLE
Skip mocking of keyfile_json field

### DIFF
--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -59,6 +59,7 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
         return {
             **parent_mock_profile,
             "threads": 1,
+            "keyfile_json": None
         }
 
     def transform_keyfile_json(self, keyfile_json: str | dict[str, str]) -> dict[str, str]:


### PR DESCRIPTION
## Description

Makes the required field `keyfile_json` empty, so that dbt can parse it if the project.yaml is mocked.
## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #586 

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
