### PR TITLE
fix: full_refresh unsused in test operators

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -109,6 +109,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
         self.compiled_sql = ""
         self.should_store_compiled_sql = should_store_compiled_sql
         self.openlineage_events_completes: list[RunEvent] = []
+        kwargs.pop("full_refresh", None)  # usage of this param should be implemented in child classes        
         super().__init__(**kwargs)
 
     @cached_property

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -109,7 +109,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
         self.compiled_sql = ""
         self.should_store_compiled_sql = should_store_compiled_sql
         self.openlineage_events_completes: list[RunEvent] = []
-        kwargs.pop("full_refresh", None)  # usage of this param should be implemented in child classes        
+        kwargs.pop("full_refresh", None)  # usage of this param should be implemented in child classes
         super().__init__(**kwargs)
 
     @cached_property

--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -28,7 +28,10 @@ basic_cosmos_dag = DbtDag(
         DBT_ROOT_PATH / "jaffle_shop",
     ),
     profile_config=profile_config,
-    operator_args={"install_deps": True},
+    operator_args={
+        "install_deps": True,  # install any necessary dependencies before running any dbt command
+        "full_refresh": True,  # used only in dbt commands that support this flag
+    },
     # normal dag parameters
     schedule_interval="@daily",
     start_date=datetime(2023, 1, 1),

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -332,6 +332,7 @@ def test_store_compiled_sql() -> None:
     [
         (DbtSeedLocalOperator, {"full_refresh": True}, {"context": {}, "cmd_flags": ["--full-refresh"]}),
         (DbtRunLocalOperator, {"full_refresh": True}, {"context": {}, "cmd_flags": ["--full-refresh"]}),
+        (DbtTestLocalOperator, {"full_refresh": True}, {"context": {}}),
         (
             DbtRunOperationLocalOperator,
             {"args": {"days": 7, "dry_run": True}, "macro_name": "bla"},


### PR DESCRIPTION
## Description

https://apache-airflow.slack.com/archives/C059CC42E9W/p1696857998959909

## Related Issue(s)

[issue 589](https://github.com/astronomer/astronomer-cosmos/issues/589)

## Breaking Change?

<details><summary>Details</summary>
<p>

airflow.exceptions.AirflowException: Invalid arguments were passed to DbtTestLocalOperator (task_id: test). Invalid arguments were:
**kwargs: {'full_refresh': True}

</p>
</details> 




