### PR TITLE
Use .parsed_*_path to allow str | Path

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -106,8 +106,8 @@ class DbtToAirflowConverter:
         project_config.validate_project()
 
         emit_datasets = render_config.emit_datasets
-        dbt_root_path = project_config.dbt_project_path.parent
-        dbt_project_name = project_config.dbt_project_path.name
+        dbt_root_path = project_config.parsed_dbt_project_path.parent
+        dbt_project_name = project_config.parsed_dbt_project_path.name
         dbt_models_dir = project_config.models_relative_path
         dbt_seeds_dir = project_config.seeds_relative_path
         dbt_snapshots_dir = project_config.snapshots_relative_path


### PR DESCRIPTION
## Description

```
Broken DAG: [/usr/local/airflow/dags/telescope/telescope_reporting.py] Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/cosmos/airflow/task_group.py", line 26, in __init__
    DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
  File "/usr/local/lib/python3.11/site-packages/cosmos/converter.py", line 109, in __init__
    dbt_root_path = project_config.dbt_project_path.parent
                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'str' object has no attribute 'parent'
```
```
DbtTaskGroup(
        ...,
        project_config=ProjectConfig(
            project_name="telescope_reporting",
            # dbt_project_path=Path("/usr/local/airflow/dags/dbt/"),  # no parse error
            dbt_project_path="/usr/local/airflow/dags/dbt/",  # parse error
        )
    )
```


## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
