### PR TITLE
Honour `OPENLINEAGE_DISABLED` env var

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -74,6 +74,10 @@ except airflow.exceptions.AirflowConfigException:
     LINEAGE_NAMESPACE = os.getenv("OPENLINEAGE_NAMESPACE", DEFAULT_OPENLINEAGE_NAMESPACE)
 
 
+# In the spirit of: https://github.com/apache/airflow/blob/8531396c7c8bf1e016db10c7d32e5e19298d67e5/airflow/providers/openlineage/plugins/openlineage.py#L30
+is_openlineage_enabled = is_openlineage_available and os.getenv("OPENLINEAGE_DISABLED", "false").lower() != "true"
+
+
 class DbtLocalBaseOperator(DbtBaseOperator):
     """
     Executes a dbt core cli command locally.
@@ -227,7 +231,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
                     output_encoding=self.output_encoding,
                     cwd=tmp_project_dir,
                 )
-                if is_openlineage_available:
+                if is_openlineage_enabled:
                     self.calculate_openlineage_events_completes(env, Path(tmp_project_dir))
                     context[
                         "task_instance"


### PR DESCRIPTION
## Description

This allows dbt tasks to succeed successfully when lineage has been disabled by honouring the `OPENLINEAGE_DISABLED` environment variable that Airflow uses.

## Related Issue(s)

This does not resolve, but is related to #612. It allows us to run dbt tasks without having errors described in the issue.

## Breaking Change?

This should not break anything.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
