### PR TITLE
Remove unnecessary stack trace from Cosmos initialization

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -57,7 +57,10 @@ except (ImportError, ModuleNotFoundError):
         from openlineage.airflow.extractors.base import OperatorLineage
     except (ImportError, ModuleNotFoundError):
         logger.warning(
-            "To enable emitting Openlineage events, upgrade to Airflow 2.7 or install astronomer-cosmos[openlineage].",
+            "To enable emitting Openlineage events, upgrade to Airflow 2.7 or install astronomer-cosmos[openlineage]."
+        )
+        logger.debug(
+            "Further details on lack of Openlineage:",
             stack_info=True,
         )
         is_openlineage_available = False


### PR DESCRIPTION
As of Cosmos 1.2.0, whenever imported, the library would print a long stack trace related to Openlineage if it was not available as a warning.

Change only to print the stack trace if DEBUG log mode is used.
