### PR TITLE
Add pre-commit hook for McCabe max complexity check and fix errors

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -76,6 +76,12 @@ repos:
         name: mypy-python
         additional_dependencies: [types-PyYAML, types-attrs, attrs, types-requests, types-python-dateutil, apache-airflow]
         files: ^cosmos
+  - repo: https://github.com/pycqa/flake8
+    rev: 6.1.0
+    hooks:
+      - id: flake8
+        entry: pflake8
+        additional_dependencies: [pyproject-flake8]
 
 ci:
   autofix_commit_msg: 🎨 [pre-commit.ci] Auto format from pre-commit.com hooks

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -145,7 +145,6 @@ class DbtModel:
         code = self.path.read_text()
 
         if self.type == DbtModelType.DBT_SNAPSHOT:
-            code = self.path.read_text()
             snapshot_name = code.split("{%")[1]
             snapshot_name = snapshot_name.split("%}")[0]
             snapshot_name = snapshot_name.split(" ")[2]

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -362,7 +362,7 @@ class LegacyDbtProject:
                 continue
             # tests
             model_tests = self._extract_model_tests(model_name, model_config, path)
-            self.tests |= model_tests
+            self.tests.update(model_tests)
 
             # config_selectors
             if model_name not in self.models:

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -137,16 +137,14 @@ class DbtModel:
         """
         Parses the file and extracts metadata (dependencies, tags, etc)
         """
-        # first, get an empty config
+        if self.type == DbtModelType.DBT_SEED or self.type == DbtModelType.DBT_TEST:
+            return
+
         config = DbtModelConfig()
-        var_args: Dict[str, Any] = self.operator_args.get("vars", {})
+        self.var_args: Dict[str, Any] = self.operator_args.get("vars", {})
+        code = self.path.read_text()
 
-        if self.type == DbtModelType.DBT_MODEL:
-            # get the code from the file
-            code = self.path.read_text()
-
-        # we remove first and last line if the code is a snapshot
-        elif self.type == DbtModelType.DBT_SNAPSHOT:
+        if self.type == DbtModelType.DBT_SNAPSHOT:
             code = self.path.read_text()
             snapshot_name = code.split("{%")[1]
             snapshot_name = snapshot_name.split("%}")[0]
@@ -156,55 +154,73 @@ class DbtModel:
             code = code.split("%}")[1]
             code = code.split("{%")[0]
 
-        elif self.type == DbtModelType.DBT_SEED or self.type == DbtModelType.DBT_TEST:
-            return
-
         if self.path.suffix == PYTHON_FILE_SUFFIX:
             config.upstream_models = config.upstream_models.union(set(extract_python_file_upstream_requirements(code)))
         else:
-            # get the dependencies
-            env = jinja2.Environment()
-            jinja2_ast = env.parse(code)
-            # iterate over the jinja nodes to extract info
-            for base_node in jinja2_ast.find_all(jinja2.nodes.Call):
-                if hasattr(base_node.node, "name"):
-                    try:
-                        # check we have a ref - this indicates a dependency
-                        if base_node.node.name == "ref":
-                            # if it is, get the first argument
-                            first_arg = base_node.args[0]
-                            # if it contains vars, render the value of the var
-                            if isinstance(first_arg, jinja2.nodes.Concat):
-                                value = ""
-                                for node in first_arg.nodes:
-                                    if isinstance(node, jinja2.nodes.Const):
-                                        value += node.value
-                                    elif (
-                                        isinstance(node, jinja2.nodes.Call)
-                                        and isinstance(node.node, jinja2.nodes.Name)
-                                        and isinstance(node.args[0], jinja2.nodes.Const)
-                                        and node.node.name == "var"
-                                    ):
-                                        value += var_args[node.args[0].value]
-                                config.upstream_models.add(value)
-                            elif isinstance(first_arg, jinja2.nodes.Const):
-                                # and add it to the config
-                                config.upstream_models.add(first_arg.value)
+            upstream_models, extracted_config = self.extract_sql_file_requirements(code)
+            config.upstream_models = config.upstream_models.union(set(upstream_models))
+            config.config_selectors |= extracted_config
 
-                        # check if we have a config - this could contain tags
-                        if base_node.node.name == "config":
-                            # if it is, check if any kwargs are tags
-                            for kwarg in base_node.kwargs:
-                                for selector in self.config.config_types:
-                                    extracted_config = self._extract_config(kwarg=kwarg, config_name=selector)
-                                    config.config_selectors |= (
-                                        set(extracted_config) if isinstance(extracted_config, (str, List)) else set()
-                                    )
-                    except KeyError as e:
-                        logger.warning(f"Could not add upstream model for config in {self.path}: {e}")
-
-        # set the config and set the parsed file flag to true
         self.config = config
+
+    def extract_sql_file_requirements(self, code: str) -> tuple[list[str], set[str]]:
+        """Extracts upstream models and config selectors from a dbt sql file."""
+        # get the dependencies
+        env = jinja2.Environment()
+        jinja2_ast = env.parse(code)
+        upstream_models = []
+        config_selectors = set()
+        # iterate over the jinja nodes to extract info
+        for base_node in jinja2_ast.find_all(jinja2.nodes.Call):
+            if hasattr(base_node.node, "name"):
+                try:
+                    # check we have a ref - this indicates a dependency
+                    if base_node.node.name == "ref":
+                        upstream_model = self._parse_jinja_ref_node(base_node)
+                        if upstream_model:
+                            upstream_models.append(upstream_model)
+                    # check if we have a config - this could contain tags
+                    if base_node.node.name == "config":
+                        config_selectors |= self._parse_jinja_config_node(base_node)
+                except KeyError as e:
+                    logger.warning(f"Could not add upstream model for config in {self.path}: {e}")
+
+        return upstream_models, config_selectors
+
+    def _parse_jinja_ref_node(self, base_node: jinja2.nodes.Call) -> str | None:
+        """Parses a jinja ref node."""
+        # get the first argument
+        first_arg = base_node.args[0]
+        value = None
+        # if it contains vars, render the value of the var
+        if isinstance(first_arg, jinja2.nodes.Concat):
+            value = ""
+            for node in first_arg.nodes:
+                if isinstance(node, jinja2.nodes.Const):
+                    value += node.value
+                elif (
+                    isinstance(node, jinja2.nodes.Call)
+                    and isinstance(node.node, jinja2.nodes.Name)
+                    and isinstance(node.args[0], jinja2.nodes.Const)
+                    and node.node.name == "var"
+                ):
+                    value += self.var_args[node.args[0].value]
+        elif isinstance(first_arg, jinja2.nodes.Const):
+            # and add it to the config
+            value = first_arg.value
+
+        return value
+
+    def _parse_jinja_config_node(self, base_node: jinja2.nodes.Call) -> set[str]:
+        """Parses a jinja config node."""
+        # check if any kwargs are tags
+        selector_config = set()
+        for kwarg in base_node.kwargs:
+            for config_name in self.config.config_types:
+                if hasattr(kwarg, "key") and kwarg.key == config_name:
+                    extracted_config = self._extract_config(kwarg, config_name)
+                    selector_config |= set(extracted_config) if isinstance(extracted_config, (str, List)) else set()
+        return selector_config
 
     # TODO following needs coverage:
     def _extract_config(self, kwarg: Any, config_name: str) -> Any:

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -362,7 +362,7 @@ class LegacyDbtProject:
                 continue
             # tests
             model_tests = self._extract_model_tests(model_name, model_config, path)
-            self.tests.update(model_tests)
+            self.tests |= model_tests
 
             # config_selectors
             if model_name not in self.models:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -250,3 +250,7 @@ line-length = 120
 
 [tool.distutils.bdist_wheel]
 universal = true
+
+[tool.flake8]
+max-complexity = 10
+select = "C"

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -415,11 +415,9 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
             ),
         ),
     )
-    with pytest.raises(CosmosLoadDbtException) as err_info:
+    expected = r"Unable to run \['.+dbt', 'deps', .*\] due to the error:\nSome stderr message"
+    with pytest.raises(CosmosLoadDbtException, match=expected):
         dbt_graph.load_via_dbt_ls()
-
-    expected = "Unable to run dbt deps command due to the error:\nSome stderr message"
-    assert err_info.value.args[0] == expected
 
 
 @pytest.mark.integration

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -438,11 +438,10 @@ def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate):
             ),
         ),
     )
-    with pytest.raises(CosmosLoadDbtException) as err_info:
+    expected = r"Unable to run \['.+dbt', 'deps', .*\] due to the error:\nSome Runtime Error"
+    with pytest.raises(CosmosLoadDbtException, match=expected):
         dbt_graph.load_via_dbt_ls()
 
-    expected = "Unable to run dbt deps command due to the error:\nSome Runtime Error"
-    assert err_info.value.args[0] == expected
     mock_popen_communicate.assert_called_once()
 
 


### PR DESCRIPTION
## Description
Opening this up as a draft to work through the code that have been flagged as too complex given the default threshold of 10 below:
```shell
❯ pre-commit run flake8 --all-files
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

cosmos/dbt/graph.py:134:5: C901 'DbtGraph.load_via_dbt_ls' is too complex (16)
cosmos/dbt/parser/project.py:136:5: C901 'DbtModel.__post_init__' is too complex (18)
cosmos/dbt/parser/project.py:346:5: C901 'LegacyDbtProject._handle_config_file' is too complex (15)
cosmos/dbt/selector.py:87:1: C901 'select_nodes_ids_by_intersection' is too complex (16)
```
I'm happy to do this since it will help be get more familiar with some inner workings of cosmos, but if someone from the team wants to take over they're welcome.

If its lowered to 6 as mentioned in the issue, there are more errors that could be fixed:
```shell
❯ pre-commit run flake8 --all-files
flake8...................................................................Failed
- hook id: flake8
- exit code: 1

cosmos/airflow/graph.py:196:1: C901 'build_airflow_graph' is too complex (9)
cosmos/config.py:66:5: C901 'ProjectConfig.__init__' is too complex (7)
cosmos/dbt/graph.py:134:5: C901 'DbtGraph.load_via_dbt_ls' is too complex (16)
cosmos/dbt/parser/project.py:63:5: C901 'DbtModelConfig._config_selector_ooo' is too complex (7)
cosmos/dbt/parser/project.py:98:1: C901 'extract_python_file_upstream_requirements' is too complex (7)
cosmos/dbt/parser/project.py:136:5: C901 'DbtModel.__post_init__' is too complex (18)
cosmos/dbt/parser/project.py:262:5: C901 'LegacyDbtProject.__post_init__' is too complex (10)
cosmos/dbt/parser/project.py:346:5: C901 'LegacyDbtProject._handle_config_file' is too complex (15)
cosmos/dbt/selector.py:52:5: C901 'SelectorConfig.load_from_statement' is too complex (7)
cosmos/dbt/selector.py:87:1: C901 'select_nodes_ids_by_intersection' is too complex (16)
cosmos/dbt/selector.py:170:1: C901 'select_nodes' is too complex (9)
cosmos/hooks/subprocess.py:34:5: C901 'FullOutputSubprocessHook.run_command' is too complex (8)
cosmos/operators/base.py:137:5: C901 'DbtBaseOperator.get_env' is too complex (7)
cosmos/operators/base.py:186:5: C901 'DbtBaseOperator.add_global_flags' is too complex (7)
cosmos/operators/local.py:136:5: C901 'DbtLocalBaseOperator.store_compiled_sql' is too complex (7)
cosmos/profiles/base.py:160:5: C901 'BaseProfileMapping.get_dbt_value' is too complex (8)
dev/dags/dbt_docs.py:45:1: C901 'which_upload' is too complex (7)
```


## Related Issue(s)
Closes: #525 

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
