### PR TITLE
Support `ProjectConfig.dbt_project_path = None` & different paths for Rendering and Execution

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import contextlib
 import tempfile
-from dataclasses import dataclass, field
+from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from typing import Any, Iterator, Callable
 
@@ -40,6 +40,13 @@ class RenderConfig:
     exclude: list[str] = field(default_factory=list)
     dbt_deps: bool = True
     node_converters: dict[DbtResourceType, Callable[..., Any]] | None = None
+    dbt_executable_path: str | Path = get_system_dbt()
+    dbt_project_path: InitVar[str | Path | None] = None
+
+    project_path: Path | None = field(init=False)
+
+    def __post_init__(self, dbt_project_path: str | Path | None) -> None:
+        self.project_path = Path(dbt_project_path) if dbt_project_path else None
 
 
 class ProjectConfig:
@@ -217,3 +224,10 @@ class ExecutionConfig:
     execution_mode: ExecutionMode = ExecutionMode.LOCAL
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER
     dbt_executable_path: str | Path = get_system_dbt()
+
+    dbt_project_path: InitVar[str | Path | None] = None
+
+    project_path: Path | None = field(init=False)
+
+    def __post_init__(self, dbt_project_path: str | Path | None) -> None:
+        self.project_path = Path(dbt_project_path) if dbt_project_path else None

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -82,11 +82,13 @@ class ProjectConfig:
         manifest_path: str | Path | None = None,
         project_name: str | None = None,
     ):
+        # Since we allow dbt_project_path to be defined in ExecutionConfig and RenderConfig
+        #   dbt_project_path may not always be defined here.
+        # We do, however, still require that both manifest_path and project_name be defined, or neither be defined.
         if not dbt_project_path:
-            if not manifest_path or not project_name:
+            if manifest_path and not project_name or project_name and not manifest_path:
                 raise CosmosValueError(
-                    "ProjectConfig requires dbt_project_path and/or manifest_path to be defined."
-                    " If only manifest_path is defined, project_name must also be defined."
+                    "If ProjectConfig.dbt_project_path is not defined, ProjectConfig.manifest_path and ProjectConfig.project_name must be defined together, or both left undefined."
                 )
         if project_name:
             self.project_name = project_name

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -31,6 +31,9 @@ class RenderConfig:
     :param select: A list of dbt select arguments (e.g. 'config.materialized:incremental')
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
     :param dbt_deps: Configure to run dbt deps when using dbt ls for dag parsing
+    :param node_converters: a dictionary mapping a ``DbtResourceType`` into a callable. Users can control how to render dbt nodes in Airflow. Only supported when using ``load_method=LoadMode.DBT_MANIFEST`` or ``LoadMode.DBT_LS``.
+    :param dbt_executable_path: The path to the dbt executable for dag generation. Defaults to dbt if available on the path. Mutually Exclusive with ProjectConfig.dbt_project_path
+    :param dbt_project_path Configures the DBT project location accessible on the airflow controller for DAG rendering - Required when using ``load_method=LoadMode.DBT_LS`` or ``load_method=LoadMode.CUSTOM``
     """
 
     emit_datasets: bool = True
@@ -217,8 +220,8 @@ class ExecutionConfig:
 
     :param execution_mode: The execution mode for dbt. Defaults to local
     :param test_indirect_selection: The mode to configure the test behavior when performing indirect selection.
-    :param dbt_executable_path: The path to the dbt executable. Defaults to dbt if
-    available on the path.
+    :param dbt_executable_path: The path to the dbt executable for runtime execution. Defaults to dbt if available on the path.
+    :param dbt_project_path Configures the DBT project location accessible at runtime for dag execution. This is the project path in a docker container for ExecutionMode.DOCKER or ExecutionMode.KUBERNETES. Mutually Exclusive with ProjectConfig.dbt_project_path
     """
 
     execution_mode: ExecutionMode = ExecutionMode.LOCAL

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -110,9 +110,6 @@ class DbtToAirflowConverter:
         # Since we now support both project_config.dbt_project_path, render_config.project_path and execution_config.project_path
         # We need to ensure that only one interface is being used.
         if project_config.dbt_project_path and (render_config.project_path or execution_config.project_path):
-            print(f"RenderConfig: {render_config.project_path}")
-            print(f"ExecutionConfig: {execution_config.project_path}")
-            print(f"ProjectConfig: {project_config.dbt_project_path}")
             raise CosmosValueError(
                 "ProjectConfig.dbt_project_path is mutually exclusive with RenderConfig.dbt_project_path and ExecutionConfig.dbt_project_path."
                 + "If using RenderConfig.dbt_project_path or ExecutionConfig.dbt_project_path, ProjectConfig.dbt_project_path should be None"

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -16,7 +16,6 @@ from cosmos.config import ProjectConfig, ExecutionConfig, RenderConfig, ProfileC
 from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
 
-
 logger = get_logger(__name__)
 
 
@@ -92,8 +91,8 @@ class DbtToAirflowConverter:
         self,
         project_config: ProjectConfig,
         profile_config: ProfileConfig,
-        execution_config: ExecutionConfig = ExecutionConfig(),
-        render_config: RenderConfig = RenderConfig(),
+        execution_config: ExecutionConfig | None = None,
+        render_config: RenderConfig | None = None,
         dag: DAG | None = None,
         task_group: TaskGroup | None = None,
         operator_args: dict[str, Any] | None = None,
@@ -103,19 +102,40 @@ class DbtToAirflowConverter:
     ) -> None:
         project_config.validate_project()
 
-        emit_datasets = render_config.emit_datasets
-        test_behavior = render_config.test_behavior
-        select = render_config.select
-        exclude = render_config.exclude
-        dbt_deps = render_config.dbt_deps
-        execution_mode = execution_config.execution_mode
-        test_indirect_selection = execution_config.test_indirect_selection
-        load_mode = render_config.load_method
-        dbt_executable_path = execution_config.dbt_executable_path
-        node_converters = render_config.node_converters
+        if not execution_config:
+            execution_config = ExecutionConfig()
+        if not render_config:
+            render_config = RenderConfig()
 
-        if not project_config.dbt_project_path:
-            raise CosmosValueError("A Project Path in ProjectConfig is required for generating a Task Operators.")
+        # Since we now support both project_config.dbt_project_path, render_config.project_path and execution_config.project_path
+        # We need to ensure that only one interface is being used.
+        if project_config.dbt_project_path and (render_config.project_path or execution_config.project_path):
+            print(f"RenderConfig: {render_config.project_path}")
+            print(f"ExecutionConfig: {execution_config.project_path}")
+            print(f"ProjectConfig: {project_config.dbt_project_path}")
+            raise CosmosValueError(
+                "ProjectConfig.dbt_project_path is mutually exclusive with RenderConfig.dbt_project_path and ExecutionConfig.dbt_project_path."
+                + "If using RenderConfig.dbt_project_path or ExecutionConfig.dbt_project_path, ProjectConfig.dbt_project_path should be None"
+            )
+
+        # If we are using the old interface, we should migrate it to the new interface
+        # This is safe to do now since we have validated which config interface we're using
+        if project_config.dbt_project_path:
+            render_config.project_path = project_config.dbt_project_path
+            execution_config.project_path = project_config.dbt_project_path
+
+        # At this point, execution_config.project_path should always be non-null
+        if not execution_config.project_path:
+            raise CosmosValueError(
+                "ExecutionConfig.dbt_project_path is required for the execution of dbt tasks in all execution modes."
+            )
+
+        # We now have a guaranteed execution_config.project_path, but still need to process render_config.project_path
+        # We require render_config.project_path when we dont have a manifest
+        if not project_config.manifest_path and not render_config.project_path:
+            raise CosmosValueError(
+                "RenderConfig.dbt_project_path is required for rendering an airflow DAG from a DBT Graph if no manifest is provided."
+            )
 
         profile_args = {}
         if profile_config.profile_mapping:
@@ -136,36 +156,33 @@ class DbtToAirflowConverter:
         # We may want to consider defaulting this value in our actual ProjceConfig class?
         dbt_graph = DbtGraph(
             project=project_config,
-            exclude=exclude,
-            select=select,
-            dbt_cmd=dbt_executable_path,
+            render_config=render_config,
+            dbt_cmd=render_config.dbt_executable_path,
             profile_config=profile_config,
             operator_args=operator_args,
-            dbt_deps=dbt_deps,
         )
-        dbt_graph.load(method=load_mode, execution_mode=execution_mode)
+        dbt_graph.load(method=render_config.load_method, execution_mode=execution_config.execution_mode)
 
         task_args = {
             **operator_args,
-            # the following args may be only needed for local / venv:
-            "project_dir": project_config.dbt_project_path,
+            "project_dir": execution_config.project_path,
             "profile_config": profile_config,
-            "emit_datasets": emit_datasets,
+            "emit_datasets": render_config.emit_datasets,
         }
-        if dbt_executable_path:
-            task_args["dbt_executable_path"] = dbt_executable_path
+        if execution_config.dbt_executable_path:
+            task_args["dbt_executable_path"] = execution_config.dbt_executable_path
 
-        validate_arguments(select, exclude, profile_args, task_args)
+        validate_arguments(render_config.select, render_config.exclude, profile_args, task_args)
 
         build_airflow_graph(
             nodes=dbt_graph.filtered_nodes,
             dag=dag or (task_group and task_group.dag),
             task_group=task_group,
-            execution_mode=execution_mode,
+            execution_mode=execution_config.execution_mode,
             task_args=task_args,
-            test_behavior=test_behavior,
-            test_indirect_selection=test_indirect_selection,
+            test_behavior=render_config.test_behavior,
+            test_indirect_selection=execution_config.test_indirect_selection,
             dbt_project_name=project_config.project_name,
             on_warning_callback=on_warning_callback,
-            node_converters=node_converters,
+            node_converters=render_config.node_converters,
         )

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -154,6 +154,7 @@ class DbtToAirflowConverter:
         dbt_graph = DbtGraph(
             project=project_config,
             render_config=render_config,
+            execution_config=execution_config,
             dbt_cmd=render_config.dbt_executable_path,
             profile_config=profile_config,
             operator_args=operator_args,

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -122,9 +122,8 @@ class DbtGraph:
 
         dbt_graph = DbtGraph(
             project=ProjectConfig(dbt_project_path=DBT_PROJECT_PATH),
-            exclude=["*orders*"],
-            select=[],
-            dbt_cmd="/usr/local/bin/dbt",
+            render_config=RenderConfig(exclude=["*orders*"], select=[]),
+            dbt_cmd="/usr/local/bin/dbt"
         )
         dbt_graph.load(method=LoadMode.DBT_LS, execution_mode=ExecutionMode.LOCAL)
     """

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -78,7 +78,7 @@ def run_command(command: list[str], tmp_dir: Path, env_vars: dict[str, str]) -> 
 
     if 'Run "dbt deps" to install package dependencies' in stdout and command[1] == "ls":
         raise CosmosLoadDbtException(
-            "Unable to run dbt ls command due to missing dbt_packages. Set render_config.dbt_deps=True."
+            "Unable to run dbt ls command due to missing dbt_packages. Set RenderConfig.dbt_deps=True."
         )
 
     if returncode or "Error" in stdout:

--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -1,5 +1,12 @@
 Execution Config
 ==================
 
-Cosmos supports multiple ways of executing your dbt models.
-For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
+Cosmos aims to give you control over how your dbt project is executed when running in airflow.
+It does this by exposing a ``cosmos.config.ExecutionConfig`` class that you can use to configure how your DAGs are executed.
+
+The ``ExecutionConfig`` class takes the following arguments:
+
+- ``execution_mode``: The way dbt is run when executing within airflow. For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
+- ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
+- ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
+- ``dbt_project_path``: Configures the DBT project location accessible on their airflow controller for DAG rendering - Required when using ``load_method=LoadMode.DBT_LS`` or ``load_method=LoadMode.CUSTOM``

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -11,7 +11,10 @@ The ``RenderConfig`` class takes the following arguments:
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``select`` and ``exclude``: which models to include or exclude from your DAGs. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.
+- ``dbt_deps``: A Boolean to run dbt deps when using dbt ls for dag parsing. Default True
 - ``node_converters``: a dictionary mapping a ``DbtResourceType`` into a callable. Users can control how to render dbt nodes in Airflow. Only supported when using ``load_method=LoadMode.DBT_MANIFEST`` or ``LoadMode.DBT_LS``. Find more information below.
+- ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
+- ``dbt_project_path``: Configures the DBT project location accessible on their airflow controller for DAG rendering - Required when using ``load_method=LoadMode.DBT_LS`` or ``load_method=LoadMode.CUSTOM``
 
 Customizing how nodes are rendered (experimental)
 -------------------------------------------------

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -336,11 +336,11 @@ def test_load_via_dbt_ls_with_invalid_dbt_path():
 def test_load_via_dbt_ls_with_sources(load_method):
     project_name = "simple"
     dbt_graph = DbtGraph(
-        dbt_deps=False,
         project=ProjectConfig(
             dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name,
             manifest_path=SAMPLE_MANIFEST_SOURCE if load_method == "load_from_dbt_manifest" else None,
         ),
+        render_config=RenderConfig(dbt_deps=False),
         profile_config=ProfileConfig(
             profile_name="simple",
             target_name="dev",

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -240,9 +240,9 @@ def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_pop
 def test_load_via_dbt_ls_with_exclude():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     render_config = RenderConfig(
-        dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME, select=["*customers*"], exclude=["*orders*"]
+        dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, select=["*customers*"], exclude=["*orders*"]
     )
-    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,
@@ -288,8 +288,8 @@ def test_load_via_dbt_ls_with_exclude():
 @pytest.mark.parametrize("project_name", ("jaffle_shop", "jaffle_shop_python"))
 def test_load_via_dbt_ls_without_exclude(project_name):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name)
-    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
-    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,
@@ -393,8 +393,8 @@ def test_load_via_dbt_ls_with_sources(load_method):
 @pytest.mark.integration
 def test_load_via_dbt_ls_without_dbt_deps():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
-    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME, dbt_deps=False)
-    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, dbt_deps=False)
+    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,
@@ -449,8 +449,8 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
     mock_popen().returncode = 1
 
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
-    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
-    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,
@@ -474,8 +474,8 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
 def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate):
     # It may seem strange, but at least until dbt 1.6.0, there are circumstances when it outputs errors to stdout
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
-    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
-    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -231,8 +231,7 @@ def test_load_via_dbt_ls_with_exclude():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
-        select=["*customers*"],
-        exclude=["*orders*"],
+        render_config=RenderConfig(select=["*customers*"], exclude=["*orders*"]),
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -357,8 +356,8 @@ def test_load_via_dbt_ls_with_sources(load_method):
 def test_load_via_dbt_ls_without_dbt_deps():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
-        dbt_deps=False,
         project=project_config,
+        render_config=RenderConfig(dbt_deps=False),
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -520,7 +519,8 @@ def test_tag_selected_node_test_exist():
         target_name="test",
         profiles_yml_filepath=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME / "profiles.yml",
     )
-    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, select=["tag:test_tag"])
+    render_config = RenderConfig(select=["tag:test_tag"])
+    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, render_config=render_config)
     dbt_graph.load_from_dbt_manifest()
 
     assert len(dbt_graph.filtered_nodes) > 0

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -212,8 +212,12 @@ def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_pop
     assert not (tmp_dbt_project_dir / "logs").exists()
 
     project_config = ProjectConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -235,9 +239,14 @@ def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_pop
 @pytest.mark.integration
 def test_load_via_dbt_ls_with_exclude():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    render_config = RenderConfig(
+        dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME, select=["*customers*"], exclude=["*orders*"]
+    )
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
-        render_config=RenderConfig(select=["*customers*"], exclude=["*orders*"]),
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -279,8 +288,12 @@ def test_load_via_dbt_ls_with_exclude():
 @pytest.mark.parametrize("project_name", ("jaffle_shop", "jaffle_shop_python"))
 def test_load_via_dbt_ls_without_exclude(project_name):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -363,7 +376,8 @@ def test_load_via_dbt_ls_with_sources(load_method):
             dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name,
             manifest_path=SAMPLE_MANIFEST_SOURCE if load_method == "load_from_dbt_manifest" else None,
         ),
-        render_config=RenderConfig(dbt_deps=False),
+        render_config=RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name, dbt_deps=False),
+        execution_config=ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name),
         profile_config=ProfileConfig(
             profile_name="simple",
             target_name="dev",
@@ -379,9 +393,12 @@ def test_load_via_dbt_ls_with_sources(load_method):
 @pytest.mark.integration
 def test_load_via_dbt_ls_without_dbt_deps():
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME, dbt_deps=False)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
-        render_config=RenderConfig(dbt_deps=False),
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -406,8 +423,12 @@ def test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr(mock_popen, t
     mock_popen().returncode = 0
 
     project_config = ProjectConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -428,8 +449,12 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
     mock_popen().returncode = 1
 
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -449,8 +474,12 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
 def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate):
     # It may seem strange, but at least until dbt 1.6.0, there are circumstances when it outputs errors to stdout
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
+        render_config=render_config,
+        execution_config=execution_config,
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",
@@ -584,6 +613,8 @@ def test_load_dbt_ls_and_manifest_with_model_version(load_method):
             dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version",
             manifest_path=SAMPLE_MANIFEST_MODEL_VERSION if load_method == "load_from_dbt_manifest" else None,
         ),
+        render_config=RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version"),
+        execution_config=ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version"),
         profile_config=ProfileConfig(
             profile_name="default",
             target_name="default",

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -5,7 +5,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cosmos.config import ProfileConfig, ProjectConfig
+from cosmos.config import ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import DbtResourceType, ExecutionMode
 from cosmos.dbt.graph import (
     CosmosLoadDbtException,
@@ -56,7 +56,8 @@ def test_load_via_manifest_with_exclude(project_name, manifest_filepath, model_f
         target_name="test",
         profiles_yml_filepath=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME / "profiles.yml",
     )
-    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, exclude=["config.materialized:table"])
+    render_config = RenderConfig(exclude=["config.materialized:table"])
+    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, render_config=render_config)
     dbt_graph.load_from_dbt_manifest()
 
     assert len(dbt_graph.nodes) == 28
@@ -502,7 +503,8 @@ def test_update_node_dependency_test_not_exist():
         target_name="test",
         profiles_yml_filepath=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME / "profiles.yml",
     )
-    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, exclude=["config.materialized:test"])
+    render_config = RenderConfig(exclude=["config.materialized:test"])
+    dbt_graph = DbtGraph(project=project_config, profile_config=profile_config, render_config=render_config)
     dbt_graph.load_from_dbt_manifest()
 
     for _, nodes in dbt_graph.filtered_nodes.items():

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -371,7 +371,7 @@ def test_load_via_dbt_ls_without_dbt_deps():
     with pytest.raises(CosmosLoadDbtException) as err_info:
         dbt_graph.load_via_dbt_ls()
 
-    expected = "Unable to run dbt ls command due to missing dbt_packages. Set render_config.dbt_deps=True."
+    expected = "Unable to run dbt ls command due to missing dbt_packages. Set RenderConfig.dbt_deps=True."
     assert err_info.value.args[0] == expected
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -42,11 +42,10 @@ def test_init_with_no_params():
     """
     with pytest.raises(CosmosValueError) as err_info:
         ProjectConfig()
-        print(err_info.value.args[0])
-        assert err_info.value.args[0] == (
-            "ProjectConfig requires dbt_project_path and/or manifest_path to be defined."
-            "If only manifest_path is defined, project_name must also be defined."
-        )
+    assert err_info.value.args[0] == (
+        "ProjectConfig requires dbt_project_path and/or manifest_path to be defined. "
+        "If only manifest_path is defined, project_name must also be defined."
+    )
 
 
 def test_init_with_manifest_path_and_not_project_path_and_not_project_name_fails():
@@ -55,11 +54,10 @@ def test_init_with_manifest_path_and_not_project_path_and_not_project_name_fails
     """
     with pytest.raises(CosmosValueError) as err_info:
         ProjectConfig(manifest_path=DBT_PROJECTS_ROOT_DIR / "manifest.json")
-        print(err_info.value.args[0])
-        assert err_info.value.args[0] == (
-            "ProjectConfig requires dbt_project_path and/or manifest_path to be defined."
-            "If only manifest_path is defined, project_name must also be defined."
-        )
+    assert err_info.value.args[0] == (
+        "ProjectConfig requires dbt_project_path and/or manifest_path to be defined. "
+        "If only manifest_path is defined, project_name must also be defined."
+    )
 
 
 def test_validate_with_project_path_and_manifest_path_succeeds():
@@ -95,7 +93,7 @@ def test_validate_project_missing_fails():
     project_config = ProjectConfig(dbt_project_path=Path("/tmp"))
     with pytest.raises(CosmosValueError) as err_info:
         assert project_config.validate_project() is None
-        assert err_info.value.args[0] == "Could not find dbt_project.yml at /tmp/dbt_project.yml"
+    assert err_info.value.args[0] == "Could not find dbt_project.yml at /tmp/dbt_project.yml"
 
 
 def test_is_manifest_available_is_true():
@@ -118,13 +116,11 @@ def test_project_name():
 def test_profile_config_post_init():
     with pytest.raises(CosmosValueError) as err_info:
         ProfileConfig(profiles_yml_filepath="/tmp/some-profile", profile_name="test", target_name="test")
-        assert err_info.value.args[0] == "The file /tmp/some-profile does not exist."
+    assert err_info.value.args[0] == "The file /tmp/some-profile does not exist."
 
 
 def test_profile_config_validate():
     with pytest.raises(CosmosValueError) as err_info:
         profile_config = ProfileConfig(profile_name="test", target_name="test")
         assert profile_config.validate_profile() is None
-        assert (
-            err_info.value.args[0] == "Either profiles_yml_filepath or profile_mapping must be set to render a profile"
-        )
+    assert err_info.value.args[0] == "Either profiles_yml_filepath or profile_mapping must be set to render a profile"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -36,16 +36,14 @@ def test_init_with_manifest_path_and_project_path_succeeds():
 
 def test_init_with_no_params():
     """
-    The constructor now validates that the required base fields are present
-    As such, we should test here that the correct exception is raised if these are not correctly defined
-    This functionality has been moved from the validate method
+    With the implementation of dbt_project_path in RenderConfig and ExecutionConfig
+    dbt_project_path becomes optional here. The only requirement is that if one of
+    manifest_path or project_name is defined, they should both be defined.
+    We used to enforce dbt_project_path or manifest_path and project_name, but this is
+    No longer the case
     """
-    with pytest.raises(CosmosValueError) as err_info:
-        ProjectConfig()
-    assert err_info.value.args[0] == (
-        "ProjectConfig requires dbt_project_path and/or manifest_path to be defined. "
-        "If only manifest_path is defined, project_name must also be defined."
-    )
+    project_config = ProjectConfig()
+    assert project_config
 
 
 def test_init_with_manifest_path_and_not_project_path_and_not_project_name_fails():
@@ -55,8 +53,7 @@ def test_init_with_manifest_path_and_not_project_path_and_not_project_name_fails
     with pytest.raises(CosmosValueError) as err_info:
         ProjectConfig(manifest_path=DBT_PROJECTS_ROOT_DIR / "manifest.json")
     assert err_info.value.args[0] == (
-        "ProjectConfig requires dbt_project_path and/or manifest_path to be defined. "
-        "If only manifest_path is defined, project_name must also be defined."
+        "If ProjectConfig.dbt_project_path is not defined, ProjectConfig.manifest_path and ProjectConfig.project_name must be defined together, or both left undefined."
     )
 
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -137,5 +137,5 @@ def test_converter_fails_execution_config_no_project_dir(mock_load_dbt_graph, ex
         )
     assert (
         err_info.value.args[0]
-        == "ExecutionConfig.project_path is required for the execution of dbt tasks in all execution modes."
+        == "ExecutionConfig.dbt_project_path is required for the execution of dbt tasks in all execution modes."
     )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -113,7 +113,7 @@ def test_converter_creates_dag_with_project_path_str(mock_load_dbt_graph, execut
 )
 @patch("cosmos.converter.DbtGraph.filtered_nodes", nodes)
 @patch("cosmos.converter.DbtGraph.load")
-def test_converter_fails_no_project_dir(mock_load_dbt_graph, execution_mode, operator_args):
+def test_converter_fails_execution_config_no_project_dir(mock_load_dbt_graph, execution_mode, operator_args):
     """
     This test validates that a project, given a manifest path and project name, with seeds
     is able to successfully generate a converter
@@ -135,4 +135,7 @@ def test_converter_fails_no_project_dir(mock_load_dbt_graph, execution_mode, ope
             render_config=render_config,
             operator_args=operator_args,
         )
-        assert err_info.value.args[0] == "A Project Path in ProjectConfig is required for generating a Task Operators."
+    assert (
+        err_info.value.args[0]
+        == "ExecutionConfig.project_path is required for the execution of dbt tasks in all execution modes."
+    )


### PR DESCRIPTION
## Description

This MR finishes the work that was started in #605 to add full support for ProjectConfig.dbt_project_path = None, and implements #568.

Within this PR, several things have been updated:

1 - Added project_path fields to RenderConfig and ExecutionConfig
2 - Simplified the consumption of RenderConfig in the dbtGraph class
3 - added option to configure different dbt executable for Rendering vs Execution.

## Related Issue(s)

Closes: #568

## Breaking Change?

None

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
