### PR TITLE
Update contributing docs for running integration tests

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -111,6 +111,16 @@ To run the integration tests for the first time, use:
 
     export AIRFLOW_HOME=`pwd`
     export AIRFLOW_CONN_AIRFLOW_DB=postgres://postgres:postgres@0.0.0.0:5432/postgres
+    export DATABRICKS_HOST=''
+    export DATABRICKS_TOKEN=''
+    export DATABRICKS_WAREHOUSE_ID=''
+    export DATABRICKS_CLUSTER_ID=''
+    export POSTGRES_PORT=5432
+    export POSTGRES_SCHEMA=public
+    export POSTGRES_DB=postgres
+    export POSTGRES_PASSWORD=postgres
+    export POSTGRES_USER=postgres
+    export POSTGRES_HOST=localhost
     hatch run tests.py3.8-2.5:test-integration-setup
     hatch run tests.py3.8-2.5:test-integration
 


### PR DESCRIPTION
## Description

In order to run the integration tests locally without errors I had to set more environment variables than the ones that are currently in the docs. If these were excluded I would get errors like: 

```shell
tests/test_example_dags_no_connections.py:59: in <module>
    @pytest.mark.parametrize("dag_id", get_dag_ids())
tests/test_example_dags_no_connections.py:54: in get_dag_ids
    dag_bag = get_dag_bag()
tests/test_example_dags_no_connections.py:49: in get_dag_bag
    assert not db.import_errors
E   AssertionError: assert not {'/Users/justin.bandoro/astronomer-cosmos/dev/dags/example_cosmos_python_models.py': 'Traceback (most recent call last...ema.yml from project jaffle_shop: Parsing Error\n    Env var required but not provided: \'DATABRICKS_CLUSTER_ID\'\n\n'}
E    +  where {'/Users/justin.bandoro/astronomer-cosmos/dev/dags/example_cosmos_python_models.py': 'Traceback (most recent call last...ema.yml from project jaffle_shop: Parsing Error\n    Env var required but not provided: \'DATABRICKS_CLUSTER_ID\'\n\n'} = <airflow.models.dagbag.DagBag object at 0x1579cd000>.import_errors
```

Let me know if I missed something that was already in the docs, this PR might help anyone else trying to run integration tests for the first time.

## Related Issue(s)

None

## Breaking Change?

None

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
