### PR TITLE
Fix issue related to Airflow 2.4 & Werkzeug =>3

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -146,7 +146,8 @@ dependencies = [
     "types-attrs",
     "types-requests",
     "types-python-dateutil",
-    "apache-airflow"
+    "apache-airflow",
+    "Werkzeug<3.0.0",
 ]
 
 [[tool.hatch.envs.tests.matrix]]


### PR DESCRIPTION
Our integration tests failed for Airflow 2.4 and under since Werkzeug 3.0 and higher during `airflow db init` with:
```
Traceback (most recent call last):
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/bin/airflow", line 10, in <module>
    sys.exit(main())
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/__main__.py", line 39, in main
    args.func(args)
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/cli/cli_parser.py", line 52, in command
    return func(*args, **kwargs)
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/cli/commands/db_command.py", line 37, in initdb
    db.initdb()
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/utils/session.py", line 75, in wrapper
    return func(*args, session=session, **kwargs)
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/utils/db.py", line 681, in initdb
    _create_db_from_orm(session=session)
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/utils/db.py", line 653, in _create_db_from_orm
    from airflow.www.fab_security.sqla.models import Model
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/airflow/www/fab_security/sqla/models.py", line 27, in <module>
    from flask_appbuilder.models.sqla import Model
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_appbuilder/__init__.py", line 5, in <module>
    from .api import ModelRestApi  # noqa: F401
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_appbuilder/api/__init__.py", line 24, in <module>
    from ..baseviews import AbstractViewApi
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_appbuilder/baseviews.py", line 22, in <module>
    from .forms import GeneralModelConverter
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_appbuilder/forms.py", line 3, in <module>
    from flask_wtf import FlaskForm
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_wtf/__init__.py", line 3, in <module>
    from .recaptcha import *
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_wtf/recaptcha/__init__.py", line 2, in <module>
    from .fields import *
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_wtf/recaptcha/fields.py", line 3, in <module>
    from . import widgets
  File "/Users/tati/Library/Application Support/hatch/env/virtual/astronomer-cosmos/4VBJdS-x/tests.py3.10-2.4/lib/python3.10/site-packages/flask_wtf/recaptcha/widgets.py", line 2, in <module>
    from werkzeug.urls import url_encode
```

This fixes the issues for our tests.