### PR TITLE
Remove Pydantic dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,10 +34,8 @@ classifiers = [
     "Programming Language :: Python :: 3.10",
 ]
 dependencies = [
-    # Airflow & Pydantic issue: https://github.com/apache/airflow/issues/32311
     "aenum",
     "attrs",
-    "pydantic>=1.10.0,<2.0.0",
     "apache-airflow>=2.3.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR removes the Pydantic dependency from Cosmos. It appears we're no longer using it.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes https://github.com/astronomer/astronomer-cosmos/issues/651

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
