### PR TITLE
Ensure local docs operators generate necessary files for datahub integration

### DIFF
--- a/cosmos/operators/__init__.py
+++ b/cosmos/operators/__init__.py
@@ -2,6 +2,7 @@ from .local import DbtDepsLocalOperator as DbtDepsOperator
 from .local import DbtDocsAzureStorageLocalOperator as DbtDocsAzureStorageOperator
 from .local import DbtDocsLocalOperator as DbtDocsOperator
 from .local import DbtDocsS3LocalOperator as DbtDocsS3Operator
+from .local import DbtFreshnessS3LocalOperator as DbtFreshnessS3Operator
 from .local import DbtDocsGCSLocalOperator as DbtDocsGCSOperator
 from .local import DbtLSLocalOperator as DbtLSOperator
 from .local import DbtRunLocalOperator as DbtRunOperator
@@ -20,6 +21,7 @@ __all__ = [
     "DbtDepsOperator",
     "DbtDocsOperator",
     "DbtDocsS3Operator",
+    "DbtFreshnessS3Operator",
     "DbtDocsAzureStorageOperator",
     "DbtDocsGCSOperator",
 ]

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -572,13 +572,13 @@ class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
 
     def __init__(
         self,
-        aws_conn_id: str,
+        connection_id: str,
         bucket_name: str,
         folder_dir: str | None = None,
         **kwargs: str,
     ) -> None:
         "Initializes the operator."
-        self.aws_conn_id = aws_conn_id
+        self.connection_id = connection_id
         self.bucket_name = bucket_name
         self.folder_dir = folder_dir
 
@@ -591,7 +591,7 @@ class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
         "Uploads the generated documentation to S3."
         logger.info(
             'Attempting to upload generated docs to S3 using S3Hook("%s")',
-            self.aws_conn_id,
+            self.connection_id,
         )
 
         from airflow.providers.amazon.aws.hooks.s3 import S3Hook
@@ -599,7 +599,7 @@ class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
         target_dir = f"{project_dir}/target"
 
         hook = S3Hook(
-            self.aws_conn_id,
+            self.connection_id,
             extra_args={
                 "ContentType": "text/html",
             },

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -538,11 +538,12 @@ class DbtDocsLocalOperator(DbtLocalBaseOperator):
 
     ui_color = "#8194E0"
 
-    required_files = ["index.html", "manifest.json", "graph.gpickle", "catalog.json"]
+    required_files = ["index.html", "manifest.json", "graph.gpickle", "catalog.json", "run_results.json"]
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["docs", "generate"]
+
 
 class DbtFreshnessLocalOperator(DbtLocalBaseOperator):
     """
@@ -555,6 +556,7 @@ class DbtFreshnessLocalOperator(DbtLocalBaseOperator):
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
         self.base_cmd = ["source", "freshness"]
+
 
 class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
     """
@@ -569,11 +571,11 @@ class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
     ui_color = "#FF9900"
 
     def __init__(
-            self,
-            aws_conn_id: str,
-            bucket_name: str,
-            folder_dir: str | None = None,
-            **kwargs: str,
+        self,
+        aws_conn_id: str,
+        bucket_name: str,
+        folder_dir: str | None = None,
+        **kwargs: str,
     ) -> None:
         "Initializes the operator."
         self.aws_conn_id = aws_conn_id
@@ -613,6 +615,7 @@ class DbtFreshnessS3LocalOperator(DbtFreshnessLocalOperator):
             key=key,
             replace=True,
         )
+
 
 class DbtDocsCloudLocalOperator(DbtDocsLocalOperator, ABC):
     """

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -20,6 +20,7 @@ from cosmos import ProfileConfig
 from cosmos.operators import (
     DbtDocsAzureStorageOperator,
     DbtDocsS3Operator,
+    DbtFreshnessS3Operator,
     DbtDocsGCSOperator,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
@@ -77,6 +78,14 @@ with DAG(
 ) as dag:
     generate_dbt_docs_aws = DbtDocsS3Operator(
         task_id="generate_dbt_docs_aws",
+        project_dir=DBT_ROOT_PATH / "jaffle_shop",
+        profile_config=profile_config,
+        connection_id=S3_CONN_ID,
+        bucket_name="cosmos-docs",
+    )
+
+    generate_dbt_freshness_aws = DbtFreshnessS3Operator(
+        task_id="generate_dbt_freshness_aws",
         project_dir=DBT_ROOT_PATH / "jaffle_shop",
         profile_config=profile_config,
         connection_id=S3_CONN_ID,

--- a/docs/configuration/generating-docs.rst
+++ b/docs/configuration/generating-docs.rst
@@ -10,6 +10,7 @@ Many users choose to generate and serve these docs on a static website. This is 
 Cosmos offers two pre-built ways of generating and uploading dbt docs and a fallback option to run custom code after the docs are generated:
 
 - :class:`~cosmos.operators.DbtDocsS3Operator`: generates and uploads docs to a S3 bucket.
+- :class:`~cosmos.operators.DbtFreshnessS3Operator`: generates and uploads `sources.json <https://docs.getdbt.com/reference/artifacts/sources-json>`_ doc to an S3 bucket
 - :class:`~cosmos.operators.DbtDocsAzureStorageOperator`: generates and uploads docs to an Azure Blob Storage.
 - :class:`~cosmos.operators.DbtDocsGCSOperator`: generates and uploads docs to a GCS bucket.
 - :class:`~cosmos.operators.DbtDocsOperator`: generates docs and runs a custom callback.
@@ -34,6 +35,15 @@ You can use the :class:`~cosmos.operators.DbtDocsS3Operator` to generate and upl
     # then, in your DAG code:
     generate_dbt_docs_aws = DbtDocsS3Operator(
         task_id="generate_dbt_docs_aws",
+        project_dir="path/to/jaffle_shop",
+        profile_config=profile_config,
+        # docs-specific arguments
+        connection_id="test_aws",
+        bucket_name="test_bucket",
+    )
+
+    generate_dbt_freshness_aws = DbtFreshnessS3Operator(
+        task_id="generate_dbt_freshness_aws",
         project_dir="path/to/jaffle_shop",
         profile_config=profile_config,
         # docs-specific arguments


### PR DESCRIPTION
## Description

Two changes with this PR:
1. Add the `DbtFreshnessLocalOperator` & `DbtFreshnessS3LocalOperator` to properly generate the [sources.json file](https://docs.getdbt.com/reference/artifacts/sources-json)
2. Add [run_results.json](https://docs.getdbt.com/reference/artifacts/run-results-json) to the list of required files for the `DbtDocsLocalOperator`. 

These files are necessary to use [the dbt integration](https://datahubproject.io/docs/generated/ingestion/sources/dbt/) with DataHub and will make it easier for cosmos users to emit their metadata to DataHub as needed.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
