### PR TITLE
Fix running models that use alias while supporting dbt versions

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -83,11 +83,11 @@ def create_test_task_metadata(
         task_args["indirect_selection"] = test_indirect_selection.value
     if node is not None:
         if node.resource_type == DbtResourceType.MODEL:
-            task_args["models"] = node.name
+            task_args["models"] = node.resource_name
         elif node.resource_type == DbtResourceType.SOURCE:
-            task_args["select"] = f"source:{node.unique_id[len('source.'):]}"
+            task_args["select"] = f"source:{node.resource_name}"
         else:  # tested with node.resource_type == DbtResourceType.SEED or DbtResourceType.SNAPSHOT
-            task_args["select"] = node.name
+            task_args["select"] = node.resource_name
     return TaskMetadata(
         id=test_task_name,
         operator_class=calculate_operator_class(
@@ -108,8 +108,8 @@ def create_task_metadata(
     :param execution_mode: Where Cosmos should run each dbt task (e.g. ExecutionMode.LOCAL, ExecutionMode.KUBERNETES).
          Default is ExecutionMode.LOCAL.
     :param args: Arguments to be used to instantiate an Airflow Task
-    :param use_name_as_task_id_prefix: If resource_type is DbtResourceType.MODEL, it determines whether
-         using name as task id prefix or not. If it is True task_id = <node.name>_run, else task_id=run.
+    :param use_task_group: It determines whether to use the name as a prefix for the task id or not.
+        If it is False, then use the name as a prefix for the task id, otherwise do not.
     :returns: The metadata necessary to instantiate the source dbt node as an Airflow task.
     """
     dbt_resource_to_class = {
@@ -118,7 +118,7 @@ def create_task_metadata(
         DbtResourceType.SEED: "DbtSeed",
         DbtResourceType.TEST: "DbtTest",
     }
-    args = {**args, **{"models": node.name}}
+    args = {**args, **{"models": node.resource_name}}
 
     if DbtResourceType(node.resource_type) in DEFAULT_DBT_RESOURCES and node.resource_type in dbt_resource_to_class:
         if node.resource_type == DbtResourceType.MODEL:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -210,9 +210,6 @@ class DbtGraph:
         This is the most accurate way of loading `dbt` projects and filtering them out, since it uses the `dbt` command
         line for both parsing and filtering the nodes.
 
-        Noted that if dbt project contains versioned models, need to use dbt>=1.6.0 instead. Because, as dbt<1.6.0,
-        dbt cli doesn't support select a specific versioned models as stg_customers_v1, customers_v1, ...
-
         Updates in-place:
         * self.nodes
         * self.filtered_nodes
@@ -338,9 +335,6 @@ class DbtGraph:
 
         However, since the Manifest does not represent filters, it relies on the Custom Cosmos implementation
         to filter out the nodes relevant to the user (based on self.exclude and self.select).
-
-        Noted that if dbt project contains versioned models, need to use dbt>=1.6.0 instead. Because, as dbt<1.6.0,
-        dbt cli doesn't support select a specific versioned models as stg_customers_v1, customers_v1, ...
 
         Updates in-place:
         * self.nodes

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -42,7 +42,6 @@ class DbtNode:
     Metadata related to a dbt node (e.g. model, seed, snapshot).
     """
 
-    name: str
     unique_id: str
     resource_type: DbtResourceType
     depends_on: list[str]
@@ -50,6 +49,23 @@ class DbtNode:
     tags: list[str] = field(default_factory=lambda: [])
     config: dict[str, Any] = field(default_factory=lambda: {})
     has_test: bool = False
+
+    @property
+    def resource_name(self) -> str:
+        """
+        Use this property to retrieve the resource name for command generation, for instance: ["dbt", "run", "--models", f"{resource_name}"].
+        The unique_id format is defined as [<resource_type>.<package>.<resource_name>](https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details).
+        For a special case like a versioned model, the unique_id follows this pattern: [model.<package>.<resource_name>.<version>](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/contracts/graph/node_args.py#L26C3-L31)
+        """
+        return self.unique_id.split(".", 2)[2]
+
+    @property
+    def name(self) -> str:
+        """
+        Use this property as the task name or task group name.
+        Replace period (.) with underscore (_) due to versioned models.
+        """
+        return self.resource_name.replace(".", "_")
 
 
 def run_command(command: list[str], tmp_dir: Path, env_vars: dict[str, str]) -> str:
@@ -89,7 +105,6 @@ def parse_dbt_ls_output(project_path: Path, ls_stdout: str) -> dict[str, DbtNode
             logger.debug("Skipped dbt ls line: %s", line)
         else:
             node = DbtNode(
-                name=node_dict.get("alias", node_dict["name"]),
                 unique_id=node_dict["unique_id"],
                 resource_type=DbtResourceType(node_dict["resource_type"]),
                 depends_on=node_dict.get("depends_on", {}).get("nodes", []),
@@ -291,8 +306,7 @@ class DbtGraph:
         for model_name, model in models:
             config = {item.split(":")[0]: item.split(":")[-1] for item in model.config.config_selectors}
             node = DbtNode(
-                name=model_name,
-                unique_id=model_name,
+                unique_id=f"{model.type.value}.{self.project.project_name}.{model_name}",
                 resource_type=DbtResourceType(model.type.value),
                 depends_on=list(model.config.upstream_models),
                 file_path=Path(
@@ -347,7 +361,6 @@ class DbtGraph:
             resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}
             for unique_id, node_dict in resources.items():
                 node = DbtNode(
-                    name=node_dict.get("alias", node_dict["name"]),
                     unique_id=unique_id,
                     resource_type=DbtResourceType(node_dict["resource_type"]),
                     depends_on=node_dict.get("depends_on", {}).get("nodes", []),

--- a/dev/dags/dbt/model_version/models/schema.yml
+++ b/dev/dags/dbt/model_version/models/schema.yml
@@ -37,7 +37,11 @@ models:
           - include: all
             exclude:
               - full_name
+        config:
+          alias: '{{ "customers_" ~ var("division", "USA") ~ "_v1" }}'
       - v: 2
+        config:
+          alias: '{{ "customers_" ~ var("division", "USA") ~ "_v2" }}'
 
   - name: orders
     description: This table has basic information about orders, as well as some derived facts based on payments

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -12,8 +12,8 @@ from cosmos.dbt.graph import (
     DbtGraph,
     DbtNode,
     LoadMode,
-    run_command,
     parse_dbt_ls_output,
+    run_command,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
@@ -40,6 +40,20 @@ def tmp_dbt_project_dir():
     yield tmp_dir
 
     shutil.rmtree(tmp_dir, ignore_errors=True)  # delete directory
+
+
+@pytest.mark.parametrize(
+    "unique_id,expected_name, expected_select",
+    [
+        ("model.my_project.customers", "customers", "customers"),
+        ("model.my_project.customers.v1", "customers_v1", "customers.v1"),
+        ("model.my_project.orders.v2", "orders_v2", "orders.v2"),
+    ],
+)
+def test_dbt_node_name_and_select(unique_id, expected_name, expected_select):
+    node = DbtNode(unique_id=unique_id, resource_type=DbtResourceType.MODEL, depends_on=[], file_path="")
+    assert node.name == expected_name
+    assert node.resource_name == expected_select
 
 
 @pytest.mark.parametrize(
@@ -692,7 +706,6 @@ def test_parse_dbt_ls_output():
 
     expected_nodes = {
         "fake-unique-id": DbtNode(
-            name="fake-name",
             unique_id="fake-unique-id",
             resource_type=DbtResourceType.MODEL,
             file_path=Path("fake-project/fake-file-path.sql"),

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -39,8 +39,7 @@ def test_is_empty_config(selector_config, paths, tags, config, other, expected):
 
 
 grandparent_node = DbtNode(
-    name="grandparent",
-    unique_id="grandparent",
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.grandparent",
     resource_type=DbtResourceType.MODEL,
     depends_on=[],
     file_path=SAMPLE_PROJ_PATH / "gen1/models/grandparent.sql",
@@ -48,8 +47,7 @@ grandparent_node = DbtNode(
     config={"materialized": "view", "tags": ["has_child"]},
 )
 parent_node = DbtNode(
-    name="parent",
-    unique_id="parent",
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.parent",
     resource_type=DbtResourceType.MODEL,
     depends_on=["grandparent"],
     file_path=SAMPLE_PROJ_PATH / "gen2/models/parent.sql",
@@ -57,8 +55,7 @@ parent_node = DbtNode(
     config={"materialized": "view", "tags": ["has_child", "is_child"]},
 )
 child_node = DbtNode(
-    name="child",
-    unique_id="child",
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.child",
     resource_type=DbtResourceType.MODEL,
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
@@ -67,8 +64,7 @@ child_node = DbtNode(
 )
 
 grandchild_1_test_node = DbtNode(
-    name="grandchild_1",
-    unique_id="grandchild_1",
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.grandchild_1",
     resource_type=DbtResourceType.MODEL,
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_1.sql",
@@ -77,8 +73,7 @@ grandchild_1_test_node = DbtNode(
 )
 
 grandchild_2_test_node = DbtNode(
-    name="grandchild_2",
-    unique_id="grandchild_2",
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.grandchild_2",
     resource_type=DbtResourceType.MODEL,
     depends_on=["parent"],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_2.sql",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -31,8 +31,7 @@ def test_validate_arguments_tags(argument_key):
 
 
 parent_seed = DbtNode(
-    name="seed_parent",
-    unique_id="seed_parent",
+    unique_id=f"{DbtResourceType.SEED}.{SAMPLE_DBT_PROJECT.stem}.seed_parent",
     resource_type=DbtResourceType.SEED,
     depends_on=[],
     file_path="",


### PR DESCRIPTION
## Description

Current version, cosmos will got bug `Not found node` because it run with alias selection as: `--models customers_abc_v1 ` and `--models customers_abc_v2` .
I propose to parsing node selection in `unique_id` instead of using `alias` .
So node selection should be: `unique_id.split('.', 2)[2]` , reference to [function](https://github.com/dbt-labs/dbt-core/blob/main/core/dbt/contracts/graph/node_args.py#L26) and [resource-details document](https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details).
In addition, with this change help cosmos also support versioned models on dbt-core `>=1.5.0` instead `>=1.6.0` as current version.

## Related Issue(s)

closes #636

## Breaking Change?

Cosmos will support dynamic alias and versioned models

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
