### PR TITLE
Fix 'Unable to find the dbt executable: dbt' error

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -60,27 +60,26 @@ class RenderConfig:
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         self.project_path = Path(dbt_project_path) if dbt_project_path else None
 
-    def validate_dbt_command(self, execution_mode: ExecutionMode, fallback_cmd: str | Path = "") -> None:
+    def validate_dbt_command(self, fallback_cmd: str | Path = "") -> None:
         """
-        When using ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV, the dbt executable path is necessary for rendering.
+        When using LoadMode.DBT_LS, the dbt executable path is necessary for rendering.
 
         Validates that the original dbt command works, if not, attempt to use the fallback_dbt_cmd.
         If neither works, raise an exception.
 
         The fallback behaviour is necessary for Cosmos < 1.2.2 backwards compatibility.
         """
-        if execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
-            if not shutil.which(self.dbt_executable_path):
-                if isinstance(fallback_cmd, Path):
-                    fallback_cmd = fallback_cmd.as_posix()
+        if not shutil.which(self.dbt_executable_path):
+            if isinstance(fallback_cmd, Path):
+                fallback_cmd = fallback_cmd.as_posix()
 
-                if fallback_cmd and shutil.which(fallback_cmd):
-                    self.dbt_executable_path = fallback_cmd
-                else:
-                    raise CosmosConfigException(
-                        "Unable to find the dbt executable, attempted: "
-                        f"<{self.dbt_executable_path}>" + (f" and <{fallback_cmd}>." if fallback_cmd else ".")
-                    )
+            if fallback_cmd and shutil.which(fallback_cmd):
+                self.dbt_executable_path = fallback_cmd
+            else:
+                raise CosmosConfigException(
+                    "Unable to find the dbt executable, attempted: "
+                    f"<{self.dbt_executable_path}>" + (f" and <{fallback_cmd}>." if fallback_cmd else ".")
+                )
 
 
 class ProjectConfig:

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -60,24 +60,27 @@ class RenderConfig:
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         self.project_path = Path(dbt_project_path) if dbt_project_path else None
 
-    def validate_dbt_command(self, fallback_cmd: str | Path = "") -> None:
+    def validate_dbt_command(self, execution_mode: ExecutionMode, fallback_cmd: str | Path = "") -> None:
         """
+        When using ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV, the dbt executable path is necessary for rendering.
+
         Validates that the original dbt command works, if not, attempt to use the fallback_dbt_cmd.
         If neither works, raise an exception.
 
         The fallback behaviour is necessary for Cosmos < 1.2.2 backwards compatibility.
         """
-        if not shutil.which(self.dbt_executable_path):
-            if isinstance(fallback_cmd, Path):
-                fallback_cmd = fallback_cmd.as_posix()
+        if execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
+            if not shutil.which(self.dbt_executable_path):
+                if isinstance(fallback_cmd, Path):
+                    fallback_cmd = fallback_cmd.as_posix()
 
-            if fallback_cmd and shutil.which(fallback_cmd):
-                self.dbt_executable_path = fallback_cmd
-            else:
-                raise CosmosConfigException(
-                    "Unable to find the dbt executable, attempted: "
-                    f"<{self.dbt_executable_path}>" + (f" and <{fallback_cmd}>." if fallback_cmd else ".")
-                )
+                if fallback_cmd and shutil.which(fallback_cmd):
+                    self.dbt_executable_path = fallback_cmd
+                else:
+                    raise CosmosConfigException(
+                        "Unable to find the dbt executable, attempted: "
+                        f"<{self.dbt_executable_path}>" + (f" and <{fallback_cmd}>." if fallback_cmd else ".")
+                    )
 
 
 class ProjectConfig:

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -108,7 +108,9 @@ class DbtToAirflowConverter:
         if not render_config:
             render_config = RenderConfig()
 
-        render_config.validate_dbt_command(fallback_cmd=execution_config.dbt_executable_path)
+        render_config.validate_dbt_command(
+            execution_mode=execution_config.execution_mode, fallback_cmd=execution_config.dbt_executable_path
+        )
 
         # Since we now support both project_config.dbt_project_path, render_config.project_path and execution_config.project_path
         # We need to ensure that only one interface is being used.

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -108,6 +108,8 @@ class DbtToAirflowConverter:
         if not render_config:
             render_config = RenderConfig()
 
+        render_config.validate_dbt_command(fallback_cmd=execution_config.dbt_executable_path)
+
         # Since we now support both project_config.dbt_project_path, render_config.project_path and execution_config.project_path
         # We need to ensure that only one interface is being used.
         if project_config.dbt_project_path and (render_config.project_path or execution_config.project_path):

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -108,10 +108,6 @@ class DbtToAirflowConverter:
         if not render_config:
             render_config = RenderConfig()
 
-        render_config.validate_dbt_command(
-            execution_mode=execution_config.execution_mode, fallback_cmd=execution_config.dbt_executable_path
-        )
-
         # Since we now support both project_config.dbt_project_path, render_config.project_path and execution_config.project_path
         # We need to ensure that only one interface is being used.
         if project_config.dbt_project_path and (render_config.project_path or execution_config.project_path):
@@ -164,7 +160,6 @@ class DbtToAirflowConverter:
             project=project_config,
             render_config=render_config,
             execution_config=execution_config,
-            dbt_cmd=render_config.dbt_executable_path,
             profile_config=profile_config,
             operator_args=operator_args,
         )

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import itertools
 import json
 import os
-import shutil
 import tempfile
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,7 +20,6 @@ from cosmos.constants import (
     ExecutionMode,
     LoadMode,
 )
-from cosmos.dbt.executable import get_system_dbt
 from cosmos.dbt.parser.project import LegacyDbtProject
 from cosmos.dbt.selector import select_nodes
 from cosmos.log import get_logger
@@ -137,7 +135,6 @@ class DbtGraph:
         render_config: RenderConfig = RenderConfig(),
         execution_config: ExecutionConfig = ExecutionConfig(),
         profile_config: ProfileConfig | None = None,
-        dbt_cmd: str = get_system_dbt(),
         operator_args: dict[str, Any] | None = None,
     ):
         self.project = project
@@ -145,7 +142,6 @@ class DbtGraph:
         self.profile_config = profile_config
         self.execution_config = execution_config
         self.operator_args = operator_args or {}
-        self.dbt_cmd = dbt_cmd
 
     def load(
         self,
@@ -183,9 +179,11 @@ class DbtGraph:
         else:
             load_method[method]()
 
-    def run_dbt_ls(self, project_path: Path, tmp_dir: Path, env_vars: dict[str, str]) -> dict[str, DbtNode]:
+    def run_dbt_ls(
+        self, dbt_cmd: str, project_path: Path, tmp_dir: Path, env_vars: dict[str, str]
+    ) -> dict[str, DbtNode]:
         """Runs dbt ls command and returns the parsed nodes."""
-        ls_command = [self.dbt_cmd, "ls", "--output", "json"]
+        ls_command = [dbt_cmd, "ls", "--output", "json"]
 
         if self.render_config.exclude:
             ls_command.extend(["--exclude", *self.render_config.exclude])
@@ -220,6 +218,10 @@ class DbtGraph:
         * self.nodes
         * self.filtered_nodes
         """
+        self.render_config.validate_dbt_command(fallback_cmd=self.execution_config.dbt_executable_path)
+        dbt_cmd = self.render_config.dbt_executable_path
+        dbt_cmd = dbt_cmd.as_posix() if isinstance(dbt_cmd, Path) else dbt_cmd
+
         logger.info(f"Trying to parse the dbt project in `{self.render_config.project_path}` using dbt ls...")
         if not self.render_config.project_path or not self.execution_config.project_path:
             raise CosmosLoadDbtException(
@@ -228,9 +230,6 @@ class DbtGraph:
 
         if not self.profile_config:
             raise CosmosLoadDbtException("Unable to load project via dbt ls without a profile config.")
-
-        if not shutil.which(self.dbt_cmd):
-            raise CosmosLoadDbtException(f"Unable to find the dbt executable: {self.dbt_cmd}")
 
         with tempfile.TemporaryDirectory() as tmpdir:
             logger.info(
@@ -260,12 +259,12 @@ class DbtGraph:
                 env[DBT_TARGET_PATH_ENVVAR] = str(self.target_dir)
 
                 if self.render_config.dbt_deps:
-                    deps_command = [self.dbt_cmd, "deps"]
+                    deps_command = [dbt_cmd, "deps"]
                     deps_command.extend(self.local_flags)
                     stdout = run_command(deps_command, tmpdir_path, env)
                     logger.debug("dbt deps output: %s", stdout)
 
-                nodes = self.run_dbt_ls(self.execution_config.project_path, tmpdir_path, env)
+                nodes = self.run_dbt_ls(dbt_cmd, self.execution_config.project_path, tmpdir_path, env)
 
                 self.nodes = nodes
                 self.filtered_nodes = nodes

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -115,15 +115,6 @@ class DbtGraph:
     Supports different ways of loading the `dbt` project into this representation.
 
     Different loading methods can result in different `nodes` and `filtered_nodes`.
-
-    Example of how to use:
-
-        dbt_graph = DbtGraph(
-            project=ProjectConfig(dbt_project_path=DBT_PROJECT_PATH),
-            render_config=RenderConfig(exclude=["*orders*"], select=[]),
-            dbt_cmd="/usr/local/bin/dbt"
-        )
-        dbt_graph.load(method=LoadMode.DBT_LS, execution_mode=ExecutionMode.LOCAL)
     """
 
     nodes: dict[str, DbtNode] = dict()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -148,8 +148,8 @@ def test_render_config_with_invalid_dbt_commands(mock_which):
 @patch("cosmos.config.shutil.which", side_effect=(None, "fallback-dbt-path"))
 def test_render_config_uses_fallback_if_default_not_found(mock_which):
     render_config = RenderConfig()
-    render_config.validate_dbt_command("fallback-dbt-path")
-    assert render_config.dbt_executable_path == "fallback-dbt-path"
+    render_config.validate_dbt_command(Path("/tmp/fallback-dbt-path"))
+    assert render_config.dbt_executable_path == "/tmp/fallback-dbt-path"
 
 
 @patch("cosmos.config.shutil.which", side_effect=("user-dbt", "fallback-dbt-path"))


### PR DESCRIPTION
Since Cosmos 1.2.2 users who used `ExecutionMode.DBT_LS` (directly or via `ExecutionMode.AUTOMATIC`) and set `ExecutionConfig.dbt_executable_path` (most, if not all, Astro CLI users), like:

```
execution_config = ExecutionConfig(
    dbt_executable_path = f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt",
)
```

Started facing the issue:
```
Broken DAG: [/usr/local/airflow/dags/my_example.py] Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/cosmos/dbt/graph.py", line 178, in load
    self.load_via_dbt_ls()
  File "/usr/local/lib/python3.11/site-packages/cosmos/dbt/graph.py", line 233, in load_via_dbt_ls
    raise CosmosLoadDbtException(f"Unable to find the dbt executable: {self.dbt_cmd}")
cosmos.dbt.graph.CosmosLoadDbtException: Unable to find the dbt executable: dbt
```

This issue was initially reported in the Airflow #airflow-astronomer Slack channel: https://apache-airflow.slack.com/archives/C03T0AVNA6A/p1699584315506629

The workaround to avoid this error in Cosmos 1.2.2 and 1.2.3 is to set the `dbt_executable_path` in the `RenderConfig`:
```
render_config=RenderConfig(dbt_executable_path = f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt",),
```

This PR solves the bug from Cosmos 1.2.4 onwards.