### PR TITLE
Store compiled_sql even when task fails (fixes issue #369)

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -139,7 +139,6 @@ class DbtLocalBaseOperator(DbtBaseOperator):
         Gets called after every dbt run.
         """
         if not self.should_store_compiled_sql:
-            logger.info("should_store_compiled_sql is False. Skipping")
             return
 
         compiled_queries = {}

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -139,6 +139,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
         Gets called after every dbt run.
         """
         if not self.should_store_compiled_sql:
+            logger.info("should_store_compiled_sql is False. Skipping")
             return
 
         compiled_queries = {}
@@ -403,7 +404,7 @@ class DbtSeedLocalOperator(DbtLocalBaseOperator):
 
     ui_color = "#F58D7E"
 
-    template_fields: Sequence[str] = DbtBaseOperator.template_fields + ("full_refresh",)  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + ("full_refresh",)  # type: ignore[operator]
 
     def __init__(self, full_refresh: bool = False, **kwargs: Any) -> None:
         self.full_refresh = full_refresh
@@ -442,7 +443,7 @@ class DbtRunLocalOperator(DbtLocalBaseOperator):
 
     ui_color = "#7352BA"
     ui_fgcolor = "#F4F2FC"
-    template_fields: Sequence[str] = DbtBaseOperator.template_fields + ("full_refresh",)  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + ("full_refresh",)  # type: ignore[operator]
 
     def __init__(self, full_refresh: bool = False, **kwargs: Any) -> None:
         self.full_refresh = full_refresh

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -252,8 +252,8 @@ class DbtLocalBaseOperator(DbtBaseOperator):
                     logger.info("Outlets: %s", outlets)
                     self.register_dataset(inlets, outlets)
 
-                self.exception_handling(result)
                 self.store_compiled_sql(tmp_project_dir, context)
+                self.exception_handling(result)
                 if self.callback:
                     self.callback(tmp_project_dir)
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -423,8 +423,8 @@ def test_calculate_openlineage_events_completes_openlineage_errors(mock_processo
 @pytest.mark.parametrize(
     "operator_class,expected_template",
     [
-        (DbtSeedLocalOperator, ("env", "vars", "full_refresh")),
-        (DbtRunLocalOperator, ("env", "vars", "full_refresh")),
+        (DbtSeedLocalOperator, ("env", "vars", "compiled_sql", "full_refresh")),
+        (DbtRunLocalOperator, ("env", "vars", "compiled_sql", "full_refresh")),
     ],
 )
 def test_dbt_base_operator_template_fields(operator_class, expected_template):


### PR DESCRIPTION
## Description

Updated DbtLocalBaseOperator code to store compiled_sql prior to exception handling so that when a task fails the compiled_sql can still be reviewed.

In the process found and fixed a related bug where compiled_sql was being dropped on some operations due to the way that the `full_refresh` field was being added to the template_fields.

## Related Issue(s)

closes #369

Fixes bug introduced in https://github.com/astronomer/astronomer-cosmos/pull/623 where compiled_sql was being lost in `DbtSeedLocalOperator` and `DbtRunLocalOperator`

## Breaking Change?

Not a breaking change

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
