### PR TITLE
Fix ExecutionConfig.dbt_executable_path to use default_factory

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -258,7 +258,7 @@ class ExecutionConfig:
 
     execution_mode: ExecutionMode = ExecutionMode.LOCAL
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER
-    dbt_executable_path: str | Path | None = None
+    dbt_executable_path: str | Path = field(default_factory=get_system_dbt)
 
     dbt_project_path: InitVar[str | Path | None] = None
 
@@ -266,5 +266,3 @@ class ExecutionConfig:
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         self.project_path = Path(dbt_project_path) if dbt_project_path else None
-        if not self.dbt_executable_path:
-            self.dbt_executable_path = get_system_dbt()

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -258,7 +258,7 @@ class ExecutionConfig:
 
     execution_mode: ExecutionMode = ExecutionMode.LOCAL
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER
-    dbt_executable_path: str | Path = get_system_dbt()
+    dbt_executable_path: str | Path | None = None
 
     dbt_project_path: InitVar[str | Path | None] = None
 
@@ -266,3 +266,5 @@ class ExecutionConfig:
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         self.project_path = Path(dbt_project_path) if dbt_project_path else None
+        if not self.dbt_executable_path:
+            self.dbt_executable_path = get_system_dbt()

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -343,7 +343,8 @@ def test_load_via_dbt_ls_without_profile(mock_validate_dbt_command):
     assert err_info.value.args[0] == expected
 
 
-def test_load_via_dbt_ls_with_invalid_dbt_path():
+@patch("cosmos.dbt.executable.shutil.which", return_value=None)
+def test_load_via_dbt_ls_with_invalid_dbt_path(mock_which):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     render_config = RenderConfig(


### PR DESCRIPTION
## Description

I was seeing unit tests failing locally for `dbt.test_graph.test_load_via_dbt_ls_with_invalid_dbt_path` because I have dbt installed on my system and after the fix in #666 this test will fail since it fallbacks to the system dbt if it exists instead of "dbt" which the test is expecting.

This PR changes `ExecutionConfig.dbt_executable_path` to use a dataclass default factory for `get_system_dbt` so it is not called when ExecutionConfig is defined and allows us to more easily patch the shutil.which in the test so it won't fail if there is a system dbt installation.

## Related Issue(s)
None

## Breaking Change?
None

