### PR TITLE
Return code or error ignores WarnErrorOptions

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -88,7 +88,7 @@ def run_command(command: list[str], tmp_dir: Path, env_vars: dict[str, str]) -> 
             "Unable to run dbt ls command due to missing dbt_packages. Set RenderConfig.dbt_deps=True."
         )
 
-    if returncode or "Error" in stdout:
+    if returncode or "Error" in stdout.replace("WarnErrorOptions", ""):
         details = stderr or stdout
         raise CosmosLoadDbtException(f"Unable to run {command} due to the error:\n{details}")
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -679,6 +679,7 @@ def test_load_dbt_ls_and_manifest_with_model_version(load_method):
     "stdout,returncode",
     [
         ("all good", None),
+        ("WarnErrorOptions", None),
         pytest.param("fail", 599, marks=pytest.mark.xfail(raises=CosmosLoadDbtException)),
         pytest.param("Error", None, marks=pytest.mark.xfail(raises=CosmosLoadDbtException)),
     ],


### PR DESCRIPTION
## Description

Ignore WarnErrorOptions string in stdout from dbt-core, do not treat it as a failure

## Related Issue(s)

Workaround for https://github.com/astronomer/astronomer-cosmos/issues/642

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
