### PR TITLE
Draft: Add config to `TaskInstance` context

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -188,7 +188,6 @@ def generate_task_or_group(
                     task_args=task_args,
                     node=node,
                     on_warning_callback=on_warning_callback,
-                    node_config=node_config,
                 )
                 test_task = create_airflow_task(test_meta, dag, task_group=model_task_group, extra_context=node_config)
                 task >> test_task

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -159,7 +159,7 @@ def generate_task_or_group(
     test_behavior: TestBehavior,
     test_indirect_selection: TestIndirectSelection,
     on_warning_callback: Callable[..., Any] | None,
-    node_config: dict[str, Any],
+    node_config: dict[str, Any] | None = None,
     **kwargs: Any,
 ) -> BaseOperator | TaskGroup | None:
     task_or_group: BaseOperator | TaskGroup | None = None

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -6,12 +6,14 @@ from airflow.utils.task_group import TaskGroup
 
 from cosmos.core.graph.entities import Task
 from cosmos.log import get_logger
-
+from typing import Any
 
 logger = get_logger(__name__)
 
 
-def get_airflow_task(task: Task, dag: DAG, task_group: "TaskGroup | None" = None) -> BaseOperator:
+def get_airflow_task(
+    task: Task, dag: DAG, task_group: "TaskGroup | None" = None, extra_context: dict[str, Any] = {}
+) -> BaseOperator:
     """
     Get the Airflow Operator class for a Task.
 
@@ -30,6 +32,7 @@ def get_airflow_task(task: Task, dag: DAG, task_group: "TaskGroup | None" = None
         task_id=task.id,
         dag=dag,
         task_group=task_group,
+        extra_context=extra_context,
         **task.arguments,
     )
 

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -12,7 +12,7 @@ logger = get_logger(__name__)
 
 
 def get_airflow_task(
-    task: Task, dag: DAG, task_group: "TaskGroup | None" = None, extra_context: dict[str, Any] = {}
+    task: Task, dag: DAG, task_group: "TaskGroup | None" = None, extra_context: dict[str, Any] | None = None
 ) -> BaseOperator:
     """
     Get the Airflow Operator class for a Task.

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -57,6 +57,7 @@ class DbtBaseOperator(BaseOperator):
         (i.e. /home/astro/.pyenv/versions/dbt_venv/bin/dbt)
     :param dbt_cmd_flags: List of flags to pass to dbt command
     :param dbt_cmd_global_flags: List of dbt global flags to be passed to the dbt command
+    :param extra_context: A dictionary of values to add to the Airflow Task context
     """
 
     template_fields: Sequence[str] = ("env", "vars")
@@ -105,6 +106,7 @@ class DbtBaseOperator(BaseOperator):
         dbt_executable_path: str = get_system_dbt(),
         dbt_cmd_flags: list[str] | None = None,
         dbt_cmd_global_flags: list[str] | None = None,
+        extra_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> None:
         self.project_dir = project_dir
@@ -132,6 +134,7 @@ class DbtBaseOperator(BaseOperator):
         self.dbt_executable_path = dbt_executable_path
         self.dbt_cmd_flags = dbt_cmd_flags
         self.dbt_cmd_global_flags = dbt_cmd_global_flags or []
+        self.extra_context = extra_context or {}
         super().__init__(**kwargs)
 
     def get_env(self, context: Context) -> dict[str, str | bytes | os.PathLike[Any]]:
@@ -231,3 +234,7 @@ class DbtBaseOperator(BaseOperator):
         env = self.get_env(context)
 
         return dbt_cmd, env
+
+    def pre_execute(self, context: Any):
+        context["model_config"] = self.extra_context
+        return super().pre_execute(context)

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -235,7 +235,7 @@ class DbtBaseOperator(BaseOperator):
 
         return dbt_cmd, env
 
-    def pre_execute(self, context: Any):
+    def pre_execute(self, context: Any) -> None:
         if self.extra_context:
             logger.info("Extra context passed to operator, injecting into TaskInstance")
             context["model_config"] = self.extra_context

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -236,5 +236,7 @@ class DbtBaseOperator(BaseOperator):
         return dbt_cmd, env
 
     def pre_execute(self, context: Any):
-        context["model_config"] = self.extra_context
+        if self.extra_context:
+            logger.info("Extra context passed to operator, injecting into TaskInstance")
+            context["model_config"] = self.extra_context
         return super().pre_execute(context)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -236,9 +236,7 @@ class DbtLocalBaseOperator(DbtBaseOperator):
                 )
                 if is_openlineage_available:
                     self.calculate_openlineage_events_completes(env, Path(tmp_project_dir))
-                    context[
-                        "task_instance"
-                    ].openlineage_events_completes = self.openlineage_events_completes  # type: ignore
+                    context["task_instance"].openlineage_events_completes = self.openlineage_events_completes  # type: ignore
 
                 if self.emit_datasets:
                     inlets = self.get_datasets("inputs")


### PR DESCRIPTION
## Description

forwards context from the parsed model config object to the Airflow `TaskInstance` `Context` so it is available in callback functions

## Related Issue(s)

closes #698 

## Breaking Change?

not that I'm aware

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works

Would like guidance on where you'd like the tests for this, eg. mocked in the operators section or integration.