### PR TITLE
Fix docs index image

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -53,7 +53,7 @@ You can render a Cosmos Airflow DAG using the ``DbtDag`` class. Here's an exampl
 
 This will generate an Airflow DAG that looks like this:
 
-.. figure:: /docs/_static/jaffle_shop_dag.png
+.. image:: https://raw.githubusercontent.com/astronomer/astronomer-cosmos/main/docs/_static/jaffle_shop_dag.png
 
 Getting Started
 _______________


### PR DESCRIPTION
Fix broken docs sample DAG image, due to different syntax to render images between Github and Sphinx.