### PR TITLE
add pydantic only for apache-airflow 2.6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ classifiers = [
 dependencies = [
     "aenum",
     "attrs",
+    "pydantic>=1.10.0,<2.0.0; apache-airflow==2.6.*",
     "apache-airflow>=2.3.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",


### PR DESCRIPTION
## Description

Adds pydantic as a requirement only if airflow version is 2.6.

## Related Issue(s)

closes #654

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
