### PR TITLE
Add support to select using graph-operators when using `LoadMode.CUSTOM` or `LoadMode.DBT_MANIFEST`

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -304,14 +304,11 @@ def select_nodes(
                 filter_parameter.startswith(PATH_SELECTOR)
                 or filter_parameter.startswith(TAG_SELECTOR)
                 or PLUS_SELECTOR in filter_parameter
+                or any([filter_parameter.startswith(CONFIG_SELECTOR + config + ":") for config in SUPPORTED_CONFIG])
             ):
-                continue
-            elif any([filter_parameter.startswith(CONFIG_SELECTOR + config + ":") for config in SUPPORTED_CONFIG]):
                 continue
             elif ":" in filter_parameter:
                 raise CosmosValueError(f"Invalid {filter_type} filter: {filter_parameter}")
-            else:
-                logger.warn(f"Best effort in processing filter {filter}")
 
     subset_ids: set[str] = set()
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -114,7 +114,7 @@ class GraphSelector:
 
         :param nodes: Original dbt nodes list
         :param root_id: Unique identifier of self.node_name
-        :param selected_nodes: Set where precursor nodes will be added to.
+        :param selected_nodes: Set where descendant nodes will be added to.
         """
         if self.descendants:
             children_by_node = defaultdict(set)

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -299,12 +299,11 @@ class NodeSelector:
         https://docs.getdbt.com/reference/node-selection/syntax
         https://docs.getdbt.com/reference/node-selection/yaml-selectors
         """
-        selected_nodes = set()
+        selected_nodes_by_selector: list[set[str]] = []
 
         for graph_selector in self.config.graph_selectors:
-            selected_nodes.update(graph_selector.filter_nodes(self.nodes))
-
-        return selected_nodes
+            selected_nodes_by_selector.append(graph_selector.filter_nodes(self.nodes))
+        return set.intersection(*selected_nodes_by_selector)
 
 
 def retrieve_by_label(statement_list: list[str], label: str) -> set[str]:
@@ -363,7 +362,7 @@ def select_nodes(
     for statement in select:
         config = SelectorConfig(project_dir, statement)
         node_selector = NodeSelector(nodes, config)
-        # TODO: Fix this
+
         if config.graph_selectors:
             select_ids = node_selector.select_by_graph_operator()
             subset_ids.update(set(select_ids))

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -10,7 +10,9 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``tag:my_tag``: include/exclude models with the tag ``my_tag``
 - ``config.materialized:table``: include/exclude models with the config ``materialized: table``
 - ``path:analytics/tables``: include/exclude models in the ``analytics/tables`` directory
-
+- ``+node_name+1`` (graph operators): include/exclude the node with name ``node_name``, all its parents, and its first generation of children (`dbt graph selector docs <https://docs.getdbt.com/reference/node-selection/graph-operators>`_)
+- ``tag:my_tag,+node_name`` (intersection): include/exclude ``node_name`` and its parents if they have the tag ``my_tag`` (`dbt set operator docs <https://docs.getdbt.com/reference/node-selection/set-operators>`_)
+- ``['tag:first_tag', 'tag:second_tag']`` (union): include/exclude nodes that have either ``tag:first_tag`` or ``tag:second_tag``
 
 .. note::
 
@@ -49,5 +51,36 @@ Examples:
     jaffle_shop = DbtDag(
         render_config=RenderConfig(
             select=["path:analytics/tables"],
+        )
+    )
+
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig
+
+    jaffle_shop = DbtDag(
+        render_config=RenderConfig(
+            select=["tag:include_tag1", "tag:include_tag2"],  # union
+        )
+    )
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig
+
+    jaffle_shop = DbtDag(
+        render_config=RenderConfig(
+            select=["tag:include_tag1,tag:include_tag2"],  # intersection
+        )
+    )
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig
+
+    jaffle_shop = DbtDag(
+        render_config=RenderConfig(
+            exclude=["node_name+"],  # node_name and its children
         )
     )

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -378,7 +378,31 @@ def test_select_node_by_descendants_intersection_with_tag():
     assert sorted(selected.keys()) == expected
 
 
-# TODO: intersection of select - one of which with graph selector
-# TODO: union of select - one of which with graph selector
-# TODO: exclude graph
-# TODO: exclude graph with include non-graph
+def test_select_node_by_descendants_and_tag_union():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["child", "tag:has_child"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.grandparent",
+        "model.dbt-proj.parent",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_exclude_by_graph_selector():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["+parent"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.orphaned",
+        "model.dbt-proj.sibling1",
+        "model.dbt-proj.sibling2",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_exclude_by_union_graph_selector_and_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["+parent", "tag:deprecated"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.orphaned",
+    ]
+    assert sorted(selected.keys()) == expected

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -249,17 +249,6 @@ def test_select_nodes_by_exclude_union_config_test_tags():
     assert selected == expected
 
 
-def test_select_nodes_by_child_and_precursors():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"])
-    expected = [
-        another_grandparent_node.unique_id,
-        child_node.unique_id,
-        grandparent_node.unique_id,
-        parent_node.unique_id,
-    ]
-    assert sorted(selected.keys()) == expected
-
-
 def test_select_nodes_by_path_dir():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen3/models"])
     expected = {
@@ -271,18 +260,29 @@ def test_select_nodes_by_path_dir():
     assert selected == expected
 
 
+def test_select_nodes_by_path_file():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models/parent.sql"])
+    expected = [parent_node.unique_id]
+    assert list(selected.keys()) == expected
+
+
+def test_select_nodes_by_child_and_precursors():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"])
+    expected = [
+        another_grandparent_node.unique_id,
+        child_node.unique_id,
+        grandparent_node.unique_id,
+        parent_node.unique_id,
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 def test_select_nodes_by_child_and_precursors_exclude_tags():
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"], exclude=["tag:has_child"]
     )
     expected = [another_grandparent_node.unique_id, child_node.unique_id]
     assert sorted(selected.keys()) == expected
-
-
-def test_select_nodes_by_path_file():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models/parent.sql"])
-    expected = [parent_node.unique_id]
-    assert list(selected.keys()) == expected
 
 
 def test_select_node_by_child_and_precursors_partial_tree():
@@ -329,7 +329,28 @@ def test_select_node_by_child_and_precursors_no_node():
     assert list(selected.keys()) == expected
 
 
-# TODO: precursors depth
-# TODO: successors logic
+def test_select_node_by_descendants():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["grandparent+"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.grandparent",
+        "model.dbt-proj.parent",
+        "model.dbt-proj.sibling1",
+        "model.dbt-proj.sibling2",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_select_node_by_descendants_depth_first_degree():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["grandparent+1"])
+    expected = [
+        "model.dbt-proj.grandparent",
+        "model.dbt-proj.parent",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 # TODO: intersection of graph selector
 # TODO: union of graph selector
+# TODO: intersection of select - one of which with graph selector
+# TODO: union of select - one of which with graph selector

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -370,6 +370,14 @@ def test_select_node_by_descendants_intersection():
     assert sorted(selected.keys()) == expected
 
 
+def test_select_node_by_descendants_intersection_with_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["parent+1,tag:has_child"])
+    expected = [
+        "model.dbt-proj.parent",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 # TODO: intersection of select - one of which with graph selector
 # TODO: union of select - one of which with graph selector
 # TODO: exclude graph

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -350,7 +350,18 @@ def test_select_node_by_descendants_depth_first_degree():
     assert sorted(selected.keys()) == expected
 
 
+def test_select_node_by_descendants_union():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["grandparent+1", "parent+1"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.grandparent",
+        "model.dbt-proj.parent",
+        "model.dbt-proj.sibling1",
+        "model.dbt-proj.sibling2",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 # TODO: intersection of graph selector
-# TODO: union of graph selector
 # TODO: intersection of select - one of which with graph selector
 # TODO: union of select - one of which with graph selector

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -297,6 +297,26 @@ def test_select_node_by_precursors_with_orphaned_node():
     assert list(selected.keys()) == expected
 
 
+def test_select_nodes_by_child_and_first_degree_precursors():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["1+child"])
+    expected = [
+        child_node.unique_id,
+        parent_node.unique_id,
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_select_nodes_by_child_and_second_degree_precursors():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["2+child"])
+    expected = [
+        another_grandparent_node.unique_id,
+        child_node.unique_id,
+        grandparent_node.unique_id,
+        parent_node.unique_id,
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 def test_select_node_by_exact_node_name():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["child"])
     expected = [child_node.unique_id]
@@ -307,3 +327,9 @@ def test_select_node_by_child_and_precursors_no_node():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+modelDoesntExist"])
     expected = []
     assert list(selected.keys()) == expected
+
+
+# TODO: precursors depth
+# TODO: successors logic
+# TODO: intersection of graph selector
+# TODO: union of graph selector

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -46,47 +46,69 @@ grandparent_node = DbtNode(
     tags=["has_child"],
     config={"materialized": "view", "tags": ["has_child"]},
 )
+
+another_grandparent_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.another_grandparent_node",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    file_path=SAMPLE_PROJ_PATH / "gen1/models/another_grandparent_node.sql",
+    tags=[],
+    config={},
+)
+
 parent_node = DbtNode(
     unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.parent",
     resource_type=DbtResourceType.MODEL,
-    depends_on=["grandparent"],
+    depends_on=[grandparent_node.unique_id, another_grandparent_node.unique_id],
     file_path=SAMPLE_PROJ_PATH / "gen2/models/parent.sql",
     tags=["has_child", "is_child"],
     config={"materialized": "view", "tags": ["has_child", "is_child"]},
 )
+
 child_node = DbtNode(
     unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.child",
     resource_type=DbtResourceType.MODEL,
-    depends_on=["parent"],
+    depends_on=[parent_node.unique_id],
     file_path=SAMPLE_PROJ_PATH / "gen3/models/child.sql",
     tags=["nightly", "is_child"],
     config={"materialized": "table", "tags": ["nightly", "is_child"]},
 )
 
-grandchild_1_test_node = DbtNode(
-    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.grandchild_1",
+sibling1_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.sibling1",
     resource_type=DbtResourceType.MODEL,
-    depends_on=["parent"],
-    file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_1.sql",
+    depends_on=[parent_node.unique_id],
+    file_path=SAMPLE_PROJ_PATH / "gen3/models/sibling1.sql",
     tags=["nightly", "deprecated", "test"],
     config={"materialized": "table", "tags": ["nightly", "deprecated", "test"]},
 )
 
-grandchild_2_test_node = DbtNode(
-    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.grandchild_2",
+sibling2_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.sibling2",
     resource_type=DbtResourceType.MODEL,
-    depends_on=["parent"],
-    file_path=SAMPLE_PROJ_PATH / "gen3/models/grandchild_2.sql",
+    depends_on=[parent_node.unique_id],
+    file_path=SAMPLE_PROJ_PATH / "gen3/models/sibling2.sql",
     tags=["nightly", "deprecated", "test2"],
     config={"materialized": "table", "tags": ["nightly", "deprecated", "test2"]},
 )
 
+orphaned_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.orphaned",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    file_path=SAMPLE_PROJ_PATH / "gen3/models/orphaned.sql",
+    tags=[],
+    config={},
+)
+
 sample_nodes = {
     grandparent_node.unique_id: grandparent_node,
+    another_grandparent_node.unique_id: another_grandparent_node,
     parent_node.unique_id: parent_node,
     child_node.unique_id: child_node,
-    grandchild_1_test_node.unique_id: grandchild_1_test_node,
-    grandchild_2_test_node.unique_id: grandchild_2_test_node,
+    sibling1_node.unique_id: sibling1_node,
+    sibling2_node.unique_id: sibling2_node,
+    orphaned_node.unique_id: orphaned_node,
 }
 
 
@@ -100,8 +122,8 @@ def test_select_nodes_by_select_config():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.materialized:table"])
     expected = {
         child_node.unique_id: child_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
     }
     assert selected == expected
 
@@ -136,8 +158,8 @@ def test_select_nodes_by_select_union_config_test_tags():
     expected = {
         grandparent_node.unique_id: grandparent_node,
         parent_node.unique_id: parent_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
     }
     assert selected == expected
 
@@ -176,8 +198,8 @@ def test_select_nodes_by_select_union():
         grandparent_node.unique_id: grandparent_node,
         parent_node.unique_id: parent_node,
         child_node.unique_id: child_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
     }
     assert selected == expected
 
@@ -191,8 +213,10 @@ def test_select_nodes_by_exclude_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["tag:has_child"])
     expected = {
         child_node.unique_id: child_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
+        another_grandparent_node.unique_id: another_grandparent_node,
+        orphaned_node.unique_id: orphaned_node,
     }
     assert selected == expected
 
@@ -217,18 +241,43 @@ def test_select_nodes_by_exclude_union_config_test_tags():
     )
     expected = {
         grandparent_node.unique_id: grandparent_node,
+        another_grandparent_node.unique_id: another_grandparent_node,
         parent_node.unique_id: parent_node,
         child_node.unique_id: child_node,
+        orphaned_node.unique_id: orphaned_node,
     }
     assert selected == expected
+
+
+def test_select_nodes_by_child_and_precursors():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"])
+    expected = [
+        another_grandparent_node.unique_id,
+        child_node.unique_id,
+        grandparent_node.unique_id,
+        parent_node.unique_id,
+    ]
+    assert sorted(selected.keys()) == expected
 
 
 def test_select_nodes_by_path_dir():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen3/models"])
     expected = {
         child_node.unique_id: child_node,
-        grandchild_1_test_node.unique_id: grandchild_1_test_node,
-        grandchild_2_test_node.unique_id: grandchild_2_test_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
+        orphaned_node.unique_id: orphaned_node,
+    }
+    assert selected == expected
+
+
+def test_select_nodes_by_child_and_precursors_exclude_tags():
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"], exclude=["tag:has_child"]
+    )
+    expected = {
+        another_grandparent_node.unique_id: another_grandparent_node,
+        child_node.unique_id: child_node,
     }
     assert selected == expected
 
@@ -238,4 +287,26 @@ def test_select_nodes_by_path_file():
     expected = {
         parent_node.unique_id: parent_node,
     }
+    assert selected == expected
+
+
+def test_select_node_by_child_and_precursors_partial_tree():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+parent"])
+    expected = {
+        grandparent_node.unique_id: grandparent_node,
+        another_grandparent_node.unique_id: another_grandparent_node,
+        parent_node.unique_id: parent_node,
+    }
+    assert selected == expected
+
+
+def test_select_node_by_dfs_leaf():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+orphaned"])
+    expected = {orphaned_node.unique_id: orphaned_node}
+    assert selected == expected
+
+
+def test_select_node_by_dfs_no_node():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+modelDoesntExist"])
+    expected = {}
     assert selected == expected

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -362,6 +362,15 @@ def test_select_node_by_descendants_union():
     assert sorted(selected.keys()) == expected
 
 
-# TODO: intersection of graph selector
+def test_select_node_by_descendants_intersection():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["grandparent+1,parent+1"])
+    expected = [
+        "model.dbt-proj.parent",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
 # TODO: intersection of select - one of which with graph selector
 # TODO: union of select - one of which with graph selector
+# TODO: exclude graph
+# TODO: exclude graph with include non-graph

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -275,38 +275,35 @@ def test_select_nodes_by_child_and_precursors_exclude_tags():
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"], exclude=["tag:has_child"]
     )
-    expected = {
-        another_grandparent_node.unique_id: another_grandparent_node,
-        child_node.unique_id: child_node,
-    }
-    assert selected == expected
+    expected = [another_grandparent_node.unique_id, child_node.unique_id]
+    assert sorted(selected.keys()) == expected
 
 
 def test_select_nodes_by_path_file():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models/parent.sql"])
-    expected = {
-        parent_node.unique_id: parent_node,
-    }
-    assert selected == expected
+    expected = [parent_node.unique_id]
+    assert list(selected.keys()) == expected
 
 
 def test_select_node_by_child_and_precursors_partial_tree():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+parent"])
-    expected = {
-        grandparent_node.unique_id: grandparent_node,
-        another_grandparent_node.unique_id: another_grandparent_node,
-        parent_node.unique_id: parent_node,
-    }
-    assert selected == expected
+    expected = [another_grandparent_node.unique_id, grandparent_node.unique_id, parent_node.unique_id]
+    assert sorted(selected.keys()) == expected
 
 
-def test_select_node_by_dfs_leaf():
+def test_select_node_by_precursors_with_orphaned_node():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+orphaned"])
-    expected = {orphaned_node.unique_id: orphaned_node}
-    assert selected == expected
+    expected = [orphaned_node.unique_id]
+    assert list(selected.keys()) == expected
 
 
-def test_select_node_by_dfs_no_node():
+def test_select_node_by_exact_node_name():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["child"])
+    expected = [child_node.unique_id]
+    assert list(selected.keys()) == expected
+
+
+def test_select_node_by_child_and_precursors_no_node():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+modelDoesntExist"])
-    expected = {}
-    assert selected == expected
+    expected = []
+    assert list(selected.keys()) == expected


### PR DESCRIPTION
Add support for the following when using `LoadMode.CUSTOM` or `LoadMode.DBT_MANIFEST`:

* Support selection of model by name
* Support the selection of models by name & their children (with or without degrees)
* Support the selection of models by name & their parents (with or without degrees)
* Support intersections and unions involving graph selectors (with or without other supported selectors, eg. tags)

Examples of select/exclusion statements that now work regardless of the `LoadMode` being used:

```
model_a
+model_b
model_c+
+model_d+
2+model_e
model_f+3
model_f+,tag:nightly
```

Related dbt documentation:
https://docs.getdbt.com/reference/node-selection/graph-operators
https://docs.getdbt.com/reference/node-selection/set-operators

Limitations:
* The at operator is not supported yet (`@`)
* If users opt to use graph selector, it will increase the DAG parsing time and the  task execution time when using `LoadMode.CUSTOM` or `LoadMode.DBT_MANIFEST`


This PR improves and extends the original implementation proposed by @tseruga in #429. Some of the changes that were introduced on top of the original PR:
* Add support to descendants (before only precursors were supported)
* Add support to different depths/degrees of precursors/descendants
* Add support to the union between graph operators and graph/non-graph operators
* Add support to the intersection between graph operators and graph/non-graph operators

Closes: #684

Co-authored-by: Tyler Seruga <t.seruga@m1finance.com>