### PR TITLE
Speed up integration tests

### DIFF
--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from functools import lru_cache
+from functools import cache
 
 import airflow
 import pytest
@@ -38,7 +38,7 @@ def session():
     return get_session()
 
 
-@lru_cache
+@cache
 def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from functools import lru_cache
 
 import airflow
 import pytest
@@ -37,6 +38,7 @@ def session():
     return get_session()
 
 
+@lru_cache
 def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
+from functools import lru_cache
 
 import airflow
 import pytest
@@ -23,6 +24,7 @@ MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
 }
 
 
+@lru_cache
 def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from pathlib import Path
-from functools import lru_cache
+from functools import cache
 
 import airflow
 import pytest
@@ -24,7 +24,7 @@ MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
 }
 
 
-@lru_cache
+@cache
 def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:


### PR DESCRIPTION
## Description

I was able to speed up the integration tests by caching the dag bag result.

Previously for each parametrized dag run test, it would reparse all of the dags which takes a non-trivial amount of time to parse all of the cosmos example dags. 

On my local machine the total time went from 1616s to 540s, which will save a good amount of GH minutes 😃.

## Related Issue(s)

None

## Breaking Change?

None
## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
