### PR TITLE
Fix functools cache test issue

### DIFF
--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,7 +1,12 @@
 from __future__ import annotations
 
 from pathlib import Path
-from functools import cache
+
+try:
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
+
 
 import airflow
 import pytest

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -1,7 +1,11 @@
 from __future__ import annotations
 
 from pathlib import Path
-from functools import cache
+
+try:
+    from functools import cache
+except ImportError:
+    from functools import lru_cache as cache
 
 import airflow
 import pytest


### PR DESCRIPTION
Fix exceptions raised for some versions of Python (e.g. 2.4) after prematurely merging #732, leading to the main branch becoming red
```
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.8-2.5/lib/python3.8/site-packages/_pytest/assertion/rewrite.py:186: in exec_module
    exec(co, module.__dict__)
tests/test_example_dags_no_connections.py:4: in <module>
    from functools import cache
E   ImportError: cannot import name 'cache' from 'functools'
```