### PR TITLE
Promote @jbandoro to committer

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -11,6 +11,7 @@ Committers
 * Chris Hronek (`@chrishronek <https://github.com/chrishronek>`_)
 * Harel Shein (`@harels <https://github.com/harels>`_)
 * Julian LaNeve (`@jlaneve <https://github.com/jlaneve>`_)
+* Justin Bandoro (`@jbandoro <https://github.com/jbandoro>`_)
 * Tatiana Al-Chueyr (`@tatiana <https://github.com/tatiana>`_)
 
 


### PR DESCRIPTION
[Justin Bandoro](https://www.linkedin.com/in/justin-bandoro-592b14a7/) (@jbandoro) is a Data Engineer at Kevala Inc. He's based in San Francisco (USA) and has been an early adopter of Cosmos, using it regularly at his company.

Not only has he been using Cosmos since the early stages, but he has consistently improved Cosmos since January 2023:
![Screenshot 2023-12-04 at 16 28 29](https://github.com/astronomer/astronomer-cosmos/assets/272048/43197938-d1ab-431f-b101-b6026e5cd3ab)

Some of his contributions include new features, code quality, documentation and overall improvements. Some examples:
* Speed up integration tests in 67% #732 
* Prevent override of dbt profile fields #702
* Add support for env vars in `RenderConfig` in #690 
* Use symbolic links to run local tasks, avoiding to copy potentially huge dbt project folders in #660
* Improve documentation in #638
* Automated and improved the code complexity checks in #629
* Added `DbtDocsGCSOperator` in #616 
* Added support for Python 3.7 in #88 and #214

Additionally, he has been interacting with users in the #airflow-dbt Slack channel in a very collaborative and supportive way.

We want to promote him as a Cosmos committer and maintainer for all these, recognising his constant efforts and achievements towards our community. Thank you very much, @jbandoro !