### PR TITLE
Tests: use temp dir for `test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages`

### DIFF
--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -438,12 +438,12 @@ def test_load_via_dbt_ls_without_dbt_deps():
 
 
 @pytest.mark.integration
-def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages():
+def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_project_dir):
     local_flags = [
         "--project-dir",
-        DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME,
+        str(tmp_dbt_project_dir / DBT_PROJECT_NAME),
         "--profiles-dir",
-        DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME,
+        str(tmp_dbt_project_dir / DBT_PROJECT_NAME),
         "--profile",
         "default",
         "--target",
@@ -456,14 +456,14 @@ def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages():
         deps_command,
         stdout=PIPE,
         stderr=PIPE,
-        cwd=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME,
+        cwd=tmp_dbt_project_dir / DBT_PROJECT_NAME,
         universal_newlines=True,
     )
     stdout, stderr = process.communicate()
 
-    project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
-    render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, dbt_deps=False)
-    execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
+    project_config = ProjectConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+    render_config = RenderConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME, dbt_deps=False)
+    execution_config = ExecutionConfig(dbt_project_path=tmp_dbt_project_dir / DBT_PROJECT_NAME)
     dbt_graph = DbtGraph(
         project=project_config,
         render_config=render_config,

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -441,9 +441,9 @@ def test_load_via_dbt_ls_without_dbt_deps():
 def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_project_dir):
     local_flags = [
         "--project-dir",
-        str(tmp_dbt_project_dir / DBT_PROJECT_NAME),
+        tmp_dbt_project_dir / DBT_PROJECT_NAME,
         "--profiles-dir",
-        str(tmp_dbt_project_dir / DBT_PROJECT_NAME),
+        tmp_dbt_project_dir / DBT_PROJECT_NAME,
         "--profile",
         "default",
         "--target",


### PR DESCRIPTION
## Description

This is a follow up to #730 so that the fixture `tmp_dbt_project_dir` is used for the test instead of the actual project directory since it installs dbt packages that need to be cleaned up.

## Related Issue(s)

None

## Breaking Change?

None

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
