### PR TITLE
Add support for dbt `selector` arg for DAG parsing

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -40,6 +40,7 @@ class RenderConfig:
     :param load_method: The parsing method for loading the dbt model. Defaults to AUTOMATIC
     :param select: A list of dbt select arguments (e.g. 'config.materialized:incremental')
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
+    :param selector: Name of a dbt YAML selector to use for parsing. Only supported when using ``load_method=LoadMode.DBT_LS``.
     :param dbt_deps: Configure to run dbt deps when using dbt ls for dag parsing
     :param node_converters: a dictionary mapping a ``DbtResourceType`` into a callable. Users can control how to render dbt nodes in Airflow. Only supported when using ``load_method=LoadMode.DBT_MANIFEST`` or ``LoadMode.DBT_LS``.
     :param dbt_executable_path: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
@@ -52,6 +53,7 @@ class RenderConfig:
     load_method: LoadMode = LoadMode.AUTOMATIC
     select: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
+    selector: str | None = None
     dbt_deps: bool = True
     node_converters: dict[DbtResourceType, Callable[..., Any]] | None = None
     dbt_executable_path: str | Path = get_system_dbt()

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -195,6 +195,9 @@ class DbtGraph:
         if self.project.dbt_vars:
             ls_command.extend(["--vars", yaml.dump(self.project.dbt_vars)])
 
+        if self.render_config.selector:
+            ls_command.extend(["--selector", self.render_config.selector])
+
         ls_command.extend(self.local_flags)
 
         stdout = run_command(ls_command, tmp_dir, env_vars)

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -11,6 +11,7 @@ The ``RenderConfig`` class takes the following arguments:
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``select`` and ``exclude``: which models to include or exclude from your DAGs. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.
+- ``selector``: (new in v1.3) name of a dbt YAML selector to use for DAG parsing. Only supported when using ``load_method=LoadMode.DBT_LS``. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.
 - ``dbt_deps``: A Boolean to run dbt deps when using dbt ls for dag parsing. Default True
 - ``node_converters``: a dictionary mapping a ``DbtResourceType`` into a callable. Users can control how to render dbt nodes in Airflow. Only supported when using ``load_method=LoadMode.DBT_MANIFEST`` or ``LoadMode.DBT_LS``. Find more information below.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -3,7 +3,11 @@
 Selecting & Excluding
 =======================
 
-Cosmos allows you to filter to a subset of your dbt project in each ``DbtDag`` / ``DbtTaskGroup`` using the ``select`` and ``exclude`` parameters in the ``RenderConfig`` class.
+Cosmos allows you to filter to a subset of your dbt project in each ``DbtDag`` / ``DbtTaskGroup`` using either the ``select`` and ``exclude`` parameters or the ``selector`` parameter in the ``RenderConfig`` class.
+
+
+Using ``select`` and ``exclude``
+--------------------------------
 
 The ``select`` and ``exclude`` parameters are lists, with values like the following:
 
@@ -82,5 +86,28 @@ Examples:
     jaffle_shop = DbtDag(
         render_config=RenderConfig(
             exclude=["node_name+"],  # node_name and its children
+        )
+    )
+
+Using ``selector``
+--------------------------------
+
+The ``selector`` parameter is a string that references a `dbt YAML selector <https://docs.getdbt.com/reference/node-selection/yaml-selectors>`_ already defined in a dbt project.
+
+.. note::
+
+    Only currently supported using the ``dbt_ls`` parsing method where the selector is passed directly to the dbt CLI command. If  ``select`` and/or ``exclude`` \
+    are used with ``selector``, dbt will ignore the ``select`` and ``exclude`` parameters.
+
+Examples:
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig, LoadMode
+
+    jaffle_shop = DbtDag(
+        render_config=RenderConfig(
+            selector="my_selector",  # this selector must be defined in your dbt project
+            load_method=LoadMode.DBT_LS,
         )
     )

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -44,6 +44,18 @@ def tmp_dbt_project_dir():
     shutil.rmtree(tmp_dir, ignore_errors=True)  # delete directory
 
 
+@pytest.fixture
+def postgres_profile_config() -> ProfileConfig:
+    return ProfileConfig(
+        profile_name="default",
+        target_name="default",
+        profile_mapping=PostgresUserPasswordProfileMapping(
+            conn_id="airflow_db",
+            profile_args={"schema": "public"},
+        ),
+    )
+
+
 @pytest.mark.parametrize(
     "unique_id,expected_name, expected_select",
     [
@@ -220,7 +232,9 @@ def test_load(
 
 @pytest.mark.integration
 @patch("cosmos.dbt.graph.Popen")
-def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_popen, tmp_dbt_project_dir):
+def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(
+    mock_popen, tmp_dbt_project_dir, postgres_profile_config
+):
     mock_popen().communicate.return_value = ("", "")
     mock_popen().returncode = 0
     assert not (tmp_dbt_project_dir / "target").exists()
@@ -233,14 +247,7 @@ def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_pop
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     dbt_graph.load_via_dbt_ls()
     assert not (tmp_dbt_project_dir / "target").exists()
@@ -252,7 +259,7 @@ def test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder(mock_pop
 
 
 @pytest.mark.integration
-def test_load_via_dbt_ls_with_exclude():
+def test_load_via_dbt_ls_with_exclude(postgres_profile_config):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     render_config = RenderConfig(
         dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, select=["*customers*"], exclude=["*orders*"]
@@ -262,14 +269,7 @@ def test_load_via_dbt_ls_with_exclude():
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
 
     dbt_graph.load_via_dbt_ls()
@@ -301,7 +301,7 @@ def test_load_via_dbt_ls_with_exclude():
 
 @pytest.mark.integration
 @pytest.mark.parametrize("project_name", ("jaffle_shop", "jaffle_shop_python"))
-def test_load_via_dbt_ls_without_exclude(project_name):
+def test_load_via_dbt_ls_without_exclude(project_name, postgres_profile_config):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / project_name)
     render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
@@ -309,14 +309,7 @@ def test_load_via_dbt_ls_without_exclude(project_name):
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     dbt_graph.load_via_dbt_ls()
 
@@ -413,7 +406,7 @@ def test_load_via_dbt_ls_with_sources(load_method):
 
 
 @pytest.mark.integration
-def test_load_via_dbt_ls_without_dbt_deps():
+def test_load_via_dbt_ls_without_dbt_deps(postgres_profile_config):
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, dbt_deps=False)
     execution_config = ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
@@ -421,14 +414,7 @@ def test_load_via_dbt_ls_without_dbt_deps():
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
 
     with pytest.raises(CosmosLoadDbtException) as err_info:
@@ -439,7 +425,7 @@ def test_load_via_dbt_ls_without_dbt_deps():
 
 
 @pytest.mark.integration
-def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_project_dir):
+def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_project_dir, postgres_profile_config):
     local_flags = [
         "--project-dir",
         tmp_dbt_project_dir / DBT_PROJECT_NAME,
@@ -469,14 +455,7 @@ def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
 
     dbt_graph.load_via_dbt_ls()  # does not raise exception
@@ -484,7 +463,9 @@ def test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages(tmp_dbt_
 
 @pytest.mark.integration
 @patch("cosmos.dbt.graph.Popen")
-def test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr(mock_popen, tmp_dbt_project_dir):
+def test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr(
+    mock_popen, tmp_dbt_project_dir, postgres_profile_config
+):
     mock_popen().communicate.return_value = ("", "Some stderr warnings")
     mock_popen().returncode = 0
 
@@ -495,14 +476,7 @@ def test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr(mock_popen, t
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
 
     dbt_graph.load_via_dbt_ls()  # does not raise exception
@@ -510,7 +484,7 @@ def test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr(mock_popen, t
 
 @pytest.mark.integration
 @patch("cosmos.dbt.graph.Popen")
-def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
+def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen, postgres_profile_config):
     mock_popen().communicate.return_value = ("", "Some stderr message")
     mock_popen().returncode = 1
 
@@ -521,14 +495,7 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     expected = r"Unable to run \['.+dbt', 'deps', .*\] due to the error:\nSome stderr message"
     with pytest.raises(CosmosLoadDbtException, match=expected):
@@ -537,7 +504,7 @@ def test_load_via_dbt_ls_with_non_zero_returncode(mock_popen):
 
 @pytest.mark.integration
 @patch("cosmos.dbt.graph.Popen.communicate", return_value=("Some Runtime Error", ""))
-def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate):
+def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate, postgres_profile_config):
     # It may seem strange, but at least until dbt 1.6.0, there are circumstances when it outputs errors to stdout
     project_config = ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
     render_config = RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME)
@@ -546,14 +513,7 @@ def test_load_via_dbt_ls_with_runtime_error_in_stdout(mock_popen_communicate):
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     expected = r"Unable to run \['.+dbt', 'deps', .*\] due to the error:\nSome Runtime Error"
     with pytest.raises(CosmosLoadDbtException, match=expected):
@@ -673,7 +633,7 @@ def test_tag_selected_node_test_exist():
 
 @pytest.mark.integration
 @pytest.mark.parametrize("load_method", ["load_via_dbt_ls", "load_from_dbt_manifest"])
-def test_load_dbt_ls_and_manifest_with_model_version(load_method):
+def test_load_dbt_ls_and_manifest_with_model_version(load_method, postgres_profile_config):
     dbt_graph = DbtGraph(
         project=ProjectConfig(
             dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version",
@@ -681,14 +641,7 @@ def test_load_dbt_ls_and_manifest_with_model_version(load_method):
         ),
         render_config=RenderConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version"),
         execution_config=ExecutionConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / "model_version"),
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     getattr(dbt_graph, load_method)()
     expected_dbt_nodes = {
@@ -890,7 +843,7 @@ def test_load_via_dbt_ls_with_project_config_vars():
 
 
 @pytest.mark.integration
-def test_load_via_dbt_ls_with_selector_arg(tmp_dbt_project_dir):
+def test_load_via_dbt_ls_with_selector_arg(tmp_dbt_project_dir, postgres_profile_config):
     """
     Tests that the dbt ls load method is successful if a selector arg is used with RenderConfig
     and that the filtered nodes are expected.
@@ -919,14 +872,7 @@ def test_load_via_dbt_ls_with_selector_arg(tmp_dbt_project_dir):
         project=project_config,
         render_config=render_config,
         execution_config=execution_config,
-        profile_config=ProfileConfig(
-            profile_name="default",
-            target_name="default",
-            profile_mapping=PostgresUserPasswordProfileMapping(
-                conn_id="airflow_db",
-                profile_args={"schema": "public"},
-            ),
-        ),
+        profile_config=postgres_profile_config,
     )
     dbt_graph.load_via_dbt_ls()
 


### PR DESCRIPTION
## Description

This PR adds support for a new `selector` arg in `RenderConfig` so users can reference[ dbt yaml selectors](https://docs.getdbt.com/reference/node-selection/yaml-selectors) when rendering a project using dbt ls by adding the `--selector` arg to the cli command. This was pretty straightforward for dbt ls, though in order to support custom and manifest filtering we would need to add logic for translating the yaml selector definitions in follow up PR(s).

Added a coverage test and integration test here, and a small update in `tests/dbt/test_graph.py` to use a fixture for a ProfileConfig that is repeated 9 times.

An open question I have is whether we want to log a warning in `RenderConfig.__post_init__` if a user uses both `select`/`exclude` with `selector`.  dbt docs [here](https://docs.getdbt.com/reference/node-selection/syntax#examples) state that when using `--selector` with `--exclude` and/or `--select` the select/exclude flags are ignored (no error or warnings are logged by dbt if both are used). 

## Related Issue(s)

Closes #718  

## Breaking Change?

None

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
