### PR TITLE
Add package location to work with hatchling 1.19.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -138,6 +138,9 @@ include = [
     "/cosmos",
 ]
 
+[tool.hatch.build.targets.wheel]
+packages = ["cosmos"]
+
 ######################################
 # TESTING
 ######################################


### PR DESCRIPTION
## Description

Fixes issue described in #760 where Cosmos tests are failing from a recent `hatchling` update that now requires package path to be specified if it can't be inferred from the package's name.

## Related Issue(s)

Closes #760 

## Breaking Change?

None

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
