### PR TITLE
Support disabling event tracking when using Cosmos profile mapping

### DIFF
--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -41,10 +41,11 @@ class BaseProfileMapping(ABC):
 
     _conn: Connection | None = None
 
-    def __init__(self, conn_id: str, profile_args: dict[str, Any] | None = None):
+    def __init__(self, conn_id: str, profile_args: dict[str, Any] | None = None, disable_event_tracking: bool = False):
         self.conn_id = conn_id
         self.profile_args = profile_args or {}
         self._validate_profile_args()
+        self.disable_event_tracking = disable_event_tracking
 
     def _validate_profile_args(self) -> None:
         """
@@ -178,6 +179,10 @@ class BaseProfileMapping(ABC):
                 "outputs": {target_name: profile_vars},
             }
         }
+
+        if self.disable_event_tracking:
+            profile_contents["config"] = {"send_anonymous_usage_stats": "False"}
+
         return str(yaml.dump(profile_contents, indent=4))
 
     def get_dbt_value(self, name: str) -> Any:

--- a/docs/templates/index.rst.jinja2
+++ b/docs/templates/index.rst.jinja2
@@ -83,6 +83,37 @@ but override the ``database`` and ``schema`` values:
 Note that when using a profile mapping, the profiles.yml file gets generated with the profile name and target name
 you specify in ``ProfileConfig``.
 
+Disabling dbt event tracking
+--------------------------------
+.. versionadded:: 1.3
+
+By default `dbt will track events <https://docs.getdbt.com/reference/global-configs/usage-stats>`_ by sending anonymous usage data
+when dbt commands are invoked. Users have an option to opt out of event tracking by updating their ``profiles.yml`` file.
+
+If you'd like to disable this behavior in the Cosmos generated profile, you can pass ``disable_event_tracking=True`` to the profile mapping like in
+the example below:
+
+.. code-block:: python
+
+    from cosmos.profiles import SnowflakeUserPasswordProfileMapping
+
+    profile_config = ProfileConfig(
+        profile_name="my_profile_name",
+        target_name="my_target_name",
+        profile_mapping=SnowflakeUserPasswordProfileMapping(
+            conn_id="my_snowflake_conn_id",
+            profile_args={
+                "database": "my_snowflake_database",
+                "schema": "my_snowflake_schema",
+            },
+            disable_event_tracking=True,
+        ),
+    )
+
+    dag = DbtDag(profile_config=profile_config, ...)
+
+
+
 
 Using your own profiles.yml file
 ++++++++++++++++++++++++++++++++++++

--- a/tests/profiles/test_base_profile.py
+++ b/tests/profiles/test_base_profile.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import pytest
 import yaml
 


### PR DESCRIPTION
## Description

Since dbt by default tracks events by sending anonymous statistic usage when dbt is invoked, users who currently use Cosmos profile mapping can only opt-out by setting environment variables as described in  https://github.com/astronomer/astronomer-cosmos/issues/724#issuecomment-1839538680

This PR adds a new arg to the profile mapping so that the [dbt recommended config block](https://docs.getdbt.com/reference/global-configs/usage-stats) can be added in the generated `profiles.yml` file:

```yaml
config:
  send_anonymous_usage_stats: False
```

## Related Issue(s)

Closes #724 

## Breaking Change?

None

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
