### PR TITLE
Remove upper limit to Pydantic

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,7 +118,7 @@ kubernetes = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
 ]
 pydantic = [
-        "pydantic>=1.10.0,<2.0.0",
+        "pydantic>=1.10.0",
 ]
 
 [project.entry-points.cosmos]


### PR DESCRIPTION
## Description

[Airflow's upgraded to Pydantic 2.0 (!!)](https://github.com/apache/airflow/pull/35551), so this removes the restriction on Cosmos to ensure it's compatible.

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
