### PR TITLE
Update README.rst quickstart link with link to getting started guide

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Run your dbt Core projects as `Apache Airflow <https://airflow.apache.org/>`_ DA
 Quickstart
 __________
 
-Check out the Getting Started guide on our `docs <https://astronomer.github.io/astronomer-cosmos/getting_started/astro.html>`_. See more examples at `/dev/dags <https://github.com/astronomer/astronomer-cosmos/tree/main/dev/dags>`_ and at the `cosmos-demo repo <https://github.com/astronomer/cosmos-demo>`_.
+Check out the Getting Started guide on our `docs <https://astronomer.github.io/astronomer-cosmos/getting_started/index.html>`_. See more examples at `/dev/dags <https://github.com/astronomer/astronomer-cosmos/tree/main/dev/dags>`_ and at the `cosmos-demo repo <https://github.com/astronomer/cosmos-demo>`_.
 
 
 Example Usage

--- a/README.rst
+++ b/README.rst
@@ -31,7 +31,7 @@ Run your dbt Core projects as `Apache Airflow <https://airflow.apache.org/>`_ DA
 Quickstart
 __________
 
-Check out the Quickstart guide on our `docs <https://astronomer.github.io/astronomer-cosmos/#quickstart>`_. See more examples at `/dev/dags <https://github.com/astronomer/astronomer-cosmos/tree/main/dev/dags>`_ and at the `cosmos-demo repo <https://github.com/astronomer/cosmos-demo>`_.
+Check out the Getting Started guide on our `docs <https://astronomer.github.io/astronomer-cosmos/getting_started/astro.html>`_. See more examples at `/dev/dags <https://github.com/astronomer/astronomer-cosmos/tree/main/dev/dags>`_ and at the `cosmos-demo repo <https://github.com/astronomer/cosmos-demo>`_.
 
 
 Example Usage


### PR DESCRIPTION
## Description

The link to the quickstart doesn't actually take users to any kind of quick start. So, instead, I've updated the link to point to the [getting started guide](https://astronomer.github.io/astronomer-cosmos/getting_started/astro.html)



## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
