### PR TITLE
Bugfix disable event tracking throwing error

### DIFF
--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -173,7 +173,7 @@ class BaseProfileMapping(ABC):
         # filter out any null values
         profile_vars = {k: v for k, v in profile_vars.items() if v is not None}
 
-        profile_contents = {
+        profile_contents: dict[str, Any] = {
             profile_name: {
                 "target": target_name,
                 "outputs": {target_name: profile_vars},
@@ -181,7 +181,7 @@ class BaseProfileMapping(ABC):
         }
 
         if self.disable_event_tracking:
-            profile_contents["config"] = {"send_anonymous_usage_stats": "False"}
+            profile_contents["config"] = {"send_anonymous_usage_stats": False}
 
         return str(yaml.dump(profile_contents, indent=4))
 

--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -18,6 +18,7 @@ profile_config = ProfileConfig(
     profile_mapping=PostgresUserPasswordProfileMapping(
         conn_id="airflow_db",
         profile_args={"schema": "public"},
+        disable_event_tracking=True,
     ),
 )
 

--- a/tests/profiles/test_base_profile.py
+++ b/tests/profiles/test_base_profile.py
@@ -49,4 +49,4 @@ def test_disable_event_tracking(disable_event_tracking: str):
 
     assert ("config" in profile_contents) == disable_event_tracking
     if disable_event_tracking:
-        assert profile_contents["config"]["send_anonymous_usage_stats"] == "False"
+        assert profile_contents["config"]["send_anonymous_usage_stats"] is False


### PR DESCRIPTION
## Description

As reported in #783 the new disabling event tracking feature was throwing an error. I didn't test an update I made changing the value from boolean to a string 🤦‍♂️. 

This PR fixes the issue and also adds it to a cosmo dag for integration testing so the error would be caught.

## Related Issue(s)

closes #783

## Breaking Change?

None
## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
