### PR TITLE
Fix Cosmos stacktrace to remove unecessary K8s errors

### DIFF
--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -37,7 +37,6 @@ except ImportError:
         # apache-airflow-providers-cncf-kubernetes < 7.4.0
         from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
     except ImportError as error:
-        logger.exception(error)
         raise ImportError(
             "Could not import KubernetesPodOperator. Ensure you've installed the Kubernetes provider "
             "separately or with with `pip install astronomer-cosmos[...,kubernetes]`."


### PR DESCRIPTION
Closes: #729

Even users who were  using cosmos without Kubernetes, would see the following errors when running Airflow:

```
Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 23, in <module>
    from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import (
ModuleNotFoundError: No module named 'airflow.providers.cncf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 31, in <module>
    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
ModuleNotFoundError: No module named 'airflow.providers.cncf' [2023-11-30 12:57:36,961] {kubernetes.py:33} ERROR - No module named 'airflow.providers.cncf' Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 23, in <module>
    from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import (
ModuleNotFoundError: No module named 'airflow.providers.cncf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 31, in <module>
    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
ModuleNotFoundError: No module named 'airflow.providers.cncf' [2023-11-30 12:57:36,961] {kubernetes.py:33} ERROR - (astronomer-cosmos) - No module named 'airflow.providers.cncf' Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 23, in <module>
    from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import (
ModuleNotFoundError: No module named 'airflow.providers.cncf'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File C:Usersu236618AppDataLocalPackagesPythonSoftwareFoundation.Python.3.11_qbz5n2kfra8p0LocalCachelocal-packagesPython311site-packagescosmosoperatorskubernetes.py, line 31, in <module>
    from airflow.providers.cncf.kubernetes.operators.kubernetes_pod import KubernetesPodOperator
ModuleNotFoundError: No module named 'airflow.providers.cncf'
```

Users who use Kubernetes or users who have enabled the DEBUG logging mode will still be able to see this information:
https://github.com/astronomer/astronomer-cosmos/blob/main/cosmos/__init__.py#L63
