### PR TITLE
FIX: add missing imports for mwaa getting started docs

### DIFF
--- a/docs/getting_started/mwaa.rst
+++ b/docs/getting_started/mwaa.rst
@@ -87,6 +87,8 @@ In your ``my_cosmos_dag.py`` file, import the ``DbtDag`` class from Cosmos and c
 
 .. code-block:: python
 
+    import os
+    from datetime import datetime
     from cosmos import DbtDag, ProjectConfig, ProfileConfig, ExecutionConfig
     from cosmos.profiles import PostgresUserPasswordProfileMapping
     from cosmos.constants import ExecutionMode


### PR DESCRIPTION
## Description

To complete this tutorial, I added two import sentence
- import os
- from datetime import datetime

## Related Issue(s)

Nothing

## Breaking Change?

Nothing

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
