### PR TITLE
Fix: ensure `DbtGraph.update_node_dependency` is called for all load methods

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -181,6 +181,11 @@ class DbtGraph:
         else:
             load_method[method]()
 
+        self.update_node_dependency()
+
+        logger.info("Total nodes: %i", len(self.nodes))
+        logger.info("Total filtered nodes: %i", len(self.nodes))
+
     def run_dbt_ls(
         self, dbt_cmd: str, project_path: Path, tmp_dir: Path, env_vars: dict[str, str]
     ) -> dict[str, DbtNode]:
@@ -276,11 +281,6 @@ class DbtGraph:
                 self.nodes = nodes
                 self.filtered_nodes = nodes
 
-        self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
-
     def load_via_dbt_ls_file(self) -> None:
         """
         This is between dbt ls and full manifest. It allows to use the output (needs to be json output) of the dbt ls as a
@@ -364,11 +364,6 @@ class DbtGraph:
             exclude=self.render_config.exclude,
         )
 
-        self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
-
     def load_from_dbt_manifest(self) -> None:
         """
         This approach accurately loads `dbt` projects using the `manifest.yml` file.
@@ -417,11 +412,6 @@ class DbtGraph:
                 select=self.render_config.select,
                 exclude=self.render_config.exclude,
             )
-
-            self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
 
     def update_node_dependency(self) -> None:
         """

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -258,6 +258,7 @@ def test_load_manifest_with_manifest(mock_load_from_dbt_manifest):
         (ExecutionMode.LOCAL, LoadMode.CUSTOM, "mock_load_via_custom_parser"),
     ],
 )
+@patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.dbt.graph.DbtGraph.load_via_custom_parser", return_value=None)
 @patch("cosmos.dbt.graph.DbtGraph.load_via_dbt_ls", return_value=None)
 @patch("cosmos.dbt.graph.DbtGraph.load_from_dbt_manifest", return_value=None)
@@ -267,6 +268,7 @@ def test_load(
     mock_load_via_dbt_ls_file,
     mock_load_via_dbt_ls,
     mock_load_via_custom_parser,
+    mock_update_node_dependency,
     exec_mode,
     method,
     expected_function,
@@ -282,6 +284,7 @@ def test_load(
     dbt_graph.load(method=method, execution_mode=exec_mode)
     load_function = locals()[expected_function]
     assert load_function.called
+    assert mock_update_node_dependency.called
 
 
 @pytest.mark.integration
@@ -675,8 +678,7 @@ def test_tag_selected_node_test_exist():
         profile_config=profile_config,
         render_config=render_config,
     )
-    dbt_graph.load_from_dbt_manifest()
-
+    dbt_graph.load()
     assert len(dbt_graph.filtered_nodes) > 0
 
     for _, node in dbt_graph.filtered_nodes.items():


### PR DESCRIPTION
## Description

This resolves #798 where when using `LoadMode.DBT_LS_FILE`, the `DbtGraph.update_node_dependency` was not called resulting in filtered nodes not having `DbtNode.has_test` set as expected. 

## Related Issue(s)

closes #798 

## Breaking Change?

None

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
