### PR TITLE
Fix: ensure operator `execute` method is consistent across all execution base subclasses

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -242,7 +242,7 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str]) -> Any:
         """Override this method for the operator to execute the dbt command"""
 
-    def execute(self, context: Context) -> None:
+    def execute(self, context: Context) -> Any | None:  # type: ignore
         self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
 
 

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -238,6 +238,13 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
 
         return dbt_cmd, env
 
+    @abstractmethod
+    def build_and_run_cmd(self, context: Context, cmd_flags: list[str]) -> Any:
+        """Override this method for the operator to execute the dbt command"""
+
+    def execute(self, context: Context) -> None:
+        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
+
 
 class DbtBuildMixin:
     """Mixin for dbt build command."""

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -63,9 +63,6 @@ class DbtDockerBaseOperator(DockerOperator, AbstractDbtBaseOperator):  # type: i
         self.environment: dict[str, Any] = {**env_vars, **self.environment}
         self.command: list[str] = dbt_cmd
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context)
-
 
 class DbtBuildDockerOperator(DbtBuildMixin, DbtDockerBaseOperator):
     """

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -50,7 +50,7 @@ class DbtDockerBaseOperator(DockerOperator, AbstractDbtBaseOperator):  # type: i
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")
-        result = super(DockerOperator, self).execute(context)
+        result = super().execute(context)
         logger.info(result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -50,7 +50,7 @@ class DbtDockerBaseOperator(DockerOperator, AbstractDbtBaseOperator):  # type: i
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")
-        result = super().execute(context)
+        result = super(DockerOperator, self).execute(context)
         logger.info(result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -97,9 +97,6 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, AbstractDbtBaseOperator):
         self.build_env_args(env_vars)
         self.arguments = dbt_cmd
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context)
-
 
 class DbtBuildKubernetesOperator(DbtBuildMixin, DbtKubernetesBaseOperator):
     """

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -73,7 +73,7 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, AbstractDbtBaseOperator):
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_kube_args(context, cmd_flags)
         self.log.info(f"Running command: {self.arguments}")
-        result = super(KubernetesPodOperator, self).execute(context)
+        result = super().execute(context)
         logger.info(result)
 
     def build_kube_args(self, context: Context, cmd_flags: list[str] | None = None) -> None:

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -73,7 +73,7 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, AbstractDbtBaseOperator):
     def build_and_run_cmd(self, context: Context, cmd_flags: list[str] | None = None) -> Any:
         self.build_kube_args(context, cmd_flags)
         self.log.info(f"Running command: {self.arguments}")
-        result = super().execute(context)
+        result = super(KubernetesPodOperator, self).execute(context)
         logger.info(result)
 
     def build_kube_args(self, context: Context, cmd_flags: list[str] | None = None) -> None:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -373,9 +373,6 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         logger.info(result.output)
         return result
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
-
     def on_kill(self) -> None:
         if self.cancel_query_on_kill:
             self.subprocess_hook.log.info("Sending SIGINT signal to process group")

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
@@ -14,9 +15,24 @@ from cosmos.operators.base import (
 
 def test_dbt_base_operator_is_abstract():
     """Tests that the abstract base operator cannot be instantiated since the base_cmd is not defined."""
-    expected_error = "Can't instantiate abstract class AbstractDbtBaseOperator with abstract methods? base_cmd"
+    expected_error = (
+        "Can't instantiate abstract class AbstractDbtBaseOperator with abstract methods base_cmd, build_and_run_cmd"
+    )
     with pytest.raises(TypeError, match=expected_error):
         AbstractDbtBaseOperator()
+
+
+@pytest.mark.parametrize("cmd_flags", [["--some-flag"], []])
+@patch("cosmos.operators.base.AbstractDbtBaseOperator.build_and_run_cmd")
+def test_dbt_base_operator_execute(mock_build_and_run_cmd, cmd_flags, monkeypatch):
+    """Tests that the base operator execute method calls the build_and_run_cmd method with the expected arguments."""
+    monkeypatch.setattr(AbstractDbtBaseOperator, "add_cmd_flags", lambda _: cmd_flags)
+    AbstractDbtBaseOperator.__abstractmethods__ = set()
+
+    base_operator = AbstractDbtBaseOperator(task_id="fake_task", project_dir="fake_dir")
+
+    base_operator.execute(context={})
+    mock_build_and_run_cmd.assert_called_once_with(context={}, cmd_flags=cmd_flags)
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

This fixes an issue reported in #804 after the refactor done in https://github.com/astronomer/astronomer-cosmos/pull/774 where the `execute` methods for `DbtLocalBaseOperator`, `DbtDockerBaseOperator`, and `DbtKubernetesBaseOperator` were different.

This PR refactors the `execute` method to the `AbstractDbtBaseOperator` so it's the same for all of the local, docker and kubernetes inherited operators, and adds `build_and_run_cmd` as an abstract method since the implementation is different across the 3 different execution modes.

## Related Issue(s)

closes #804

## Breaking Change?

None

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
