### PR TITLE
Pin pendulum < 3.0.0 for Airflow < 2.8

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,6 +170,7 @@ matrix.airflow.dependencies = [
     { value = "pydantic>=1.10.0,<2.0.0", if = ["2.6"]},
     { value = "apache-airflow==2.7", if = ["2.7"] },
     { value = "apache-airflow==2.8", if = ["2.8"] },
+    { value = "pendulum<3.0.0", if = ["2.3", "2.4", "2.5", "2.6", "2.7"] },
 ]
 
 [tool.hatch.envs.tests.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,7 +155,6 @@ dependencies = [
     "types-python-dateutil",
     "apache-airflow",
     "Werkzeug<3.0.0",
-    "apache-airflow-providers-common-sql",
 ]
 
 [[tool.hatch.envs.tests.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -193,7 +193,6 @@ airflow db init; \
 pip install  'dbt-core'  'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'"""
 test-integration = """rm -rf dbt/jaffle_shop/dbt_packages;
 pytest -vv \
-tests/operators/test_local.py::test_run_test_operator_with_callback \
 --cov=cosmos \
 --cov-report=term-missing \
 --cov-report=xml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,6 +155,7 @@ dependencies = [
     "types-python-dateutil",
     "apache-airflow",
     "Werkzeug<3.0.0",
+    "apache-airflow-providers-common-sql",
 ]
 
 [[tool.hatch.envs.tests.matrix]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,14 +147,16 @@ packages = ["cosmos"]
 [tool.hatch.envs.tests]
 dependencies = [
     "astronomer-cosmos[tests]",
-    "apache-airflow-providers-docker>=3.5.0",
-    "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "types-PyYAML",
     "types-attrs",
     "types-requests",
     "types-python-dateutil",
-    "apache-airflow",
     "Werkzeug<3.0.0",
+    "apache-airflow-providers-cncf-kubernetes>=5.1.1",
+    "apache-airflow-providers-docker>=3.5.0",
+]
+post-install-commands = [
+  "pip uninstall -y apache-airflow-providers-common-io"
 ]
 
 [[tool.hatch.envs.tests.matrix]]
@@ -175,6 +177,7 @@ matrix.airflow.dependencies = [
     { value = "apache-airflow==2.7", if = ["2.7"] },
     { value = "pendulum<3.0.0", if = ["2.7"] },
     { value = "apache-airflow==2.8", if = ["2.8"] },
+    { value = "apache-airflow-providers-common-io", if = ["2.8"] },
 ]
 
 [tool.hatch.envs.tests.scripts]
@@ -184,7 +187,7 @@ test = 'pytest -vv --durations=0 . -m "not integration" --ignore=tests/test_exam
 test-cov = """pytest -vv --cov=cosmos --cov-report=term-missing --cov-report=xml --durations=0 -m "not integration" --ignore=tests/test_example_dags.py --ignore=tests/test_example_dags_no_connections.py"""
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-test-integration-setup = """pip uninstall dbt-postgres dbt-databricks dbt-vertica; \
+test-integration-setup = """pip uninstall -y dbt-postgres dbt-databricks dbt-vertica; \
 rm -rf airflow.*; \
 airflow db init; \
 pip install  'dbt-core'  'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'"""


### PR DESCRIPTION
## Description

 Cosmos unit tests are failing with errors like: 
```
_________________ ERROR collecting tests/airflow/test_graph.py _________________
tests/airflow/test_graph.py:6: in <module>
    from airflow import __version__ as airflow_version
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.8-2.4/lib/python3.8/site-packages/airflow/__init__.py:34: in <module>
    from airflow import settings
../../../.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.8-2.4/lib/python3.8/site-packages/airflow/settings.py:49: in <module>
    TIMEZONE = pendulum.tz.timezone('UTC')
E   TypeError: 'module' object is not callable
```
[Example here](https://github.com/astronomer/astronomer-cosmos/actions/runs/7590233614/job/20676384033). I think this is because Airflow v2.8.1 was [released today](https://github.com/apache/airflow/releases/tag/2.8.1) that now targets the 3.0.0 version of Pendulum that has the breaking API changes seen above. Any pip install of `apache-airflow<2.8.1` I think is now installing `pendulum==3.0.0` because the pendulum constraint is only specified if you install airflow [with a constraint file.](https://airflow.apache.org/docs/apache-airflow/stable/installation/installing-from-pypi.html)

I don't think hatch dependencies allows constraint file referencing so this attempt pins `pendulum` directly kind of like what is already done for pydantic.

## Related Issue(s)

## Breaking Change?

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
