### PR TITLE
Fix OpenLineage integration documentation

### DIFF
--- a/docs/configuration/lineage.rst
+++ b/docs/configuration/lineage.rst
@@ -9,7 +9,7 @@ and virtualenv execution methods (read `execution modes <../getting_started/exec
 
 To emit lineage events, Cosmos can use one of the following:
 
-1. Airflow 2.7 `built-in support to OpenLineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
+1. Airflow official OpenLineage provider <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
 2. `Additional libraries <https://openlineage.io/docs/integrations/airflow/>`_.
 
 No change to the user DAG files is required to use OpenLineage.
@@ -18,7 +18,7 @@ No change to the user DAG files is required to use OpenLineage.
 Installation
 ------------
 
-If using Airflow 2.7, no other dependency is required.
+If using Airflow 2.7 or higher, install ``apache-airflow-providers-openlineage``.
 
 Otherwise, install Cosmos using ``astronomer-cosmos[openlineage]``.
 

--- a/docs/configuration/lineage.rst
+++ b/docs/configuration/lineage.rst
@@ -9,7 +9,7 @@ and virtualenv execution methods (read `execution modes <../getting_started/exec
 
 To emit lineage events, Cosmos can use one of the following:
 
-1. Airflow official OpenLineage provider <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
+1. Airflow `official OpenLineage provider <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
 2. `Additional libraries <https://openlineage.io/docs/integrations/airflow/>`_.
 
 No change to the user DAG files is required to use OpenLineage.

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``select`` and ``exclude``: which models to include or exclude from your DAGs. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.


### PR DESCRIPTION
[Cosmos docs](https://astronomer.github.io/astronomer-cosmos/configuration/lineage.html) stated that users didn't have to install any dependency to use OpenLineage with Cosmos.

However, for inlets and outlets to be emitted, Airflow 2.7 users must install `apache-airflow-providers-openlineage` or `astronomer-cosmos[openlineage]`.

Closes: #796 