### PR TITLE
Fix custom selector when `test` node has no `depends_on` values

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -294,7 +294,7 @@ class NodeSelector:
 
         self.visited_nodes.add(node_id)
 
-        if node.resource_type == DbtResourceType.TEST:
+        if node.resource_type == DbtResourceType.TEST and node.depends_on:
             node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
 
         if not self._is_tags_subset(node):

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -406,3 +406,16 @@ def test_exclude_by_union_graph_selector_and_tag():
         "model.dbt-proj.orphaned",
     ]
     assert sorted(selected.keys()) == expected
+
+
+def test_node_without_depends_on_with_tag_selector_should_not_raise_exception():
+    standalone_test_node = DbtNode(
+        unique_id=f"{DbtResourceType.TEST.value}.{SAMPLE_PROJ_PATH.stem}.standalone",
+        resource_type=DbtResourceType.TEST,
+        depends_on=[],
+        tags=[],
+        config={},
+        file_path=SAMPLE_PROJ_PATH / "tests/generic/builtin.sql",
+    )
+    nodes = {standalone_test_node.unique_id: standalone_test_node}
+    assert not select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=nodes, select=["tag:some-tag"])


### PR DESCRIPTION
A user reported the following issue while using Cosmos 1.3.1:

```
    def _should_include_node(self, node_id: str, node: DbtNode) -> bool:
        "Checks if a single node should be included. Only runs once per node with caching."
        if node_id in self.visited_nodes:
            return node_id in self.selected_nodes

        self.visited_nodes.add(node_id)

        if node.resource_type == DbtResourceType.TEST:
>           node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
E           IndexError: list index out of range

cosmos/dbt/selector.py:298: IndexError
```

In order to reproduce this issue, it was necessary to add a tag-based select statement.

Based on the error, it seems their dbt project has a test without `depends_on`. This CR adds support to this use case.

Closes: #813
