### PR TITLE
Release 1.3.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,7 +41,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
     steps:
       - uses: actions/checkout@v3
         with:
@@ -80,7 +80,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
     services:
       postgres:
         image: postgres

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - --py37-plus
           - --keep-runtime-typing
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.13
+    rev: v0.1.14
     hooks:
       - id: ruff
         args:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -54,7 +54,7 @@ repos:
           - --py37-plus
           - --keep-runtime-typing
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.1.11
+    rev: v0.1.13
     hooks:
       - id: ruff
         args:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,26 @@
 Changelog
 =========
 
+1.3.2 (2023-01-26)
+------------------
+
+Bug fixes
+
+* Fix: ensure ``DbtGraph.update_node_dependency`` is called for all load methods by @jbandoro in #803
+* Fix: ensure operator ``execute`` method is consistent across all execution base subclasses by @jbandoro in #805
+* Fix custom selector when ``test`` node has no ``depends_on`` values by @tatiana in #814
+* Fix forwarding selectors to test task when using ``TestBehavior.AFTER_ALL`` by @tatiana in #816
+
+Others
+
+* Docs: Remove incorrect docstring from ``DbtLocalBaseOperator`` by @jakob-hvitnov-telia in #797
+* Add more logs to troubleshoot custom selector by @tatiana in #809
+* Fix OpenLineage integration documentation by @tatiana in #810
+* Fix test dependencies after Airflow 2.8 release by @jbandoro and @tatiana in #806
+* Use Airflow constraint file for test environment setup by @jbandoro in #812
+* pre-commit updates in #799, #807
+
+
 1.3.1 (2023-01-10)
 ------------------
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -14,6 +14,7 @@ from cosmos.constants import (
     TESTABLE_DBT_RESOURCES,
     DEFAULT_DBT_RESOURCES,
 )
+from cosmos.config import RenderConfig
 from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
@@ -66,6 +67,7 @@ def create_test_task_metadata(
     task_args: dict[str, Any],
     on_warning_callback: Callable[..., Any] | None = None,
     node: DbtNode | None = None,
+    render_config: RenderConfig | None = None,
 ) -> TaskMetadata:
     """
     Create the metadata that will be used to instantiate the Airflow Task that will be used to run the Dbt test node.
@@ -89,6 +91,11 @@ def create_test_task_metadata(
             task_args["select"] = f"source:{node.resource_name}"
         else:  # tested with node.resource_type == DbtResourceType.SEED or DbtResourceType.SNAPSHOT
             task_args["select"] = node.resource_name
+    elif render_config is not None:  # TestBehavior.AFTER_ALL
+        task_args["select"] = render_config.select
+        task_args["selector"] = render_config.selector
+        task_args["exclude"] = render_config.exclude
+
     return TaskMetadata(
         id=test_task_name,
         operator_class=calculate_operator_class(
@@ -199,12 +206,11 @@ def build_airflow_graph(
     dag: DAG,  # Airflow-specific - parent DAG where to associate tasks and (optional) task groups
     execution_mode: ExecutionMode,  # Cosmos-specific - decide what which class to use
     task_args: dict[str, Any],  # Cosmos/DBT - used to instantiate tasks
-    test_behavior: TestBehavior,  # Cosmos-specific: how to inject tests to Airflow DAG
     test_indirect_selection: TestIndirectSelection,  # Cosmos/DBT - used to set test indirect selection mode
     dbt_project_name: str,  # DBT / Cosmos - used to name test task if mode is after_all,
+    render_config: RenderConfig,
     task_group: TaskGroup | None = None,
     on_warning_callback: Callable[..., Any] | None = None,  # argument specific to the DBT test command
-    node_converters: dict[DbtResourceType, Callable[..., Any]] | None = None,
 ) -> None:
     """
     Instantiate dbt `nodes` as Airflow tasks within the given `task_group` (optional) or `dag` (mandatory).
@@ -224,13 +230,13 @@ def build_airflow_graph(
     :param execution_mode: Where Cosmos should run each dbt task (e.g. ExecutionMode.LOCAL, ExecutionMode.KUBERNETES).
         Default is ExecutionMode.LOCAL.
     :param task_args: Arguments to be used to instantiate an Airflow Task
-    :param test_behavior: When to run `dbt` tests. Default is TestBehavior.AFTER_EACH, that runs tests after each model.
     :param dbt_project_name: Name of the dbt pipeline of interest
     :param task_group: Airflow Task Group instance
     :param on_warning_callback: A callback function called on warnings with additional Context variables “test_names”
     and “test_results” of type List.
     """
-    node_converters = node_converters or {}
+    node_converters = render_config.node_converters or {}
+    test_behavior = render_config.test_behavior
     tasks_map = {}
     task_or_group: TaskGroup | BaseOperator
 
@@ -266,6 +272,7 @@ def build_airflow_graph(
             test_indirect_selection,
             task_args=task_args,
             on_warning_callback=on_warning_callback,
+            render_config=render_config,
         )
         test_task = create_airflow_task(test_meta, dag, task_group=task_group)
         leaves_ids = calculate_leaves(tasks_ids=list(tasks_map.keys()), nodes=nodes)

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -268,9 +268,8 @@ class DbtToAirflowConverter:
             task_group=task_group,
             execution_mode=execution_config.execution_mode,
             task_args=task_args,
-            test_behavior=render_config.test_behavior,
             test_indirect_selection=execution_config.test_indirect_selection,
             dbt_project_name=project_config.project_name,
             on_warning_callback=on_warning_callback,
-            node_converters=render_config.node_converters,
+            render_config=render_config,
         )

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -181,6 +181,11 @@ class DbtGraph:
         else:
             load_method[method]()
 
+        self.update_node_dependency()
+
+        logger.info("Total nodes: %i", len(self.nodes))
+        logger.info("Total filtered nodes: %i", len(self.nodes))
+
     def run_dbt_ls(
         self, dbt_cmd: str, project_path: Path, tmp_dir: Path, env_vars: dict[str, str]
     ) -> dict[str, DbtNode]:
@@ -276,11 +281,6 @@ class DbtGraph:
                 self.nodes = nodes
                 self.filtered_nodes = nodes
 
-        self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
-
     def load_via_dbt_ls_file(self) -> None:
         """
         This is between dbt ls and full manifest. It allows to use the output (needs to be json output) of the dbt ls as a
@@ -364,11 +364,6 @@ class DbtGraph:
             exclude=self.render_config.exclude,
         )
 
-        self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
-
     def load_from_dbt_manifest(self) -> None:
         """
         This approach accurately loads `dbt` projects using the `manifest.yml` file.
@@ -417,11 +412,6 @@ class DbtGraph:
                 select=self.render_config.select,
                 exclude=self.render_config.exclude,
             )
-
-            self.update_node_dependency()
-
-        logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
 
     def update_node_dependency(self) -> None:
         """

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -289,6 +289,7 @@ class NodeSelector:
 
     def _should_include_node(self, node_id: str, node: DbtNode) -> bool:
         "Checks if a single node should be included. Only runs once per node with caching."
+        logger.debug("Inspecting if the node <%s> should be included.", node_id)
         if node_id in self.visited_nodes:
             return node_id in self.selected_nodes
 
@@ -296,8 +297,15 @@ class NodeSelector:
 
         if node.resource_type == DbtResourceType.TEST:
             node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
+            logger.debug(
+                "The test node <%s> inherited these tags from the parent node <%s>: %s",
+                node_id,
+                node.depends_on[0],
+                node.tags,
+            )
 
         if not self._is_tags_subset(node):
+            logger.debug("Excluding node <%s>", node_id)
             return False
 
         node_config = {key: value for key, value in node.config.items() if key in SUPPORTED_CONFIG}

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -295,7 +295,7 @@ class NodeSelector:
 
         self.visited_nodes.add(node_id)
 
-        if node.resource_type == DbtResourceType.TEST:
+        if node.resource_type == DbtResourceType.TEST and node.depends_on:
             node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
             logger.debug(
                 "The test node <%s> inherited these tags from the parent node <%s>: %s",

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -238,6 +238,13 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
 
         return dbt_cmd, env
 
+    @abstractmethod
+    def build_and_run_cmd(self, context: Context, cmd_flags: list[str]) -> Any:
+        """Override this method for the operator to execute the dbt command"""
+
+    def execute(self, context: Context) -> Any | None:  # type: ignore
+        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
+
 
 class DbtLSMixin:
     """

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -317,6 +317,30 @@ class DbtTestMixin:
     base_cmd = ["test"]
     ui_color = "#8194E0"
 
+    def __init__(
+        self,
+        exclude: str | None = None,
+        select: str | None = None,
+        selector: str | None = None,
+        **kwargs: Any,
+    ) -> None:
+        self.select = select
+        self.exclude = exclude
+        self.selector = selector
+        super().__init__(exclude=exclude, select=select, selector=selector, **kwargs)  # type: ignore
+
+    def add_cmd_flags(self) -> list[str]:
+        flags = []
+        if self.exclude:
+            flags.extend(["--exclude", *self.exclude])
+
+        if self.select:
+            flags.extend(["--select", *self.select])
+
+        if self.selector:
+            flags.extend(["--selector", self.selector])
+        return flags
+
 
 class DbtRunOperationMixin:
     """

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -62,9 +62,6 @@ class DbtDockerBaseOperator(DockerOperator, AbstractDbtBaseOperator):  # type: i
         self.environment: dict[str, Any] = {**env_vars, **self.environment}
         self.command: list[str] = dbt_cmd
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context)
-
 
 class DbtLSDockerOperator(DbtLSMixin, DbtDockerBaseOperator):
     """

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -96,9 +96,6 @@ class DbtKubernetesBaseOperator(KubernetesPodOperator, AbstractDbtBaseOperator):
         self.build_env_args(env_vars)
         self.arguments = dbt_cmd
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context)
-
 
 class DbtLSKubernetesOperator(DbtLSMixin, DbtKubernetesBaseOperator):
     """

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -371,9 +371,6 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         logger.info(result.output)
         return result
 
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
-
     def on_kill(self) -> None:
         if self.cancel_query_on_kill:
             self.subprocess_hook.log.info("Sending SIGINT signal to process group")

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -440,7 +440,7 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
         self.on_warning_callback and self.on_warning_callback(warning_context)
 
     def execute(self, context: Context) -> None:
-        result = self.build_and_run_cmd(context=context)
+        result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
         should_trigger_callback = all(
             [
                 self.on_warning_callback,

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -96,7 +96,6 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
     :param profile_name: A name to use for the dbt profile. If not provided, and no profile target is found
         in your project's dbt_project.yml, "cosmos_profile" is used.
     :param install_deps: If true, install dependencies before running the command
-    :param install_deps: If true, the operator will set inlets and outlets
     :param callback: A callback function called on after a dbt run with a path to the dbt project directory.
     :param target_name: A name to use for the dbt target. If not provided, and no target is found
         in your project's dbt_project.yml, "cosmos_target" is used.

--- a/docs/configuration/lineage.rst
+++ b/docs/configuration/lineage.rst
@@ -9,7 +9,7 @@ and virtualenv execution methods (read `execution modes <../getting_started/exec
 
 To emit lineage events, Cosmos can use one of the following:
 
-1. Airflow 2.7 `built-in support to OpenLineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
+1. Airflow `official OpenLineage provider <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/1.0.2/guides/user.html>`_, or
 2. `Additional libraries <https://openlineage.io/docs/integrations/airflow/>`_.
 
 No change to the user DAG files is required to use OpenLineage.
@@ -18,7 +18,7 @@ No change to the user DAG files is required to use OpenLineage.
 Installation
 ------------
 
-If using Airflow 2.7, no other dependency is required.
+If using Airflow 2.7 or higher, install ``apache-airflow-providers-openlineage``.
 
 Otherwise, install Cosmos using ``astronomer-cosmos[openlineage]``.
 

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``select`` and ``exclude``: which models to include or exclude from your DAGs. See `Selecting & Excluding <selecting-excluding.html>`_ for more information.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -155,30 +155,19 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "apache-airflow-providers-docker>=3.5.0",
 ]
-post-install-commands = [
-  "pip uninstall -y apache-airflow-providers-common-io"
+# Airflow install with constraint file, Airflow versions < 2.7 require a workaround for PyYAML
+pre-install-commands = ["""
+    if [[ "2.3 2.4 2.5 2.6" =~ "{matrix:airflow}" ]]; then
+        echo "Cython < 3" >> /tmp/constraint.txt
+        pip wheel "PyYAML==6.0.0" -c /tmp/constraint.txt
+    fi
+    pip install 'apache-airflow=={matrix:airflow}' --constraint 'https://raw.githubusercontent.com/apache/airflow/constraints-{matrix:airflow}.0/constraints-{matrix:python}.txt'
+    """
 ]
-
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.8", "3.9", "3.10"]
 airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
 
-[tool.hatch.envs.tests.overrides]
-matrix.airflow.dependencies = [
-    { value = "apache-airflow==2.3", if = ["2.3"] },
-    { value = "pendulum<3.0.0", if = ["2.3"] },
-    { value = "apache-airflow==2.4", if = ["2.4"] },
-    { value = "pendulum<3.0.0", if = ["2.4"] },
-    { value = "apache-airflow==2.5", if = ["2.5"] },
-    { value = "pendulum<3.0.0", if = ["2.5"] },
-    { value = "apache-airflow==2.6", if = ["2.6"] },
-    { value = "pendulum<3.0.0", if = ["2.6"] },
-    { value = "pydantic>=1.10.0,<2.0.0", if = ["2.6"]},
-    { value = "apache-airflow==2.7", if = ["2.7"] },
-    { value = "pendulum<3.0.0", if = ["2.7"] },
-    { value = "apache-airflow==2.8", if = ["2.8"] },
-    { value = "apache-airflow-providers-common-io", if = ["2.8"] },
-]
 
 [tool.hatch.envs.tests.scripts]
 freeze = "pip freeze"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -147,14 +147,16 @@ packages = ["cosmos"]
 [tool.hatch.envs.tests]
 dependencies = [
     "astronomer-cosmos[tests]",
-    "apache-airflow-providers-docker>=3.5.0",
-    "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "types-PyYAML",
     "types-attrs",
     "types-requests",
     "types-python-dateutil",
-    "apache-airflow",
     "Werkzeug<3.0.0",
+    "apache-airflow-providers-cncf-kubernetes>=5.1.1",
+    "apache-airflow-providers-docker>=3.5.0",
+]
+post-install-commands = [
+  "pip uninstall -y apache-airflow-providers-common-io"
 ]
 
 [[tool.hatch.envs.tests.matrix]]
@@ -164,12 +166,18 @@ airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [
     { value = "apache-airflow==2.3", if = ["2.3"] },
+    { value = "pendulum<3.0.0", if = ["2.3"] },
     { value = "apache-airflow==2.4", if = ["2.4"] },
+    { value = "pendulum<3.0.0", if = ["2.4"] },
     { value = "apache-airflow==2.5", if = ["2.5"] },
+    { value = "pendulum<3.0.0", if = ["2.5"] },
     { value = "apache-airflow==2.6", if = ["2.6"] },
+    { value = "pendulum<3.0.0", if = ["2.6"] },
     { value = "pydantic>=1.10.0,<2.0.0", if = ["2.6"]},
     { value = "apache-airflow==2.7", if = ["2.7"] },
+    { value = "pendulum<3.0.0", if = ["2.7"] },
     { value = "apache-airflow==2.8", if = ["2.8"] },
+    { value = "apache-airflow-providers-common-io", if = ["2.8"] },
 ]
 
 [tool.hatch.envs.tests.scripts]
@@ -179,7 +187,7 @@ test = 'pytest -vv --durations=0 . -m "not integration" --ignore=tests/test_exam
 test-cov = """pytest -vv --cov=cosmos --cov-report=term-missing --cov-report=xml --durations=0 -m "not integration" --ignore=tests/test_example_dags.py --ignore=tests/test_example_dags_no_connections.py"""
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-test-integration-setup = """pip uninstall dbt-postgres dbt-databricks dbt-vertica; \
+test-integration-setup = """pip uninstall -y dbt-postgres dbt-databricks dbt-vertica; \
 rm -rf airflow.*; \
 airflow db init; \
 pip install  'dbt-core'  'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'"""

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -258,6 +258,7 @@ def test_load_manifest_with_manifest(mock_load_from_dbt_manifest):
         (ExecutionMode.LOCAL, LoadMode.CUSTOM, "mock_load_via_custom_parser"),
     ],
 )
+@patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.dbt.graph.DbtGraph.load_via_custom_parser", return_value=None)
 @patch("cosmos.dbt.graph.DbtGraph.load_via_dbt_ls", return_value=None)
 @patch("cosmos.dbt.graph.DbtGraph.load_from_dbt_manifest", return_value=None)
@@ -267,6 +268,7 @@ def test_load(
     mock_load_via_dbt_ls_file,
     mock_load_via_dbt_ls,
     mock_load_via_custom_parser,
+    mock_update_node_dependency,
     exec_mode,
     method,
     expected_function,
@@ -282,6 +284,7 @@ def test_load(
     dbt_graph.load(method=method, execution_mode=exec_mode)
     load_function = locals()[expected_function]
     assert load_function.called
+    assert mock_update_node_dependency.called
 
 
 @pytest.mark.integration
@@ -675,8 +678,7 @@ def test_tag_selected_node_test_exist():
         profile_config=profile_config,
         render_config=render_config,
     )
-    dbt_graph.load_from_dbt_manifest()
-
+    dbt_graph.load()
     assert len(dbt_graph.filtered_nodes) > 0
 
     for _, node in dbt_graph.filtered_nodes.items():

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -406,3 +406,16 @@ def test_exclude_by_union_graph_selector_and_tag():
         "model.dbt-proj.orphaned",
     ]
     assert sorted(selected.keys()) == expected
+
+
+def test_node_without_depends_on_with_tag_selector_should_not_raise_exception():
+    standalone_test_node = DbtNode(
+        unique_id=f"{DbtResourceType.TEST.value}.{SAMPLE_PROJ_PATH.stem}.standalone",
+        resource_type=DbtResourceType.TEST,
+        depends_on=[],
+        tags=[],
+        config={},
+        file_path=SAMPLE_PROJ_PATH / "tests/generic/builtin.sql",
+    )
+    nodes = {standalone_test_node.unique_id: standalone_test_node}
+    assert not select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=nodes, select=["tag:some-tag"])

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -1,4 +1,5 @@
 import pytest
+from unittest.mock import patch
 
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
@@ -13,9 +14,24 @@ from cosmos.operators.base import (
 
 def test_dbt_base_operator_is_abstract():
     """Tests that the abstract base operator cannot be instantiated since the base_cmd is not defined."""
-    expected_error = "Can't instantiate abstract class AbstractDbtBaseOperator with abstract methods? base_cmd"
+    expected_error = (
+        "Can't instantiate abstract class AbstractDbtBaseOperator with abstract methods base_cmd, build_and_run_cmd"
+    )
     with pytest.raises(TypeError, match=expected_error):
         AbstractDbtBaseOperator()
+
+
+@pytest.mark.parametrize("cmd_flags", [["--some-flag"], []])
+@patch("cosmos.operators.base.AbstractDbtBaseOperator.build_and_run_cmd")
+def test_dbt_base_operator_execute(mock_build_and_run_cmd, cmd_flags, monkeypatch):
+    """Tests that the base operator execute method calls the build_and_run_cmd method with the expected arguments."""
+    monkeypatch.setattr(AbstractDbtBaseOperator, "add_cmd_flags", lambda _: cmd_flags)
+    AbstractDbtBaseOperator.__abstractmethods__ = set()
+
+    base_operator = AbstractDbtBaseOperator(task_id="fake_task", project_dir="fake_dir")
+
+    base_operator.execute(context={})
+    mock_build_and_run_cmd.assert_called_once_with(context={}, cmd_flags=cmd_flags)
 
 
 @pytest.mark.parametrize(

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -359,7 +359,16 @@ def test_store_compiled_sql() -> None:
     [
         (DbtSeedLocalOperator, {"full_refresh": True}, {"context": {}, "cmd_flags": ["--full-refresh"]}),
         (DbtRunLocalOperator, {"full_refresh": True}, {"context": {}, "cmd_flags": ["--full-refresh"]}),
-        (DbtTestLocalOperator, {"full_refresh": True}, {"context": {}}),
+        (
+            DbtTestLocalOperator,
+            {"full_refresh": True, "select": ["tag:daily"], "exclude": ["tag:disabled"]},
+            {"context": {}, "cmd_flags": ["--exclude", "tag:disabled", "--select", "tag:daily"]},
+        ),
+        (
+            DbtTestLocalOperator,
+            {"full_refresh": True, "selector": "nightly_snowplow"},
+            {"context": {}, "cmd_flags": ["--selector", "nightly_snowplow"]},
+        ),
         (
             DbtRunOperationLocalOperator,
             {"args": {"days": 7, "dry_run": True}, "macro_name": "bla"},
@@ -400,10 +409,7 @@ def test_operator_execute_without_flags(mock_build_and_run_cmd, operator_class):
         **operator_class_kwargs.get(operator_class, {}),
     )
     task.execute(context={})
-    if operator_class == DbtTestLocalOperator:
-        mock_build_and_run_cmd.assert_called_once_with(context={})
-    else:
-        mock_build_and_run_cmd.assert_called_once_with(context={}, cmd_flags=[])
+    mock_build_and_run_cmd.assert_called_once_with(context={}, cmd_flags=[])
 
 
 @patch("cosmos.operators.local.DbtLocalArtifactProcessor")


### PR DESCRIPTION
**Bug fixes**

* Fix: ensure ``DbtGraph.update_node_dependency`` is called for all load methods by @jbandoro in #803
* Fix: ensure operator ``execute`` method is consistent across all execution base subclasses by @jbandoro in #805
* Fix custom selector when ``test`` node has no ``depends_on`` values by @tatiana in #814
* Fix forwarding selectors to test task when using ``TestBehavior.AFTER_ALL`` by @tatiana in #816

**Others**

* Docs: Remove incorrect docstring from ``DbtLocalBaseOperator`` by @jakob-hvitnov-telia in #797
* Add more logs to troubleshoot custom selector by @tatiana in #809
* Fix OpenLineage integration documentation by @tatiana in #810
* Fix test dependencies after Airflow 2.8 release by @jbandoro and @tatiana in #806
* Use Airflow constraint file for test environment setup by @jbandoro in #812
* pre-commit updates in #799, #807