### PR TITLE
Exclude unsupported Airflow versions for Python 3.11 tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,6 +42,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+        exclude:
+          - python-version: "3.11"
+            airflow-version: "2.3"
+          - python-version: "3.11"
+            airflow-version: "2.4"
     steps:
       - uses: actions/checkout@v3
         with:
@@ -81,6 +86,11 @@ jobs:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
         airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+        exclude:
+          - python-version: "3.11"
+            airflow-version: "2.3"
+          - python-version: "3.11"
+            airflow-version: "2.4"
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
## Description

After #821 was added, tests in the matrix like [this one](https://github.com/astronomer/astronomer-cosmos/actions/runs/7717880587/job/21037953569) for Airflow v2.3 and Python 3.11 are failing because the minimum Airflow version supported for 3.11 is v2.5.

This PR excludes Airflow v2.3 and 2.4 from the testing matrix for 3.11.

