### PR TITLE
Fix error when running unit test `test_created_pod` with Py3.11

### DIFF
--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,10 +226,11 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
+@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.config.load_incluster_config")
 @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook._get_default_client")
 @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 @patch("cosmos.operators.kubernetes.KubernetesPodOperator.hook")
-def test_created_pod(test_hook1, test_hook2, test_client):
+def test_created_pod(test_hook1, test_hook2, test_client, load_cluster_config):
     test_hook1.is_in_cluster = False
     test_hook2.is_in_cluster = False
     test_hook1._get_namespace.return_value.to_dict.return_value = "foo"

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,7 +226,7 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook")
+@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes")
 @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 def test_created_pod(test_hook1, test_hook2):
     test_hook1.is_in_cluster = False

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,7 +226,9 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
+# @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
+@pytest.mark.integration
+@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook")
 def test_created_pod(test_hook):
     test_hook.is_in_cluster = False
     test_hook._get_namespace.return_value.to_dict.return_value = "foo"

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,12 +226,13 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-# @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
-@pytest.mark.integration
+@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook")
-def test_created_pod(test_hook):
-    test_hook.is_in_cluster = False
-    test_hook._get_namespace.return_value.to_dict.return_value = "foo"
+def test_created_pod(test_hook1, test_hook2):
+    test_hook1.is_in_cluster = False
+    test_hook2.is_in_cluster = False
+    test_hook1._get_namespace.return_value.to_dict.return_value = "foo"
+    test_hook2._get_namespace.return_value.to_dict.return_value = "foo"
     ls_kwargs = {"env_vars": {"FOO": "BAR"}}
     ls_kwargs.update(base_kwargs)
     ls_operator = DbtLSKubernetesOperator(**ls_kwargs)

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,18 +226,18 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.config.load_incluster_config")
-@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook._get_default_client")
 @patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
-@patch("cosmos.operators.kubernetes.KubernetesPodOperator.hook")
-def test_created_pod(test_hook1, test_hook2, test_client, load_cluster_config):
-    test_hook1.is_in_cluster = False
-    test_hook2.is_in_cluster = False
-    test_hook1._get_namespace.return_value.to_dict.return_value = "foo"
-    test_hook2._get_namespace.return_value.to_dict.return_value = "foo"
+def test_created_pod(test_hook):
+    test_hook.is_in_cluster = False
+    test_hook._get_namespace.return_value.to_dict.return_value = "foo"
     ls_kwargs = {"env_vars": {"FOO": "BAR"}}
     ls_kwargs.update(base_kwargs)
     ls_operator = DbtLSKubernetesOperator(**ls_kwargs)
+    from unittest.mock import MagicMock
+
+    ls_operator.hook = MagicMock()
+    ls_operator.hook.is_in_cluster = False
+    ls_operator.hook._get_namespace.return_value.to_dict.return_value = "foo"
     ls_operator.build_kube_args(context={}, cmd_flags=MagicMock())
     pod_obj = ls_operator.build_pod_request_obj()
     expected_result = {

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,15 +226,10 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
-def test_created_pod(test_hook):
-    test_hook.is_in_cluster = False
-    test_hook._get_namespace.return_value.to_dict.return_value = "foo"
+def test_created_pod():
     ls_kwargs = {"env_vars": {"FOO": "BAR"}}
     ls_kwargs.update(base_kwargs)
     ls_operator = DbtLSKubernetesOperator(**ls_kwargs)
-    from unittest.mock import MagicMock
-
     ls_operator.hook = MagicMock()
     ls_operator.hook.is_in_cluster = False
     ls_operator.hook._get_namespace.return_value.to_dict.return_value = "foo"

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,8 +226,7 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.hooks.kubernetes")
-@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
+@patch("cosmos.operators.kubernetes.KubernetesPodOperator.hook")
 def test_created_pod(test_hook1, test_hook2):
     test_hook1.is_in_cluster = False
     test_hook2.is_in_cluster = False

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,8 +226,8 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
-@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 @patch("airflow.providers.cncf.kubernetes.hooks.kubernetes.KubernetesHook")
+@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 def test_created_pod(test_hook1, test_hook2):
     test_hook1.is_in_cluster = False
     test_hook2.is_in_cluster = False

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -226,8 +226,10 @@ def test_dbt_test_kubernetes_operator_handle_warnings_and_cleanup_pod():
     test_operator._handle_warnings(context)
 
 
+@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook._get_default_client")
+@patch("airflow.providers.cncf.kubernetes.operators.pod.KubernetesPodOperator.hook")
 @patch("cosmos.operators.kubernetes.KubernetesPodOperator.hook")
-def test_created_pod(test_hook1, test_hook2):
+def test_created_pod(test_hook1, test_hook2, test_client):
     test_hook1.is_in_cluster = False
     test_hook2.is_in_cluster = False
     test_hook1._get_namespace.return_value.to_dict.return_value = "foo"


### PR DESCRIPTION
When the CI ran:
`hatch run tests.py3.11-2.7:test-cov`

It was consistently raising the exception:
```
FAILED tests/operators/test_kubernetes.py::test_created_pod - kubernetes.config.config_exception.ConfigException: Invalid kube-config file. No configuration found.
```

Example:
https://github.com/astronomer/astronomer-cosmos/actions/runs/7726274202/job/21063656952

I could not reproduce this issue locally, even when using Python 3.11.8. An explanation I see is that the built-in `unittest.mock` library changed in the Python version the CI was using - and for some reason, the way the mock was set stopped working. I changed how the mock was defined, and things seem to work fine.