### PR TITLE
Add `connect_retries` to databricks profile to fix expensive integration failures

### DIFF
--- a/dev/dags/dbt/jaffle_shop_python/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop_python/profiles.yml
@@ -8,5 +8,4 @@ jaffle_shop:
      threads: 1
      token: "{{ env_var('DATABRICKS_TOKEN') }}"
      type: databricks
-     connect_retries: 3
  target: dev

--- a/dev/dags/dbt/jaffle_shop_python/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop_python/profiles.yml
@@ -8,4 +8,5 @@ jaffle_shop:
      threads: 1
      token: "{{ env_var('DATABRICKS_TOKEN') }}"
      type: databricks
+     connect_retries: 3
  target: dev

--- a/dev/dags/example_cosmos_python_models.py
+++ b/dev/dags/example_cosmos_python_models.py
@@ -29,7 +29,7 @@ profile_config = ProfileConfig(
     target_name="dev",
     profile_mapping=DatabricksTokenProfileMapping(
         conn_id="databricks_default",
-        profile_args={"schema": SCHEMA},
+        profile_args={"schema": SCHEMA, "connect_retries": 3},
     ),
 )
 

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -51,7 +51,7 @@ To use this:
         ),
         render_config=RenderConfig(
             load_method=LoadMode.DBT_MANIFEST,
-        )
+        ),
         # ...,
     )
 


### PR DESCRIPTION
## Description

Since we're seeing intermittent failures of the expensive integration test, for example [here](https://github.com/astronomer/astronomer-cosmos/actions/runs/7702383256/job/20990581739) with the error:
```shell
FAILED tests/test_example_dags.py::test_example_dag[example_cosmos_python_models] - airflow.exceptions.AirflowException: ('dbt command failed. The command returned a non-zero exit code 2. Details: ', '\x1b[0m21:08:13  Running with dbt=1.7.6', '\x1b[0m21:08:15  Registered adapter: databricks=1.7.4', '\x1b[0m21:08:15  Unable to do partial parsing because saved manifest not found. Starting full parse.', '\x1b[0m21:08:18  Found 5 models, 3 seeds, 20 tests, 0 sources, 0 exposures, 0 metrics, 535 macros, 0 groups, 0 semantic models', '\x1b[0m21:08:18', '\x1b[0m21:10:52', '\x1b[0m21:10:52  Finished running  in 0 hours 2 minutes and 33.98 seconds (153.98s).', '\x1b[0m21:10:52  Encountered an error:', 'Runtime Error', "  HTTPSConnectionPool(host='***', port=443): Max retries exceeded with url: /sql/1.0/warehouses/*** (Caused by ResponseError('too many 503 error responses'))")
```
which can be sometimes be resolved by rerunning the action. This PR  adds a [connect_retries](https://docs.getdbt.com/docs/core/connect-data-platform/databricks-setup) field to the databricks profile.