### PR TITLE
Add support for `InvocationMode.DBT_RUNNER` for local execution mode

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -293,6 +293,7 @@ jobs:
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
   Run-Performance-Tests:
+    needs: Authorize
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -346,13 +346,14 @@ jobs:
           AIRFLOW_CONN_AIRFLOW_DB: postgres://postgres:postgres@0.0.0.0:5432/postgres
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
-          MODEL_COUNT: ${{ matrix.num-models }}
+          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
           POSTGRES_HOST: localhost
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          MODEL_COUNT: ${{ matrix.num-models }}
     env:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       AIRFLOW_CONN_AIRFLOW_DB: postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -299,7 +299,18 @@ jobs:
         python-version: ["3.11"]
         airflow-version: ["2.7"]
         num-models: [1, 10, 50, 100]
-
+    services:
+      postgres:
+        image: postgres
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
     steps:
       - uses: actions/checkout@v3
         with:
@@ -336,7 +347,12 @@ jobs:
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           MODEL_COUNT: ${{ matrix.num-models }}
-
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
     env:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       AIRFLOW_CONN_AIRFLOW_DB: postgres://postgres:postgres@0.0.0.0:5432/postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, 717-add-dbtrunner-local-executor] # # TODO:remove before merge
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -10,7 +10,14 @@ from pathlib import Path
 import warnings
 from typing import Any, Iterator, Callable
 
-from cosmos.constants import DbtResourceType, TestBehavior, ExecutionMode, LoadMode, TestIndirectSelection
+from cosmos.constants import (
+    DbtResourceType,
+    TestBehavior,
+    ExecutionMode,
+    LoadMode,
+    TestIndirectSelection,
+    InvocationMode,
+)
 from cosmos.dbt.executable import get_system_dbt
 from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
@@ -290,12 +297,15 @@ class ExecutionConfig:
     Contains configuration about how to execute dbt.
 
     :param execution_mode: The execution mode for dbt. Defaults to local
+    :param invocation_mode: The invocation mode for the dbt command. This is only configurable for ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV
+        execution modes.
     :param test_indirect_selection: The mode to configure the test behavior when performing indirect selection.
     :param dbt_executable_path: The path to the dbt executable for runtime execution. Defaults to dbt if available on the path.
     :param dbt_project_path Configures the DBT project location accessible at runtime for dag execution. This is the project path in a docker container for ExecutionMode.DOCKER or ExecutionMode.KUBERNETES. Mutually Exclusive with ProjectConfig.dbt_project_path
     """
 
     execution_mode: ExecutionMode = ExecutionMode.LOCAL
+    invocation_mode: InvocationMode | None = None
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER
     dbt_executable_path: str | Path = field(default_factory=get_system_dbt)
 
@@ -303,4 +313,8 @@ class ExecutionConfig:
     project_path: Path | None = field(init=False)
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
+        if self.invocation_mode and self.execution_mode not in {ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV}:
+            raise CosmosValueError(
+                "ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV modes."
+            )
         self.project_path = Path(dbt_project_path) if dbt_project_path else None

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -297,8 +297,7 @@ class ExecutionConfig:
     Contains configuration about how to execute dbt.
 
     :param execution_mode: The execution mode for dbt. Defaults to local
-    :param invocation_mode: The invocation mode for the dbt command. This is only configurable for ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV
-        execution modes.
+    :param invocation_mode: The invocation mode for the dbt command. This is only configurable for ExecutionMode.LOCAL.
     :param test_indirect_selection: The mode to configure the test behavior when performing indirect selection.
     :param dbt_executable_path: The path to the dbt executable for runtime execution. Defaults to dbt if available on the path.
     :param dbt_project_path Configures the DBT project location accessible at runtime for dag execution. This is the project path in a docker container for ExecutionMode.DOCKER or ExecutionMode.KUBERNETES. Mutually Exclusive with ProjectConfig.dbt_project_path
@@ -313,8 +312,6 @@ class ExecutionConfig:
     project_path: Path | None = field(init=False)
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
-        if self.invocation_mode and self.execution_mode not in {ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV}:
-            raise CosmosValueError(
-                "ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV modes."
-            )
+        if self.invocation_mode and self.execution_mode != ExecutionMode.LOCAL:
+            raise CosmosValueError("ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL.")
         self.project_path = Path(dbt_project_path) if dbt_project_path else None

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -53,6 +53,15 @@ class ExecutionMode(Enum):
     AZURE_CONTAINER_INSTANCE = "azure_container_instance"
 
 
+class InvocationMode(Enum):
+    """
+    How the dbt command should be invoked.
+    """
+
+    SUBPROCESS = "subprocess"
+    DBT_RUNNER = "dbt_runner"
+
+
 class TestIndirectSelection(Enum):
     """
     Modes to configure the test behavior when performing indirect selection.

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -253,6 +253,8 @@ class DbtToAirflowConverter:
         }
         if execution_config.dbt_executable_path:
             task_args["dbt_executable_path"] = execution_config.dbt_executable_path
+        if execution_config.invocation_mode:
+            task_args["invocation_mode"] = execution_config.invocation_mode
 
         validate_arguments(
             render_config.select,

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -1,33 +1,53 @@
+from __future__ import annotations
+
 import logging
 import re
-from typing import List, Tuple
+from typing import List, Tuple, TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dbt.cli.main import dbtRunnerResult
 
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
 
-def parse_output(result: FullOutputSubprocessResult, keyword: str) -> int:
+DBT_NO_TESTS_MSG = "Nothing to do"
+DBT_WARN_MSG = "WARN"
+
+
+def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
     """
-    Parses the dbt test output message and returns the number of errors or warnings.
+    Parses the dbt test output message and returns the number of warnings.
 
     :param result: String containing the output to be parsed.
-    :param keyword: String representing the keyword to search for in the output (WARN, ERROR).
     :return: An integer value associated with the keyword, or 0 if parsing fails.
 
     Usage:
     -----
     output_str = "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16"
-    keyword = "WARN"
-    num_warns = parse_output(output_str, keyword)
+    num_warns = parse_output(output_str)
     print(num_warns)
     # Output: 1
     """
     output = result.output
-    try:
-        num = int(output.split(f"{keyword}=")[1].split()[0])
-    except ValueError:
-        logging.error(
-            f"Could not parse number of {keyword}s. Check your dbt/airflow version or if --quiet is not being used"
-        )
+    num = 0
+    if DBT_NO_TESTS_MSG not in result.output and DBT_WARN_MSG in result.output:
+        try:
+            num = int(output.split(f"{DBT_WARN_MSG}=")[1].split()[0])
+        except ValueError:
+            logging.error(
+                f"Could not parse number of {DBT_WARN_MSG}s. Check your dbt/airflow version or if --quiet is not being used"
+            )
+    return num
+
+
+def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
+    """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
+    from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
+    """
+    num = 0
+    for run_result in result.result.results:  # type: ignore
+        if run_result.status == "warn":
+            num += 1
     return num
 
 
@@ -65,5 +85,27 @@ def extract_log_issues(log_list: List[str]) -> Tuple[List[str], List[str]]:
 
             test_names.append(test_name)
             test_results.append(test_result)
+
+    return test_names, test_results
+
+
+def extract_dbt_runner_issues(result: dbtRunnerResult) -> Tuple[List[str], List[str]]:
+    """
+    Extracts warning messages from the dbt runner result and returns them as a formatted string.
+
+    This function searches for warning messages in dbt run. It extracts and formats the relevant
+    information and appends it to a list of warnings.
+
+    :param result: dbtRunnerResult object containing the output to be parsed.
+    :return: two lists of strings, the first one containing the test names and the second one
+        containing the test results.
+    """
+    test_names = []
+    test_results = []
+
+    for run_result in result.result.results:  # type: ignore
+        if run_result.status == "warn":
+            test_names.append(str(run_result.node.name))
+            test_results.append(str(run_result.message))
 
     return test_names, test_results

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -36,3 +36,16 @@ def environ(env_vars: dict[str, str]) -> Generator[None, None, None]:
                 del os.environ[key]
             else:
                 os.environ[key] = value
+
+
+@contextmanager
+def change_working_directory(path: str) -> Generator[None, None, None]:
+    """Temporarily changes the working directory to the given path, and then restores
+    back to the previous value on exit.
+    """
+    previous_cwd = os.getcwd()
+    os.chdir(path)
+    try:
+        yield
+    finally:
+        os.chdir(previous_cwd)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -421,12 +421,13 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         return result
 
     def on_kill(self) -> None:
-        if self.cancel_query_on_kill:
-            self.subprocess_hook.log.info("Sending SIGINT signal to process group")
-            if self.subprocess_hook.sub_process and hasattr(self.subprocess_hook.sub_process, "pid"):
-                os.killpg(os.getpgid(self.subprocess_hook.sub_process.pid), signal.SIGINT)
-        else:
-            self.subprocess_hook.send_sigterm()
+        if self.invocation_mode == InvocationMode.SUBPROCESS:
+            if self.cancel_query_on_kill:
+                self.subprocess_hook.log.info("Sending SIGINT signal to process group")
+                if self.subprocess_hook.sub_process and hasattr(self.subprocess_hook.sub_process, "pid"):
+                    os.killpg(os.getpgid(self.subprocess_hook.sub_process.pid), signal.SIGINT)
+            else:
+                self.subprocess_hook.send_sigterm()
 
 
 class DbtBuildLocalOperator(DbtBuildMixin, DbtLocalBaseOperator):

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -224,7 +224,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
             from dbt.cli.main import dbtRunner
         except ImportError:
             raise ImportError(
-                "Could not import dbt core. Ensure that dbt is installed and available in the environment where the operator is running."
+                "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
             )
 
         if self._dbt_runner is None:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -33,7 +33,6 @@ if TYPE_CHECKING:
     from airflow.datasets import Dataset  # noqa: F811
     from openlineage.client.run import RunEvent
     from dbt.cli.main import dbtRunner, dbtRunnerResult
-    from typing import Callable
 
 from sqlalchemy.orm import Session
 

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -85,11 +85,16 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         self.log.info("Using dbt version %s available at %s", dbt_version, dbt_binary)
         return str(dbt_binary)
 
-    def run_subprocess(self, *args: Any, command: list[str], **kwargs: Any) -> FullOutputSubprocessResult:
+    def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str) -> FullOutputSubprocessResult:
         if self.py_requirements:
             command[0] = self.venv_dbt_path
 
-        subprocess_result: FullOutputSubprocessResult = self.subprocess_hook.run_command(command, *args, **kwargs)
+        subprocess_result: FullOutputSubprocessResult = self.subprocess_hook.run_command(
+            command=command,
+            env=env,
+            cwd=cwd,
+            output_encoding=self.output_encoding,
+        )
         return subprocess_result
 
     def execute(self, context: Context) -> None:

--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -12,6 +12,7 @@ from airflow.operators.empty import EmptyOperator
 
 from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, RenderConfig, ExecutionConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
+from cosmos.constants import InvocationMode
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
@@ -25,7 +26,7 @@ profile_config = ProfileConfig(
     ),
 )
 
-shared_execution_config = ExecutionConfig()
+shared_execution_config = ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER)
 
 
 @dag(

--- a/dev/dags/dbt/perf/profiles.yml
+++ b/dev/dags/dbt/perf/profiles.yml
@@ -1,11 +1,12 @@
-simple:
+default:
   target: dev
   outputs:
     dev:
-      type: sqlite
-      threads: 1
-      database: "database"
-      schema: "main"
-      schemas_and_paths:
-        main: "{{ env_var('DBT_SQLITE_PATH') }}/imdb.db"
-      schema_directory: "{{ env_var('DBT_SQLITE_PATH') }}"
+      type: postgres
+      host: "{{ env_var('POSTGRES_HOST') }}"
+      user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4

--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.ExecutionConfig`` class that you can 
 The ``ExecutionConfig`` class takes the following arguments:
 
 - ``execution_mode``: The way dbt is run when executing within airflow. For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
-- ``invocation_mode`` (new in v1.4): The way dbt is invoked within the execution mode. This is only configurable for ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``. For more information, see `invocation modes <../getting_started/execution-modes.html#invocation-modes>`_.
+- ``invocation_mode`` (new in v1.4): The way dbt is invoked within the execution mode. This is only configurable for ``ExecutionMode.LOCAL``. For more information, see `invocation modes <../getting_started/execution-modes.html#invocation-modes>`_.
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
 - ``dbt_project_path``: Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.

--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -7,6 +7,7 @@ It does this by exposing a ``cosmos.config.ExecutionConfig`` class that you can 
 The ``ExecutionConfig`` class takes the following arguments:
 
 - ``execution_mode``: The way dbt is run when executing within airflow. For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
+- ``invocation_mode`` (new in v1.4): The way dbt is invoked within the execution mode. This is only configurable for ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``. For more information, see `invocation modes <../getting_started/execution-modes.html#invocation-modes>`_.
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
 - ``dbt_project_path``: Configures the DBT project location accessible on their airflow controller for DAG rendering - Required when using ``load_method=LoadMode.DBT_LS`` or ``load_method=LoadMode.CUSTOM``

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -180,3 +180,30 @@ Each task will create a new container on Azure, giving full isolation. This, how
             "image": "dbt-jaffle-shop:1.0.0",
         },
     )
+
+
+.. _invocation_modes:
+Invocation Modes
+================
+.. versionadded:: 1.4
+
+For ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV`` execution modes, Cosmos supports two invocation modes for running dbt:
+
+1. ``InvocationMode.SUBPROCESS``: This is currently the default mode and does not need to be specified. In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
+
+2. ``InvocationMode.DBT_RUNNER``: In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
+   In order to use this mode, dbt must be installed in the same environment, either local or virtualenv for the worker. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and can be expected to be faster than ``InvocationMode.SUBPROCESS``.
+
+The invocation mode can be set in the ``ExecutionConfig`` as shown below:
+
+.. code-block:: python
+
+    from cosmos.constants import InvocationMode
+
+    dag = DbtDag(
+        # ...
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.LOCAL,
+            invocation_mode=InvocationMode.DBT_RUNNER,
+        ),
+    )

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -192,7 +192,8 @@ For ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV`` execution modes, Co
 1. ``InvocationMode.SUBPROCESS``: This is currently the default mode and does not need to be specified. In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
 
 2. ``InvocationMode.DBT_RUNNER``: In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
-   In order to use this mode, dbt must be installed in the same environment, either local or virtualenv for the worker. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and can be expected to be faster than ``InvocationMode.SUBPROCESS``.
+   In order to use this mode, dbt must be installed in the same environment, either local or virtualenv for the worker. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and can be expected to be faster than ``InvocationMode.SUBPROCESS``. \
+   This mode requires dbt version 1.5.0 or higher.
 
 The invocation mode can be set in the ``ExecutionConfig`` as shown below:
 

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -187,12 +187,12 @@ Invocation Modes
 ================
 .. versionadded:: 1.4
 
-For ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV`` execution modes, Cosmos supports two invocation modes for running dbt:
+For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes for running dbt:
 
-1. ``InvocationMode.SUBPROCESS``: This is currently the default mode and does not need to be specified. In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
+1. ``InvocationMode.SUBPROCESS``: In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
 
 2. ``InvocationMode.DBT_RUNNER``: In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
-   In order to use this mode, dbt must be installed in the same environment, either local or virtualenv for the worker. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and can be expected to be faster than ``InvocationMode.SUBPROCESS``. \
+   In order to use this mode, dbt must be installed in the same environment, either local or virtualenv for the worker. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and is faster than ``InvocationMode.SUBPROCESS``. \
    This mode requires dbt version 1.5.0 or higher.
 
 The invocation mode can be set in the ``ExecutionConfig`` as shown below:
@@ -208,3 +208,5 @@ The invocation mode can be set in the ``ExecutionConfig`` as shown below:
             invocation_mode=InvocationMode.DBT_RUNNER,
         ),
     )
+
+If the invocation mode is not set, Cosmos will attempt to use ``InvocationMode.DBT_RUNNER`` if dbt is installed in the same environment as the worker, otherwise it will default to ``InvocationMode.SUBPROCESS``.

--- a/scripts/test/performance-setup.sh
+++ b/scripts/test/performance-setup.sh
@@ -1,4 +1,4 @@
-pip uninstall -y dbt-core dbt-sqlite openlineage-airflow openlineage-integration-common; \
+pip uninstall -y dbt-core dbt-sqlite dbt-postgres openlineage-airflow openlineage-integration-common; \
 rm -rf airflow.*; \
 airflow db init; \
-pip install 'dbt-core==1.4' 'dbt-sqlite<=1.4' 'dbt-databricks<=1.4' 'dbt-postgres<=1.4'
+pip install 'dbt-postgres'

--- a/tests/dbt/test_project.py
+++ b/tests/dbt/test_project.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from cosmos.dbt.project import create_symlinks, environ
+from cosmos.dbt.project import create_symlinks, environ, change_working_directory
 import os
 from unittest.mock import patch
 
@@ -33,3 +33,18 @@ def test_environ_context_manager():
     # Check if the original environment variables are still set
     assert "value1" == os.environ.get("VAR1")
     assert "value2" == os.environ.get("VAR2")
+
+
+@patch("os.chdir")
+def test_change_working_directory(mock_chdir):
+    """Tests that the working directory is changed and then restored correctly."""
+    # Define the path to change the working directory to
+    path = "/path/to/directory"
+
+    # Use the change_working_directory context manager
+    with change_working_directory(path):
+        # Check if os.chdir is called with the correct path
+        mock_chdir.assert_called_once_with(path)
+
+    # Check if os.chdir is called with the previous working directory
+    mock_chdir.assert_called_with(os.getcwd())

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -177,7 +177,7 @@ def test_dbt_base_operator_run_dbt_runner_cannot_import():
         project_dir="my/dir",
         invocation_mode=InvocationMode.DBT_RUNNER,
     )
-    expected_error_message = "Could not import dbt core. Ensure that dbt is installed and available in the environment where the operator is running."
+    expected_error_message = "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
     with patch.dict(sys.modules, {"dbt.cli.main": None}):
         with pytest.raises(ImportError, match=expected_error_message):
             dbt_base_operator.run_dbt_runner(command=["cmd"], env={}, cwd="some-project")

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -7,6 +7,7 @@ from airflow.models.connection import Connection
 from cosmos.config import ProfileConfig
 
 from cosmos.profiles import PostgresUserPasswordProfileMapping
+from cosmos.constants import InvocationMode
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -53,6 +54,7 @@ def test_run_command(
         py_system_site_packages=False,
         py_requirements=["dbt-postgres==1.6.0b1"],
         emit_datasets=False,
+        invocation_mode=InvocationMode.SUBPROCESS,
     )
     assert venv_operator._venv_tmp_dir is None  # Otherwise we are creating empty directories during DAG parsing time
     # and not deleting them

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -25,7 +25,7 @@ class ConcreteDbtVirtualenvBaseOperator(DbtVirtualenvBaseOperator):
 @patch("airflow.utils.python_virtualenv.execute_in_subprocess")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.calculate_openlineage_events_completes")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.store_compiled_sql")
-@patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.exception_handling")
+@patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.handle_exception_subprocess")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.subprocess_hook")
 @patch("airflow.hooks.base.BaseHook.get_connection")
 def test_run_command(

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -60,12 +60,12 @@ def test_run_command(
     run_command_args = mock_subprocess_hook.run_command.call_args_list
     assert len(run_command_args) == 3
     python_cmd = run_command_args[0]
-    dbt_deps = run_command_args[1]
-    dbt_cmd = run_command_args[2]
+    dbt_deps = run_command_args[1].kwargs
+    dbt_cmd = run_command_args[2].kwargs
     assert python_cmd[0][0][0].endswith("/bin/python")
     assert python_cmd[0][-1][-1] == "from importlib.metadata import version; print(version('dbt-core'))"
-    assert dbt_deps[0][0][1] == "deps"
-    assert dbt_deps[0][0][0].endswith("/bin/dbt")
-    assert dbt_deps[0][0][0] == dbt_cmd[0][0][0]
-    assert dbt_cmd[0][0][1] == "do-something"
+    assert dbt_deps["command"][1] == "deps"
+    assert dbt_deps["command"][0].endswith("/bin/dbt")
+    assert dbt_deps["command"][0] == dbt_cmd["command"][0]
+    assert dbt_cmd["command"][1] == "do-something"
     assert mock_execute.call_count == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -203,7 +203,7 @@ def test_render_config_env_vars_deprecated():
     "execution_mode, expectation",
     [
         (ExecutionMode.LOCAL, does_not_raise()),
-        (ExecutionMode.VIRTUALENV, does_not_raise()),
+        (ExecutionMode.VIRTUALENV, pytest.raises(CosmosValueError)),
         (ExecutionMode.KUBERNETES, pytest.raises(CosmosValueError)),
         (ExecutionMode.DOCKER, pytest.raises(CosmosValueError)),
         (ExecutionMode.AZURE_CONTAINER_INSTANCE, pytest.raises(CosmosValueError)),

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -409,14 +409,16 @@ def test_converter_project_config_dbt_vars_with_custom_load_mode(
 
 @pytest.mark.parametrize("invocation_mode", [None, InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
 @patch("cosmos.config.ProjectConfig.validate_project")
+@patch("cosmos.converter.validate_initial_user_config")
+@patch("cosmos.converter.DbtGraph")
 @patch("cosmos.converter.build_airflow_graph")
-def test_converter_invocation_mode_added_to_task_args(mock_build_airflow_graph, mock_validate_project, invocation_mode):
-    """Tests that the `task_args` passed to build_airflow_graph has invocation_mode if
-    it is not None.
-    """
+def test_converter_invocation_mode_added_to_task_args(
+    mock_build_airflow_graph, mock_user_config, mock_dbt_graph, mock_validate_project, invocation_mode
+):
+    """Tests that the `task_args` passed to build_airflow_graph has invocation_mode if it is not None."""
     project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
     execution_config = ExecutionConfig(invocation_mode=invocation_mode)
-    render_config = RenderConfig()
+    render_config = MagicMock()
     profile_config = MagicMock()
 
     with DAG("test-id", start_date=datetime(2024, 1, 1)) as dag:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -7,7 +7,7 @@ import pytest
 from airflow.models import DAG
 
 from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
-from cosmos.constants import DbtResourceType, ExecutionMode, LoadMode
+from cosmos.constants import DbtResourceType, ExecutionMode, LoadMode, InvocationMode
 from cosmos.config import ProjectConfig, ProfileConfig, ExecutionConfig, RenderConfig, CosmosConfigException
 from cosmos.dbt.graph import DbtNode
 from cosmos.exceptions import CosmosValueError
@@ -405,3 +405,32 @@ def test_converter_project_config_dbt_vars_with_custom_load_mode(
         )
     _, kwargs = mock_legacy_dbt_project.call_args
     assert kwargs["dbt_vars"] == {"key": "value"}
+
+
+@pytest.mark.parametrize("invocation_mode", [None, InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
+@patch("cosmos.config.ProjectConfig.validate_project")
+@patch("cosmos.converter.build_airflow_graph")
+def test_converter_invocation_mode_added_to_task_args(mock_build_airflow_graph, mock_validate_project, invocation_mode):
+    """Tests that the `task_args` passed to build_airflow_graph has invocation_mode if
+    it is not None.
+    """
+    project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
+    execution_config = ExecutionConfig(invocation_mode=invocation_mode)
+    render_config = RenderConfig()
+    profile_config = MagicMock()
+
+    with DAG("test-id", start_date=datetime(2024, 1, 1)) as dag:
+        DbtToAirflowConverter(
+            dag=dag,
+            nodes=nodes,
+            project_config=project_config,
+            profile_config=profile_config,
+            execution_config=execution_config,
+            render_config=render_config,
+            operator_args={},
+        )
+    _, kwargs = mock_build_airflow_graph.call_args
+    if invocation_mode:
+        assert kwargs["task_args"]["invocation_mode"] == invocation_mode
+    else:
+        assert "invocation_mode" not in kwargs["task_args"]


### PR DESCRIPTION
## Description

This PR adds `dbtRunner` programmatic invocation for `ExecutionMode.LOCAL`. I decided to not make a new execution mode for each (e.g. `ExecutionMode.LOCAL_DBT_RUNNER`) and all of the child operators but instead added an additional config `ExecutionConfig.invocation_mode` where `InvocationMode.DBT_RUNNER` could be specified. This is so that users who are already using local execution mode could use dbt runner and see performance improvements. 

With the `dbtRunnerResult` it makes it easy to know whether the dbt run was successful and logs do not need to be parsed but are still logged in the operator:

![image](https://github.com/astronomer/astronomer-cosmos/assets/79104794/76a4cf82-f0f2-4133-8d68-a0a6a145b1d8)

## Performance Testing

After #827 was added, I modified it slightly to use postgres adapter instead of sqlite because the latest dbt-core support for sqlite is 1.4 when programmatic invocation requires >=1.5.0. I got the following results comparing subprocess to dbt runner for 10 models:

1. `InvocationMode.SUBPROCESS`:
```shell
Ran 10 models in 23.77661895751953 seconds
NUM_MODELS=10
TIME=23.77661895751953
```
2. `InvocationMode.DBT_RUNNER`:
```shell
Ran 10 models in 8.390100002288818 seconds
NUM_MODELS=10
TIME=8.390100002288818
```

So using `InvocationMode.DBT_RUNNER` is almost 3x faster, and can speed up dag runs if there are a lot of models that execute relatively quickly since there seems to be a 1-2s speed up per task.


One thing I found while working on this is that a [manifest](https://docs.getdbt.com/reference/programmatic-invocations#reusing-objects) is stored in the result if you parse a project with the runner, and can be reused in subsequent commands to avoid reparsing. This could be a useful way for caching the manifest if we use dbt runner for dbt ls parsing and could speed up the initial render as well.


I thought at first it would be easy to have this also work for virtualenv execution, since I at first thought the entire `execute` method was run in the virtualenv, which is not the case since the virtualenv operator creates a virtualenv and then passes the executable path to a subprocess. It may be possible to have this work for virtualenv and would be better suited for a follow-up PR.

## Related Issue(s)

closes #717 

## Breaking Change?

None

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works - added unit tests and integration tests.
