### PR TITLE
Fix typo in MWAA getting started guide

### DIFF
--- a/docs/getting_started/mwaa.rst
+++ b/docs/getting_started/mwaa.rst
@@ -104,7 +104,6 @@ In your ``my_cosmos_dag.py`` file, import the ``DbtDag`` class from Cosmos and c
 
     execution_config = ExecutionConfig(
         dbt_executable_path=f"{os.environ['AIRFLOW_HOME']}/dbt_venv/bin/dbt",
-        execution_mode=ExecutionMode.VIRTUALENV,
     )
 
     my_cosmos_dag = DbtDag(


### PR DESCRIPTION
## Description

This fixes a typo in the MWAA getting started guide. We instruct the user to create a virtualenv using MWAA's startup script, but then the execution config uses the virtual env mode which will re-create the venv every task.

Instead, the user should let Cosmos use the default (local) execution mode.

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
