### PR TITLE
Fix docs:`ExecutionConfig.dbt_project_path`

### DIFF
--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -9,4 +9,4 @@ The ``ExecutionConfig`` class takes the following arguments:
 - ``execution_mode``: The way dbt is run when executing within airflow. For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
-- ``dbt_project_path``: Configures the DBT project location accessible on their airflow controller for DAG rendering - Required when using ``load_method=LoadMode.DBT_LS`` or ``load_method=LoadMode.CUSTOM``
+- ``dbt_project_path``:  Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.

--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -9,4 +9,4 @@ The ``ExecutionConfig`` class takes the following arguments:
 - ``execution_mode``: The way dbt is run when executing within airflow. For more information, see the `execution modes <../getting_started/execution-modes.html>`_ page.
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
-- ``dbt_project_path``:  Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.
+- ``dbt_project_path``: Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.


### PR DESCRIPTION
## Description

I think this was originally copied over from RenderConfig, and clears up confusion for users using docker/k8s execution mode where they should specify the project path.