### PR TITLE
Improve `dbt ls` parsing resilience to missing tags/config

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -110,8 +110,8 @@ def parse_dbt_ls_output(project_path: Path, ls_stdout: str) -> dict[str, DbtNode
                 resource_type=DbtResourceType(node_dict["resource_type"]),
                 depends_on=node_dict.get("depends_on", {}).get("nodes", []),
                 file_path=project_path / node_dict["original_file_path"],
-                tags=node_dict["tags"],
-                config=node_dict["config"],
+                tags=node_dict.get("tags", []),
+                config=node_dict.get("config", {}),
             )
             nodes[node.unique_id] = node
             logger.debug("Parsed dbt resource `%s` of type `%s`", node.unique_id, node.resource_type)

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -811,6 +811,24 @@ def test_parse_dbt_ls_output():
     assert expected_nodes == nodes
 
 
+def test_parse_dbt_ls_output_with_json_without_tags_or_config():
+    some_ls_stdout = '{"resource_type": "model", "name": "some-name", "original_file_path": "some-file-path.sql", "unique_id": "some-unique-id", "config": {}}'
+
+    expected_nodes = {
+        "some-unique-id": DbtNode(
+            unique_id="some-unique-id",
+            resource_type=DbtResourceType.MODEL,
+            file_path=Path("some-project/some-file-path.sql"),
+            tags=[],
+            config={},
+            depends_on=[],
+        ),
+    }
+    nodes = parse_dbt_ls_output(Path("some-project"), some_ls_stdout)
+
+    assert expected_nodes == nodes
+
+
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")


### PR DESCRIPTION
An Astronomer customer reported an issue when using `LoadMode.DBT_LS` and Cosmos raising the error:

```
E               KeyError: 'tags'

cosmos/dbt/graph.py:113: KeyError
```

While parsing the DAG in Airflow. It is unclear which of the thousand nodes in their project had this behaviour, but it feels like a good idea to make Cosmos more resilient to this use case regardless.