### PR TITLE
Fix global flags for lists

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -340,18 +340,6 @@ class DbtTestMixin:
         self.selector = selector
         super().__init__(exclude=exclude, select=select, selector=selector, **kwargs)  # type: ignore
 
-    def add_cmd_flags(self) -> list[str]:
-        flags = []
-        if self.exclude:
-            flags.extend(["--exclude", *self.exclude])
-
-        if self.select:
-            flags.extend(["--select", *self.select])
-
-        if self.selector:
-            flags.extend(["--selector", self.selector])
-        return flags
-
 
 class DbtRunOperationMixin:
     """

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -198,7 +198,7 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
                     yaml_string = yaml.dump(global_flag_value)
                     flags.extend([dbt_name, yaml_string])
                 elif isinstance(global_flag_value, list):
-                    flags.extend([i for j in global_flag_value for i in [dbt_name, j]])
+                    flags.extend([dbt_name, " ".join(global_flag_value)])
                 else:
                     flags.extend([dbt_name, str(global_flag_value)])
         for global_boolean_flag in self.global_boolean_flags:

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -198,6 +198,8 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
                 if isinstance(global_flag_value, dict):
                     yaml_string = yaml.dump(global_flag_value)
                     flags.extend([dbt_name, yaml_string])
+                elif isinstance(global_flag_value, list):
+                    flags.extend([i for j in global_flag_value for i in [dbt_name, j]])
                 else:
                     flags.extend([dbt_name, str(global_flag_value)])
         for global_boolean_flag in self.global_boolean_flags:

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -194,20 +194,27 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
 
             dbt_name = f"--{global_flag.replace('_', '-')}"
             global_flag_value = self.__getattribute__(global_flag)
-            if global_flag_value is not None:
-                if isinstance(global_flag_value, dict):
-                    yaml_string = yaml.dump(global_flag_value)
-                    flags.extend([dbt_name, yaml_string])
-                elif isinstance(global_flag_value, list) and global_flag_value:
-                    flags.extend([dbt_name, " ".join(global_flag_value)])
-                elif isinstance(global_flag_value, list):
-                    continue
-                else:
-                    flags.extend([dbt_name, str(global_flag_value)])
+            flags.extend(self._process_global_flag(dbt_name, global_flag_value))
+
         for global_boolean_flag in self.global_boolean_flags:
             if self.__getattribute__(global_boolean_flag):
                 flags.append(f"--{global_boolean_flag.replace('_', '-')}")
         return flags
+
+    @staticmethod
+    def _process_global_flag(flag_name: str, flag_value: Any) -> list[str]:
+        """Helper method to process global flags and reduce complexity."""
+        if flag_value is None:
+            return []
+        elif isinstance(flag_value, dict):
+            yaml_string = yaml.dump(flag_value)
+            return [flag_name, yaml_string]
+        elif isinstance(flag_value, list) and flag_value:
+            return [flag_name, " ".join(flag_value)]
+        elif isinstance(flag_value, list):
+            return []
+        else:
+            return [flag_name, str(flag_value)]
 
     def add_cmd_flags(self) -> list[str]:
         """Allows subclasses to override to add flags for their dbt command"""

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -198,8 +198,10 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
                 if isinstance(global_flag_value, dict):
                     yaml_string = yaml.dump(global_flag_value)
                     flags.extend([dbt_name, yaml_string])
-                elif isinstance(global_flag_value, list):
+                elif isinstance(global_flag_value, list) and global_flag_value:
                     flags.extend([dbt_name, " ".join(global_flag_value)])
+                elif isinstance(global_flag_value, list):
+                    continue
                 else:
                     flags.extend([dbt_name, str(global_flag_value)])
         for global_boolean_flag in self.global_boolean_flags:

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -589,6 +589,11 @@ def test_store_compiled_sql() -> None:
         ),
         (
             DbtTestLocalOperator,
+            {"select": []},
+            {"context": {}, "env": {}, "cmd_flags": ["test"]},
+        ),
+        (
+            DbtTestLocalOperator,
             {"full_refresh": True, "select": ["tag:daily"], "exclude": ["tag:disabled"]},
             {"context": {}, "env": {}, "cmd_flags": ["test", "--select", "tag:daily", "--exclude", "tag:disabled"]},
         ),

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -584,6 +584,11 @@ def test_store_compiled_sql() -> None:
         ),
         (
             DbtTestLocalOperator,
+            {},
+            {"context": {}, "env": {}, "cmd_flags": ["test"]},
+        ),
+        (
+            DbtTestLocalOperator,
             {"full_refresh": True, "select": ["tag:daily"], "exclude": ["tag:disabled"]},
             {"context": {}, "env": {}, "cmd_flags": ["test", "--select", "tag:daily", "--exclude", "tag:disabled"]},
         ),
@@ -608,6 +613,7 @@ def test_operator_execute_with_flags(mock_run_cmd, operator_class, kwargs, expec
         invocation_mode=InvocationMode.DBT_RUNNER,
         **kwargs,
     )
+    task.get_env = MagicMock(return_value={})
     task.execute(context={})
     mock_run_cmd.assert_called_once_with(
         cmd=[task.dbt_executable_path, *expected_call_kwargs.pop("cmd_flags")], **expected_call_kwargs

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -88,8 +88,11 @@ def test_dbt_base_operator_add_global_flags() -> None:
             "end_time": "{{ data_interval_end.strftime('%Y%m%d%H%M%S') }}",
         },
         no_version_check=True,
+        select=["my_first_model", "my_second_model"],
     )
     assert dbt_base_operator.add_global_flags() == [
+        "--select",
+        "my_first_model my_second_model",
         "--vars",
         "end_time: '{{ data_interval_end.strftime(''%Y%m%d%H%M%S'') }}'\n"
         "start_time: '{{ data_interval_start.strftime(''%Y%m%d%H%M%S'') }}'\n",


### PR DESCRIPTION
## Description

Correctly deals with global flags when they are a list.
Note - in the module there's no distinguishing which are and which aren't.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

Fixes the resulting bug in #838, though the type discrepancy is still there.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
