### PR TITLE
Add import sorting (isort) to Cosmos

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -11,12 +11,12 @@ __version__ = "1.3.2"
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
 from cosmos.config import (
-    ProjectConfig,
-    ProfileConfig,
     ExecutionConfig,
+    ProfileConfig,
+    ProjectConfig,
     RenderConfig,
 )
-from cosmos.constants import LoadMode, TestBehavior, ExecutionMode
+from cosmos.constants import ExecutionMode, LoadMode, TestBehavior
 from cosmos.log import get_logger
 from cosmos.operators.lazy_load import MissingPackage
 from cosmos.operators.local import (

--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -8,7 +8,7 @@ from typing import Any
 
 from airflow.models.dag import DAG
 
-from cosmos.converter import airflow_kwargs, specific_kwargs, DbtToAirflowConverter
+from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 
 
 class DbtDag(DAG, DbtToAirflowConverter):

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,26 +1,24 @@
 from __future__ import annotations
 
-from typing import Any, Callable
+from typing import Any, Callable, Union
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG
 from airflow.utils.task_group import TaskGroup
 
+from cosmos.config import RenderConfig
 from cosmos.constants import (
+    DEFAULT_DBT_RESOURCES,
+    TESTABLE_DBT_RESOURCES,
     DbtResourceType,
+    ExecutionMode,
     TestBehavior,
     TestIndirectSelection,
-    ExecutionMode,
-    TESTABLE_DBT_RESOURCES,
-    DEFAULT_DBT_RESOURCES,
 )
-from cosmos.config import RenderConfig
 from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
-from typing import Union
-
 
 logger = get_logger(__name__)
 

--- a/cosmos/airflow/task_group.py
+++ b/cosmos/airflow/task_group.py
@@ -3,11 +3,12 @@ This module contains a function to render a dbt project as an Airflow Task Group
 """
 
 from __future__ import annotations
+
 from typing import Any
 
 from airflow.utils.task_group import TaskGroup
 
-from cosmos.converter import airflow_kwargs, specific_kwargs, DbtToAirflowConverter
+from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 
 
 class DbtTaskGroup(TaskGroup, DbtToAirflowConverter):

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -5,18 +5,18 @@ from __future__ import annotations
 import contextlib
 import shutil
 import tempfile
+import warnings
 from dataclasses import InitVar, dataclass, field
 from pathlib import Path
-import warnings
-from typing import Any, Iterator, Callable
+from typing import Any, Callable, Iterator
 
 from cosmos.constants import (
     DbtResourceType,
-    TestBehavior,
     ExecutionMode,
-    LoadMode,
-    TestIndirectSelection,
     InvocationMode,
+    LoadMode,
+    TestBehavior,
+    TestIndirectSelection,
 )
 from cosmos.dbt.executable import get_system_dbt
 from cosmos.exceptions import CosmosValueError

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -4,7 +4,6 @@ from pathlib import Path
 
 import aenum
 
-
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
 DEFAULT_DBT_TARGET_NAME = "cosmos_target"

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -3,19 +3,19 @@
 
 from __future__ import annotations
 
+import copy
 import inspect
 from typing import Any, Callable
-import copy
 from warnings import warn
 
 from airflow.models.dag import DAG
 from airflow.utils.task_group import TaskGroup
 
 from cosmos.airflow.graph import build_airflow_graph
+from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import ExecutionMode
 from cosmos.dbt.graph import DbtGraph
 from cosmos.dbt.selector import retrieve_by_label
-from cosmos.config import ProjectConfig, ExecutionConfig, RenderConfig, ProfileConfig
 from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
 

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -7,7 +7,6 @@ from airflow.utils.task_group import TaskGroup
 from cosmos.core.graph.entities import Task
 from cosmos.log import get_logger
 
-
 logger = get_logger(__name__)
 
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -4,11 +4,12 @@ import itertools
 import json
 import os
 import tempfile
-import yaml
 from dataclasses import dataclass, field
 from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import Any
+
+import yaml
 
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import (
@@ -22,7 +23,7 @@ from cosmos.constants import (
     LoadMode,
 )
 from cosmos.dbt.parser.project import LegacyDbtProject
-from cosmos.dbt.project import create_symlinks, copy_msgpack_for_partial_parse, environ
+from cosmos.dbt.project import copy_msgpack_for_partial_parse, create_symlinks, environ
 from cosmos.dbt.selector import select_nodes
 from cosmos.log import get_logger
 

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -2,13 +2,12 @@ from __future__ import annotations
 
 import logging
 import re
-from typing import List, Tuple, TYPE_CHECKING
+from typing import TYPE_CHECKING, List, Tuple
 
 if TYPE_CHECKING:
     from dbt.cli.main import dbtRunnerResult
 
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
-
 
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -4,8 +4,8 @@ Used to parse and extract information from dbt projects.
 
 from __future__ import annotations
 
-import os
 import ast
+import os
 from dataclasses import dataclass, field
 from enum import Enum
 from pathlib import Path

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from pathlib import Path
-import shutil
 import os
-from cosmos.constants import DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME
+import shutil
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Generator
+
+from cosmos.constants import DBT_LOG_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME
 
 
 def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool) -> None:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -1,4 +1,5 @@
 from __future__ import annotations
+
 import copy
 import re
 from collections import defaultdict

--- a/cosmos/hooks/subprocess.py
+++ b/cosmos/hooks/subprocess.py
@@ -7,9 +7,9 @@ from __future__ import annotations
 import contextlib
 import os
 import signal
-from typing import NamedTuple
 from subprocess import PIPE, STDOUT, Popen
 from tempfile import TemporaryDirectory, gettempdir
+from typing import NamedTuple
 
 from airflow.hooks.base import BaseHook
 

--- a/cosmos/log.py
+++ b/cosmos/log.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
+
 import logging
 
 from airflow.configuration import conf
 from airflow.utils.log.colored_log import CustomTTYColoredFormatter
-
 
 LOG_FORMAT: str = (
     "[%(blue)s%(asctime)s%(reset)s] "

--- a/cosmos/operators/__init__.py
+++ b/cosmos/operators/__init__.py
@@ -1,9 +1,9 @@
 from .local import DbtBuildLocalOperator as DbtBuildOperator
 from .local import DbtDepsLocalOperator as DbtDepsOperator
 from .local import DbtDocsAzureStorageLocalOperator as DbtDocsAzureStorageOperator
+from .local import DbtDocsGCSLocalOperator as DbtDocsGCSOperator
 from .local import DbtDocsLocalOperator as DbtDocsOperator
 from .local import DbtDocsS3LocalOperator as DbtDocsS3Operator
-from .local import DbtDocsGCSLocalOperator as DbtDocsGCSOperator
 from .local import DbtLSLocalOperator as DbtLSOperator
 from .local import DbtRunLocalOperator as DbtRunOperator
 from .local import DbtRunOperationLocalOperator as DbtRunOperationOperator

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -3,17 +3,17 @@ from __future__ import annotations
 from typing import Any, Callable, Sequence
 
 from airflow.utils.context import Context
-from cosmos.config import ProfileConfig
 
+from cosmos.config import ProfileConfig
 from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
+    DbtLSMixin,
     DbtRunMixin,
+    DbtRunOperationMixin,
     DbtSeedMixin,
     DbtSnapshotMixin,
     DbtTestMixin,
-    DbtLSMixin,
-    DbtRunOperationMixin,
 )
 
 logger = get_logger(__name__)

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
 import os
-from typing import Any, Sequence, Tuple
 from abc import ABCMeta, abstractmethod
+from typing import Any, Sequence, Tuple
 
 import yaml
 from airflow.models.baseoperator import BaseOperator
@@ -11,7 +11,6 @@ from airflow.utils.operator_helpers import context_to_airflow_vars
 
 from cosmos.dbt.executable import get_system_dbt
 from cosmos.log import get_logger
-
 
 logger = get_logger(__name__)
 

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -8,12 +8,12 @@ from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtLSMixin,
     DbtRunMixin,
+    DbtRunOperationMixin,
     DbtSeedMixin,
     DbtSnapshotMixin,
     DbtTestMixin,
-    DbtLSMixin,
-    DbtRunOperationMixin,
 )
 
 logger = get_logger(__name__)

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -3,23 +3,22 @@ from __future__ import annotations
 from os import PathLike
 from typing import Any, Callable, Sequence
 
+from airflow.models import TaskInstance
 from airflow.utils.context import Context, context_merge
 
-from cosmos.log import get_logger
 from cosmos.config import ProfileConfig
+from cosmos.dbt.parser.output import extract_log_issues
+from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtLSMixin,
     DbtRunMixin,
+    DbtRunOperationMixin,
     DbtSeedMixin,
     DbtSnapshotMixin,
     DbtTestMixin,
-    DbtLSMixin,
-    DbtRunOperationMixin,
 )
-
-from airflow.models import TaskInstance
-from cosmos.dbt.parser.output import extract_log_issues
 
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
+from functools import cached_property
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any
 
-from functools import cached_property
 from airflow.utils.python_virtualenv import prepare_virtualenv
-from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
+from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.log import get_logger
 from cosmos.operators.local import (
     DbtBuildLocalOperator,

--- a/cosmos/profiles/__init__.py
+++ b/cosmos/profiles/__init__.py
@@ -4,20 +4,19 @@ from __future__ import annotations
 
 from typing import Any, Type
 
-
 from .athena import AthenaAccessKeyProfileMapping
 from .base import BaseProfileMapping, DbtProfileConfigVars
+from .bigquery.oauth import GoogleCloudOauthProfileMapping
 from .bigquery.service_account_file import GoogleCloudServiceAccountFileProfileMapping
 from .bigquery.service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
-from .bigquery.oauth import GoogleCloudOauthProfileMapping
 from .databricks.token import DatabricksTokenProfileMapping
 from .exasol.user_pass import ExasolUserPasswordProfileMapping
 from .postgres.user_pass import PostgresUserPasswordProfileMapping
 from .redshift.user_pass import RedshiftUserPasswordProfileMapping
+from .snowflake.user_encrypted_privatekey_env_variable import SnowflakeEncryptedPrivateKeyPemProfileMapping
+from .snowflake.user_encrypted_privatekey_file import SnowflakeEncryptedPrivateKeyFilePemProfileMapping
 from .snowflake.user_pass import SnowflakeUserPasswordProfileMapping
 from .snowflake.user_privatekey import SnowflakePrivateKeyPemProfileMapping
-from .snowflake.user_encrypted_privatekey_file import SnowflakeEncryptedPrivateKeyFilePemProfileMapping
-from .snowflake.user_encrypted_privatekey_env_variable import SnowflakeEncryptedPrivateKeyPemProfileMapping
 from .spark.thrift import SparkThriftProfileMapping
 from .trino.certificate import TrinoCertificateProfileMapping
 from .trino.jwt import TrinoJWTProfileMapping

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -5,13 +5,13 @@ inherit from to ensure consistency.
 
 from __future__ import annotations
 
-from abc import ABC, abstractmethod
-from typing import Any, Optional, Literal, Dict, TYPE_CHECKING
 import warnings
+from abc import ABC, abstractmethod
+from typing import TYPE_CHECKING, Any, Dict, Literal, Optional
 
+import yaml
 from airflow.hooks.base import BaseHook
 from pydantic import dataclasses
-import yaml
 
 from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger

--- a/cosmos/profiles/bigquery/__init__.py
+++ b/cosmos/profiles/bigquery/__init__.py
@@ -1,8 +1,8 @@
 "BigQuery Airflow connection -> dbt profile mappings"
 
+from .oauth import GoogleCloudOauthProfileMapping
 from .service_account_file import GoogleCloudServiceAccountFileProfileMapping
 from .service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
-from .oauth import GoogleCloudOauthProfileMapping
 
 __all__ = [
     "GoogleCloudServiceAccountFileProfileMapping",

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -1,10 +1,10 @@
 "Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json."
 from __future__ import annotations
 
-from typing import Any
 import json
-from cosmos.exceptions import CosmosValueError
+from typing import Any
 
+from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.base import BaseProfileMapping
 
 

--- a/cosmos/profiles/snowflake/__init__.py
+++ b/cosmos/profiles/snowflake/__init__.py
@@ -1,9 +1,9 @@
 "Snowflake Airflow connection -> dbt profile mapping."
 
+from .user_encrypted_privatekey_env_variable import SnowflakeEncryptedPrivateKeyPemProfileMapping
+from .user_encrypted_privatekey_file import SnowflakeEncryptedPrivateKeyFilePemProfileMapping
 from .user_pass import SnowflakeUserPasswordProfileMapping
 from .user_privatekey import SnowflakePrivateKeyPemProfileMapping
-from .user_encrypted_privatekey_file import SnowflakeEncryptedPrivateKeyFilePemProfileMapping
-from .user_encrypted_privatekey_env_variable import SnowflakeEncryptedPrivateKeyPemProfileMapping
 
 __all__ = [
     "SnowflakeUserPasswordProfileMapping",

--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig
+from cosmos import DbtDag, ProfileConfig, ProjectConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"

--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -3,16 +3,15 @@ An example DAG that uses Cosmos to render a dbt project as a TaskGroup.
 """
 
 import os
-
 from datetime import datetime
 from pathlib import Path
 
 from airflow.decorators import dag
 from airflow.operators.empty import EmptyOperator
 
-from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, RenderConfig, ExecutionConfig
-from cosmos.profiles import PostgresUserPasswordProfileMapping
+from cosmos import DbtTaskGroup, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import InvocationMode
+from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -6,8 +6,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig, RenderConfig, LoadMode, ExecutionConfig
-from cosmos.profiles import PostgresUserPasswordProfileMapping, DbtProfileConfigVars
+from cosmos import DbtDag, ExecutionConfig, LoadMode, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.profiles import DbtProfileConfigVars, PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))

--- a/dev/dags/cosmos_profile_mapping.py
+++ b/dev/dags/cosmos_profile_mapping.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from airflow.decorators import dag
 from airflow.operators.empty import EmptyOperator
 
-from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig
+from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig
 from cosmos.profiles import get_automatic_profile_mapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"

--- a/dev/dags/dbt/simple/convert_csv_to_db.py
+++ b/dev/dags/dbt/simple/convert_csv_to_db.py
@@ -1,5 +1,6 @@
-import pandas as pd
 import sqlite3
+
+import pandas as pd
 
 df = pd.read_csv("imdb.csv")
 conn = sqlite3.connect("imdb.db")

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -11,16 +11,16 @@ import os
 from pathlib import Path
 
 from airflow import DAG
-from airflow.hooks.base import BaseHook
-from airflow.exceptions import AirflowNotFoundException
 from airflow.decorators import task
+from airflow.exceptions import AirflowNotFoundException
+from airflow.hooks.base import BaseHook
 from pendulum import datetime
 
 from cosmos import ProfileConfig
 from cosmos.operators import (
     DbtDocsAzureStorageOperator,
-    DbtDocsS3Operator,
     DbtDocsGCSOperator,
+    DbtDocsS3Operator,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 

--- a/dev/dags/example_cosmos_python_models.py
+++ b/dev/dags/example_cosmos_python_models.py
@@ -17,7 +17,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig
+from cosmos import DbtDag, ProfileConfig, ProjectConfig
 from cosmos.profiles import DatabricksTokenProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"

--- a/dev/dags/example_cosmos_sources.py
+++ b/dev/dags/example_cosmos_sources.py
@@ -16,11 +16,11 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.operators.dummy import DummyOperator
 from airflow.models.dag import DAG
+from airflow.operators.dummy import DummyOperator
 from airflow.utils.task_group import TaskGroup
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig, RenderConfig
+from cosmos import DbtDag, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import DbtResourceType
 from cosmos.dbt.graph import DbtNode
 

--- a/dev/dags/example_model_version.py
+++ b/dev/dags/example_model_version.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig
+from cosmos import DbtDag, ProfileConfig, ProjectConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ExecutionMode, ExecutionConfig, ProjectConfig, ProfileConfig
+from cosmos import DbtDag, ExecutionConfig, ExecutionMode, ProfileConfig, ProjectConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"

--- a/dev/dags/performance_dag.py
+++ b/dev/dags/performance_dag.py
@@ -2,13 +2,12 @@
 An airflow DAG that uses Cosmos to render a dbt project for performance testing.
 """
 
-from datetime import datetime
 import os
+from datetime import datetime
 from pathlib import Path
 
-from cosmos import DbtDag, ProjectConfig, ProfileConfig, RenderConfig
+from cosmos import DbtDag, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
-
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))

--- a/dev/dags/user_defined_profile.py
+++ b/dev/dags/user_defined_profile.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from airflow.decorators import dag
 from airflow.operators.empty import EmptyOperator
 
-from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, RenderConfig, LoadMode
+from cosmos import DbtTaskGroup, LoadMode, ProfileConfig, ProjectConfig, RenderConfig
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))

--- a/docs/generate_mappings.py
+++ b/docs/generate_mappings.py
@@ -9,7 +9,8 @@ from dataclasses import dataclass
 from typing import Type
 
 from jinja2 import Environment, FileSystemLoader
-from cosmos.profiles import profile_mappings, BaseProfileMapping
+
+from cosmos.profiles import BaseProfileMapping, profile_mappings
 
 
 @dataclass

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -197,7 +197,7 @@ no_warn_unused_ignores = true
 [tool.ruff]
 line-length = 120
 [tool.ruff.lint]
-select = ["C901"]
+select = ["C901", "I"]
 [tool.ruff.lint.mccabe]
 max-complexity = 8
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -9,13 +9,13 @@ from airflow.utils.task_group import TaskGroup
 from packaging import version
 
 from cosmos.airflow.graph import (
+    _snake_case_to_camelcase,
     build_airflow_graph,
     calculate_leaves,
     calculate_operator_class,
     create_task_metadata,
     create_test_task_metadata,
     generate_task_or_group,
-    _snake_case_to_camelcase,
 )
 from cosmos.config import ProfileConfig, RenderConfig
 from cosmos.constants import (

--- a/tests/dbt/parser/test_output.py
+++ b/tests/dbt/parser/test_output.py
@@ -1,13 +1,14 @@
-import pytest
 import logging
 from unittest.mock import MagicMock
+
+import pytest
 from airflow.hooks.subprocess import SubprocessResult
 
 from cosmos.dbt.parser.output import (
     extract_dbt_runner_issues,
     extract_log_issues,
-    parse_number_of_warnings_subprocess,
     parse_number_of_warnings_dbt_runner,
+    parse_number_of_warnings_subprocess,
 )
 
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1,12 +1,13 @@
 import shutil
 import tempfile
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-import yaml
+from subprocess import PIPE, Popen
+from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 
-from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig, CosmosConfigException
+from cosmos.config import CosmosConfigException, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import DbtResourceType, ExecutionMode
 from cosmos.dbt.graph import (
     CosmosLoadDbtException,
@@ -17,7 +18,6 @@ from cosmos.dbt.graph import (
     run_command,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
-from subprocess import Popen, PIPE
 
 DBT_PROJECTS_ROOT_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt"
 DBT_PROJECT_NAME = "jaffle_shop"

--- a/tests/dbt/test_project.py
+++ b/tests/dbt/test_project.py
@@ -4,7 +4,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cosmos.dbt.project import create_symlinks, copy_msgpack_for_partial_parse, environ, change_working_directory
+from cosmos.dbt.project import change_working_directory, copy_msgpack_for_partial_parse, create_symlinks, environ
 
 DBT_PROJECTS_ROOT_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt"
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -2,10 +2,9 @@ from pathlib import Path
 
 import pytest
 
-from cosmos.dbt.selector import SelectorConfig
 from cosmos.constants import DbtResourceType
 from cosmos.dbt.graph import DbtNode
-from cosmos.dbt.selector import select_nodes
+from cosmos.dbt.selector import SelectorConfig, select_nodes
 from cosmos.exceptions import CosmosValueError
 
 SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")

--- a/tests/hooks/test_subprocess.py
+++ b/tests/hooks/test_subprocess.py
@@ -1,7 +1,7 @@
+import signal
 from pathlib import Path
 from tempfile import TemporaryDirectory
 from unittest.mock import MagicMock, patch
-import signal
 
 import pytest
 

--- a/tests/operators/test_azure_container_instance.py
+++ b/tests/operators/test_azure_container_instance.py
@@ -8,8 +8,8 @@ from cosmos.operators.azure_container_instance import (
     DbtAzureContainerInstanceBaseOperator,
     DbtLSAzureContainerInstanceOperator,
     DbtRunAzureContainerInstanceOperator,
-    DbtTestAzureContainerInstanceOperator,
     DbtSeedAzureContainerInstanceOperator,
+    DbtTestAzureContainerInstanceOperator,
 )
 
 

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -1,15 +1,16 @@
-import pytest
 from unittest.mock import patch
+
+import pytest
 
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
     DbtLSMixin,
-    DbtSeedMixin,
-    DbtRunOperationMixin,
-    DbtTestMixin,
-    DbtSnapshotMixin,
     DbtRunMixin,
+    DbtRunOperationMixin,
+    DbtSeedMixin,
+    DbtSnapshotMixin,
+    DbtTestMixin,
 )
 
 

--- a/tests/operators/test_docker.py
+++ b/tests/operators/test_docker.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from unittest.mock import MagicMock, patch
-import pytest
 
+import pytest
 from airflow.utils.context import Context
 from pendulum import datetime
 

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -2,6 +2,8 @@ from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
+from airflow.models import TaskInstance
+from airflow.utils.context import Context, context_merge
 from pendulum import datetime
 
 from cosmos.operators.kubernetes import (
@@ -11,9 +13,6 @@ from cosmos.operators.kubernetes import (
     DbtSeedKubernetesOperator,
     DbtTestKubernetesOperator,
 )
-
-from airflow.utils.context import Context, context_merge
-from airflow.models import TaskInstance
 
 try:
     from airflow.providers.cncf.kubernetes.utils.pod_manager import OnFinishAction

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1,10 +1,10 @@
 import logging
 import os
-import sys
 import shutil
+import sys
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock, patch, call
+from unittest.mock import MagicMock, call, patch
 
 import pytest
 from airflow import DAG
@@ -16,28 +16,28 @@ from packaging import version
 from pendulum import datetime
 
 from cosmos.config import ProfileConfig
-from cosmos.operators.local import (
-    DbtLocalBaseOperator,
-    DbtLSLocalOperator,
-    DbtSnapshotLocalOperator,
-    DbtRunLocalOperator,
-    DbtTestLocalOperator,
-    DbtBuildLocalOperator,
-    DbtDocsLocalOperator,
-    DbtDocsS3LocalOperator,
-    DbtDocsAzureStorageLocalOperator,
-    DbtDocsGCSLocalOperator,
-    DbtSeedLocalOperator,
-    DbtRunOperationLocalOperator,
-)
-from cosmos.profiles import PostgresUserPasswordProfileMapping
 from cosmos.constants import InvocationMode
-from tests.utils import test_dag as run_test_dag
 from cosmos.dbt.parser.output import (
     extract_dbt_runner_issues,
-    parse_number_of_warnings_subprocess,
     parse_number_of_warnings_dbt_runner,
+    parse_number_of_warnings_subprocess,
 )
+from cosmos.operators.local import (
+    DbtBuildLocalOperator,
+    DbtDocsAzureStorageLocalOperator,
+    DbtDocsGCSLocalOperator,
+    DbtDocsLocalOperator,
+    DbtDocsS3LocalOperator,
+    DbtLocalBaseOperator,
+    DbtLSLocalOperator,
+    DbtRunLocalOperator,
+    DbtRunOperationLocalOperator,
+    DbtSeedLocalOperator,
+    DbtSnapshotLocalOperator,
+    DbtTestLocalOperator,
+)
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+from tests.utils import test_dag as run_test_dag
 
 DBT_PROJ_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_shop"
 MINI_DBT_PROJ_DIR = Path(__file__).parent.parent / "sample/mini"

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -1,13 +1,11 @@
-from unittest.mock import patch, MagicMock
-
-from cosmos.operators.virtualenv import DbtVirtualenvBaseOperator
+from unittest.mock import MagicMock, patch
 
 from airflow.models.connection import Connection
 
 from cosmos.config import ProfileConfig
-
-from cosmos.profiles import PostgresUserPasswordProfileMapping
 from cosmos.constants import InvocationMode
+from cosmos.operators.virtualenv import DbtVirtualenvBaseOperator
+from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 profile_config = ProfileConfig(
     profile_name="default",

--- a/tests/perf/test_performance.py
+++ b/tests/perf/test_performance.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-import time
 import os
-from pathlib import Path
+import time
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Generator
 
 try:

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -7,15 +7,15 @@
 try:
     import flask  # noqa: F401
 except ImportError:
-    import markupsafe
     import jinja2
+    import markupsafe
 
     jinja2.Markup = markupsafe.Markup
     jinja2.escape = markupsafe.escape
 
-from unittest.mock import mock_open, patch, MagicMock, PropertyMock
-
 import sys
+from unittest.mock import MagicMock, PropertyMock, mock_open, patch
+
 import pytest
 from airflow.configuration import conf
 from airflow.exceptions import AirflowConfigException
@@ -25,17 +25,15 @@ from airflow.www.extensions.init_appbuilder import AirflowAppBuilder
 from flask.testing import FlaskClient
 
 import cosmos.plugin
-
 from cosmos.plugin import (
     dbt_docs_view,
     iframe_script,
-    open_gcs_file,
     open_azure_file,
+    open_file,
+    open_gcs_file,
     open_http_file,
     open_s3_file,
-    open_file,
 )
-
 
 original_conf_get = conf.get
 

--- a/tests/profiles/athena/test_athena_access_key.py
+++ b/tests/profiles/athena/test_athena_access_key.py
@@ -1,9 +1,10 @@
 "Tests for the Athena profile."
 
 import json
-from collections import namedtuple
 import sys
+from collections import namedtuple
 from unittest.mock import MagicMock, patch
+
 import pytest
 from airflow.models.connection import Connection
 

--- a/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
+++ b/tests/profiles/bigquery/test_bq_service_account_keyfile_dict.py
@@ -3,8 +3,8 @@ from unittest.mock import patch
 
 import pytest
 from airflow.models.connection import Connection
-from cosmos.exceptions import CosmosValueError
 
+from cosmos.exceptions import CosmosValueError
 from cosmos.profiles import get_automatic_profile_mapping
 from cosmos.profiles.bigquery.service_account_keyfile_dict import GoogleCloudServiceAccountDictProfileMapping
 

--- a/tests/profiles/test_base_profile.py
+++ b/tests/profiles/test_base_profile.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
+
 from typing import Any
 
 import pytest
 import yaml
 from pydantic.error_wrappers import ValidationError
 
-from cosmos.profiles.base import BaseProfileMapping, DbtProfileConfigVars
 from cosmos.exceptions import CosmosValueError
+from cosmos.profiles.base import BaseProfileMapping, DbtProfileConfigVars
 
 
 class TestProfileMapping(BaseProfileMapping):

--- a/tests/profiles/trino/test_trino_base.py
+++ b/tests/profiles/trino/test_trino_base.py
@@ -1,7 +1,7 @@
 "Tests for the Trino profile."
 
-from unittest.mock import patch
 import json
+from unittest.mock import patch
 
 from airflow.models.connection import Connection
 

--- a/tests/profiles/trino/test_trino_jwt.py
+++ b/tests/profiles/trino/test_trino_jwt.py
@@ -6,8 +6,7 @@ from unittest.mock import patch
 import pytest
 from airflow.models.connection import Connection
 
-from cosmos.profiles import get_automatic_profile_mapping
-from cosmos.profiles import TrinoJWTProfileMapping
+from cosmos.profiles import TrinoJWTProfileMapping, get_automatic_profile_mapping
 
 
 @pytest.fixture()

--- a/tests/profiles/trino/test_trino_ldap.py
+++ b/tests/profiles/trino/test_trino_ldap.py
@@ -5,8 +5,7 @@ from unittest.mock import patch
 import pytest
 from airflow.models.connection import Connection
 
-from cosmos.profiles import get_automatic_profile_mapping
-from cosmos.profiles import TrinoLDAPProfileMapping
+from cosmos.profiles import TrinoLDAPProfileMapping, get_automatic_profile_mapping
 
 
 @pytest.fixture()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,14 +1,13 @@
+from contextlib import nullcontext as does_not_raise
 from pathlib import Path
 from unittest.mock import patch
-from cosmos.profiles.postgres.user_pass import PostgresUserPasswordProfileMapping
-from contextlib import nullcontext as does_not_raise
 
 import pytest
 
+from cosmos.config import CosmosConfigException, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import ExecutionMode, InvocationMode
-from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig, CosmosConfigException
 from cosmos.exceptions import CosmosValueError
-
+from cosmos.profiles.postgres.user_pass import PostgresUserPasswordProfileMapping
 
 DBT_PROJECTS_ROOT_DIR = Path(__file__).parent / "sample/"
 SAMPLE_PROFILE_YML = Path(__file__).parent / "sample/profiles.yml"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,17 +1,16 @@
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import patch, MagicMock
-from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
+from unittest.mock import MagicMock, patch
 
 import pytest
 from airflow.models import DAG
 
+from cosmos.config import CosmosConfigException, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import DbtResourceType, ExecutionMode, InvocationMode, LoadMode
 from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
-from cosmos.constants import DbtResourceType, ExecutionMode, LoadMode, InvocationMode
-from cosmos.config import ProjectConfig, ProfileConfig, ExecutionConfig, RenderConfig, CosmosConfigException
 from cosmos.dbt.graph import DbtNode
 from cosmos.exceptions import CosmosValueError
-
+from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
 
 SAMPLE_PROFILE_YML = Path(__file__).parent / "sample/profiles.yml"
 SAMPLE_DBT_PROJECT = Path(__file__).parent / "sample/"

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -13,7 +13,6 @@ from airflow.models.dagbag import DagBag
 from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
-
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
 DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,8 +1,9 @@
 import logging
 
+from airflow.configuration import conf
+
 from cosmos import get_provider_info
 from cosmos.log import get_logger
-from airflow.configuration import conf
 
 
 def test_get_logger():


### PR DESCRIPTION
## Description

Cosmos doesn't currently have any import sorting set in the `pyproject.toml`, and I thought it would be nice to have a uniform import style and clean up the existing imports. 

This PR updates adds ruff isort that will now be fixed by pre-commit.
