### PR TITLE
[Bug] [1.4.0a] Fix #869 - Cosmos does not set dbt project dir to the tmp dir

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -298,6 +298,8 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
                 env.update(env_vars)
 
                 flags = [
+                    "--project-dir",
+                    str(tmp_project_dir),
                     "--profiles-dir",
                     str(profile_path.parent),
                     "--profile",


### PR DESCRIPTION
Fix #869.

Version of dbt I was running is `1.6.4`. It's unclear to me if this is specific to that version, but I couldn't get the Dbt docs operator to work without this change. With it, it works, and I do not see any other issues.