### PR TITLE
Improve dbt docs plugin rendering padding

### DIFF
--- a/cosmos/plugin/__init__.py
+++ b/cosmos/plugin/__init__.py
@@ -136,7 +136,7 @@ iframe_script = """
         // Model page
         getMaxElement('bottom', 'section.section') + 75,
         // Search page
-        getMaxElement('bottom', 'div.result-body') + 110
+        getMaxElement('bottom', 'div.result-body') + 125
       )
     }
   }


### PR DESCRIPTION
In my testing, I've found that the padding for the search box is a little under-shot. This PR just adds a teeny bit more padding.