### PR TITLE
docs: use of datasets for airflow >= 2.4

### DIFF
--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -50,7 +50,7 @@ Then, you can use Airflow's data-aware scheduling capabilities to schedule ``my_
 
     project_two = DbtDag(
         # ...
-        schedule_interval=[get_dbt_dataset("my_conn", "project_one", "my_model")],
+        schedule=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         dbt_project_name="project_two",
     )
 

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -50,7 +50,7 @@ Then, you can use Airflow's data-aware scheduling capabilities to schedule ``my_
 
     project_two = DbtDag(
         # for airflow >=2.3
-        #schedule_interval=[get_dbt_dataset("my_conn", "project_one", "my_model")],
+        # schedule_interval=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         # for airflow > 2.3
         schedule=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         dbt_project_name="project_two",

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -17,7 +17,7 @@ To schedule a dbt project on a time-based schedule, you can use Airflow's schedu
     jaffle_shop = DbtDag(
         # ...
         start_date=datetime(2023, 1, 1),
-        schedule_interval="@daily",
+        schedule="@daily",
     )
 
 
@@ -45,12 +45,12 @@ Then, you can use Airflow's data-aware scheduling capabilities to schedule ``my_
     project_one = DbtDag(
         # ...
         start_date=datetime(2023, 1, 1),
-        schedule_interval="@daily",
+        schedule="@daily",
     )
 
     project_two = DbtDag(
-        # for airflow >=2.3
-        # schedule_interval=[get_dbt_dataset("my_conn", "project_one", "my_model")],
+        # for airflow <=2.3
+        # schedule=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         # for airflow > 2.3
         schedule=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         dbt_project_name="project_two",

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -49,7 +49,9 @@ Then, you can use Airflow's data-aware scheduling capabilities to schedule ``my_
     )
 
     project_two = DbtDag(
-        # ...
+        # for airflow >=2.3
+        #schedule_interval=[get_dbt_dataset("my_conn", "project_one", "my_model")],
+        # for airflow > 2.3
         schedule=[get_dbt_dataset("my_conn", "project_one", "my_model")],
         dbt_project_name="project_two",
     )


### PR DESCRIPTION
schedule is right parameter name

## Description

schedule is right parameter name. 

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
