### PR TITLE
[Bugfix] Dbt docs operator should not look for `graph.gpickle` file when `--no-write-json` is passed.

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -570,7 +570,7 @@ class DbtDocsLocalOperator(DbtLocalBaseOperator):
     """
 
     ui_color = "#8194E0"
-    required_files = ["index.html", "manifest.json", "graph.gpickle", "catalog.json"]
+    required_files = ["index.html", "manifest.json", "catalog.json"]
     base_cmd = ["docs", "generate"]
 
     def __init__(self, **kwargs: Any) -> None:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -578,11 +578,13 @@ class DbtDocsLocalOperator(DbtLocalBaseOperator):
         self.check_static_flag()
 
     def check_static_flag(self) -> None:
-        flag = "--static"
         if self.dbt_cmd_flags:
-            if flag in self.dbt_cmd_flags:
+            if "--static" in self.dbt_cmd_flags:
                 # For the --static flag we only upload the generated static_index.html file
                 self.required_files = ["static_index.html"]
+        if self.dbt_cmd_global_flags:
+            if "--no-write-json" in self.dbt_cmd_global_flags and "graph.gpickle" in self.required_files:
+                self.required_files.remove("graph.gpickle")
 
 
 class DbtDocsCloudLocalOperator(DbtDocsLocalOperator, ABC):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -759,6 +759,21 @@ def test_dbt_docs_local_operator_with_static_flag():
     assert operator.required_files == ["static_index.html"]
 
 
+def test_dbt_docs_local_operator_ignores_graph_gpickle():
+    # Check when --no-write-json is passed, graph.gpickle is removed.
+    # This is only currently relevant for subclasses, but will become more generally relevant in the future.
+    class CustomDbtDocsLocalOperator(DbtDocsLocalOperator):
+        required_files = ["index.html", "manifest.json", "graph.gpickle", "catalog.json"]
+
+    operator = CustomDbtDocsLocalOperator(
+        task_id="fake-task",
+        project_dir="fake-dir",
+        profile_config=profile_config,
+        dbt_cmd_flags=["--no-write-json"],
+    )
+    assert operator.required_files == ["index.html", "manifest.json", "catalog.json"]
+
+
 @patch("cosmos.hooks.subprocess.FullOutputSubprocessHook.send_sigint")
 def test_dbt_local_operator_on_kill_sigint(mock_send_sigint) -> None:
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -745,7 +745,7 @@ def test_operator_execute_deps_parameters(
     if invocation_mode == InvocationMode.SUBPROCESS:
         assert mock_subprocess.call_args_list[0].kwargs["command"] == expected_call_kwargs
     elif invocation_mode == InvocationMode.DBT_RUNNER:
-        mock_dbt_runner.all_args_list[0].kwargs["command"] == expected_call_kwargs
+        assert mock_dbt_runner.all_args_list[0].kwargs["command"] == expected_call_kwargs
 
 
 def test_dbt_docs_local_operator_with_static_flag():
@@ -757,17 +757,6 @@ def test_dbt_docs_local_operator_with_static_flag():
         dbt_cmd_flags=["--static"],
     )
     assert operator.required_files == ["static_index.html"]
-
-
-def test_dbt_docs_local_operator_with_no_write_json():
-    # Check when static flag is passed, the required files are correctly adjusted to a single file
-    operator = DbtDocsLocalOperator(
-        task_id="fake-task",
-        project_dir="fake-dir",
-        profile_config=profile_config,
-        dbt_cmd_global_flags=["--no-write-json"],
-    )
-    assert operator.required_files == ["index.html", "manifest.json", "catalog.json"]
 
 
 @patch("cosmos.hooks.subprocess.FullOutputSubprocessHook.send_sigint")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -745,7 +745,7 @@ def test_operator_execute_deps_parameters(
     if invocation_mode == InvocationMode.SUBPROCESS:
         assert mock_subprocess.call_args_list[0].kwargs["command"] == expected_call_kwargs
     elif invocation_mode == InvocationMode.DBT_RUNNER:
-        assert mock_dbt_runner.all_args_list[0].kwargs["command"] == expected_call_kwargs
+        mock_dbt_runner.all_args_list[0].kwargs["command"] == expected_call_kwargs
 
 
 def test_dbt_docs_local_operator_with_static_flag():

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -759,6 +759,17 @@ def test_dbt_docs_local_operator_with_static_flag():
     assert operator.required_files == ["static_index.html"]
 
 
+def test_dbt_docs_local_operator_with_no_write_json():
+    # Check when static flag is passed, the required files are correctly adjusted to a single file
+    operator = DbtDocsLocalOperator(
+        task_id="fake-task",
+        project_dir="fake-dir",
+        profile_config=profile_config,
+        dbt_cmd_global_flags=["--no-write-json"],
+    )
+    assert operator.required_files == ["index.html", "manifest.json", "catalog.json"]
+
+
 @patch("cosmos.hooks.subprocess.FullOutputSubprocessHook.send_sigint")
 def test_dbt_local_operator_on_kill_sigint(mock_send_sigint) -> None:
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -769,7 +769,7 @@ def test_dbt_docs_local_operator_ignores_graph_gpickle():
         task_id="fake-task",
         project_dir="fake-dir",
         profile_config=profile_config,
-        dbt_cmd_flags=["--no-write-json"],
+        dbt_cmd_global_flags=["--no-write-json"],
     )
     assert operator.required_files == ["index.html", "manifest.json", "catalog.json"]
 


### PR DESCRIPTION
Fixes #882