### PR TITLE
Expose the dbt graph in the `DbtToAirflowConverter` class

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Union, Dict
+from typing import Any, Callable, Dict, Union
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Dict, Union
+from typing import Any, Callable, Union, Dict
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Union
+from typing import Any, Callable, Union, Dict
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Union, Dict
+from typing import Any, Callable, Union
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -222,7 +222,7 @@ def build_airflow_graph(
     render_config: RenderConfig,
     task_group: TaskGroup | None = None,
     on_warning_callback: Callable[..., Any] | None = None,  # argument specific to the DBT test command
-) -> Dict[str, Any]:
+) -> None:
     """
     Instantiate dbt `nodes` as Airflow tasks within the given `task_group` (optional) or `dag` (mandatory).
 
@@ -291,7 +291,6 @@ def build_airflow_graph(
             tasks_map[leaf_node_id] >> test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)
-    return tasks_map
 
 
 def create_airflow_task_dependencies(

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -222,7 +222,7 @@ def build_airflow_graph(
     render_config: RenderConfig,
     task_group: TaskGroup | None = None,
     on_warning_callback: Callable[..., Any] | None = None,  # argument specific to the DBT test command
-) -> None:
+) -> Dict[str, Any]:
     """
     Instantiate dbt `nodes` as Airflow tasks within the given `task_group` (optional) or `dag` (mandatory).
 
@@ -291,6 +291,7 @@ def build_airflow_graph(
             tasks_map[leaf_node_id] >> test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)
+    return tasks_map
 
 
 def create_airflow_task_dependencies(

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -265,7 +265,7 @@ class DbtToAirflowConverter:
             execution_mode=execution_config.execution_mode,
         )
 
-        self.tasks_map = build_airflow_graph(
+        build_airflow_graph(
             nodes=self.dbt_graph.filtered_nodes,
             dag=dag or (task_group and task_group.dag),
             task_group=task_group,

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -234,14 +234,14 @@ class DbtToAirflowConverter:
         # To keep this logic working, if converter is given no ProfileConfig,
         #   we can create a default retaining this value to preserve this functionality.
         # We may want to consider defaulting this value in our actual ProjceConfig class?
-        dbt_graph = DbtGraph(
+        self.dbt_graph = DbtGraph(
             project=project_config,
             render_config=render_config,
             execution_config=execution_config,
             profile_config=profile_config,
             dbt_vars=dbt_vars,
         )
-        dbt_graph.load(method=render_config.load_method, execution_mode=execution_config.execution_mode)
+        self.dbt_graph.load(method=render_config.load_method, execution_mode=execution_config.execution_mode)
 
         task_args = {
             **operator_args,
@@ -266,7 +266,7 @@ class DbtToAirflowConverter:
         )
 
         build_airflow_graph(
-            nodes=dbt_graph.filtered_nodes,
+            nodes=self.dbt_graph.filtered_nodes,
             dag=dag or (task_group and task_group.dag),
             task_group=task_group,
             execution_mode=execution_config.execution_mode,

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -265,7 +265,7 @@ class DbtToAirflowConverter:
             execution_mode=execution_config.execution_mode,
         )
 
-        build_airflow_graph(
+        self.tasks_map = build_airflow_graph(
             nodes=self.dbt_graph.filtered_nodes,
             dag=dag or (task_group and task_group.dag),
             task_group=task_group,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -470,6 +470,12 @@ def test_converter_invocation_mode_added_to_task_args(
         assert "invocation_mode" not in kwargs["task_args"]
 
 
+@pytest.mark.parametrize(
+    "execution_mode,operator_args",
+    [
+        (ExecutionMode.KUBERNETES, {}),
+    ],
+)
 @patch("cosmos.converter.DbtGraph.filtered_nodes", nodes)
 @patch("cosmos.converter.DbtGraph.load")
 def test_converter_contains_dbt_graph(mock_load_dbt_graph, execution_mode, operator_args):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -8,7 +8,7 @@ from airflow.models import DAG
 from cosmos.config import CosmosConfigException, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import DbtResourceType, ExecutionMode, InvocationMode, LoadMode
 from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
-from cosmos.dbt.graph import DbtNode
+from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
 
@@ -468,3 +468,28 @@ def test_converter_invocation_mode_added_to_task_args(
         assert kwargs["task_args"]["invocation_mode"] == invocation_mode
     else:
         assert "invocation_mode" not in kwargs["task_args"]
+
+
+@patch("cosmos.converter.DbtGraph.filtered_nodes", nodes)
+@patch("cosmos.converter.DbtGraph.load")
+def test_converter_contains_dbt_graph(mock_load_dbt_graph, execution_mode, operator_args):
+    """
+    This test validates that DbtToAirflowConverter contains and exposes a DbtGraph instance
+    """
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    execution_config = ExecutionConfig(execution_mode=execution_mode)
+    render_config = RenderConfig(emit_datasets=True)
+    profile_config = ProfileConfig(
+        profile_name="my_profile_name",
+        target_name="my_target_name",
+        profiles_yml_filepath=SAMPLE_PROFILE_YML,
+    )
+    converter = DbtToAirflowConverter(
+        nodes=nodes,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+        render_config=render_config,
+        operator_args=operator_args,
+    )
+    assert isinstance(converter.dbt_graph, DbtGraph)


### PR DESCRIPTION
## Description

`dbt_graph` is now accessible from generated dbt task groups, through `DbtToAirflowConverter`

## Related Issue(s)

closes #885 

## Breaking Change?

non-breaking change

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
