### PR TITLE
Update pip install instructions in docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -35,8 +35,8 @@ Then install ``airflow`` and ``astronomer-cosmos`` using python-venv:
 .. code-block:: bash
 
     python3 -m venv env && source env/bin/activate
-    pip3 install apache-airflow[cncf.kubernetes,openlineage]
-    pip3 install -e .[dbt-postgres,dbt-databricks]
+    pip3 install "apache-airflow[cncf.kubernetes,openlineage]"
+    pip3 install -e ".[dbt-postgres,dbt-databricks]"
 
 Set airflow home to the ``dev/`` directory and disabled loading example DAGs:
 


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

### Current Behaviour

The pip3 install step does not work
```
pip3 install -e apache-airflow[cncf.kubernetes,openlineage]
```

<img width="619" alt="Screenshot 2024-03-11 at 21 33 28" src="https://github.com/astronomer/astronomer-cosmos/assets/15151957/b5e3b710-ff5d-4af2-9048-8cc681ef5d64">

### Proposed change

Update pip install with double quotation marks so that the command works for both unix and windows environment

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
