### PR TITLE
fix:Adjust dbt_packages handling based on packages.yml existence

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -14,7 +14,7 @@ DBT_TARGET_DIR_NAME = "target"
 DBT_PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
 DBT_LOG_FILENAME = "dbt.log"
 DBT_BINARY_NAME = "dbt"
-DBT_PACKAGES_YML_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/packages.yml") 
+DBT_PACKAGES_YML_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/packages.yml")
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -14,7 +14,7 @@ DBT_TARGET_DIR_NAME = "target"
 DBT_PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
 DBT_LOG_FILENAME = "dbt.log"
 DBT_BINARY_NAME = "dbt"
-DBT_PACKAGES_YML_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/packages.yml")
+DBT_PACKAGES_CONFIG_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/packages.yml")
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -14,6 +14,7 @@ DBT_TARGET_DIR_NAME = "target"
 DBT_PARTIAL_PARSE_FILE_NAME = "partial_parse.msgpack"
 DBT_LOG_FILENAME = "dbt.log"
 DBT_BINARY_NAME = "dbt"
+DBT_PACKAGES_YML_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/packages.yml") 
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 
-from cosmos.constants import DBT_LOG_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME
+from cosmos.constants import DBT_LOG_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME, DBT_PACKAGES_CONFIG_PATH
 
 
 def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool) -> None:

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -13,7 +13,7 @@ def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool
     """Helper function to create symlinks to the dbt project files."""
     ignore_paths = [DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, "profiles.yml"]
 
-    if ignore_dbt_packages && DBT_PACKAGES_CONFIG_PATH.exists():
+    if ignore_dbt_packages and DBT_PACKAGES_CONFIG_PATH.exists():
         # This is linked to dbt deps so if dbt deps is true and packages.yml exists, then ignore existing dbt_packages folder
         ignore_paths.append("dbt_packages")
 

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -15,11 +15,10 @@ def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool
 
     if ignore_dbt_packages:
         # Check for the presence of 'packages.yml' in the project directory:
-        if (project_path / 'packages.yml').exists():
+        if (project_path / "packages.yml").exists():
             # This is linked to dbt deps so if dbt deps is true then ignore existing dbt_packages folder
             ignore_paths.append("dbt_packages")
 
-    
     for child_name in os.listdir(project_path):
         if child_name not in ignore_paths:
             os.symlink(project_path / child_name, tmp_dir / child_name)

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -6,7 +6,12 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Generator
 
-from cosmos.constants import DBT_LOG_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME, DBT_PACKAGES_CONFIG_PATH
+from cosmos.constants import (
+    DBT_LOG_DIR_NAME,
+    DBT_PACKAGES_CONFIG_PATH,
+    DBT_PARTIAL_PARSE_FILE_NAME,
+    DBT_TARGET_DIR_NAME,
+)
 
 
 def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool) -> None:

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -13,11 +13,9 @@ def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool
     """Helper function to create symlinks to the dbt project files."""
     ignore_paths = [DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, "profiles.yml"]
 
-    if ignore_dbt_packages:
-        # Check for the presence of 'packages.yml' in the project directory:
-        if (project_path / "packages.yml").exists():
-            # This is linked to dbt deps so if dbt deps is true then ignore existing dbt_packages folder
-            ignore_paths.append("dbt_packages")
+    if ignore_dbt_packages && DBT_PACKAGES_CONFIG_PATH.exists():
+        # This is linked to dbt deps so if dbt deps is true and packages.yml exists, then ignore existing dbt_packages folder
+        ignore_paths.append("dbt_packages")
 
     for child_name in os.listdir(project_path):
         if child_name not in ignore_paths:

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -12,9 +12,14 @@ from cosmos.constants import DBT_LOG_DIR_NAME, DBT_PARTIAL_PARSE_FILE_NAME, DBT_
 def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool) -> None:
     """Helper function to create symlinks to the dbt project files."""
     ignore_paths = [DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, "profiles.yml"]
+
     if ignore_dbt_packages:
-        # this is linked to dbt deps so if dbt deps is true then ignore existing dbt_packages folder
-        ignore_paths.append("dbt_packages")
+        # Check for the presence of 'packages.yml' in the project directory:
+        if (project_path / 'packages.yml').exists():
+            # This is linked to dbt deps so if dbt deps is true then ignore existing dbt_packages folder
+            ignore_paths.append("dbt_packages")
+
+    
     for child_name in os.listdir(project_path):
         if child_name not in ignore_paths:
             os.symlink(project_path / child_name, tmp_dir / child_name)


### PR DESCRIPTION
his commit refines the logic for handling the `dbt_packages` directory during the symlink creation process in `create_symlinks` function. Previously, the decision to ignore `dbt_packages` was solely based on the `ignore_dbt_packages` flag. The updated logic now also checks for the presence of a `packages.yml` file within the project directory.

- If `ignore_dbt_packages` is True and `packages.yml` exists, the function will add `dbt_packages` to the list of directories to ignore. This ensures that the symlink creation process respects the project's dependency management setup.

## Description

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
