### PR TITLE
update testing behavior docs

### DIFF
--- a/docs/configuration/testing-behavior.rst
+++ b/docs/configuration/testing-behavior.rst
@@ -37,7 +37,7 @@ Warning Behavior
 
 .. note::
 
-    As of now, this feature is only available for the default execution mode ``local``
+    As of now, this feature is only available for the default execution mode ``local`` and for ``virtualenv``
 
 Cosmos enables you to receive warning notifications from tests and process them using a callback function.
 The ``on_warning_callback`` parameter adds two extra context variables to the callback function: ``test_names`` and ``test_results``.


### PR DESCRIPTION
## Description

Update testing behavior docs to reflect support of warning feature in virtualenv execution mode. Currently, the docs say that only `local` executor mode is supporting `on_warning_callback`. However, this also works with `virtualenv` mode.

## Related Issue(s)

#909 

## Breaking Change?

None

## Checklist

- [x ] I have made corresponding changes to the documentation (if required)

