### PR TITLE
add magic loop check to speed up task execution

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -9,8 +9,8 @@ from typing import Any, Callable
 from warnings import warn
 
 from airflow.models.dag import DAG
-from airflow.utils.task_group import TaskGroup
 from airflow.utils.dag_parsing_context import get_parsing_context
+from airflow.utils.task_group import TaskGroup
 
 from cosmos.airflow.graph import build_airflow_graph
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -217,7 +217,9 @@ class DbtToAirflowConverter:
             raise CosmosValueError("Either a dag or task_group must be provided.")
 
         if not parse_all_dags:
-            if dag.dag_id != get_parsing_context().dag_id:
+            current_dag_id = get_parsing_context().dag_id
+
+            if dag.dag_id != current_dag_id and current_dag_id is not None:
                 return
 
         # if the dag is not what we're trying to parse, we can skip for performance reasons


### PR DESCRIPTION
## Description

This PR adds logic to not parse a DAG unless it's in the parse context. This is called out by Airflow's docs as a nice method to improve task efficiency, because you don't require the worker to re-parse all DAGs.

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
