### PR TITLE
fix: missed required parameter for non method authentication

### DIFF
--- a/cosmos/profiles/trino/base.py
+++ b/cosmos/profiles/trino/base.py
@@ -13,16 +13,19 @@ class TrinoBaseProfileMapping(BaseProfileMapping):
     dbt_profile_type: str = "trino"
     is_community: bool = True
 
-    required_fields = [
+    base_fields = [
         "host",
         "database",
         "schema",
         "port",
     ]
 
+    required_fields = base_fields + ["user"]
+
     airflow_param_mapping = {
         "host": "host",
         "port": "port",
+        "user": "login",
         "session_properties": "extra.session_properties",
     }
 

--- a/cosmos/profiles/trino/certificate.py
+++ b/cosmos/profiles/trino/certificate.py
@@ -15,7 +15,7 @@ class TrinoCertificateProfileMapping(TrinoBaseProfileMapping):
 
     dbt_profile_method: str = "certificate"
 
-    required_fields = TrinoBaseProfileMapping.required_fields + [
+    required_fields = TrinoBaseProfileMapping.base_fields + [
         "client_certificate",
         "client_private_key",
     ]

--- a/cosmos/profiles/trino/jwt.py
+++ b/cosmos/profiles/trino/jwt.py
@@ -16,7 +16,7 @@ class TrinoJWTProfileMapping(TrinoBaseProfileMapping):
 
     dbt_profile_method: str = "jwt"
 
-    required_fields = TrinoBaseProfileMapping.required_fields + [
+    required_fields = TrinoBaseProfileMapping.base_fields + [
         "jwt_token",
     ]
     secret_fields = [

--- a/cosmos/profiles/trino/ldap.py
+++ b/cosmos/profiles/trino/ldap.py
@@ -16,7 +16,7 @@ class TrinoLDAPProfileMapping(TrinoBaseProfileMapping):
 
     dbt_profile_method: str = "ldap"
 
-    required_fields = TrinoBaseProfileMapping.required_fields + [
+    required_fields = TrinoBaseProfileMapping.base_fields + [
         "user",
         "password",
     ]

--- a/tests/profiles/trino/test_trino_base.py
+++ b/tests/profiles/trino/test_trino_base.py
@@ -40,6 +40,7 @@ def test_profile_args() -> None:
             "schema": "my_schema",
             "host": "my_host",
             "port": 8080,
+            "user": "my_login",
             "session_properties": {"my_property": "my_value"},
         }
 
@@ -80,5 +81,6 @@ def test_profile_args_overrides() -> None:
             "schema": "my_schema",
             "host": "my_host_override",
             "port": 8080,
+            "user": "my_login",
             "session_properties": {"my_property": "my_value_override"},
         }


### PR DESCRIPTION
## Description

Usage of TrinoBaseProfileMapping leads to the issue related with missed user field in profile with authentication method equals to None
```
Runtime Error
  Credentials in profile "test_profile", target "dev" invalid: 'user' is a required property
```

## Related Issue(s)

## Breaking Change?

No breaking changes

## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
