### PR TITLE
Ensure tags don't run into index errors when there are no upstream nodes

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -296,7 +296,7 @@ class NodeSelector:
 
         self.visited_nodes.add(node_id)
 
-        if node.resource_type == DbtResourceType.TEST and node.depends_on:
+        if node.resource_type == DbtResourceType.TEST and node.depends_on and len(node.depends_on) > 0:
             node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
             logger.debug(
                 "The test node <%s> inherited these tags from the parent node <%s>: %s",

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -4,7 +4,7 @@ import pytest
 
 from cosmos.constants import DbtResourceType
 from cosmos.dbt.graph import DbtNode
-from cosmos.dbt.selector import SelectorConfig, select_nodes
+from cosmos.dbt.selector import NodeSelector, SelectorConfig, select_nodes
 from cosmos.exceptions import CosmosValueError
 
 SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
@@ -418,3 +418,17 @@ def test_node_without_depends_on_with_tag_selector_should_not_raise_exception():
     )
     nodes = {standalone_test_node.unique_id: standalone_test_node}
     assert not select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=nodes, select=["tag:some-tag"])
+
+
+def test_should_include_node_without_depends_on(selector_config):
+    node = DbtNode(
+        unique_id=f"{DbtResourceType.TEST.value}.{SAMPLE_PROJ_PATH.stem}.standalone",
+        resource_type=DbtResourceType.TEST,
+        depends_on=None,
+        tags=[],
+        config={},
+        file_path=SAMPLE_PROJ_PATH / "tests/generic/builtin.sql",
+    )
+    selector = NodeSelector({}, selector_config)
+    selector.visited_nodes = set()
+    selector._should_include_node(node.unique_id, node)


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

This PR ensures we only try to access `node.depends_on[0]` if there's at least one element in the list.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
