### PR TITLE
Fix netlify error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,3 +1,4 @@
+google-re2==1.1
 aenum
 sphinx
 pydata-sphinx-theme


### PR DESCRIPTION
It seems the [google/re2](https://github.com/google/re2) release `1.1.20240501` is leading to an initialization issue in Netlify:
```
2:32:59 PM:     Running setup.py install for google-re2: finished with status 'error'
2:32:59 PM:     ERROR: Command errored out with exit status 1:
2:32:59 PM:      command: /opt/buildhome/python3.8/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"/tmp/pip-install-ti3twlby/google-re2/setup.py"'; __file__='"/tmp/pip-install-ti3twlby/google-re2/setup.py"';f=getattr(tokenize, '"open"', open)(__file__);code=f.read().replace('"rn"', '"n"');f.close();exec(compile(code, __file__, '"exec"'))' install --record /tmp/pip-record-8yg4w9lc/install-record.txt --single-version-externally-managed --compile --install-headers /opt/buildhome/python3.8/include/site/python3.8/google-re2
2:32:59 PM:          cwd: /tmp/pip-install-ti3twlby/google-re2/
2:32:59 PM:     Complete output (28 lines):
2:32:59 PM:     running install
2:32:59 PM:     /opt/buildhome/python3.8/lib/python3.8/site-packages/setuptools/_distutils/cmd.py:66: SetuptoolsDeprecationWarning: setup.py install is deprecated.
2:32:59 PM:     git checkout main
2:32:59 PM:             ********************************************************************************
2:32:59 PM:             Please avoid running setup.py directly.
2:32:59 PM:             Instead, use pypa/build, pypa/installer or other
2:32:59 PM:             standards-based tools.
2:32:59 PM:             See https://blog.ganssle.io/articles/2021/10/setup-py-deprecated.html for details.
2:32:59 PM:             ********************************************************************************
2:32:59 PM:     git checkout main
2:32:59 PM:       self.initialize_options()
2:32:59 PM:     running build
2:32:59 PM:     running build_py
2:32:59 PM:     creating build
2:32:59 PM:     creating build/lib.linux-x86_64-cpython-38
2:32:59 PM:     copying re2.py -> build/lib.linux-x86_64-cpython-38
2:32:59 PM:     running build_ext
2:32:59 PM:     building '_re2' extension
2:32:59 PM:     creating build/temp.linux-x86_64-cpython-38
2:32:59 PM:     x86_64-linux-gnu-gcc -pthread -Wno-unused-result -Wsign-compare -DNDEBUG -g -fwrapv -O2 -Wall -g -fstack-protector-strong -Wformat -Werror=format-security -g -fwrapv -O2 -fPIC -I/opt/buildhome/python3.8/lib/python3.8/site-packages/pybind11/include -I/opt/buildhome/python3.8/include -I/usr/include/python3.8 -c _re2.cc -o build/temp.linux-x86_64-cpython-38/_re2.o -fvisibility=hidden
2:32:59 PM:     _re2.cc:13:10: fatal error: absl/strings/string_view.h: No such file or directory
2:32:59 PM:        13 | #include absl/strings/string_view.h
2:32:59 PM:           |          ^~~~~~~~~~~~~~~~~~~~~~~~~~~~
2:32:59 PM:     compilation terminated.
2:32:59 PM:     error: command '/usr/bin/x86_64-linux-gnu-gcc' failed with exit code 1
2:32:59 PM:     ----------------------------------------
2:33:00 PM: Failed during stage 'Install dependencies': dependency_installation script returned non-zero exit code: 1
2:33:00 PM: ERROR: Command errored out with exit status 1: /opt/buildhome/python3.8/bin/python -u -c 'import sys, setuptools, tokenize; sys.argv[0] = '"/tmp/pip-install-ti3twlby/google-re2/setup.py"'; __file__='"/tmp/pip-install-ti3twlby/google-re2/setup.py"';f=getattr(tokenize, '"open"', open)(__file__);code=f.read().replace('"rn"', '"n"');f.close();exec(compile(code, __file__, '"exec"'))' install --record /tmp/pip-record-8yg4w9lc/install-record.txt --single-version-externally-managed --compile --install-headers /opt/buildhome/python3.8/include/site/python3.8/google-re2 Check the logs for full command output.
```

As seen in:
https://app.netlify.com/sites/sunny-pastelito-5ecb04/deploys/663395dcce3dc1000843d9fd

During the Cosmos release 1.4.0:
https://github.com/astronomer/astronomer-cosmos/pull/934
