### PR TITLE
Make Pydantic a required dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,11 @@ dependencies = [
     "apache-airflow>=2.3.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",
+    # The issue regarding Airflow and Pydantic, documented in https://github.com/apache/airflow/issues/32311, was
+    # resolved through the pull request https://github.com/apache/airflow/pull/32366. This PR was included in the
+    # release of Airflow 2.7.0. Therefore, once we set here the minimum version of Airflow to 2.7.0, we can eliminate
+    # the upper bound constraint on the version of Pydantic.
+    "pydantic>=1.10.0,<2.0.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,11 +32,7 @@ dependencies = [
     "apache-airflow>=2.3.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",
-    # The issue regarding Airflow and Pydantic, documented in https://github.com/apache/airflow/issues/32311, was
-    # resolved through the pull request https://github.com/apache/airflow/pull/32366. This PR was included in the
-    # release of Airflow 2.7.0. Therefore, once we set here the minimum version of Airflow to 2.7.0, we can eliminate
-    # the upper bound constraint on the version of Pydantic.
-    "pydantic>=1.10.0,<2.0.0",
+    "pydantic>=1.10.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]
@@ -89,9 +85,6 @@ docker = [
 ]
 kubernetes = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
-]
-pydantic = [
-        "pydantic>=1.10.0",
 ]
 azure-container-instance = [
     "apache-airflow-providers-microsoft-azure>=8.4.0",


### PR DESCRIPTION
The pull request #736 initially designated Pydantic as an 
optional dependency. However, a subsequent pull request, 
#794 as an [import](https://github.com/astronomer/astronomer-cosmos/pull/794/files#diff-bd3fa47d7a9b96d7bb365f3ba3b60eaf0b20e06a48b28814cf6f6e6fb64d4da6R12), introduced an implementation that requires Pydantic 
to be a mandatory dependency for astronomer-cosmos. 
This pull request addresses the bug encountered while 
running `airflow db init`, as described in #936, by enforcing 
Pydantic as a required dependency.

closes: #936

## Description

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
