### PR TITLE
Add Apache Airflow 2.9 to the test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.3"
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.3"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -133,7 +133,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]
-airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8"]
+airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [


### PR DESCRIPTION
[Apache Airflow 2.9](https://pypi.org/project/apache-airflow/2.9.0/ ) was released in April 2024; this PR adds it to our test matrix to confirm Cosmos continues behaving as expected in this last Airflow release.
