### PR TITLE
Fix issue when publishing a new release to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Install build dependencies
         run: python -m pip install --upgrade build

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,7 @@ path = "cosmos/__init__.py"
 include = ["/cosmos"]
 
 [tool.hatch.build.targets.wheel]
-packages = ["cosmos"]
+packages = ["/cosmos"]
 
 ######################################
 # TESTING


### PR DESCRIPTION
Faced while running the following command in the CI (I was not able to reproduce this locally):
```
Run python -m build
```

Resulted in the stacktrace:
```
    val = self.func(instance)
  File "/tmp/build-env-o83v4k67/lib/python3.10/site-packages/hatchling/builders/wheel.py", line 247, in default_file_selection_options
    raise ValueError(message)
ValueError: Unable to determine which files to ship inside the wheel using the following heuristics: https://hatch.pypa.io/latest/plugins/builder/wheel/#default-file-selection

The most likely cause of this is that there is no directory that matches the name of your project (astronomer_cosmos).

At least one file selection option must be defined in the `tool.hatch.build.targets.wheel` table, see: https://hatch.pypa.io/latest/config/build/

As an example, if you intend to ship a directory named `foo` that resides within a `src` directory located at the root of your project, you can define the following:

[tool.hatch.build.targets.wheel]
packages = ["src/foo"]

ERROR Backend subprocess exited when trying to invoke build_wheel
```

As seen in:
https://github.com/astronomer/astronomer-cosmos/actions/runs/8986616060/job/24683237685

I confirmed this worked between releasing Cosmos 1.4.0a3 and Cosmos 1.4.0a4.

(cherry picked from commit ebbc50cbcd270205f1819334d4601df6e2ae34fa)