### PR TITLE
Gracefully error if users try to emit_datasets with Airflow 2.9.0 or 2.9.1

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -3,6 +3,7 @@ from enum import Enum
 from pathlib import Path
 
 import aenum
+from packaging.version import Version
 
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
@@ -19,6 +20,10 @@ DBT_BINARY_NAME = "dbt"
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
+
+# Cosmos will not emit datasets for the following Airflow versions, due to a breaking change that's fixed in later Airflow 2.x versions
+# https://github.com/apache/airflow/issues/39486
+PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS = [Version("2.9.0"), Version("2.9.1")]
 
 
 class LoadMode(Enum):

--- a/cosmos/exceptions.py
+++ b/cosmos/exceptions.py
@@ -3,3 +3,7 @@
 
 class CosmosValueError(ValueError):
     """Raised when a Cosmos config value is invalid."""
+
+
+class AirflowCompatibilityError(Exception):
+    """Raised when Cosmos features are limited for Airflow version being used."""

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -21,6 +21,7 @@ from attr import define
 from cosmos import cache
 from cosmos.constants import InvocationMode
 from cosmos.dbt.project import get_partial_parse_path
+from cosmos.exceptions import AirflowCompatibilityError
 
 try:
     from airflow.datasets import Dataset
@@ -407,7 +408,21 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
                 dataset_uri = output.namespace + "/" + output.name
                 uris.append(dataset_uri)
         logger.debug("URIs to be converted to Dataset: %s", uris)
-        return [Dataset(uri) for uri in uris]
+
+        datasets = []
+        try:
+            datasets = [Dataset(uri) for uri in uris]
+        except ValueError as e:
+            raise AirflowCompatibilityError(
+                """
+                Apache Airflow 2.9.0 & 2.9.1 introduced a breaking change in Dataset URIs, to be fixed in newer versions:
+                https://github.com/apache/airflow/issues/39486
+
+                If you want to use Cosmos with one of these Airflow versions, you will have to disable emission of Datasets:
+                By setting ``emit_datasets=False`` in ``RenderConfig``. For more information, see https://astronomer.github.io/astronomer-cosmos/configuration/render-config.html.
+                """
+            )
+        return datasets
 
     def register_dataset(self, new_inlets: list[Dataset], new_outlets: list[Dataset]) -> None:
         """

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -36,6 +36,7 @@ example_virtualenv = DbtDag(
         "py_system_site_packages": False,
         "py_requirements": ["dbt-postgres==1.6.0b1"],
         "install_deps": True,
+        "emit_datasets": False,  # Example of how to not set inlets and outlets
     },
     # normal dag parameters
     schedule_interval="@daily",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -120,6 +120,7 @@ dependencies = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "apache-airflow-providers-docker>=3.5.0",
     "apache-airflow-providers-microsoft-azure",
+    "apache-airflow-providers-postgres",
     "types-PyYAML",
     "types-attrs",
     "types-requests",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,10 +117,10 @@ packages = ["/cosmos"]
 [tool.hatch.envs.tests]
 dependencies = [
     "astronomer-cosmos[tests]",
+    "apache-airflow-providers-postgres",
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "apache-airflow-providers-docker>=3.5.0",
     "apache-airflow-providers-microsoft-azure",
-    "apache-airflow-providers-postgres",
     "types-PyYAML",
     "types-attrs",
     "types-requests",
@@ -136,7 +136,7 @@ airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [
-    { value = "typing_extensions<4.6", if = ["2.6"] }
+    { value = "typing_extensions<4.6", if = ["2.6"] },
 ]
 
 [tool.hatch.envs.tests.scripts]

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -1,6 +1,6 @@
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
 pip uninstall -y dbt-postgres dbt-databricks dbt-vertica;
-pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow' 'apache-airflow-providers-postgres';
+pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
 rm -rf airflow.*;
 airflow db init;

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -3,4 +3,4 @@
 pip uninstall -y dbt-postgres dbt-databricks dbt-vertica; \
 rm -rf airflow.*; \
 airflow db init; \
-pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
+pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow' 'apache-airflow-providers-postgres'

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -1,6 +1,6 @@
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-pip uninstall -y dbt-postgres dbt-databricks dbt-vertica;
+pip uninstall -y dbt-postgres dbt-databricks dbt-vertica; \
+rm -rf airflow.*; \
+airflow db init; \
 pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
-rm -rf airflow.*;
-airflow db init;

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -1,6 +1,6 @@
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-pip uninstall -y dbt-postgres dbt-databricks dbt-vertica; \
-rm -rf airflow.*; \
-airflow db init; \
-pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow' 'apache-airflow-providers-postgres'
+pip uninstall -y dbt-postgres dbt-databricks dbt-vertica;
+pip install 'dbt-core' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow' 'apache-airflow-providers-postgres';
+rm -rf airflow.*;
+airflow db init;

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -23,6 +23,7 @@ from . import utils as test_utils
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
 DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
+AIRFLOW_VERSION = Version(airflow.__version__)
 
 MIN_VER_DAG_FILE: dict[str, list[str]] = {
     "2.4": ["cosmos_seed_dag.py"],
@@ -51,12 +52,12 @@ def session():
 @cache
 def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
+    if AIRFLOW_VERSION in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS:
+        return DagBag(dag_folder=None, include_examples=False)
+
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:
         for min_version, files in MIN_VER_DAG_FILE_VER.items():
-            if (
-                Version(airflow.__version__) < min_version
-                or Version(airflow.__version__) in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
-            ):
+            if AIRFLOW_VERSION < min_version:
                 print(f"Adding {files} to .airflowignore")
                 file.writelines([f"{file}\n" for file in files])
 
@@ -83,6 +84,10 @@ def get_dag_ids() -> list[str]:
     return dag_bag.dag_ids
 
 
+@pytest.mark.skipif(
+    AIRFLOW_VERSION in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS,
+    reason="Airflow 2.9.0 and 2.9.1 have a breaking change in Dataset URIs, and Cosmos errors if `emit_datasets` is not False",
+)
 @pytest.mark.integration
 @pytest.mark.parametrize("dag_id", get_dag_ids())
 def test_example_dag(session, dag_id: str):

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -16,6 +16,8 @@ from airflow.utils.session import provide_session
 from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
+from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
+
 from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
@@ -27,6 +29,7 @@ MIN_VER_DAG_FILE: dict[str, list[str]] = {
 }
 
 IGNORED_DAG_FILES = ["performance_dag.py"]
+
 
 # Sort descending based on Versions and convert string to an actual version
 MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
@@ -50,7 +53,10 @@ def get_dag_bag() -> DagBag:
     """Create a DagBag by adding the files that are not supported to .airflowignore"""
     with open(AIRFLOW_IGNORE_FILE, "w+") as file:
         for min_version, files in MIN_VER_DAG_FILE_VER.items():
-            if Version(airflow.__version__) < min_version:
+            if (
+                Version(airflow.__version__) < min_version
+                or Version(airflow.__version__) in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
+            ):
                 print(f"Adding {files} to .airflowignore")
                 file.writelines([f"{file}\n" for file in files])
 


### PR DESCRIPTION
Improve Cosmos error message when using Airflow 2.9.0 or 2.9.1 and emitting OL events, to avoid this:

```
[2024-05-07, 14:20:09 UTC] {local.py:409} DEBUG - URIs to be converted to Dataset: []
[2024-05-07, 14:20:09 UTC] {local.py:409} DEBUG - URIs to be converted to Dataset: ['***://***:5432/***.dbt.stg_customers']
[2024-05-07, 14:20:09 UTC] {providers_manager.py:376} DEBUG - Initializing Providers Manager[dataset_uris]
[2024-05-07, 14:20:09 UTC] {providers_manager.py:379} DEBUG - Initialization of Providers Manager[dataset_uris] took 0.00 seconds
[2024-05-07, 14:20:09 UTC] {taskinstance.py:441} ▼ Post task execution logs
[2024-05-07, 14:20:09 UTC] {taskinstance.py:2905} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/usr/local/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 465, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/airflow/models/taskinstance.py", line 432, in _execute_callable
    return execute_callable(context=context, **execute_callable_kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/airflow/models/baseoperator.py", line 400, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cosmos/operators/base.py", line 266, in execute
    self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
  File "/usr/local/lib/python3.11/site-packages/cosmos/operators/local.py", line 470, in build_and_run_cmd
    result = self.run_command(cmd=dbt_cmd, env=env, context=context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cosmos/operators/local.py", line 343, in run_command
    outlets = self.get_datasets("outputs")
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cosmos/operators/local.py", line 410, in get_datasets
    return [Dataset(uri) for uri in uris]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/cosmos/operators/local.py", line 410, in <listcomp>
    return [Dataset(uri) for uri in uris]
            ^^^^^^^^^^^^
  File "<attrs generated init airflow.datasets.Dataset>", line 3, in __init__
    _setattr('uri', __attr_converter_uri(uri))
                    ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/airflow/datasets/__init__.py", line 81, in _sanitize_uri
    parsed = normalizer(parsed)
             ^^^^^^^^^^^^^^^^^^
  File "/usr/local/lib/python3.11/site-packages/airflow/providers/postgres/datasets/postgres.py", line 34, in sanitize_uri
    raise ValueError("URI format postgres:// must contain database, schema, and table names")
ValueError: URI format ***:// must contain database, schema, and table names
```

Closes: #945
