### PR TITLE
Enable pre-commit run and fix type-check job

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -238,6 +238,8 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         ti = context["ti"]
 
         if isinstance(ti, TaskInstance):  # verifies ti is a TaskInstance in order to access and use the "task" field
+            if TYPE_CHECKING:
+                assert ti.task is not None
             ti.task.template_fields = self.template_fields
             rtif = RenderedTaskInstanceFields(ti, render_templates=False)
 

--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -42,7 +42,8 @@ class DbtProfileConfigVars:
     def as_dict(self) -> dict[str, Any] | None:
         result = {
             field.name: getattr(self, field.name)
-            for field in self.__dataclass_fields__.values()
+            # Look like the __dataclass_fields__ attribute is not recognized by mypy
+            for field in self.__dataclass_fields__.values()  # type: ignore[attr-defined]
             if getattr(self, field.name) is not None
         }
         if result != {}:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,8 +78,8 @@ tests = [
     "pytest-describe",
     "sqlalchemy-stubs", # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
     "types-requests",
-    "mypy",
     "sqlalchemy-stubs", # Change when sqlalchemy is upgraded https://docs.sqlalchemy.org/en/14/orm/extensions/mypy.html
+    "pre-commit",
 ]
 docker = [
     "apache-airflow-providers-docker>=3.5.0",
@@ -152,7 +152,7 @@ test-integration-sqlite = 'sh scripts/test/integration-sqlite.sh'
 test-integration-sqlite-setup = 'sh scripts/test/integration-sqlite-setup.sh'
 test-performance = 'sh scripts/test/performance.sh'
 test-performance-setup = 'sh scripts/test/performance-setup.sh'
-type-check = "mypy cosmos"
+type-check = " pre-commit run mypy --files cosmos/**/*"
 
 [tool.pytest.ini_options]
 filterwarnings = ["ignore::DeprecationWarning"]


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/952

This PR addresses the following issues:

**1. Pre-commit Setup:**
- Pre-commit was not running in the CI pipeline because it was neither configured for this repository nor were we using the pre-commit command in CI to run it manually. To fix this:
Installed and added pre-commit to this repository. This allows pre-commit to automatically run the pre-commit configuration on every push.

**2. Type Check Job:**
- Previously, the type-check job was running with mypy directly, and the pre-commit type check command had different configurations. This PR aligns the configurations.

**3. Type Check Fixes:**
- Ignored the type check for __dataclass_fields__ since mypy seems to not recognize it.
- Added a check for None for ti.task