### PR TITLE
Update emeritus contributors list

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -18,7 +18,6 @@ Emeritus Committers
 -------------------------------
 
 * Chris Hronek (`@chrishronek <https://github.com/chrishronek>`_)
-* Harel Shein (`@harels <https://github.com/harels>`_)
 
 Contributors
 ------------

--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -8,9 +8,7 @@ Learn more about the project contributors roles in :ref:`contributors-roles`.
 Committers
 ----------------------
 
-* Chris Hronek (`@chrishronek <https://github.com/chrishronek>`_)
 * Daniel Reeves (`@dwreeves <https://github.com/dwreeves>`_)
-* Harel Shein (`@harels <https://github.com/harels>`_)
 * Julian LaNeve (`@jlaneve <https://github.com/jlaneve>`_)
 * Justin Bandoro (`@jbandoro <https://github.com/jbandoro>`_)
 * Tatiana Al-Chueyr (`@tatiana <https://github.com/tatiana>`_)
@@ -19,7 +17,8 @@ Committers
 Emeritus Committers
 -------------------------------
 
-(none at the moment)
+* Chris Hronek (`@chrishronek <https://github.com/chrishronek>`_)
+* Harel Shein (`@harels <https://github.com/harels>`_)
 
 Contributors
 ------------


### PR DESCRIPTION
There have been people who had a major role in the creation and/or development of Cosmos in previous phases, but for different circumstances, they have not been able to continue contributing to it in more recent times. This is not only from a code perspective, but also from a community perspective:

<img width="410" alt="Screenshot 2024-05-14 at 11 38 12" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/c8312fcb-db7d-44bf-b18a-a5867dbbbb4e">
<img width="413" alt="Screenshot 2024-05-14 at 11 38 03" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/48e43f7d-9625-4139-a4b3-5c2b4b92662e">

With this change, we recognize their contributions. If, in the future, they start to contribute again to the project, we'll move them to the contributions section again, regaining committer superpowers.

More information in the contributors roles can be found at: https://github.com/astronomer/astronomer-cosmos/blob/main/docs/contributors-roles.rst