### PR TITLE
Handle `ValueError` when `unpacking partial_parse.msgpack`

### DIFF
--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -127,7 +127,7 @@ def patch_partial_parse_content(partial_parse_filepath: Path, project_path: Path
     :param project_path: Path to the target dbt project directory
     """
 
-    should_patch_partial_parse_content = True
+    should_patch_partial_parse_content = bool(partial_parse_filepath) and partial_parse_filepath.exists()
     try:
         with partial_parse_filepath.open("rb") as f:
             # Issue reported: https://github.com/astronomer/astronomer-cosmos/issues/971

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,3 +1,4 @@
+import logging
 import shutil
 import tempfile
 import time
@@ -74,6 +75,7 @@ def test_get_latest_partial_parse(tmp_path):
 @patch("cosmos.cache.msgpack.unpack", side_effect=ValueError)
 def test__copy_partial_parse_to_project_msg_fails_msgpack(mock_unpack, tmp_path, caplog):
     # setup
+    caplog.set_level(logging.INFO)
     source_dir = tmp_path / DBT_TARGET_DIR_NAME
     source_dir.mkdir()
     partial_parse_filepath = source_dir / DBT_PARTIAL_PARSE_FILE_NAME


### PR DESCRIPTION
After upgrading to Cosmos v1.4, users have been getting the following error intermittently on some tasks. Rerunning the task succeeds, but the error continues on subsequent DAG runs.

```
  File /home/airflow/.local/lib/python3.8/site-packages/cosmos/cache.py, line 134, in _copy_partial_parse_to_project
    data = msgpack.unpack(f)
  File /home/airflow/.local/lib/python3.8/site-packages/msgpack/__init__.py, line 47, in unpack
    return unpackb(data, **kwargs)
  File msgpack/_unpacker.pyx, line 205, in msgpack._cmsgpack.unpackb
ValueError: Unpack failed: incomplete input
```

Closes: #971