### PR TITLE
Move airflow conf fetch call to setting.py

### DIFF
--- a/cosmos/log.py
+++ b/cosmos/log.py
@@ -2,8 +2,9 @@ from __future__ import annotations
 
 import logging
 
-from airflow.configuration import conf
 from airflow.utils.log.colored_log import CustomTTYColoredFormatter
+
+from cosmos.settings import propagate_logs
 
 LOG_FORMAT: str = (
     "[%(blue)s%(asctime)s%(reset)s] "
@@ -24,13 +25,10 @@ def get_logger(name: str | None = None) -> logging.Logger:
     By using this logger, we introduce a (yellow) astronomer-cosmos string into the project's log messages:
     [2023-08-09T14:20:55.532+0100] {subprocess.py:94} INFO - (astronomer-cosmos) - 13:20:55  Completed successfully
     """
-    propagateLogs: bool = True
-    if conf.has_option("cosmos", "propagate_logs"):
-        propagateLogs = conf.getboolean("cosmos", "propagate_logs")
     logger = logging.getLogger(name)
     formatter: logging.Formatter = CustomTTYColoredFormatter(fmt=LOG_FORMAT)  # type: ignore
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)
     logger.addHandler(handler)
-    logger.propagate = propagateLogs
+    logger.propagate = propagate_logs
     return logger

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -8,10 +8,8 @@ from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
 
-import airflow
 import jinja2
 from airflow import DAG
-from airflow.configuration import conf
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.context import Context
@@ -22,6 +20,7 @@ from cosmos import cache
 from cosmos.constants import InvocationMode
 from cosmos.dbt.project import get_partial_parse_path
 from cosmos.exceptions import AirflowCompatibilityError
+from cosmos.settings import LINEAGE_NAMESPACE
 
 try:
     from airflow.datasets import Dataset
@@ -41,7 +40,6 @@ from sqlalchemy.orm import Session
 
 from cosmos.config import ProfileConfig
 from cosmos.constants import (
-    DEFAULT_OPENLINEAGE_NAMESPACE,
     OPENLINEAGE_PRODUCER,
 )
 from cosmos.dbt.parser.output import (
@@ -90,12 +88,6 @@ except (ImportError, ModuleNotFoundError):
             outputs: list[str] = list()
             run_facets: dict[str, str] = dict()
             job_facets: dict[str, str] = dict()
-
-
-try:
-    LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
-except airflow.exceptions.AirflowConfigException:
-    LINEAGE_NAMESPACE = os.getenv("OPENLINEAGE_NAMESPACE", DEFAULT_OPENLINEAGE_NAMESPACE)
 
 
 class DbtLocalBaseOperator(AbstractDbtBaseOperator):

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -1,11 +1,21 @@
+import os
 import tempfile
 from pathlib import Path
 
+import airflow
 from airflow.configuration import conf
 
-from cosmos.constants import DEFAULT_COSMOS_CACHE_DIR_NAME
+from cosmos.constants import DEFAULT_COSMOS_CACHE_DIR_NAME, DEFAULT_OPENLINEAGE_NAMESPACE
 
 # In MacOS users may want to set the envvar `TMPDIR` if they do not want the value of the temp directory to change
 DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache = conf.get("cosmos", "enable_cache", fallback=True)
+propagate_logs = conf.getboolean("cosmos", "propagate_logs", fallback=True)
+dbt_docs_dir = conf.get("cosmos", "dbt_docs_dir", fallback=None)
+dbt_docs_conn_id = conf.get("cosmos", "dbt_docs_conn_id", fallback=None)
+
+try:
+    LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
+except airflow.exceptions.AirflowConfigException:
+    LINEAGE_NAMESPACE = os.getenv("OPENLINEAGE_NAMESPACE", DEFAULT_OPENLINEAGE_NAMESPACE)

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -1,0 +1,79 @@
+Cosmos Config
+=============
+
+This page lists all available Airflow configurations that affect ``astronomer-cosmos`` Astronomer Cosmos behavior. They can be set in the ``airflow.cfg file`` or using environment variables.
+
+.. note::
+    For more information, see `Setting Configuration Options <https://airflow.apache.org/docs/apache-airflow/stable/howto/set-config.html>`_.
+
+**Sections:**
+
+- [cosmos]
+- [openlineage]
+
+[cosmos]
+~~~~~~~~
+
+.. _cache_dir:
+
+`cache_dir`_:
+    The directory used for caching Cosmos data.
+
+    - Default: ``{TMPDIR}/cosmos_cache`` (where ``{TMPDIR}`` is the system temporary directory)
+    - Environment Variable: ``AIRFLOW__COSMOS__CACHE_DIR``
+
+.. _enable_cache:
+
+`enable_cache`_:
+    Enable or disable caching of Cosmos data.
+
+    - Default: ``True``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE``
+
+.. _propagate_logs:
+
+`propagate_logs`_:
+    Whether to propagate logs in the Cosmos module.
+
+    - Default: ``True``
+    - Environment Variable: ``AIRFLOW__COSMOS__PROPAGATE_LOGS``
+
+.. _dbt_docs_dir:
+
+`dbt_docs_dir`_:
+    The directory path for dbt documentation.
+
+    - Default: ``None``
+    - Environment Variable: ``AIRFLOW__COSMOS__DBT_DOCS_DIR``
+
+.. _dbt_docs_conn_id:
+
+`dbt_docs_conn_id`_:
+    The connection ID for dbt documentation.
+
+    - Default: ``None``
+    - Environment Variable: ``AIRFLOW__COSMOS__DBT_DOCS_CONN_ID``
+
+[openlineage]
+~~~~~~~~~~~~~
+
+.. _namespace:
+
+`namespace`_:
+    The OpenLineage namespace for tracking lineage.
+
+    - Default: If not configured in Airflow configuration, it falls back to the environment variable ``OPENLINEAGE_NAMESPACE``, otherwise it uses ``DEFAULT_OPENLINEAGE_NAMESPACE``.
+    - Environment Variable: ``AIRFLOW__OPENLINEAGE__NAMESPACE``
+
+.. note::
+    For more information, see `Openlieage Configuration Options <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/guides/user.html>`_.
+
+Environment Variables
+~~~~~~~~~~~~~~~~~~~~~
+
+.. _LINEAGE_NAMESPACE:
+
+`LINEAGE_NAMESPACE`_:
+    The OpenLineage namespace for tracking lineage.
+
+    - Default: If not configured in Airflow configuration, it falls back to the environment variable ``OPENLINEAGE_NAMESPACE``, otherwise it uses ``DEFAULT_OPENLINEAGE_NAMESPACE``.

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -14,6 +14,7 @@ Cosmos offers a number of configuration options to customize its behavior. For m
    Render Config <render-config>
 
    Parsing Methods <parsing-methods>
+   Configuring in Airflow <cosmos-conf>
    Configuring Lineage <lineage>
    Generating Docs <generating-docs>
    Hosting Docs <hosting-docs>

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -71,6 +71,7 @@ def test_dbt_docs(monkeypatch, app):
             return original_conf_get(section, key, *args, **kwargs)
 
     monkeypatch.setattr(conf, "get", conf_get)
+    monkeypatch.setattr("cosmos.plugin.dbt_docs_dir", "path/to/docs/dir")
 
     response = app.get("/cosmos/dbt_docs")
 
@@ -96,6 +97,7 @@ def test_dbt_docs_artifact(mock_open_file, monkeypatch, app, artifact):
             return original_conf_get(section, key, *args, **kwargs)
 
     monkeypatch.setattr(conf, "get", conf_get)
+    monkeypatch.setattr("cosmos.plugin.dbt_docs_dir", "path/to/docs/dir")
 
     if artifact == "dbt_docs_index.html":
         mock_open_file.return_value = "<head></head><body></body>"
@@ -134,6 +136,7 @@ def test_open_file_calls(path, open_file_callback, monkeypatch):
             return original_conf_get(section, key, *args, **kwargs)
 
     monkeypatch.setattr(conf, "get", conf_get)
+    monkeypatch.setattr("cosmos.plugin.dbt_docs_conn_id", "mock_conn_id")
 
     with patch.object(cosmos.plugin, open_file_callback) as mock_callback:
         mock_callback.return_value = "mock file contents"

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,7 +1,5 @@
 import logging
 
-from airflow.configuration import conf
-
 from cosmos import get_provider_info
 from cosmos.log import get_logger
 
@@ -17,10 +15,8 @@ def test_get_logger():
     assert custom_string in custom_logger.handlers[0].formatter._fmt
 
 
-def test_propagate_logs_conf():
-    if not conf.has_section("cosmos"):
-        conf.add_section("cosmos")
-    conf.set("cosmos", "propagate_logs", "False")
+def test_propagate_logs_conf(monkeypatch):
+    monkeypatch.setattr("cosmos.log.propagate_logs", False)
     custom_logger = get_logger("cosmos-log")
     assert custom_logger.propagate is False
 


### PR DESCRIPTION
## Description

- Centralizing environment or configuration fetching by moving the Airflow configuration call to the Cosmos settings.py file.
- Add documentation for cosmos config sections

Sample HTML page
<img width="798" alt="Screenshot 2024-05-18 at 1 04 13 AM" src="https://github.com/astronomer/astronomer-cosmos/assets/98807258/55f353d5-7f3f-4f08-9e65-3f7269a93bd5">



## Related Issue(s)

closes: https://github.com/astronomer/astronomer-cosmos/issues/928

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
