### PR TITLE
Add support for DAG & TaskGroup level caching (performance improvement)

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,25 @@
 Changelog
 =========
 
-1.4.1 (2024-05-17)
+1.5.0a1 (2024-05-23)
 --------------------
+
+New Features
+
+* Support for running dbt tasks in AWS EKS in #944 by @VolkerSchiewe
+* Support caching at a DbtDag and DbtTaskGroupLevel in #992 by @tatiana (WIP)
+
+Others
+
+* Drop support for Airflow 2.3 in #994 by @pankajkoti
+* Update Astro Runtime image in #988 and #989 by @RNHTTR
+* Enable ruff F linting in #985 by @pankajastro
+* Move Cosmos Airflow configuration to settings.py in #975 by @pankajastro
+
+
+
+1.4.1 (2024-05-17)
+------------------
 
 Bug fixes
 
@@ -20,7 +37,7 @@ Others
 
 
 1.4.0 (2024-05-13)
---------------------
+------------------
 
 Features
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,13 +1,14 @@
 Changelog
 =========
 
-1.5.0a1 (2024-05-23)
+1.5.0a2 (2024-05-23)
 --------------------
 
 New Features
 
 * Support for running dbt tasks in AWS EKS in #944 by @VolkerSchiewe
 * Support caching at a DbtDag and DbtTaskGroupLevel in #992 by @tatiana (WIP)
+   - difference from 1.5.0a1: Include timestamp of the DAG in the cache version
 
 Others
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -5,7 +5,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 
 Contains dags, task groups, and operators.
 """
-__version__ = "1.5.0a1"
+__version__ = "1.5.0a2"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -5,7 +5,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 
 Contains dags, task groups, and operators.
 """
-__version__ = "1.4.1"
+__version__ = "1.5.0a1"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -4,11 +4,17 @@ This module contains a function to render a dbt project as an Airflow DAG.
 
 from __future__ import annotations
 
+import pickle
+from pathlib import Path
 from typing import Any
 
 from airflow.models.dag import DAG
 
+from cosmos import cache, settings
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
+from cosmos.log import get_logger
+
+logger = get_logger()
 
 
 class DbtDag(DAG, DbtToAirflowConverter):
@@ -16,11 +22,38 @@ class DbtDag(DAG, DbtToAirflowConverter):
     Render a dbt project as an Airflow DAG.
     """
 
+    @staticmethod
+    def get_cache_filepath(cache_identifier: str) -> Path:
+        cache_dir_path = cache._obtain_cache_dir_path(cache_identifier)
+        return cache_dir_path / f"{cache_identifier}.pkl"
+
+    @staticmethod
+    def should_use_cache() -> bool:
+        return True
+
+    def __new__(cls, *args, **kwargs):  # type: ignore
+        dag_id = kwargs.get("dag_id")
+        if dag_id is not None:
+            cache_filepath = DbtDag.get_cache_filepath(dag_id)
+            if settings.enable_cache and settings.experimental_cache and cache_filepath.exists():
+                logger.info(f"Restoring DbtDag {dag_id} from cache {cache_filepath}")
+                with open(cache_filepath, "rb") as fp:
+                    return pickle.load(fp)
+
+        instance = DAG.__new__(DAG)
+        DbtDag.__init__(instance, *args, **kwargs)  # type: ignore
+        return instance
+
     def __init__(
         self,
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        logger.info(f"Creating DbtDag {kwargs.get('dag_id')}")
         DAG.__init__(self, *args, **airflow_kwargs(**kwargs))
         kwargs["dag"] = self
         DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
+        cache_filepath = DbtDag.get_cache_filepath(kwargs["dag_id"])
+        if settings.enable_cache and settings.experimental_cache:
+            with open(cache_filepath, "wb") as fp:
+                pickle.dump(self, fp)

--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -4,7 +4,11 @@ This module contains a function to render a dbt project as an Airflow DAG.
 
 from __future__ import annotations
 
+import functools
+
+# import inspect
 import pickle
+import time
 from pathlib import Path
 from typing import Any
 
@@ -23,37 +27,97 @@ class DbtDag(DAG, DbtToAirflowConverter):
     """
 
     @staticmethod
+    @functools.lru_cache
     def get_cache_filepath(cache_identifier: str) -> Path:
         cache_dir_path = cache._obtain_cache_dir_path(cache_identifier)
         return cache_dir_path / f"{cache_identifier}.pkl"
 
     @staticmethod
+    @functools.lru_cache
+    def get_cache_version_filepath(cache_identifier: str) -> Path:
+        return Path(str(DbtDag.get_cache_filepath(cache_identifier)) + ".version")
+
+    @staticmethod
+    @functools.lru_cache
     def should_use_cache() -> bool:
-        return True
+        return settings.enable_cache and settings.experimental_cache
+
+    @staticmethod
+    @functools.lru_cache
+    def is_project_unmodified(dag_id: str, current_version: str) -> Path | None:
+        cache_filepath = DbtDag.get_cache_filepath(dag_id)
+        cache_version_filepath = DbtDag.get_cache_version_filepath(dag_id)
+        if cache_version_filepath.exists() and cache_filepath.exists():
+            previous_cache_version = cache_version_filepath.read_text()
+            if previous_cache_version == current_version:
+                return cache_filepath
+        return None
+
+    @staticmethod
+    @functools.lru_cache
+    def calculate_current_version(dag_id: str, project_dir: Path) -> str:
+        start_time = time.process_time()
+
+        # When DAG file was last changed - this is very slow (e.g. 0.6s)
+        # caller_dag_frame = inspect.stack()[1]
+        # caller_dag_filepath = Path(caller_dag_frame.filename)
+        # logger.info("The %s DAG is located in: %s" % (dag_id, caller_dag_filepath))
+        # dag_last_modified = caller_dag_filepath.stat().st_mtime
+        # mid_time = time.process_time() - start_time
+        # logger.info(f"It took {mid_time:.3}s to calculate the first part of the version")
+        dag_last_modified = None
+
+        # Combined value for when the dbt project directory files were last modified
+        # This is fast (e.g. 0.01s for jaffle shop, 0.135s for a 5k models dbt folder)
+        dbt_combined_last_modified = sum([path.stat().st_mtime for path in project_dir.glob("**/*")])
+
+        elapsed_time = time.process_time() - start_time
+        logger.info(f"It took {elapsed_time:.3}s to calculate the cache version for the DbtDag {dag_id}")
+        return f"{dag_last_modified} {dbt_combined_last_modified}"
 
     def __new__(cls, *args, **kwargs):  # type: ignore
         dag_id = kwargs.get("dag_id")
-        if dag_id is not None:
-            cache_filepath = DbtDag.get_cache_filepath(dag_id)
-            if settings.enable_cache and settings.experimental_cache and cache_filepath.exists():
+        project_config = kwargs.get("project_config")
+
+        # When we load a Pickle dump of a DbtDag, __new__ is invoked without kwargs
+        # In those cases, we should not call DbtDag.__new__ again, otherwise we'll have an infinite recursion
+        if dag_id is not None and project_config and project_config.dbt_project_path:
+            current_version = DbtDag.calculate_current_version(dag_id, project_config.dbt_project_path)
+            cache_filepath = DbtDag.should_use_cache() and DbtDag.is_project_unmodified(dag_id, current_version)
+            if cache_filepath:
                 logger.info(f"Restoring DbtDag {dag_id} from cache {cache_filepath}")
                 with open(cache_filepath, "rb") as fp:
-                    return pickle.load(fp)
+                    start_time = time.process_time()
+                    dbt_dag = pickle.load(fp)
+                    elapsed_time = time.process_time() - start_time
+                    logger.info(f"It took {elapsed_time:.3}s to restore the cached version of the DbtDag {dag_id}")
+                    return dbt_dag
 
         instance = DAG.__new__(DAG)
         DbtDag.__init__(instance, *args, **kwargs)  # type: ignore
         return instance
 
+    # The __init__ is not called when restoring the cached DbtDag in __new__
     def __init__(
         self,
         *args: Any,
         **kwargs: Any,
     ) -> None:
-        logger.info(f"Creating DbtDag {kwargs.get('dag_id')}")
+        start_time = time.process_time()
+        dag_id = kwargs["dag_id"]
+        project_config = kwargs.get("project_config")
+
         DAG.__init__(self, *args, **airflow_kwargs(**kwargs))
         kwargs["dag"] = self
         DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
-        cache_filepath = DbtDag.get_cache_filepath(kwargs["dag_id"])
-        if settings.enable_cache and settings.experimental_cache:
+        elapsed_time = time.process_time() - start_time
+        logger.info(f"It took {elapsed_time} to create the DbtDag {dag_id} from scratch")
+
+        if DbtDag.should_use_cache() and project_config:
+            cache_filepath = DbtDag.get_cache_filepath(dag_id)
             with open(cache_filepath, "wb") as fp:
                 pickle.dump(self, fp)
+            cache_version_filepath = DbtDag.get_cache_version_filepath(dag_id)
+            current_version = DbtDag.calculate_current_version(dag_id, project_config.dbt_project_path)
+            cache_version_filepath.write_text(current_version)
+            logger.info(f"Stored DbtDag {dag_id} cache {cache_filepath}")

--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -4,17 +4,14 @@ This module contains a function to render a dbt project as an Airflow DAG.
 
 from __future__ import annotations
 
-import functools
-
 # import inspect
 import pickle
 import time
-from pathlib import Path
 from typing import Any
 
 from airflow.models.dag import DAG
 
-from cosmos import cache, settings
+from cosmos import cache
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 from cosmos.log import get_logger
 
@@ -26,78 +23,32 @@ class DbtDag(DAG, DbtToAirflowConverter):
     Render a dbt project as an Airflow DAG.
     """
 
-    @staticmethod
-    @functools.lru_cache
-    def get_cache_filepath(cache_identifier: str) -> Path:
-        cache_dir_path = cache._obtain_cache_dir_path(cache_identifier)
-        return cache_dir_path / f"{cache_identifier}.pkl"
-
-    @staticmethod
-    @functools.lru_cache
-    def get_cache_version_filepath(cache_identifier: str) -> Path:
-        return Path(str(DbtDag.get_cache_filepath(cache_identifier)) + ".version")
-
-    @staticmethod
-    @functools.lru_cache
-    def should_use_cache() -> bool:
-        return settings.enable_cache and settings.experimental_cache
-
-    @staticmethod
-    @functools.lru_cache
-    def is_project_unmodified(dag_id: str, current_version: str) -> Path | None:
-        cache_filepath = DbtDag.get_cache_filepath(dag_id)
-        cache_version_filepath = DbtDag.get_cache_version_filepath(dag_id)
-        if cache_version_filepath.exists() and cache_filepath.exists():
-            previous_cache_version = cache_version_filepath.read_text()
-            if previous_cache_version == current_version:
-                return cache_filepath
-        return None
-
-    @staticmethod
-    @functools.lru_cache
-    def calculate_current_version(dag_id: str, project_dir: Path) -> str:
-        start_time = time.process_time()
-
-        # When DAG file was last changed - this is very slow (e.g. 0.6s)
-        # caller_dag_frame = inspect.stack()[1]
-        # caller_dag_filepath = Path(caller_dag_frame.filename)
-        # logger.info("The %s DAG is located in: %s" % (dag_id, caller_dag_filepath))
-        # dag_last_modified = caller_dag_filepath.stat().st_mtime
-        # mid_time = time.process_time() - start_time
-        # logger.info(f"It took {mid_time:.3}s to calculate the first part of the version")
-        dag_last_modified = None
-
-        # Combined value for when the dbt project directory files were last modified
-        # This is fast (e.g. 0.01s for jaffle shop, 0.135s for a 5k models dbt folder)
-        dbt_combined_last_modified = sum([path.stat().st_mtime for path in project_dir.glob("**/*")])
-
-        elapsed_time = time.process_time() - start_time
-        logger.info(f"It took {elapsed_time:.3}s to calculate the cache version for the DbtDag {dag_id}")
-        return f"{dag_last_modified} {dbt_combined_last_modified}"
-
     def __new__(cls, *args, **kwargs):  # type: ignore
         dag_id = kwargs.get("dag_id")
         project_config = kwargs.get("project_config")
 
-        # When we load a Pickle dump of a DbtDag, __new__ is invoked without kwargs
-        # In those cases, we should not call DbtDag.__new__ again, otherwise we'll have an infinite recursion
+        # When we load a Pickle dump of an instance, __new__ is invoked without kwargs
+        # In those cases, we should not call __new__ again, otherwise we'll have an infinite recursion
         if dag_id is not None and project_config and project_config.dbt_project_path:
-            current_version = DbtDag.calculate_current_version(dag_id, project_config.dbt_project_path)
-            cache_filepath = DbtDag.should_use_cache() and DbtDag.is_project_unmodified(dag_id, current_version)
+            cache_id = cache.create_cache_identifier_v2(dag_id, None)
+            current_version = cache.calculate_current_version(cache_id, project_config.dbt_project_path)
+            cache_filepath = cache.should_use_cache() and cache.is_project_unmodified(cache_id, current_version)
             if cache_filepath:
-                logger.info(f"Restoring DbtDag {dag_id} from cache {cache_filepath}")
+                logger.info(f"Restoring {cls.__name__} {dag_id} from cache {cache_filepath}")
                 with open(cache_filepath, "rb") as fp:
                     start_time = time.process_time()
                     dbt_dag = pickle.load(fp)
                     elapsed_time = time.process_time() - start_time
-                    logger.info(f"It took {elapsed_time:.3}s to restore the cached version of the DbtDag {dag_id}")
+                    logger.info(
+                        f"It took {elapsed_time:.3}s to restore the cached version of the {cls.__name__} {dag_id}"
+                    )
                     return dbt_dag
 
         instance = DAG.__new__(DAG)
-        DbtDag.__init__(instance, *args, **kwargs)  # type: ignore
+        cls.__init__(instance, *args, **kwargs)  # type: ignore
         return instance
 
-    # The __init__ is not called when restoring the cached DbtDag in __new__
+    # The __init__ is not called when restoring the cached in __new__
     def __init__(
         self,
         *args: Any,
@@ -110,14 +61,16 @@ class DbtDag(DAG, DbtToAirflowConverter):
         DAG.__init__(self, *args, **airflow_kwargs(**kwargs))
         kwargs["dag"] = self
         DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
-        elapsed_time = time.process_time() - start_time
-        logger.info(f"It took {elapsed_time} to create the DbtDag {dag_id} from scratch")
 
-        if DbtDag.should_use_cache() and project_config:
-            cache_filepath = DbtDag.get_cache_filepath(dag_id)
+        elapsed_time = time.process_time() - start_time
+        logger.info(f"It took {elapsed_time} to create the {self.__class__.__name__} {dag_id} from scratch")
+
+        if cache.should_use_cache() and project_config:
+            cache_id = cache.create_cache_identifier_v2(dag_id, None)
+            cache_filepath = cache.get_cache_filepath(cache_id)
             with open(cache_filepath, "wb") as fp:
                 pickle.dump(self, fp)
-            cache_version_filepath = DbtDag.get_cache_version_filepath(dag_id)
-            current_version = DbtDag.calculate_current_version(dag_id, project_config.dbt_project_path)
+            cache_version_filepath = cache.get_cache_version_filepath(cache_id)
+            current_version = cache.calculate_current_version(cache_id, project_config.dbt_project_path)
             cache_version_filepath.write_text(current_version)
-            logger.info(f"Stored DbtDag {dag_id} cache {cache_filepath}")
+            logger.info(f"Stored {self.__class__.__name__} {dag_id} cache {cache_filepath}")

--- a/cosmos/airflow/task_group.py
+++ b/cosmos/airflow/task_group.py
@@ -4,11 +4,17 @@ This module contains a function to render a dbt project as an Airflow Task Group
 
 from __future__ import annotations
 
+import pickle
+import time
 from typing import Any
 
 from airflow.utils.task_group import TaskGroup
 
+from cosmos import cache
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
+from cosmos.log import get_logger
+
+logger = get_logger()
 
 
 class DbtTaskGroup(TaskGroup, DbtToAirflowConverter):
@@ -16,13 +22,56 @@ class DbtTaskGroup(TaskGroup, DbtToAirflowConverter):
     Render a dbt project as an Airflow Task Group.
     """
 
+    def __new__(cls, *args, **kwargs):  # type: ignore
+        dag_id = kwargs.get("dag_id")
+        task_id = kwargs.get("task_id")
+        project_config = kwargs.get("project_config")
+
+        # When we load a Pickle dump of an instance, __new__ is invoked without kwargs
+        # In those cases, we should not call __new__ again, otherwise we'll have an infinite recursion
+        if task_id is not None and project_config and project_config.dbt_project_path:
+            cache_id = cache.create_cache_identifier_v2(dag_id, task_id)
+            current_version = cache.calculate_current_version(cache_id, project_config.dbt_project_path)
+            cache_filepath = cache.should_use_cache() and cache.is_project_unmodified(cache_id, current_version)
+            if cache_filepath:
+                logger.info(f"Restoring {cls.__name__} {dag_id} from cache {cache_filepath}")
+                with open(cache_filepath, "rb") as fp:
+                    start_time = time.process_time()
+                    dbt_dag = pickle.load(fp)
+                    elapsed_time = time.process_time() - start_time
+                    logger.info(
+                        f"It took {elapsed_time:.3}s to restore the cached version of the {cls.__name__} {dag_id}"
+                    )
+                    return dbt_dag
+
+        instance = TaskGroup.__new__(TaskGroup)
+        cls.__init__(instance, *args, **kwargs)  # type: ignore
+        return instance
+
     def __init__(
         self,
         group_id: str = "dbt_task_group",
         *args: Any,
         **kwargs: Any,
     ) -> None:
+        start_time = time.process_time()
         kwargs["group_id"] = group_id
+        dag_id = kwargs.get("dag_id")
+        project_config = kwargs.get("project_config")
+
         TaskGroup.__init__(self, *args, **airflow_kwargs(**kwargs))
         kwargs["task_group"] = self
         DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
+
+        elapsed_time = time.process_time() - start_time
+        logger.info(f"It took {elapsed_time} to create the {self.__class__.__name__} {dag_id} from scratch")
+
+        if cache.should_use_cache() and project_config:
+            cache_id = cache.create_cache_identifier_v2(dag_id, group_id)
+            cache_filepath = cache.get_cache_filepath(cache_id)
+            with open(cache_filepath, "wb") as fp:
+                pickle.dump(self, fp)
+            cache_version_filepath = cache.get_cache_version_filepath(cache_id)
+            current_version = cache.calculate_current_version(cache_id, project_config.dbt_project_path)
+            cache_version_filepath.write_text(current_version)
+            logger.info(f"Stored {self.__class__.__name__} {dag_id} cache {cache_filepath}")

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import functools
+import inspect
 import shutil
 import time
 from pathlib import Path
@@ -227,12 +228,12 @@ def calculate_current_version(dag_id: str, project_dir: Path) -> str:
     start_time = time.process_time()
 
     # When DAG file was last changed - this is very slow (e.g. 0.6s)
-    # caller_dag_frame = inspect.stack()[1]
-    # caller_dag_filepath = Path(caller_dag_frame.filename)
-    # logger.info("The %s DAG is located in: %s" % (dag_id, caller_dag_filepath))
-    # dag_last_modified = caller_dag_filepath.stat().st_mtime
-    # mid_time = time.process_time() - start_time
-    # logger.info(f"It took {mid_time:.3}s to calculate the first part of the version")
+    caller_dag_frame = inspect.stack()[1]
+    caller_dag_filepath = Path(caller_dag_frame.filename)
+    logger.info(f"The {dag_id} DAG is located in: {caller_dag_filepath}")
+    dag_last_modified = caller_dag_filepath.stat().st_mtime
+    mid_time = time.process_time() - start_time
+    logger.info(f"It took {mid_time:.3}s to calculate the first part of the version")
     # dag_last_modified = None
 
     # Combined value for when the dbt project directory files were last modified
@@ -241,8 +242,8 @@ def calculate_current_version(dag_id: str, project_dir: Path) -> str:
 
     elapsed_time = time.process_time() - start_time
     logger.info(f"It took {elapsed_time:.3}s to calculate the cache version for the {dag_id}")
-    # return f"{dag_last_modified} {dbt_combined_last_modified}"
-    return f"{dbt_combined_last_modified}"
+    return f"{dag_last_modified} {dbt_combined_last_modified}"
+    # return f"{dbt_combined_last_modified}"
 
 
 @functools.lru_cache

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -228,7 +228,7 @@ def calculate_current_version(dag_id: str, project_dir: Path) -> str:
     start_time = time.process_time()
 
     # When DAG file was last changed - this is very slow (e.g. 0.6s)
-    caller_dag_frame = inspect.stack()[1]
+    caller_dag_frame = inspect.stack()[2]
     caller_dag_filepath = Path(caller_dag_frame.filename)
     logger.info(f"The {dag_id} DAG is located in: {caller_dag_filepath}")
     dag_last_modified = caller_dag_filepath.stat().st_mtime

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -10,7 +10,9 @@ from cosmos.constants import DEFAULT_COSMOS_CACHE_DIR_NAME, DEFAULT_OPENLINEAGE_
 # In MacOS users may want to set the envvar `TMPDIR` if they do not want the value of the temp directory to change
 DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
-enable_cache = conf.get("cosmos", "enable_cache", fallback=True)
+
+enable_cache = conf.getboolean("cosmos", "enable_cache", fallback=True)
+experimental_cache = conf.getboolean("cosmos", "experimental_cache", fallback=False)
 propagate_logs = conf.getboolean("cosmos", "propagate_logs", fallback=True)
 dbt_docs_dir = conf.get("cosmos", "dbt_docs_dir", fallback=None)
 dbt_docs_conn_id = conf.get("cosmos", "dbt_docs_conn_id", fallback=None)


### PR DESCRIPTION
Introduce DAG level cache. Based on initial tests, this can improve the performance of running a Cosmos-powered DAG by 59% (validated with the repo's `basic_cosmos_dag`).

To enable this feature, users should set the environment variable `AIRFLOW__COSMOS__EXPERIMENTAL_CACHE=1`.

What is missing (why this is draft PR):
* Allow users to customise their own `calculate_current_version`
* Refactor so there isn't so much code duplicate between `DbtDag` and `TaskGroup`
* Allow users to purge the cache (via env var or param passed in the Airflow UI - second option is probably preferable)
* Unify `_create_cache_identifier` and `create_cache_identifier_v2`
* Write tests
* The cache should be invalidated if there is an error unpickling

This will be done in a separate PR:
* have a way of storing cache remotely (to be addressed in a separate ticket: https://github.com/astronomer/astronomer-cosmos/issues/927). There is a concern about how secure is pickle, so we may need to cache representation.
* button in the UI to purge cache for individual DAG/TaskGroup
* button in the UI to purge all Cosmos cache
* enable feature by default before 1.5 release (TODO: log ticket)

Closes: #926
Closes: #990

**How to reproduce**

Run using the new cache feature:
```
time AIRFLOW__COSMOS__ENABLE_CACHE=1 AIRFLOW__COSMOS__EXPERIMENTAL_CACHE=1 airflow dags test basic_cosmos_dag  `date -Iseconds`
```
Ran in `7.03s user 2.59s system 81% cpu 11.808 total`
<img width="1506" alt="Screenshot 2024-05-21 at 17 28 27" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/4b2974e9-3cf9-4161-b442-229108e1fc6b">

Run without the new cache feature:
```
time  AIRFLOW__COSMOS__ENABLE_CACHE=1 AIRFLOW__COSMOS__EXPERIMENTAL_CACHE=0 airflow dags test basic_cosmos_dag  `date -Iseconds`
```
Ran in `18.75s user 2.62s system 73% cpu 28.898 total`
<img width="1504" alt="Screenshot 2024-05-21 at 17 28 39" src="https://github.com/astronomer/astronomer-cosmos/assets/272048/cbf9c81e-33ca-472c-8bf0-0bb62ce52a3b">
