### PR TITLE
Drop support for Airflow 2.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,10 +39,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
         exclude:
-          - python-version: "3.11"
-            airflow-version: "2.3"
           - python-version: "3.11"
             airflow-version: "2.4"
     steps:
@@ -83,10 +81,8 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
         exclude:
-          - python-version: "3.11"
-            airflow-version: "2.3"
           - python-version: "3.11"
             airflow-version: "2.4"
     services:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ classifiers = [
 dependencies = [
     "aenum",
     "attrs",
-    "apache-airflow>=2.3.0",
+    "apache-airflow>=2.4.0",
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",
     "msgpack",
@@ -133,7 +133,7 @@ pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow}
 
 [[tool.hatch.envs.tests.matrix]]
 python = ["3.8", "3.9", "3.10", "3.11"]
-airflow = ["2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
+airflow = ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9"]
 
 [tool.hatch.envs.tests.overrides]
 matrix.airflow.dependencies = [


### PR DESCRIPTION
Airflow 2.3 was released more than 2 years ago on Apr 30, 2022
and few of the apache-airflow providers are known to no longer
support it. We've observed cosmos users are not on Airflow 2.3 
based on the analysis in https://github.com/astronomer/astronomer-cosmos/issues/963#issuecomment-2121165722
and hence, to avoid maintenance & support efforts for an older version,
this PR drops Cosmos support for Airflow 2.3