### PR TITLE
Improve error logging in DbtLocalBaseOperator

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -179,10 +179,8 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
             raise AirflowSkipException(f"dbt command returned exit code {self.skip_exit_code}. Skipping.")
         elif result.exit_code != 0:
-            raise AirflowException(
-                f"dbt command failed. The command returned a non-zero exit code {result.exit_code}. Details: ",
-                *result.full_output,
-            )
+            logger.error("\n".join(result.full_output))
+            raise AirflowException(f"dbt command failed. The command returned a non-zero exit code {result.exit_code}.")
 
     def handle_exception_dbt_runner(self, result: dbtRunnerResult) -> None:
         """dbtRunnerResult has an attribute `success` that is False if the command failed."""

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -922,7 +922,7 @@ def test_handle_exception_subprocess(caplog):
     """
     Test the handle_exception_subprocess method of the DbtLocalBaseOperator class for non-zero dbt exit code.
     """
-    operator = DbtLocalBaseOperator(profile_config=None)
+    operator = ConcreteDbtLocalBaseOperator(profile_config=None)
     result = FullOutputSubprocessResult(
         exit_code=1, output="test", full_output=["n" * n for n in range(1, 1000)]
     )

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -24,6 +24,7 @@ from cosmos.dbt.parser.output import (
     parse_number_of_warnings_subprocess,
 )
 from cosmos.exceptions import AirflowCompatibilityError
+from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
     DbtDocsAzureStorageLocalOperator,
@@ -957,3 +958,20 @@ def test_dbt_local_operator_on_kill_sigterm(mock_send_sigterm) -> None:
     dbt_base_operator.on_kill()
 
     mock_send_sigterm.assert_called_once()
+
+
+def test_handle_exception_subprocess(caplog):
+    """
+    Test the handle_exception_subprocess method of the DbtLocalBaseOperator class for non-zero dbt exit code.
+    """
+    operator = DbtLocalBaseOperator(profile_config=None)
+    result = FullOutputSubprocessResult(
+        exit_code=1, output="test", full_output=["n" * n for n in range(1, 1000)]
+    )
+
+    caplog.set_level(logging.ERROR)
+    # Test when exit_code is non-zero
+    with pytest.raises(AirflowException) as err_context:
+        operator.handle_exception_subprocess(result)
+    assert len(str(err_context.value)) < 100  # Ensure the error message is not too long
+    assert len(caplog.text) > 1000  # Ensure the log message is not truncated

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -23,7 +23,6 @@ from cosmos.dbt.parser.output import (
     parse_number_of_warnings_dbt_runner,
     parse_number_of_warnings_subprocess,
 )
-from cosmos.exceptions import AirflowCompatibilityError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
@@ -923,9 +922,7 @@ def test_handle_exception_subprocess(caplog):
     Test the handle_exception_subprocess method of the DbtLocalBaseOperator class for non-zero dbt exit code.
     """
     operator = ConcreteDbtLocalBaseOperator(profile_config=None)
-    result = FullOutputSubprocessResult(
-        exit_code=1, output="test", full_output=["n" * n for n in range(1, 1000)]
-    )
+    result = FullOutputSubprocessResult(exit_code=1, output="test", full_output=["n" * n for n in range(1, 1000)])
 
     caplog.set_level(logging.ERROR)
     # Test when exit_code is non-zero

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -921,7 +921,11 @@ def test_handle_exception_subprocess(caplog):
     """
     Test the handle_exception_subprocess method of the DbtLocalBaseOperator class for non-zero dbt exit code.
     """
-    operator = ConcreteDbtLocalBaseOperator(profile_config=None)
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=None,
+        task_id="my-task",
+        project_dir="my/dir",
+    )
     result = FullOutputSubprocessResult(exit_code=1, output="test", full_output=["n" * n for n in range(1, 1000)])
 
     caplog.set_level(logging.ERROR)


### PR DESCRIPTION
Improve error logging when the `dbt` command returns a non-zero exit code. Instead of raising an `AirflowException` with the full output, log the output using the logger and then raise the exception with a concise error message. This makes the dbt output more readable and not in a single line.

## Description
AirflowException logs message in a single line, can be very long. 
## Related Issue(s)

closes #1003 

## Breaking Change?

No
