### PR TITLE
Read mock value from env for mock profile

### DIFF
--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -188,12 +188,11 @@ class BaseProfileMapping(ABC):
             # if someone has passed in a value for this field, use it
             if self.profile_args.get(field):
                 mock_profile[field] = self.profile_args[field]
-
-            # otherwise, use the default value
+            # otherwise, use the mock value from env
             else:
-                mock_profile[field] = "mock_value"
+                mock_profile[field] = self.get_env_var_format(field)
 
-        return mock_profile
+        return self.filter_null(mock_profile)
 
     @property
     def env_vars(self) -> dict[str, str]:


### PR DESCRIPTION
## Description

Read the mock value for mock_profile from the environment. This change allows partial parsing without enable_mock_profile=False, but it may require setting the necessary environment variables.

## Related Issue(s)
closes: https://github.com/astronomer/astronomer-cosmos/issues/924

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
