### PR TITLE
Add GitHub issue templates for bug reports and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -1,0 +1,145 @@
+---
+name: Bug Report
+description: File a bug report.
+title: "[Bug]: "
+labels: ["bug", "triage-needed"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+  - type: dropdown
+    id: cosmos-version
+    attributes:
+      label: Astronomer Cosmos Version
+      description: What version of Astronomer Cosmos are you running? If you do not see your version in the list, please (ideally) test on
+        the latest release or main to see if the issue is fixed before reporting it.
+      options:
+        - "1.4.1"
+        - "main (development)"
+        - "Other Astronomer Cosmos version (please specify below)"
+      multiple: false
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: If "Other Astronomer Cosmos version" selected, which one?
+      # yamllint disable rule:line-length
+      description: >
+        On what version of Astronomer Cosmos are you currently experiencing the issue? Remember, you are encouraged to
+        test with the latest release or on the main branch to verify your issue still exists.
+  - type: input
+    id: dbt-core-version
+    attributes:
+      label: dbt-core version
+      description: What version of dbt-core are you running?
+      placeholder: ex. 1.8.0
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Versions of dbt adapters
+      description: What dbt adapter versions are you using?
+      placeholder: You can use `pip freeze | grep dbt` (you can leave only relevant ones)
+  - type: input
+    id: airflow-version
+    attributes:
+      label: airflow version
+      description: What version of Apache Airflow are you running?
+      placeholder: ex. 2.9.0
+    validations:
+      required: true
+  - type: input
+    attributes:
+      label: Operating System
+      description: What Operating System are you using?
+      placeholder: "You can get it via `cat /etc/os-release` for example"
+    validations:
+      required: true
+  - type: dropdown
+    id: browsers
+    attributes:
+      label: If a you think it's an UI issue, what browsers are you seeing the problem on?
+      multiple: true
+      options:
+        - Firefox
+        - Chrome
+        - Safari
+        - Microsoft Edge
+  - type: dropdown
+    attributes:
+      label: Deployment
+      description: >
+        What kind of deployment do you have?
+      multiple: false
+      options:
+        - "Official Apache Airflow Helm Chart"
+        - "Other 3rd-party Helm chart"
+        - "Docker-Compose"
+        - "Other Docker-based deployment"
+        - "Virtualenv installation"
+        - "Astronomer"
+        - "Google Cloud Composer"
+        - "Amazon (AWS) MWAA"
+        - "Microsoft ADF Managed Airflow"
+        - "Other"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Deployment details
+      description: Additional description of your deployment.
+      placeholder: >
+        Enter any relevant details of your deployment. Especially version of your tools,
+        software (docker-compose, helm, k8s, etc.), any customisation and configuration you added.
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened?
+      description: Also tell us, what did you expect to happen?
+      placeholder: Tell us what you see!
+      value: "A bug happened!"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant log output
+      description: Please copy and paste any relevant log output. This will be automatically formatted into code, so no need for backticks.
+      render: shell
+  - type: textarea
+    attributes:
+      label: How to reproduce
+      description: What should we do to reproduce the problem?
+      placeholder: >
+        Please make sure you provide a reproducible step-by-step case of how to reproduce the problem
+        as minimally and precisely as possible. Keep in mind we do not have access to your cluster or DAGs.
+        Remember that non-reproducible issues make it hard for us to help you or resolve the issue!
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: Anything else :)?
+      description: Anything else we need to know?
+      placeholder: >
+        How often does this problem occur? (Once? Every time? Only when certain conditions are met?)
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit PR?
+      description: >
+        This is absolutely not required, but we are happy to guide you in the contribution process
+        especially if you already have a good understanding of how to implement the fix. We love to bring new
+        contributors in.
+      options:
+        - label: Yes I am willing to submit a PR!
+  - type: input
+    id: contact
+    attributes:
+      label: Contact Details
+      description: (Optional) How can we get in touch with you if we need more info?
+      placeholder: ex. email@example.com
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"

--- a/.github/ISSUE_TEMPLATE/02-feature.yml
+++ b/.github/ISSUE_TEMPLATE/02-feature.yml
@@ -1,0 +1,33 @@
+---
+name: Feature request
+description: Suggest an idea for this project
+labels: ["enhancement", "needs-triage"]
+body:
+  - type: markdown
+    attributes:
+      # yamllint disable rule:line-length
+      value: "
+        Thank you for finding the time to propose new feature!
+
+        We really appreciate the community efforts to improve Cosmos."
+      # yamllint enable rule:line-length
+  - type: textarea
+    attributes:
+      label: Description
+      description: A short description of your feature
+  - type: textarea
+    attributes:
+      label: Use case/motivation
+      description: What would you like to happen?
+  - type: textarea
+    attributes:
+      label: Related issues
+      description: Is there currently another issue associated with this?
+  - type: checkboxes
+    attributes:
+      label: Are you willing to submit a PR?
+      options:
+        - label: Yes, I am willing to submit a PR!
+  - type: markdown
+    attributes:
+      value: "Thanks for completing our form!"


### PR DESCRIPTION
We currently do not have GitHub issue templates when 
the community creates issues. Having issue templates
would aid us in catching relevant information that would
help in faster resolution of those issues reported.

With this PR, we're are adding issue templates for bug 
reports and feature requests.

closes: #977 