### PR TITLE
Athena profile mapping set aws_session_token in profile only if it exist

### DIFF
--- a/cosmos/profiles/athena/access_key.py
+++ b/cosmos/profiles/athena/access_key.py
@@ -66,8 +66,10 @@ class AthenaAccessKeyProfileMapping(BaseProfileMapping):
             **self.profile_args,
             "aws_access_key_id": self.temporary_credentials.access_key,
             "aws_secret_access_key": self.get_env_var_format("aws_secret_access_key"),
-            "aws_session_token": self.get_env_var_format("aws_session_token"),
         }
+
+        if self.temporary_credentials.token:
+            profile["aws_session_token"] = self.get_env_var_format("aws_session_token")
 
         return self.filter_null(profile)
 

--- a/tests/profiles/athena/test_athena_access_key.py
+++ b/tests/profiles/athena/test_athena_access_key.py
@@ -1,11 +1,12 @@
 "Tests for the Athena profile."
+from __future__ import annotations
 
 import json
 import sys
 from collections import namedtuple
+from unittest import mock
 from unittest.mock import MagicMock, patch
 
-from unittest import mock
 import pytest
 from airflow.models.connection import Connection
 
@@ -170,7 +171,7 @@ def test_athena_profile_args_without_token(mock_temp_cred, mock_athena_conn_with
     """
     Tests that the profile values get set correctly for Athena.
     """
-    ReadOnlyCredentials = namedtuple('ReadOnlyCredentials', ['access_key', 'secret_key', 'token'])
+    ReadOnlyCredentials = namedtuple("ReadOnlyCredentials", ["access_key", "secret_key", "token"])
     credentials = ReadOnlyCredentials(access_key="my_aws_access_key", secret_key="my_aws_secret_key", token=None)
     mock_temp_cred.return_value = credentials
 


### PR DESCRIPTION
## Description
Set aws_session_token in the Athena profile only if it exists to avoid passing an empty string as a token to the AWS API.

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)
closes: https://github.com/astronomer/astronomer-cosmos/issues/962
<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
