### PR TITLE
Fix Cosmos enable_cache setting

### DIFF
--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -10,7 +10,7 @@ from cosmos.constants import DEFAULT_COSMOS_CACHE_DIR_NAME, DEFAULT_OPENLINEAGE_
 # In MacOS users may want to set the envvar `TMPDIR` if they do not want the value of the temp directory to change
 DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
-enable_cache = conf.get("cosmos", "enable_cache", fallback=True)
+enable_cache = conf.getboolean("cosmos", "enable_cache", fallback=True)
 propagate_logs = conf.getboolean("cosmos", "propagate_logs", fallback=True)
 dbt_docs_dir = conf.get("cosmos", "dbt_docs_dir", fallback=None)
 dbt_docs_conn_id = conf.get("cosmos", "dbt_docs_conn_id", fallback=None)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,11 @@
+import os
+from importlib import reload
+from unittest.mock import patch
+
+from cosmos import settings
+
+
+@patch.dict(os.environ, {"AIRFLOW__COSMOS__ENABLE_CACHE": "False"}, clear=True)
+def test_enable_cache_env_var():
+    reload(settings)
+    assert settings.enable_cache is False


### PR DESCRIPTION
As of Cosmos 1.4.1, users are not able to disable the cache in Cosmos using `AIRFLOW__COSMOS__ENABLE_CACHE=0`.

During a recent refactoring #975, the `enable_cache` was changed to a non-boolean config. This PR fixes this issue.
