### PR TITLE
Update documentation for DbtDocs generator

### DIFF
--- a/docs/configuration/generating-docs.rst
+++ b/docs/configuration/generating-docs.rst
@@ -85,6 +85,12 @@ You can use the :class:`~cosmos.operators.DbtDocsGCSOperator` to generate and up
         bucket_name="test_bucket",
     )
 
+Choosing a folder
+~~~~~~~~~~~~~~~~~~~~~~~
+
+All the DbtDocsOperators support specification of a custom folder (prefix) to place documentation in on the target cloud storage. This can be done by
+adding a ``folder_dir`` parameter to the operator definition.
+
 Static Flag
 ~~~~~~~~~~~~~~~~~~~~~~~
 


### PR DESCRIPTION
## Description

It isn't particularly clear on how to choose a folder on the specified bucket for any of the cloud storage options. It is of course present in the source, but I think it would be a nice addition to have on the documentation page. 

## Related Issue(s)

N/A

## Breaking Change?

None. 

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
