### PR TITLE
[Bug] Accidentally attaching adapters to root logger leads to increased logging costs

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -30,7 +30,7 @@ from cosmos.operators.local import (
     DbtTestLocalOperator,
 )
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 try:
     from cosmos.operators.docker import (

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -12,7 +12,7 @@ from cosmos.constants import DBT_MANIFEST_FILE_NAME, DBT_TARGET_DIR_NAME
 from cosmos.dbt.project import get_partial_parse_path
 from cosmos.log import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 # It was considered to create a cache identifier based on the dbt project path, as opposed

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -13,7 +13,7 @@ from cosmos.constants import (
 )
 from cosmos.log import get_logger
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 
 def has_non_empty_dependencies_file(project_path: Path) -> bool:

--- a/cosmos/log.py
+++ b/cosmos/log.py
@@ -14,6 +14,8 @@ LOG_FORMAT: str = (
     "%(log_color)s%(message)s%(reset)s"
 )
 
+LOGGER_NAME_TEMPLATE = "astronomer-cosmos-{}"
+
 
 def get_logger(name: str) -> logging.Logger:
     """
@@ -25,7 +27,7 @@ def get_logger(name: str) -> logging.Logger:
     By using this logger, we introduce a (yellow) astronomer-cosmos string into the project's log messages:
     [2023-08-09T14:20:55.532+0100] {subprocess.py:94} INFO - (astronomer-cosmos) - 13:20:55  Completed successfully
     """
-    logger = logging.getLogger(name)
+    logger = logging.getLogger(LOGGER_NAME_TEMPLATE.format(name))
     formatter: logging.Formatter = CustomTTYColoredFormatter(fmt=LOG_FORMAT)  # type: ignore
     handler = logging.StreamHandler()
     handler.setFormatter(formatter)

--- a/cosmos/log.py
+++ b/cosmos/log.py
@@ -15,7 +15,7 @@ LOG_FORMAT: str = (
 )
 
 
-def get_logger(name: str | None = None) -> logging.Logger:
+def get_logger(name: str) -> logging.Logger:
     """
     Get custom Astronomer cosmos logger.
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -6,7 +6,6 @@ from cosmos import get_provider_info
 from cosmos.log import get_logger
 
 
-
 def test_get_logger():
     custom_string = "%(purple)s(astronomer-cosmos)%(reset)s"
     standard_logger = logging.getLogger()
@@ -20,15 +19,16 @@ def test_get_logger():
     with pytest.raises(TypeError):
         # Ensure that the get_logger signature is not changed in the future
         # and name is still a required parameter
-        custom_logger = get_logger() # noqa
+        custom_logger = get_logger()  # noqa
 
     # Explicitly ensure that even if we pass None or empty string
     # we will not get root logger in any case
-    custom_logger = get_logger('')
-    assert custom_logger.name != ''
+    custom_logger = get_logger("")
+    assert custom_logger.name != ""
 
-    custom_logger = get_logger(None) # noqa
-    assert custom_logger.name != ''
+    custom_logger = get_logger(None)  # noqa
+    assert custom_logger.name != ""
+
 
 def test_propagate_logs_conf(monkeypatch):
     monkeypatch.setattr("cosmos.log.propagate_logs", False)

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -1,7 +1,10 @@
 import logging
 
+import pytest
+
 from cosmos import get_provider_info
 from cosmos.log import get_logger
+
 
 
 def test_get_logger():
@@ -14,6 +17,18 @@ def test_get_logger():
     assert custom_logger.handlers[0].formatter.__class__.__name__ == "CustomTTYColoredFormatter"
     assert custom_string in custom_logger.handlers[0].formatter._fmt
 
+    with pytest.raises(TypeError):
+        # Ensure that the get_logger signature is not changed in the future
+        # and name is still a required parameter
+        custom_logger = get_logger() # noqa
+
+    # Explicitly ensure that even if we pass None or empty string
+    # we will not get root logger in any case
+    custom_logger = get_logger('')
+    assert custom_logger.name != ''
+
+    custom_logger = get_logger(None) # noqa
+    assert custom_logger.name != ''
 
 def test_propagate_logs_conf(monkeypatch):
     monkeypatch.setattr("cosmos.log.propagate_logs", False)


### PR DESCRIPTION
Closes #1048 

## Description

After having upgraded to `astronomer-cosmos==1.4.3` we noticed an unusual 2x increase of the cost of the logs in our cloud provider. Quick investigation showed that the logs from cosmos logger were duplicated multiple times. 
**Example:**
```bash 
[2024-06-17 12:18:48,259] {{manager.py:165}} INFO - Launched DagFileProcessorManager with pid: 656
2024-06-17T12:18:48.260107549Z [2024-06-17 12:18:48,259] {manager.py:165} INFO - (astronomer-cosmos) - Launched DagFileProcessorManager with pid: 656
2024-06-17T12:18:48.260225215Z [2024-06-17 12:18:48,259] {manager.py:165} INFO - (astronomer-cosmos) - Launched DagFileProcessorManager with pid: 656
2024-06-17T12:18:48.260345799Z [2024-06-17 12:18:48,259] {manager.py:165} INFO - (astronomer-cosmos) - Launched DagFileProcessorManager with pid: 656
```

After reproducing the problem locally I've found the highest version that seemed to not have the problem, which was `1.3.2`. However, the problem repeated itself when `cosmos` was imported in the dag. Afterwards, I looked at the changed files and saw that airflow plugin was added in the 1.4.0 version. It explains why the issue reproduces in all the version, but is hidden at first in 1.3.2
```toml
[project.entry-points."airflow.plugins"]
cosmos = "cosmos.plugin:CosmosPlugin"
```

Following this discovery i looked through the source code and saw that in some of the lines the logger was initialized though function `get_logger` without the name argument. If you call `logging.getLogger(None)`, you get a root logger. Hence, cosmos adapter got attached to root logger multiple times in these places.  

```python 
def get_logger(name: str) -> logging.Logger:
    logger = logging.getLogger(None) # Now it is a root logger
    ....
    logger.addHandler(handler) # now we have added astronomer logger to root logger, which is not intented
```

## What was done

-  I made the `name` argument in `get_logger` required, otherwise it would be easy to forget to add it when a new file with logger call is created. 
- Added `LOGGER_NAME_TEMPLATE` so that there are no collisions with the adapters attaching to wrong loggers in the future. The name is not used in the actual format of the log message, so it does not matter much.

The previous tests did not catch this corner case, but when the argument is required there is no need to check it


## Related Issue(s)

No

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
