### PR TITLE
Fix AKS permission error in restricted env

### DIFF
--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -97,10 +97,8 @@ def _get_latest_partial_parse(dbt_project_path: Path, cache_dir: Path) -> Path |
     return None
 
 
-def _copy(src, dst, *, follow_symlinks=True):
-    """
-    Copy a file from `src` to `dst` and preserve metadata if possible.
-    """
+def _copy(src: str, dst: str, *, follow_symlinks: bool = True) -> None:
+    """Copy a file from `src` to `dst` and preserve metadata if possible."""
     # Handle destination as directory
     if os.path.isdir(dst):
         dst = os.path.join(dst, os.path.basename(src))

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import os
 import shutil
 from pathlib import Path
 
@@ -97,25 +96,6 @@ def _get_latest_partial_parse(dbt_project_path: Path, cache_dir: Path) -> Path |
     return None
 
 
-def _copy(src: str, dst: str, *, follow_symlinks: bool = True) -> None:
-    """Copy a file from `src` to `dst` and preserve metadata if possible."""
-    # Handle destination as directory
-    if os.path.isdir(dst):
-        dst = os.path.join(dst, os.path.basename(src))
-    # shutil.copy includes permission copying via chmod.
-    # If the user lacks permission to run chmod, a PermissionError occurs.
-    # To avoid this, we split the operation into two steps:
-    # first, copy the file contents; then, copy metadata if feasible without raising exceptions.
-    # Step 1: Copy file contents (no metadata)
-    shutil.copyfile(src, dst, follow_symlinks=follow_symlinks)
-
-    try:
-        # Step 2: Copy file metadata (permission bits and other metadata)
-        shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
-    except PermissionError:
-        logger.info("Failed to copy the partial parse file metadata")
-
-
 def _update_partial_parse_cache(latest_partial_parse_filepath: Path, cache_dir: Path) -> None:
     """
     Update the cache to have the latest partial parse file contents.
@@ -127,8 +107,8 @@ def _update_partial_parse_cache(latest_partial_parse_filepath: Path, cache_dir: 
     manifest_path = get_partial_parse_path(cache_dir).parent / DBT_MANIFEST_FILE_NAME
     latest_manifest_filepath = latest_partial_parse_filepath.parent / DBT_MANIFEST_FILE_NAME
 
-    _copy(str(latest_partial_parse_filepath), str(cache_path))
-    _copy(str(latest_manifest_filepath), str(manifest_path))
+    shutil.copyfile(str(latest_partial_parse_filepath), str(cache_path))
+    shutil.copyfile(str(latest_manifest_filepath), str(manifest_path))
 
 
 def patch_partial_parse_content(partial_parse_filepath: Path, project_path: Path) -> bool:

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import shutil
 from pathlib import Path
 
@@ -96,6 +97,27 @@ def _get_latest_partial_parse(dbt_project_path: Path, cache_dir: Path) -> Path |
     return None
 
 
+def _copy(src, dst, *, follow_symlinks=True):
+    """
+    Copy a file from `src` to `dst` and preserve metadata if possible.
+    """
+    # Handle destination as directory
+    if os.path.isdir(dst):
+        dst = os.path.join(dst, os.path.basename(src))
+    # shutil.copy includes permission copying via chmod.
+    # If the user lacks permission to run chmod, a PermissionError occurs.
+    # To avoid this, we split the operation into two steps:
+    # first, copy the file contents; then, copy metadata if feasible without raising exceptions.
+    # Step 1: Copy file contents (no metadata)
+    shutil.copyfile(src, dst, follow_symlinks=follow_symlinks)
+
+    try:
+        # Step 2: Copy file metadata (permission bits and other metadata)
+        shutil.copystat(src, dst, follow_symlinks=follow_symlinks)
+    except PermissionError:
+        logger.info("Failed to copy the partial parse file metadata")
+
+
 def _update_partial_parse_cache(latest_partial_parse_filepath: Path, cache_dir: Path) -> None:
     """
     Update the cache to have the latest partial parse file contents.
@@ -107,8 +129,8 @@ def _update_partial_parse_cache(latest_partial_parse_filepath: Path, cache_dir: 
     manifest_path = get_partial_parse_path(cache_dir).parent / DBT_MANIFEST_FILE_NAME
     latest_manifest_filepath = latest_partial_parse_filepath.parent / DBT_MANIFEST_FILE_NAME
 
-    shutil.copy(str(latest_partial_parse_filepath), str(cache_path))
-    shutil.copy(str(latest_manifest_filepath), str(manifest_path))
+    _copy(str(latest_partial_parse_filepath), str(cache_path))
+    _copy(str(latest_manifest_filepath), str(manifest_path))
 
 
 def patch_partial_parse_content(partial_parse_filepath: Path, project_path: Path) -> bool:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,4 +1,5 @@
 import logging
+import os
 import shutil
 import tempfile
 import time
@@ -10,7 +11,7 @@ import pytest
 from airflow import DAG
 from airflow.utils.task_group import TaskGroup
 
-from cosmos.cache import _copy_partial_parse_to_project, _create_cache_identifier, _get_latest_partial_parse
+from cosmos.cache import _copy, _copy_partial_parse_to_project, _create_cache_identifier, _get_latest_partial_parse
 from cosmos.constants import DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME
 
 START_DATE = datetime(2024, 4, 16)
@@ -86,3 +87,23 @@ def test__copy_partial_parse_to_project_msg_fails_msgpack(mock_unpack, tmp_path,
         _copy_partial_parse_to_project(partial_parse_filepath, Path(tmp_dir))
 
     assert "Unable to patch the partial_parse.msgpack file due to ValueError()" in caplog.text
+
+
+def test_copy_file_to_directory():
+    """Test copying a file to an existing directory."""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        src_file = os.path.join(tmpdir, "source.txt")
+        dst_dir = os.path.join(tmpdir, "destination")
+        os.makedirs(dst_dir)
+
+        # Create a source file
+        with open(src_file, "w") as f:
+            f.write("Test content")
+
+        # Call _copy function
+        _copy(src_file, dst_dir)
+
+        # Verify that the file was copied to the destination directory
+        assert os.path.isfile(os.path.join(dst_dir, "source.txt"))
+        with open(Path(dst_dir) / "source.txt") as f:
+            assert f.read() == "Test content"

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,5 +1,4 @@
 import logging
-import os
 import shutil
 import tempfile
 import time
@@ -11,7 +10,7 @@ import pytest
 from airflow import DAG
 from airflow.utils.task_group import TaskGroup
 
-from cosmos.cache import _copy, _copy_partial_parse_to_project, _create_cache_identifier, _get_latest_partial_parse
+from cosmos.cache import _copy_partial_parse_to_project, _create_cache_identifier, _get_latest_partial_parse
 from cosmos.constants import DBT_PARTIAL_PARSE_FILE_NAME, DBT_TARGET_DIR_NAME
 
 START_DATE = datetime(2024, 4, 16)
@@ -87,23 +86,3 @@ def test__copy_partial_parse_to_project_msg_fails_msgpack(mock_unpack, tmp_path,
         _copy_partial_parse_to_project(partial_parse_filepath, Path(tmp_dir))
 
     assert "Unable to patch the partial_parse.msgpack file due to ValueError()" in caplog.text
-
-
-def test_copy_file_to_directory():
-    """Test copying a file to an existing directory."""
-    with tempfile.TemporaryDirectory() as tmpdir:
-        src_file = os.path.join(tmpdir, "source.txt")
-        dst_dir = os.path.join(tmpdir, "destination")
-        os.makedirs(dst_dir)
-
-        # Create a source file
-        with open(src_file, "w") as f:
-            f.write("Test content")
-
-        # Call _copy function
-        _copy(src_file, dst_dir)
-
-        # Verify that the file was copied to the destination directory
-        assert os.path.isfile(os.path.join(dst_dir, "source.txt"))
-        with open(Path(dst_dir) / "source.txt") as f:
-            assert f.read() == "Test content"


### PR DESCRIPTION
## Description
~shutil.copy includes permission copying via chmod.
If the user lacks permission to run chmod, a PermissionError occurs.
To avoid this, we split the operation into two steps:
first, copy the file contents; then, copy metadata if feasible without raising exceptions.
Step 1: Copy file contents (no metadata)
Step 2: Copy file metadata (permission bits and other metadata) without raising exception~

use shutil.copyfile(...) instead of shutil.copy(...) to avoid running chmod

## Related Issue(s)

closes: https://github.com/astronomer/astronomer-cosmos/issues/1008

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
