### PR TITLE
[Bug fix] Add CSP header to iframe contents

### DIFF
--- a/cosmos/plugin/__init__.py
+++ b/cosmos/plugin/__init__.py
@@ -208,7 +208,7 @@ class DbtDocsView(AirflowBaseView):
 
     @expose("/dbt_docs_index.html")  # type: ignore[misc]
     @has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE)])
-    def dbt_docs_index(self) -> str:
+    def dbt_docs_index(self) -> Tuple[str, int, Dict[str, Any]]:
         if dbt_docs_dir is None:
             abort(404)
         try:
@@ -219,7 +219,7 @@ class DbtDocsView(AirflowBaseView):
             # Hack the dbt docs to render properly in an iframe
             iframe_resizer_url = url_for(".static", filename="iframeResizer.contentWindow.min.js")
             html = html.replace("</head>", f'{iframe_script}<script src="{iframe_resizer_url}"></script></head>', 1)
-            return html
+            return html, 200, {"Content-Security-Policy": "frame-ancestors 'self'"}
 
     @expose("/catalog.json")  # type: ignore[misc]
     @has_access([(permissions.ACTION_CAN_READ, permissions.RESOURCE_WEBSITE)])


### PR DESCRIPTION
**This should be released as part of 1.5**. 😃

## Description

There was a bug in some environments relating to the lack of a CSP header explicitly allowing for same-origin iframes to render `dbt_docs_index.html`.

@joppevos and I were able to fix this issue and confirm that it works by adding `Content-Security-Policy: frame-ancestors 'self';` to the response header for `dbt_docs_index.html`.

Discussion here: https://apache-airflow.slack.com/archives/C059CC42E9W/p1718807254386149

