### PR TITLE
Cache hatch folder in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, ci-cache-hatch]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -66,7 +66,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -120,7 +120,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -190,7 +190,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -252,7 +252,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: integration-sqlite-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -326,7 +326,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: integration-dbt-1-5-4-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
@@ -399,7 +399,7 @@ jobs:
         with:
           path: |
             ~/.cache/pip
-            .nox
+            .local/share/hatch/
           key: perf-test-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, ci-cache-hatch]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 


### PR DESCRIPTION
As part of the CI build, we create a Python virtual environment with the dependencies necessary to run the tests.

Currently, we recreate this environment variable every time a Github Action job is run.
This PR caches the folder hatch and stores the Python virtualenv.

It seems to have helped to reduce a bit, although the jobs are still very slow:
- Unit tests execution from ~[2:40](https://github.com/astronomer/astronomer-cosmos/actions/runs/9550554350/job/26322778438) to [~2:25](https://github.com/astronomer/astronomer-cosmos/actions/runs/9598977261/job/26471650029)
- Integration tests execution from [~11:07](https://github.com/astronomer/astronomer-cosmos/actions/runs/9550554350/job/26322894839) to [~10:27](https://github.com/astronomer/astronomer-cosmos/actions/runs/9598977261/job/26471677561)

