### PR TITLE
Add ability to specify host/port for Snowflake connection

### DIFF
--- a/cosmos/profiles/snowflake/user_pass.py
+++ b/cosmos/profiles/snowflake/user_pass.py
@@ -40,6 +40,8 @@ class SnowflakeUserPasswordProfileMapping(BaseProfileMapping):
         "warehouse": "extra.warehouse",
         "schema": "schema",
         "role": "extra.role",
+        "host": "extra.host",
+        "port": "extra.port",
     }
 
     def can_claim_connection(self) -> bool:

--- a/tests/profiles/snowflake/test_snowflake_user_pass.py
+++ b/tests/profiles/snowflake/test_snowflake_user_pass.py
@@ -231,3 +231,27 @@ def test_appends_region() -> None:
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
         }
+
+
+def test_appends_host_and_port() -> None:
+    """
+    Tests that host/port extras are appended to the connection settings.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_connection",
+        conn_type="snowflake",
+        login="my_user",
+        password="my_password",
+        schema="my_schema",
+        extra=json.dumps(
+            {
+                "host": "snowflake.localhost.localstack.cloud",
+                "port": 4566,
+            }
+        ),
+    )
+
+    with patch("airflow.hooks.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakeUserPasswordProfileMapping(conn)
+        assert profile_mapping.profile["host"] == "snowflake.localhost.localstack.cloud"
+        assert profile_mapping.profile["port"] == 4566


### PR DESCRIPTION
## Description

Add ability to specify `host`/`port` for Snowflake connection.

**Motivation:** At LocalStack, we have recently started building a Snowflake emulator that allows running SF queries entirely on the local machine: https://blog.localstack.cloud/2024-05-22-introducing-localstack-for-snowflake/ . As part of a sample application we're building, we have an Apache Airflow DAG that uses Cosmos (and DBT) to connect to the local Snowflake emulator running on `localhost`. Here is a link to the sample app: https://github.com/localstack-samples/localstack-snowflake-samples/pull/12

Currently, we're hardcoding this integration in the user DAG file itself, [see here](https://github.com/localstack-samples/localstack-snowflake-samples/pull/12/files#diff-559d4f883ad589522b8a9d33f87fe95b0da72ac29b775e98b273a8eb3ede9924R10-R19):
```
...
from cosmos.profiles.snowflake.user_pass import SnowflakeUserPasswordProfileMapping
...
SnowflakeUserPasswordProfileMapping.airflow_param_mapping["host"] = "extra.host"
SnowflakeUserPasswordProfileMapping.airflow_param_mapping["port"] = "extra.port"
...
```

It would be awesome if this integration was provided by Cosmos out of the box! Looking forward to getting your feedback..

**TODO:** Please let me know where is the best place to add a description to these new attributes, happy to add a short note in the docs! Thanks 🙌 

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
