### PR TITLE
[Docs]: Fix rendering for env enable_cache_dbt_ls

### DIFF
--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -30,7 +30,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE``
 
-.. enable_cache_dbt_ls:
+.. _enable_cache_dbt_ls:
 
 `enable_cache_dbt_ls`_:
     Enable or disable caching of the dbt ls command in case using ``LoadMode.DBT_LS`` in an Airflow Variable.


### PR DESCRIPTION
## Description

Look like rendering for conf `enable_cache_dbt_ls` is broken in docs

**Before change**
<img width="834" alt="Screenshot 2024-06-27 at 1 36 27 AM" src="https://github.com/astronomer/astronomer-cosmos/assets/98807258/38565e3c-0b23-4764-936a-be40c53c0a00">

**After change**

<img width="815" alt="Screenshot 2024-06-27 at 1 37 09 AM" src="https://github.com/astronomer/astronomer-cosmos/assets/98807258/1c301d6a-c233-440d-801f-f9475435fc69">


## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
