### PR TITLE
Teradata Profile Mapping Issue - Credentials in profile "generated_profile", target "dev" invalid: Runtime Error     Must specify `schema` in Teradata profile

### DIFF
--- a/cosmos/profiles/teradata/user_pass.py
+++ b/cosmos/profiles/teradata/user_pass.py
@@ -49,3 +49,10 @@ class TeradataUserPasswordProfileMapping(BaseProfileMapping):
             profile["schema"] = profile["user"]
 
         return self.filter_null(profile)
+
+    @property
+    def mock_profile(self) -> dict[str, Any | None]:
+        """Gets mock profile. Assigning user to schema as default"""
+        mock_profile = super().mock_profile
+        mock_profile["schema"] = mock_profile["user"]
+        return mock_profile

--- a/tests/profiles/teradata/test_teradata_user_pass.py
+++ b/tests/profiles/teradata/test_teradata_user_pass.py
@@ -96,6 +96,12 @@ def test_profile_mapping_selected(
     assert isinstance(profile_mapping, TeradataUserPasswordProfileMapping)
 
 
+def test_profile_mapping_schema_validation(mock_teradata_conn: Connection) -> None:
+    # port is not handled in airflow connection so adding it as profile_args
+    profile = TeradataUserPasswordProfileMapping(mock_teradata_conn.conn_id)
+    assert profile.profile["schema"] == "my_user"
+
+
 def test_profile_mapping_keeps_port(mock_teradata_conn: Connection) -> None:
     # port is not handled in airflow connection so adding it as profile_args
     profile = TeradataUserPasswordProfileMapping(mock_teradata_conn.conn_id, profile_args={"port": 1025})
@@ -174,3 +180,6 @@ def test_mock_profile() -> None:
     """
     profile = TeradataUserPasswordProfileMapping("mock_conn_id")
     assert profile.mock_profile.get("host") == "mock_value"
+    assert profile.mock_profile.get("user") == "mock_value"
+    assert profile.mock_profile.get("password") == "mock_value"
+    assert profile.mock_profile.get("schema") == "mock_value"


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
TeradataUserPassword profile mapping throwing below error for mock profile
`Credentials in profile "generated_profile", target "dev" invalid: Runtime Error     Must specify schema in Teradata profile`

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes https://github.com/astronomer/astronomer-cosmos/issues/1087
## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
