### PR TITLE
Fix issue 'No such file or directory'

### DIFF
--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -230,9 +230,12 @@ def _create_folder_version_hash(dir_path: Path) -> str:
         filepaths.extend(paths)
 
     for filepath in sorted(filepaths):
-        with open(str(filepath), "rb") as fp:
-            buf = fp.read()
-            hasher.update(buf)
+        try:
+            with open(str(filepath), "rb") as fp:
+                buf = fp.read()
+                hasher.update(buf)
+        except FileNotFoundError:
+            logger.debug(f"Skipping invalid path {filepath}")
 
     return hasher.hexdigest()
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,6 +15,7 @@ from airflow.utils.task_group import TaskGroup
 from cosmos.cache import (
     _copy_partial_parse_to_project,
     _create_cache_identifier,
+    _create_folder_version_hash,
     _get_latest_partial_parse,
     _get_or_create_profile_cache_dir,
     _update_partial_parse_cache,
@@ -98,6 +99,38 @@ def test__copy_partial_parse_to_project_msg_fails_msgpack(mock_unpack, tmp_path,
         _copy_partial_parse_to_project(partial_parse_filepath, Path(tmp_dir))
 
     assert "Unable to patch the partial_parse.msgpack file due to ValueError()" in caplog.text
+
+
+def test__create_folder_version_hash(tmp_path, caplog):
+    """
+    Test that Cosmos is still able to create the hash of a dbt project folder even when
+    there is a symbolic link referencing a no longer existing file.
+
+    This test addresses the issue:
+    https://github.com/astronomer/astronomer-cosmos/issues/1096
+    """
+    caplog.set_level(logging.INFO)
+
+    # Create a source folder with two files
+    source_dir = tmp_path / "original_dbt_folder"
+    source_dir.mkdir()
+    file_1 = Path(source_dir / "file_1.sql")
+    file_1.touch()
+    file_2 = Path(source_dir / "file_2.sql")
+    file_2.touch()
+
+    # Create a target folder with symbolic links to the two files in the source folder
+    target_dir = tmp_path / "cosmos_dbt_folder"
+    target_dir.mkdir()
+    file_1_symlink = Path(target_dir / "file_1.sql")
+    file_1_symlink.symlink_to(file_1)
+    file_2_symlink = Path(target_dir / "file_2.sql")
+    file_2_symlink.symlink_to(file_2)
+
+    # Delete one of the original files from the source folder
+    file_1.unlink()
+
+    _create_folder_version_hash(target_dir)
 
 
 @patch("cosmos.cache.shutil.copyfile")


### PR DESCRIPTION
Two Astronomer customers reported issues while trying to upgrade to Cosmos 1.5:

```
No such file or directory "/usr/local/aiflow/dags/dbt/dbt_venv/bin/python"
```

The issue is that their dbt project folder had a symbolic link to a file that no longer existed. When Cosmos attempted to iterate over that directory to create a hash representing the cache version, it could not open the file referenced by the symbolic link.

This PR reproduces the issue and fixes the behaviour. Users are also advised to check if there are any broken sym links on their dbt folder and delete them.

Closes: #1096