### PR TITLE
Change Cosmos dev status from alpha to prod

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ requires-python = ">=3.8"
 authors = [{ name = "Astronomer", email = "humans@astronomer.io" }]
 keywords = ["airflow", "apache-airflow", "astronomer", "dags", "dbt"]
 classifiers = [
-    "Development Status :: 3 - Alpha",
+    "Development Status :: 5 - Production/Stable",
     "Environment :: Web Environment",
     "Framework :: Apache Airflow",
     "Framework :: Apache Airflow :: Provider",


### PR DESCRIPTION
Cosmos 1.0 was released almost a year ago. I know at least 70 companies are using it in production, and we are seeing nearly a million downloads per month in PyPI. I believe it's safe to change the project status from alpha to prod.