### PR TITLE
Install requirements.txt by default during dev env spin up

### DIFF
--- a/dev/Dockerfile
+++ b/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/astronomer/astro-runtime:11.3.0-base
+FROM quay.io/astronomer/astro-runtime:11.6.0-base
 
 USER root
 
@@ -15,9 +15,11 @@ RUN pip install -U uv
 COPY ./pyproject.toml  ${AIRFLOW_HOME}/astronomer_cosmos/
 COPY ./README.rst  ${AIRFLOW_HOME}/astronomer_cosmos/
 COPY ./cosmos/  ${AIRFLOW_HOME}/astronomer_cosmos/cosmos/
-
+COPY ./dev/requirements.txt ${AIRFLOW_HOME}/requirements.txt
 # install the package in editable mode
-RUN uv pip install --system -e "${AIRFLOW_HOME}/astronomer_cosmos"[dbt-postgres,dbt-databricks]
+RUN uv pip install --system -e "${AIRFLOW_HOME}/astronomer_cosmos"[dbt-postgres,dbt-databricks] && \
+    uv pip install --system -r ${AIRFLOW_HOME}/requirements.txt
+
 
 # make sure astro user owns the package
 RUN chown -R astro:astro ${AIRFLOW_HOME}/astronomer_cosmos


### PR DESCRIPTION
## Description

I bumped the astronomer image to 11.6 since it uses the newest airflow, incorporating [tatiana's change in airflow version](https://github.com/apache/airflow/pull/39670) for datasets and I am installing requirements.txt by default in the image, since if the user wants to add some custom package, he needs to change not only the requirements.txt file but also the Dockerfile. With this only adding dependencies to requirements.txt will already install them in the image for dev development. 

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
