### PR TITLE
Use `dbt ls` as the default parser when profile_config is provided

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -323,7 +323,6 @@ class DbtGraph:
                 if self.profile_config and self.project_path:
                     try:
                         self.load_via_dbt_ls()
-                        logger.info("Using DBT ls")
                     except FileNotFoundError:
                         self.load_via_custom_parser()
                 else:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -320,9 +320,10 @@ class DbtGraph:
             if self.project.is_manifest_available():
                 self.load_from_dbt_manifest()
             else:
-                if self.profile_config:
+                if self.profile_config and self.project_path:
                     try:
                         self.load_via_dbt_ls()
+                        logger.info("Using DBT ls")
                     except FileNotFoundError:
                         self.load_via_custom_parser()
                 else:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -320,7 +320,7 @@ class DbtGraph:
             if self.project.is_manifest_available():
                 self.load_from_dbt_manifest()
             else:
-                if execution_mode == ExecutionMode.LOCAL and self.profile_config:
+                if self.profile_config:
                     try:
                         self.load_via_dbt_ls()
                     except FileNotFoundError:

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -369,9 +369,9 @@ def test_load_manifest_with_manifest(mock_load_from_dbt_manifest):
     "exec_mode,method,expected_function",
     [
         (ExecutionMode.LOCAL, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
-        (ExecutionMode.VIRTUALENV, LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
-        (ExecutionMode.KUBERNETES, LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
-        (ExecutionMode.DOCKER, LoadMode.AUTOMATIC, "mock_load_via_custom_parser"),
+        (ExecutionMode.VIRTUALENV, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
+        (ExecutionMode.KUBERNETES, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
+        (ExecutionMode.DOCKER, LoadMode.AUTOMATIC, "mock_load_via_dbt_ls"),
         (ExecutionMode.LOCAL, LoadMode.DBT_LS, "mock_load_via_dbt_ls"),
         (ExecutionMode.LOCAL, LoadMode.CUSTOM, "mock_load_via_custom_parser"),
     ],


### PR DESCRIPTION
## Description

The `load_via_custom_parser` method is not very effective 
when it comes to filtering. Currently, if the ExecutionMode 
is not Local, we always use load_via_custom_parser to parse 
the dbt project. However, I believe it's beneficial to utilize DBT LS 
whenever it's available. This PR remove the check if the 
execution mode is ExecutionMode.LOCAL before `load_via_dbt_ls`


## Related Issue(s)

Related: https://github.com/astronomer/astronomer-cosmos/issues/943

## Breaking Change?

I believe no :) 

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
