### PR TITLE
Fix some docs typo

### DIFF
--- a/docs/getting_started/azure-container-instance.rst
+++ b/docs/getting_started/azure-container-instance.rst
@@ -1,4 +1,4 @@
-.. _azure-container-instance
+.. _azure-container-instance:
 
 Azure Container Instance Execution Mode
 =======================================

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -11,6 +11,7 @@
    Execution Modes <execution-modes>
    Docker Execution Mode <docker>
    Kubernetes Execution Mode <kubernetes>
+   Azure Container Instance Execution Mode <azure-container-instance>
    dbt and Airflow Similar Concepts <dbt-airflow-concepts>
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,7 +45,7 @@ You can render a Cosmos Airflow DAG using the ``DbtDag`` class. Here's an exampl
 ..
    The following renders in Sphinx but not Github:
 
-.. literalinclude:: ./dev/dags/basic_cosmos_dag.py
+.. literalinclude:: ./../dev/dags/basic_cosmos_dag.py
     :language: python
     :start-after: [START local_example]
     :end-before: [END local_example]


### PR DESCRIPTION
## Description

- Fix the example rendering 
- Azure container instance reference 
- Add Azure Container Instance Execution Mode on the index page

## Related Issue(s)

No

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
