### PR TITLE
Add support for loading manifest from cloud store using Airflow Object Store

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, 448-remote-manifest-support]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, 448-remote-manifest-support]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, 448-remote-manifest-support]
+    branches: [main, "448-remote-manifest-support"]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -143,6 +143,9 @@ jobs:
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           DATABRICKS_HOST: mock
           DATABRICKS_WAREHOUSE_ID: mock
           DATABRICKS_TOKEN: mock
@@ -213,6 +216,9 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           AIRFLOW_CONN_DATABRICKS_DEFAULT: ${{ secrets.AIRFLOW_CONN_DATABRICKS_DEFAULT }}
           DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
@@ -275,6 +281,9 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
@@ -348,6 +357,9 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, "448-remote-manifest-support"]
+    branches: [main, 448-remote-manifest-support]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -10,9 +10,12 @@ from dataclasses import InitVar, dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterator
 
+from airflow.version import version as airflow_version
+
 from cosmos.cache import create_cache_profile, get_cached_profile, is_profile_cache_enabled
 from cosmos.constants import (
     DEFAULT_PROFILES_FILE_NAME,
+    FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP,
     DbtResourceType,
     ExecutionMode,
     InvocationMode,
@@ -24,6 +27,7 @@ from cosmos.dbt.executable import get_system_dbt
 from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
 from cosmos.profiles import BaseProfileMapping
+from cosmos.settings import AIRFLOW_IO_AVAILABLE
 
 logger = get_logger(__name__)
 
@@ -150,6 +154,7 @@ class ProjectConfig:
         seeds_relative_path: str | Path = "seeds",
         snapshots_relative_path: str | Path = "snapshots",
         manifest_path: str | Path | None = None,
+        manifest_conn_id: str | None = None,
         project_name: str | None = None,
         env_vars: dict[str, str] | None = None,
         dbt_vars: dict[str, str] | None = None,
@@ -175,7 +180,25 @@ class ProjectConfig:
                 self.project_name = self.dbt_project_path.stem
 
         if manifest_path:
-            self.manifest_path = Path(manifest_path)
+            manifest_path_str = str(manifest_path)
+            if not manifest_conn_id:
+                manifest_scheme = manifest_path_str.split("://")[0]
+                # Use the default Airflow connection ID for the scheme if it is not provided.
+                manifest_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(manifest_scheme, None)
+
+            if manifest_conn_id is not None and not AIRFLOW_IO_AVAILABLE:
+                raise CosmosValueError(
+                    f"The manifest path {manifest_path_str} uses a remote file scheme, but the required Object "
+                    f"Storage feature is unavailable in Airflow version {airflow_version}. Please upgrade to "
+                    f"Airflow 2.8 or later."
+                )
+
+            if AIRFLOW_IO_AVAILABLE:
+                from airflow.io.path import ObjectStoragePath
+
+                self.manifest_path = ObjectStoragePath(manifest_path_str, conn_id=manifest_conn_id)
+            else:
+                self.manifest_path = Path(manifest_path_str)
 
         self.env_vars = env_vars
         self.dbt_vars = dbt_vars
@@ -196,24 +219,21 @@ class ProjectConfig:
         if self.dbt_project_path:
             project_yml_path = self.dbt_project_path / "dbt_project.yml"
             mandatory_paths = {
-                "dbt_project.yml": project_yml_path,
-                "models directory ": self.models_path,
+                "dbt_project.yml": Path(project_yml_path) if project_yml_path else None,
+                "models directory ": Path(self.models_path) if self.models_path else None,
             }
         if self.manifest_path:
             mandatory_paths["manifest"] = self.manifest_path
 
         for name, path in mandatory_paths.items():
-            if path is None or not Path(path).exists():
+            if path is None or not path.exists():
                 raise CosmosValueError(f"Could not find {name} at {path}")
 
     def is_manifest_available(self) -> bool:
         """
         Check if the `dbt` project manifest is set and if the file exists.
         """
-        if not self.manifest_path:
-            return False
-
-        return self.manifest_path.exists()
+        return self.manifest_path.exists() if self.manifest_path else False
 
 
 @dataclass

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -215,7 +215,12 @@ class ProjectConfig:
         """
 
         mandatory_paths = {}
-
+        # We validate the existence of paths added to the `mandatory_paths` map by calling the `exists()` method on each
+        # one. Starting with Cosmos 1.6.0, if the Airflow version is `>= 2.8.0` and a `manifest_path` is provided, we
+        # cast it to an `airflow.io.path.ObjectStoragePath` instance during `ProjectConfig` initialisation, and it
+        # includes the `exists()` method. For the remaining paths in the `mandatory_paths` map, we cast them to
+        # `pathlib.Path` objects to ensure that the subsequent `exists()` call while iterating on the `mandatory_paths`
+        # map works correctly for all paths, thereby validating the project.
         if self.dbt_project_path:
             project_yml_path = self.dbt_project_path / "dbt_project.yml"
             mandatory_paths = {

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import aenum
 from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 from airflow.providers.google.cloud.hooks.gcs import GCSHook
-from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
+from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from packaging.version import Version
 
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
@@ -38,7 +38,7 @@ ABFS_FILE_SCHEME = "abfs"
 FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP = {
     S3_FILE_SCHEME: S3Hook.default_conn_name,
     GS_FILE_SCHEME: GCSHook.default_conn_name,
-    ABFS_FILE_SCHEME: AzureDataLakeHook.default_conn_name,
+    ABFS_FILE_SCHEME: WasbHook.default_conn_name,
 }
 
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -3,6 +3,9 @@ from enum import Enum
 from pathlib import Path
 
 import aenum
+from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+from airflow.providers.google.cloud.hooks.gcs import GCSHook
+from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeHook
 from packaging.version import Version
 
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
@@ -26,6 +29,17 @@ OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
 # Cosmos will not emit datasets for the following Airflow versions, due to a breaking change that's fixed in later Airflow 2.x versions
 # https://github.com/apache/airflow/issues/39486
 PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS = [Version("2.9.0"), Version("2.9.1")]
+
+
+S3_FILE_SCHEME = "s3"
+GS_FILE_SCHEME = "gs"
+ABFS_FILE_SCHEME = "abfs"
+
+FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP = {
+    S3_FILE_SCHEME: S3Hook.default_conn_name,
+    GS_FILE_SCHEME: GCSHook.default_conn_name,
+    ABFS_FILE_SCHEME: AzureDataLakeHook.default_conn_name,
+}
 
 
 class LoadMode(Enum):

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -613,7 +613,7 @@ class DbtGraph:
         nodes = {}
 
         if TYPE_CHECKING:
-            assert self.project.manifest_path is not None
+            assert self.project.manifest_path is not None  # pragma: no cover
 
         with self.project.manifest_path.open() as fp:
             manifest = json.load(fp)

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from subprocess import PIPE, Popen
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from airflow.models import Variable
 
@@ -611,7 +611,11 @@ class DbtGraph:
             raise CosmosLoadDbtException("Unable to load manifest without ExecutionConfig.dbt_project_path")
 
         nodes = {}
-        with open(self.project.manifest_path) as fp:  # type: ignore[arg-type]
+
+        if TYPE_CHECKING:
+            assert self.project.manifest_path is not None
+
+        with self.project.manifest_path.open() as fp:
             manifest = json.load(fp)
 
             resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -4,6 +4,8 @@ from pathlib import Path
 
 import airflow
 from airflow.configuration import conf
+from airflow.version import version as airflow_version
+from packaging.version import Version
 
 from cosmos.constants import DEFAULT_COSMOS_CACHE_DIR_NAME, DEFAULT_OPENLINEAGE_NAMESPACE
 
@@ -24,3 +26,5 @@ try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
 except airflow.exceptions.AirflowConfigException:
     LINEAGE_NAMESPACE = os.getenv("OPENLINEAGE_NAMESPACE", DEFAULT_OPENLINEAGE_NAMESPACE)
+
+AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -55,19 +55,19 @@ def cosmos_manifest_example() -> None:
     # [END local_example]
 
     # [START aws_s3_example]
-    aws_s3_example = DbtTaskGroup(
-        group_id="aws_s3_example",
-        project_config=ProjectConfig(
-            manifest_path="s3://cosmos-manifest-test/manifest.json",
-            manifest_conn_id="aws_s3_conn",
-            # `manifest_conn_id` is optional. If not provided, the default connection ID `aws_default` is used.
-            project_name="jaffle_shop",
-        ),
-        profile_config=profile_config,
-        render_config=render_config,
-        execution_config=execution_config,
-        operator_args={"install_deps": True},
-    )
+    # aws_s3_example = DbtTaskGroup(
+    #     group_id="aws_s3_example",
+    #     project_config=ProjectConfig(
+    #         manifest_path="s3://cosmos-manifest-test/manifest.json",
+    #         manifest_conn_id="aws_s3_conn",
+    #         # `manifest_conn_id` is optional. If not provided, the default connection ID `aws_default` is used.
+    #         project_name="jaffle_shop",
+    #     ),
+    #     profile_config=profile_config,
+    #     render_config=render_config,
+    #     execution_config=execution_config,
+    #     operator_args={"install_deps": True},
+    # )
     # [END aws_s3_example]
 
     # [START gcp_gs_example]
@@ -104,7 +104,9 @@ def cosmos_manifest_example() -> None:
 
     post_dbt = EmptyOperator(task_id="post_dbt")
 
-    (pre_dbt >> local_example >> aws_s3_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
+    # (pre_dbt >> local_example >> aws_s3_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
+
+    (pre_dbt >> local_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
 
 
 cosmos_manifest_example()

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -55,19 +55,19 @@ def cosmos_manifest_example() -> None:
     # [END local_example]
 
     # [START aws_s3_example]
-    # aws_s3_example = DbtTaskGroup(
-    #     group_id="aws_s3_example",
-    #     project_config=ProjectConfig(
-    #         manifest_path="s3://cosmos-manifest-test/manifest.json",
-    #         manifest_conn_id="aws_s3_conn",
-    #         # `manifest_conn_id` is optional. If not provided, the default connection ID `aws_default` is used.
-    #         project_name="jaffle_shop",
-    #     ),
-    #     profile_config=profile_config,
-    #     render_config=render_config,
-    #     execution_config=execution_config,
-    #     operator_args={"install_deps": True},
-    # )
+    aws_s3_example = DbtTaskGroup(
+        group_id="aws_s3_example",
+        project_config=ProjectConfig(
+            manifest_path="s3://cosmos-manifest-test/manifest.json",
+            manifest_conn_id="aws_s3_conn",
+            # `manifest_conn_id` is optional. If not provided, the default connection ID `aws_default` is used.
+            project_name="jaffle_shop",
+        ),
+        profile_config=profile_config,
+        render_config=render_config,
+        execution_config=execution_config,
+        operator_args={"install_deps": True},
+    )
     # [END aws_s3_example]
 
     # [START gcp_gs_example]
@@ -104,9 +104,7 @@ def cosmos_manifest_example() -> None:
 
     post_dbt = EmptyOperator(task_id="post_dbt")
 
-    # (pre_dbt >> local_example >> aws_s3_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
-
-    (pre_dbt >> local_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
+    (pre_dbt >> local_example >> aws_s3_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
 
 
 cosmos_manifest_example()

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -34,7 +34,6 @@ When you don't supply an argument to the ``load_mode`` parameter (or you supply 
 
 To use this method, you don't need to supply any additional config. This is the default.
 
-.. _manifest_parsing:
 
 ``dbt_manifest``
 ----------------
@@ -69,8 +68,8 @@ using the following command: ``pip install "astronomer-cosmos[amazon]"``
 
 .. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
     :language: python
-    :start-after: [START s3_example]
-    :end-before: [END s3_example]
+    :start-after: [START aws_s3_example]
+    :end-before: [END aws_s3_example]
 
 - GCP GCS URL:
 
@@ -79,8 +78,8 @@ using the following command: ``pip install "astronomer-cosmos[google]"``
 
 .. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
     :language: python
-    :start-after: [START gcs_example]
-    :end-before: [END gcs_example]
+    :start-after: [START gcp_gs_example]
+    :end-before: [END gcp_gs_example]
 
 - Azure Blob Storage URL:
 

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -61,7 +61,7 @@ Examples of how to supply ``manifest.json`` using ``manifest_path`` argument:
     :start-after: [START local_example]
     :end-before: [END local_example]
 
-- AWS S3 URL:
+- AWS S3 URL (available since Cosmos 1.6):
 
 Ensure that you have the required dependencies installed to use the S3 URL. You can install the required dependencies
 using the following command: ``pip install "astronomer-cosmos[amazon]"``
@@ -71,7 +71,7 @@ using the following command: ``pip install "astronomer-cosmos[amazon]"``
     :start-after: [START aws_s3_example]
     :end-before: [END aws_s3_example]
 
-- GCP GCS URL:
+- GCP GCS URL (available since Cosmos 1.6):
 
 Ensure that you have the required dependencies installed to use the GCS URL. You can install the required dependencies
 using the following command: ``pip install "astronomer-cosmos[google]"``
@@ -81,7 +81,7 @@ using the following command: ``pip install "astronomer-cosmos[google]"``
     :start-after: [START gcp_gs_example]
     :end-before: [END gcp_gs_example]
 
-- Azure Blob Storage URL:
+- Azure Blob Storage URL (available since Cosmos 1.6):
 
 Ensure that you have the required dependencies installed to use the Azure blob URL. You can install the required
 dependencies using the following command: ``pip install "astronomer-cosmos[microsoft]"``

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -34,6 +34,8 @@ When you don't supply an argument to the ``load_mode`` parameter (or you supply 
 
 To use this method, you don't need to supply any additional config. This is the default.
 
+.. _manifest_parsing:
+
 ``dbt_manifest``
 ----------------
 
@@ -41,19 +43,55 @@ If you already have a ``manifest.json`` file created by dbt, Cosmos will parse t
 
 You can supply a ``manifest_path`` parameter on the DbtDag / DbtTaskGroup with a path to a ``manifest.json`` file.
 
-To use this:
+Before Cosmos 1.6.0, the path to ``manifest.json`` supplied via the ``DbtDag`` / ``DbtTaskGroup`` ``manifest_path``
+argument accepted only local paths. However, starting with Cosmos 1.6.0, if you've Airflow >= 2.8.0, you can supply a
+a remote path (e.g., an S3 URL) too. For supporting remote paths, Cosmos leverages the
+`Airflow Object Storage <https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/objectstorage.html>`_
+feature released in Airflow 2.8.0.
+For remote paths, you can specify a ``manifest_conn_id``, which is an
+Airflow connection ID containing the credentials to access the remote path. If you do not specify a
+``manifest_conn_id``, Cosmos will use the default connection ID specific to the scheme, identified using the Airflow
+hook's ``default_conn_id`` corresponding to the URL's scheme.
 
-.. code-block:: python
+Examples of how to supply ``manifest.json`` using ``manifest_path`` argument:
 
-    DbtDag(
-        project_config=ProjectConfig(
-            manifest_path="/path/to/manifest.json",
-        ),
-        render_config=RenderConfig(
-            load_method=LoadMode.DBT_MANIFEST,
-        ),
-        # ...,
-    )
+- Local path:
+
+.. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
+    :language: python
+    :start-after: [START local_example]
+    :end-before: [END local_example]
+
+- AWS S3 URL:
+
+Ensure that you have the required dependencies installed to use the S3 URL. You can install the required dependencies
+using the following command: ``pip install "astronomer-cosmos[amazon]"``
+
+.. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
+    :language: python
+    :start-after: [START s3_example]
+    :end-before: [END s3_example]
+
+- GCP GCS URL:
+
+Ensure that you have the required dependencies installed to use the GCS URL. You can install the required dependencies
+using the following command: ``pip install "astronomer-cosmos[google]"``
+
+.. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
+    :language: python
+    :start-after: [START gcs_example]
+    :end-before: [END gcs_example]
+
+- Azure Blob Storage URL:
+
+Ensure that you have the required dependencies installed to use the Azure blob URL. You can install the required
+dependencies using the following command: ``pip install "astronomer-cosmos[microsoft]"``
+
+.. literalinclude:: ../../dev/dags/cosmos_manifest_example.py
+    :language: python
+    :start-after: [START azure_abfs_example]
+    :end-before: [END azure_abfs_example]
+
 
 ``dbt_ls``
 ----------

--- a/docs/configuration/project-config.rst
+++ b/docs/configuration/project-config.rst
@@ -12,7 +12,8 @@ variables that should be used for rendering and execution. It takes the followin
 - ``snapshots_relative_path``: The path to your snapshots directory, relative to the ``dbt_project_path``. This defaults
   to ``snapshots/``
 - ``manifest_path``: The absolute path to your manifests directory. This is only required if you're using Cosmos' manifest
-  parsing mode
+  parsing mode. Alongwith supporting local paths for manifest parsing, starting with Cosmos 1.6.0, if you've
+  Airflow >= 2.8.0, Cosmos also supports remote paths for manifest parsing(e.g. S3 URL). See :ref:`manifest-parsing` for more details.
 - ``project_name`` : The name of the project. If ``dbt_project_path`` is provided, the ``project_name`` defaults to the
   folder name containing ``dbt_project.yml``. If ``dbt_project_path`` is not provided, and ``manifest_path`` is provided,
   ``project_name`` is required as the name can not be inferred from ``dbt_project_path``

--- a/docs/configuration/project-config.rst
+++ b/docs/configuration/project-config.rst
@@ -12,8 +12,8 @@ variables that should be used for rendering and execution. It takes the followin
 - ``snapshots_relative_path``: The path to your snapshots directory, relative to the ``dbt_project_path``. This defaults
   to ``snapshots/``
 - ``manifest_path``: The absolute path to your manifests directory. This is only required if you're using Cosmos' manifest
-  parsing mode. Alongwith supporting local paths for manifest parsing, starting with Cosmos 1.6.0, if you've
-  Airflow >= 2.8.0, Cosmos also supports remote paths for manifest parsing(e.g. S3 URL). See :ref:`manifest-parsing` for more details.
+  parsing mode. Along with supporting local paths for manifest parsing, starting with Cosmos 1.6.0, if you've
+  Airflow >= 2.8.0, Cosmos also supports remote paths for manifest parsing(e.g. S3 URL). See :ref:`parsing-methods` for more details.
 - ``project_name`` : The name of the project. If ``dbt_project_path`` is provided, the ``project_name`` defaults to the
   folder name containing ``dbt_project.yml``. If ``dbt_project_path`` is not provided, and ``manifest_path`` is provided,
   ``project_name`` is required as the name can not be inferred from ``dbt_project_path``

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,6 @@
 aenum
 apache-airflow
-apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0 # https://github.com/apache/airflow/issues/39103
+apache-airflow-providers-amazon[s3fs]>=3.0.0
 apache-airflow-providers-cncf-kubernetes>=5.1.1
 apache-airflow-providers-google
 apache-airflow-providers-microsoft-azure

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,6 +1,9 @@
 aenum
 apache-airflow
+apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0 # https://github.com/apache/airflow/issues/39103
 apache-airflow-providers-cncf-kubernetes>=5.1.1
+apache-airflow-providers-google
+apache-airflow-providers-microsoft-azure
 google-re2==1.1
 msgpack
 openlineage-airflow

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dbt-teradata = ["dbt-teradata"]
 dbt-vertica = ["dbt-vertica<=1.5.4"]
 openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
 amazon = [
-    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0",
 ]
 google = ["apache-airflow-providers-google"]
 microsoft = ["apache-airflow-providers-microsoft-azure"]
@@ -106,7 +106,7 @@ kubernetes = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
 ]
 aws_eks = [
-    "apache-airflow-providers-amazon>=8.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon>=8.0.0",
 ]
 azure-container-instance = [
     "apache-airflow-providers-microsoft-azure>=8.4.0",
@@ -140,7 +140,7 @@ packages = ["/cosmos"]
 dependencies = [
     "astronomer-cosmos[tests]",
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
-    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0",
     "apache-airflow-providers-docker>=3.5.0",
     "apache-airflow-providers-google",
     "apache-airflow-providers-microsoft-azure",
@@ -189,7 +189,7 @@ markers = ["integration", "sqlite", "perf"]
 [tool.hatch.envs.docs]
 dependencies = [
     "aenum",
-    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0",
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
     "apache-airflow-providers-google",
     "apache-airflow-providers-microsoft-azure",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -129,7 +129,7 @@ packages = ["/cosmos"]
 dependencies = [
     "astronomer-cosmos[tests]",
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
-    "apache-airflow-providers-amazon>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
     "apache-airflow-providers-docker>=3.5.0",
     "apache-airflow-providers-google",
     "apache-airflow-providers-microsoft-azure",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,7 +66,18 @@ dbt-spark = ["dbt-spark"]
 dbt-teradata = ["dbt-teradata"]
 dbt-vertica = ["dbt-vertica<=1.5.4"]
 openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
-all = ["astronomer-cosmos[dbt-all]", "astronomer-cosmos[openlineage]"]
+amazon = [
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+]
+google = ["apache-airflow-providers-google"]
+microsoft = ["apache-airflow-providers-microsoft-azure"]
+all = [
+    "astronomer-cosmos[dbt-all]",
+    "astronomer-cosmos[openlineage]",
+    "astronomer-cosmos[amazon]",
+    "astronomer-cosmos[google]",
+    "astronomer-cosmos[microsoft]",
+]
 docs = [
     "sphinx",
     "pydata-sphinx-theme",
@@ -178,7 +189,10 @@ markers = ["integration", "sqlite", "perf"]
 [tool.hatch.envs.docs]
 dependencies = [
     "aenum",
+    "apache-airflow-providers-amazon[s3fs]>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
+    "apache-airflow-providers-google",
+    "apache-airflow-providers-microsoft-azure",
     "msgpack",
     "openlineage-airflow",
     "pydantic>=1.10.0",

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -298,3 +298,36 @@ def test_execution_config_with_invocation_option(execution_mode, invocation_mode
 def test_execution_config_default_config(execution_mode, expected_invocation_mode):
     execution_config = ExecutionConfig(execution_mode=execution_mode)
     assert execution_config.invocation_mode == expected_invocation_mode
+
+
+@pytest.mark.parametrize(
+    "manifest_path, given_manifest_conn_id, used_manifest_conn_id",
+    [
+        ("s3://cosmos-manifest-test/manifest.json", None, "aws_default"),
+        ("s3://cosmos-manifest-test/manifest.json", "aws_s3_conn", "aws_s3_conn"),
+        ("gs://cosmos-manifest-test/manifest.json", None, "google_cloud_default"),
+        ("gs://cosmos-manifest-test/manifest.json", "gcp_gs_conn", "gcp_gs_conn"),
+        ("abfs://cosmos-manifest-test/manifest.json", None, "wasb_default"),
+        ("abfs://cosmos-manifest-test/manifest.json", "azure_abfs_conn", "azure_abfs_conn"),
+    ],
+)
+def test_remote_manifest_path(manifest_path, given_manifest_conn_id, used_manifest_conn_id):
+    if AIRFLOW_IO_AVAILABLE:
+        project_config = ProjectConfig(
+            dbt_project_path="/tmp/some-path", manifest_path=manifest_path, manifest_conn_id=given_manifest_conn_id
+        )
+
+        from airflow.io.path import ObjectStoragePath
+
+        assert project_config.manifest_path == ObjectStoragePath(manifest_path, conn_id=used_manifest_conn_id)
+    else:
+        from airflow.version import version as airflow_version
+
+        error_msg = (
+            f"The manifest path {manifest_path} uses a remote file scheme, but the required Object Storage feature is "
+            f"unavailable in Airflow version {airflow_version}. Please upgrade to Airflow 2.8 or later."
+        )
+        with pytest.raises(CosmosValueError, match=error_msg):
+            _ = ProjectConfig(
+                dbt_project_path="/tmp/some-path", manifest_path=manifest_path, manifest_conn_id=given_manifest_conn_id
+            )

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -9,6 +9,7 @@ from cosmos.constants import ExecutionMode, InvocationMode
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.athena.access_key import AthenaAccessKeyProfileMapping
 from cosmos.profiles.postgres.user_pass import PostgresUserPasswordProfileMapping
+from cosmos.settings import AIRFLOW_IO_AVAILABLE
 
 DBT_PROJECTS_ROOT_DIR = Path(__file__).parent / "sample/"
 SAMPLE_PROFILE_YML = Path(__file__).parent / "sample/profiles.yml"
@@ -35,7 +36,12 @@ def test_init_with_manifest_path_and_project_path_succeeds():
     project_name in this case should be based on dbt_project_path
     """
     project_config = ProjectConfig(dbt_project_path="/tmp/some-path", manifest_path="target/manifest.json")
-    assert project_config.manifest_path == Path("target/manifest.json")
+    if AIRFLOW_IO_AVAILABLE:
+        from airflow.io.path import ObjectStoragePath
+
+        assert project_config.manifest_path == ObjectStoragePath("target/manifest.json")
+    else:
+        assert project_config.manifest_path == Path("target/manifest.json")
     assert project_config.project_name == "some-path"
 
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -27,6 +27,7 @@ AIRFLOW_VERSION = Version(airflow.__version__)
 
 MIN_VER_DAG_FILE: dict[str, list[str]] = {
     "2.4": ["cosmos_seed_dag.py"],
+    "2.8": ["cosmos_manifest_example.py"],
 }
 
 IGNORED_DAG_FILES = ["performance_dag.py"]

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -19,6 +19,7 @@ DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
 
 MIN_VER_DAG_FILE: dict[str, list[str]] = {
     "2.4": ["cosmos_seed_dag.py"],
+    "2.8": ["cosmos_manifest_example.py"],
 }
 
 IGNORED_DAG_FILES = ["performance_dag.py"]


### PR DESCRIPTION
## Summary

This PR introduces the capability to load `manifest.json` files from various cloud storage services using Airflow's Object Store integration. The supported cloud storages include AWS S3, Google Cloud Storage (GCS), and Azure Blob Storage. The feature allows seamless integration with remote paths, providing enhanced flexibility and scalability for managing DBT projects.

### Key Changes

1. Parameters in DbtDag and DbtTaskGroup:
`manifest_path`: Accepts both local paths and remote URLs (e.g., S3, GCS, Azure Blob Storage).
`manifest_conn_id`: (Optional) An Airflow connection ID for accessing the remote path.
2. Automatic Detection of Storage Type:
The system automatically identifies the storage service based on the scheme of the URL provided (e.g., s3://, gs://, abfs://) by integrating with Airflow Object Store
3. If a `manifest_conn_id` is provided, it is used to fetch the necessary credentials.
4. If no `manifest_conn_id` is provided, the default connection ID for the identified scheme is used.

### Validation and Error Handling

1. Validates the existence of the `manifest.json` file when a path is specified.
2. Raises appropriate errors if a remote `manifest_path` is given but the required min Airflow version 2.8(Object Store feature) support is not available.


### Backward Compatibility
Ensures compatibility with existing workflows that use local paths for the manifest.json.


### How to Use

1. Local Path:
```
DbtDag(
    project_config=ProjectConfig(
        manifest_path="/path/to/local/manifest.json",
    ),
    ...
)
```
2. Remote Path (e.g., S3):
```
DbtDag(
    project_config=ProjectConfig(
        manifest_path="s3://bucket/path/to/manifest.json",
        manifest_conn_id="aws_s3_conn",
    ),
    ...
)
```
3.  Remote Path without Explicit Connection ID:
```
DbtDag(
    project_config=ProjectConfig(
        manifest_path="gs://bucket/path/to/manifest.json",
        # No manifest_conn_id provided, will use default Airflow GCS connection `google_cloud_default`
    ),
    ...
)
```


### Additional Notes

1. Ensure that the required Airflow version (2.8 or later) is used to take advantage of the Object Store features.
2. Review the updated documentation for detailed usage instructions and examples.


### Testing

1. Added unit tests to cover various scenarios including local paths, remote paths with and without manifest_conn_id.
2. Verified integration with different cloud storage services (AWS S3, GCS, Azure Blob Storage).
3. Ensured backward compatibility with existing local path workflows.

## Related Issue(s)

closes: https://github.com/astronomer/astronomer-cosmos/issues/448

## Breaking Change?
No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
