### PR TITLE
Remove upper bound for the amazon provider to test in CI

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ kubernetes = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
 ]
 aws_eks = [
-    "apache-airflow-providers-amazon>=8.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon>=8.0.0",
 ]
 azure-container-instance = [
     "apache-airflow-providers-microsoft-azure>=8.4.0",
@@ -129,7 +129,7 @@ packages = ["/cosmos"]
 dependencies = [
     "astronomer-cosmos[tests]",
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
-    "apache-airflow-providers-amazon>=3.0.0,<8.20.0", # https://github.com/apache/airflow/issues/39103
+    "apache-airflow-providers-amazon>=3.0.0",
     "apache-airflow-providers-docker>=3.5.0",
     "apache-airflow-providers-google",
     "apache-airflow-providers-microsoft-azure",


### PR DESCRIPTION
We previously had pinned the apache-airflow-amazon-provider version 
in PR #944 due to the issue https://github.com/apache/airflow/issues/39103 which has gotten [resolved](https://github.com/apache/airflow/issues/39103#issuecomment-2104729821). 
Hence, remove the upper bound.