### PR TITLE
[CI] Disable test for Airflow-2.5 and Python-3.11 combination

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"
+          - python-version: "3.11"
+            airflow-version: "2.5"
           # Apache Airflow versions prior to 2.9.0 have not been tested with Python 3.12.
           # Official support for Python 3.12 and the corresponding constraints.txt are available only for Apache Airflow >= 2.9.0.
           # See: https://github.com/apache/airflow/tree/2.9.0?tab=readme-ov-file#requirements
@@ -100,6 +102,8 @@ jobs:
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"
+          - python-version: "3.11"
+            airflow-version: "2.5"
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
## Description
We noticed in PR https://github.com/astronomer/astronomer-cosmos/pull/1107 that tests are failing with errors
```
    TIMEZONE = pendulum.tz.timezone("UTC")
E   TypeError: 'module' object is not callable
```
Found that this is happening because pendulum upgrade and CI is not using the constraints file.
This PR disabled the test for Airflow2.5 and Python3.11 combination because constraints does not exist this.

CI Job success: https://github.com/astronomer/astronomer-cosmos/actions/runs/10139381920
CI Job failure: https://github.com/astronomer/astronomer-cosmos/actions/runs/10136915016/
Airflow 2.5 constraints: https://github.com/apache/airflow/tree/constraints-2-5


## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
