### PR TITLE
Fix import handling by lazy loading hooks introduced in PR #1109

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -184,7 +184,7 @@ class ProjectConfig:
             if not manifest_conn_id:
                 manifest_scheme = manifest_path_str.split("://")[0]
                 # Use the default Airflow connection ID for the scheme if it is not provided.
-                manifest_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(manifest_scheme, None)
+                manifest_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(manifest_scheme, lambda: None)()
 
             if manifest_conn_id is not None and not AIRFLOW_IO_AVAILABLE:
                 raise CosmosValueError(

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -29,7 +29,6 @@ OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
 PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS = [Version("2.9.0"), Version("2.9.1")]
 
 
-ABFS_FILE_SCHEME = "abfs"
 
 
 def _default_s3_conn() -> str:

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -29,8 +29,6 @@ OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
 PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS = [Version("2.9.0"), Version("2.9.1")]
 
 
-
-
 def _default_s3_conn() -> str:
     from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -1,7 +1,7 @@
 import os
 from enum import Enum
 from pathlib import Path
-from typing import Dict, Callable
+from typing import Callable, Dict
 
 import aenum
 from packaging.version import Version
@@ -34,29 +34,28 @@ ABFS_FILE_SCHEME = "abfs"
 
 def _default_s3_conn() -> str:
     from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-    return S3Hook.default_conn_name
+
+    return S3Hook.default_conn_name  # type: ignore[no-any-return]
 
 
 def _default_gcs_conn() -> str:
     from airflow.providers.google.cloud.hooks.gcs import GCSHook
-    return GCSHook.default_conn_name
+
+    return GCSHook.default_conn_name  # type: ignore[no-any-return]
 
 
 def _default_wasb_conn() -> str:
     from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
-    return WasbHook.default_conn_name
 
-
-def _default_abfs_conn() -> str:
-    from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeStorageV2Hook
-    return AzureDataLakeStorageV2Hook.default_conn_name
+    return WasbHook.default_conn_name  # type: ignore[no-any-return]
 
 
 FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP: Dict[str, Callable[[], str]] = {
     "s3": _default_s3_conn,
     "gs": _default_gcs_conn,
-    "wasb": _default_wasb_conn,
-    "abfs": _default_abfs_conn,
+    "adl": _default_wasb_conn,
+    "abfs": _default_wasb_conn,
+    "abfss": _default_wasb_conn,
 }
 
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -1,11 +1,9 @@
 import os
 from enum import Enum
 from pathlib import Path
+from typing import Dict, Callable
 
 import aenum
-from airflow.providers.amazon.aws.hooks.s3 import S3Hook
-from airflow.providers.google.cloud.hooks.gcs import GCSHook
-from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 from packaging.version import Version
 
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
@@ -31,14 +29,34 @@ OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
 PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS = [Version("2.9.0"), Version("2.9.1")]
 
 
-S3_FILE_SCHEME = "s3"
-GS_FILE_SCHEME = "gs"
 ABFS_FILE_SCHEME = "abfs"
 
-FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP = {
-    S3_FILE_SCHEME: S3Hook.default_conn_name,
-    GS_FILE_SCHEME: GCSHook.default_conn_name,
-    ABFS_FILE_SCHEME: WasbHook.default_conn_name,
+
+def _default_s3_conn() -> str:
+    from airflow.providers.amazon.aws.hooks.s3 import S3Hook
+    return S3Hook.default_conn_name
+
+
+def _default_gcs_conn() -> str:
+    from airflow.providers.google.cloud.hooks.gcs import GCSHook
+    return GCSHook.default_conn_name
+
+
+def _default_wasb_conn() -> str:
+    from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
+    return WasbHook.default_conn_name
+
+
+def _default_abfs_conn() -> str:
+    from airflow.providers.microsoft.azure.hooks.data_lake import AzureDataLakeStorageV2Hook
+    return AzureDataLakeStorageV2Hook.default_conn_name
+
+
+FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP: Dict[str, Callable[[], str]] = {
+    "s3": _default_s3_conn,
+    "gs": _default_gcs_conn,
+    "wasb": _default_wasb_conn,
+    "abfs": _default_abfs_conn,
 }
 
 


### PR DESCRIPTION
## Description

Making an update to #1109, which introduced module-level imports of optional dependencies. This is inappropriate as it will break if the user does not have them installed, and indeed the user really does not need them installed if they are not relying on them directly.

This PR lazy-loads the imports so that it does not impact users who do not need them.

Additionally, the scheme added for Azure only supported the Azure Data Lake Storage V2 protocol and not the (legacy, but also I believe more common?) `wasb://` protocol, which I added. Additionally, the `conn_id` was being pulled from the wrong hook for the `abfs://` scheme. This is not just nitpicking, as the default `conn_id` for each hook is actually different: the `conn_id` that corresponds with the `abfs://` scheme is `adls_default`, whereas for the `wasb://` scheme it is `wasb_default`.

**This PR should be merged before releasing `1.6` to prevent breaking anyone's environments. 😄** Sorry to sound the **bold** alarms, but this one is actually pretty important.