### PR TITLE
Extend Cosmos custom selector to support + when using paths and tags

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -35,6 +35,10 @@ class GraphSelector:
         +model_d+
         2+model_e
         model_f+3
+        +/path/to/model_g+
+        path:/path/to/model_h+
+        +tag:nightly
+        +config.materialized:view
 
     https://docs.getdbt.com/reference/node-selection/graph-operators
     """

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -155,20 +155,21 @@ class GraphSelector:
         # Index nodes by name, we can improve performance by doing this once
         # for multiple GraphSelectors
         if PATH_SELECTOR in self.node_name:
-            path_selection = self.node_name[len(PATH_SELECTOR):]
+            path_selection = self.node_name[len(PATH_SELECTOR) :]
 
             for node_id, node in nodes.items():
                 if path_selection in str(node.file_path):
                     root_nodes.add(node_id)
 
         elif TAG_SELECTOR in self.node_name:
-            tag_selection = self.node_name[len(TAG_SELECTOR):]
+            tag_selection = self.node_name[len(TAG_SELECTOR) :]
 
             for node_id, node in nodes.items():
                 if tag_selection in node.tags:
                     root_nodes.add(node_id)
 
-        elif CONFIG_SELECTOR in self.node_name: ...
+        elif CONFIG_SELECTOR in self.node_name:
+            ...
 
         else:
             node_by_name = {}

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -163,7 +163,32 @@ class GraphSelector:
             root_nodes.update({node_id for node_id, node in nodes.items() if tag_selection in node.tags})
 
         elif CONFIG_SELECTOR in self.node_name:
-            ...
+            config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
+            if config_selection_key not in SUPPORTED_CONFIG:
+                logger.warning("Unsupported config key selector: %s", config_selection_key)
+
+            # currently tags, materialized, and schema are the only supported config keys
+            # logic is separated into two conditions because the config 'tags' contains a
+            # list of tags, but the config 'materialized', and 'schema' contain strings
+            elif config_selection_key == "tags":
+                root_nodes.update(
+                    {
+                        node_id
+                        for node_id, node in nodes.items()
+                        if config_selection_value in node.config.get(config_selection_key, [])
+                    }
+                )
+            elif config_selection_key in (
+                "materialized",
+                "schema",
+            ):
+                root_nodes.update(
+                    {
+                        node_id
+                        for node_id, node in nodes.items()
+                        if config_selection_value == node.config.get(config_selection_key, "")
+                    }
+                )
 
         else:
             node_by_name = {}

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -237,8 +237,8 @@ class SelectorConfig:
             regex_match = re.search(GRAPH_SELECTOR_REGEX, item)
             if regex_match:
                 precursors, node_name, descendants = regex_match.groups()
-
-                if precursors or descendants:
+                if node_name is None: ...
+                elif precursors or descendants:
                     self._parse_unknown_selector(item)
                 elif node_name.startswith(PATH_SELECTOR):
                     self._parse_path_selector(item)

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -156,17 +156,11 @@ class GraphSelector:
         # for multiple GraphSelectors
         if PATH_SELECTOR in self.node_name:
             path_selection = self.node_name[len(PATH_SELECTOR) :]
-
-            for node_id, node in nodes.items():
-                if path_selection in str(node.file_path):
-                    root_nodes.add(node_id)
+            root_nodes.update({node_id for node_id, node in nodes.items() if path_selection in str(node.file_path)})
 
         elif TAG_SELECTOR in self.node_name:
             tag_selection = self.node_name[len(TAG_SELECTOR) :]
-
-            for node_id, node in nodes.items():
-                if tag_selection in node.tags:
-                    root_nodes.add(node_id)
+            root_nodes.update({node_id for node_id, node in nodes.items() if tag_selection in node.tags})
 
         elif CONFIG_SELECTOR in self.node_name:
             ...

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -237,7 +237,8 @@ class SelectorConfig:
             regex_match = re.search(GRAPH_SELECTOR_REGEX, item)
             if regex_match:
                 precursors, node_name, descendants = regex_match.groups()
-                if node_name is None: ...
+                if node_name is None:
+                    ...
                 elif precursors or descendants:
                     self._parse_unknown_selector(item)
                 elif node_name.startswith(PATH_SELECTOR):

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -479,6 +479,22 @@ def test_should_include_node_without_depends_on(selector_config):
                 "model.dbt-proj.sibling2",
             ],
         ),
+        (
+            ["1+config.tags:deprecated"],
+            [
+                "model.dbt-proj.parent",
+                "model.dbt-proj.sibling1",
+                "model.dbt-proj.sibling2",
+            ],
+        ),
+        (
+            ["config.materialized:table+"],
+            [
+                "model.dbt-proj.child",
+                "model.dbt-proj.sibling1",
+                "model.dbt-proj.sibling2",
+            ],
+        ),
     ],
 )
 def test_select_using_graph_operators(select_statement, expected):

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -432,3 +432,34 @@ def test_should_include_node_without_depends_on(selector_config):
     selector = NodeSelector({}, selector_config)
     selector.visited_nodes = set()
     selector._should_include_node(node.unique_id, node)
+
+
+def test_select_upstream_nodes_with_select_path():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+path:gen2/models"])
+    expected = [
+        "model.dbt-proj.another_grandparent_node",
+        "model.dbt-proj.grandparent",
+        "model.dbt-proj.parent",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_select_downstream_nodes_with_select_path():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models+"])
+    expected = [
+        "model.dbt-proj.child",
+        "model.dbt-proj.parent",
+        "model.dbt-proj.sibling1",
+        "model.dbt-proj.sibling2",
+    ]
+    assert sorted(selected.keys()) == expected
+
+
+def test_select_upstream_nodes_with_select_tag():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["1+tag:deprecated"])
+    expected = [
+        "model.dbt-proj.parent",
+        "model.dbt-proj.sibling1",
+        "model.dbt-proj.sibling2",
+    ]
+    assert sorted(selected.keys()) == expected

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -191,6 +191,14 @@ def test_select_nodes_by_select_path():
     assert selected == expected
 
 
+def test_select_nodes_with_slash_but_no_path_selector():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["gen2/models"])
+    expected = {
+        parent_node.unique_id: parent_node,
+    }
+    assert selected == expected
+
+
 def test_select_nodes_by_select_union():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["tag:has_child", "tag:nightly"])
     expected = {

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -434,32 +434,53 @@ def test_should_include_node_without_depends_on(selector_config):
     selector._should_include_node(node.unique_id, node)
 
 
-def test_select_upstream_nodes_with_select_path():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+path:gen2/models"])
-    expected = [
-        "model.dbt-proj.another_grandparent_node",
-        "model.dbt-proj.grandparent",
-        "model.dbt-proj.parent",
-    ]
-    assert sorted(selected.keys()) == expected
-
-
-def test_select_downstream_nodes_with_select_path():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models+"])
-    expected = [
-        "model.dbt-proj.child",
-        "model.dbt-proj.parent",
-        "model.dbt-proj.sibling1",
-        "model.dbt-proj.sibling2",
-    ]
-    assert sorted(selected.keys()) == expected
-
-
-def test_select_upstream_nodes_with_select_tag():
-    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["1+tag:deprecated"])
-    expected = [
-        "model.dbt-proj.parent",
-        "model.dbt-proj.sibling1",
-        "model.dbt-proj.sibling2",
-    ]
+@pytest.mark.parametrize(
+    "select_statement, expected",
+    [
+        (
+            ["+path:gen2/models"],
+            [
+                "model.dbt-proj.another_grandparent_node",
+                "model.dbt-proj.grandparent",
+                "model.dbt-proj.parent",
+            ],
+        ),
+        (
+            ["path:gen2/models+"],
+            [
+                "model.dbt-proj.child",
+                "model.dbt-proj.parent",
+                "model.dbt-proj.sibling1",
+                "model.dbt-proj.sibling2",
+            ],
+        ),
+        (
+            ["gen2/models+"],
+            [
+                "model.dbt-proj.child",
+                "model.dbt-proj.parent",
+                "model.dbt-proj.sibling1",
+                "model.dbt-proj.sibling2",
+            ],
+        ),
+        (
+            ["+gen2/models"],
+            [
+                "model.dbt-proj.another_grandparent_node",
+                "model.dbt-proj.grandparent",
+                "model.dbt-proj.parent",
+            ],
+        ),
+        (
+            ["1+tag:deprecated"],
+            [
+                "model.dbt-proj.parent",
+                "model.dbt-proj.sibling1",
+                "model.dbt-proj.sibling2",
+            ],
+        ),
+    ],
+)
+def test_select_using_graph_operators(select_statement, expected):
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=select_statement)
     assert sorted(selected.keys()) == expected


### PR DESCRIPTION
## Description

This PR resolves #1141 where dbt projects loaded with DBT_MANIFEST were unable to parse using the GraphSelector.

Changes:
- updated GraphSelector to take into account path and tag dbt selector methods
- update SelectorConfig to use regex to parse selection statement to handle graph and path statements

ToDo:
- ~add tests covering change~
- ~enable config dbt selector method~
- refactor

## Related Issue(s)

closes #1141
closes #823 

## Breaking Change? No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
