### PR TITLE
Proposal for different fix to 2.10 regression

### DIFF
--- a/cosmos/operators/aws_eks.py
+++ b/cosmos/operators/aws_eks.py
@@ -79,17 +79,11 @@ class DbtBuildAwsEksOperator(DbtAwsEksBaseOperator, DbtBuildKubernetesOperator):
         DbtAwsEksBaseOperator.template_fields + DbtBuildKubernetesOperator.template_fields  # type: ignore[operator]
     )
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtLSAwsEksOperator(DbtAwsEksBaseOperator, DbtLSKubernetesOperator):
     """
     Executes a dbt core ls command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtSeedAwsEksOperator(DbtAwsEksBaseOperator, DbtSeedKubernetesOperator):
@@ -101,26 +95,17 @@ class DbtSeedAwsEksOperator(DbtAwsEksBaseOperator, DbtSeedKubernetesOperator):
         DbtAwsEksBaseOperator.template_fields + DbtSeedKubernetesOperator.template_fields  # type: ignore[operator]
     )
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSnapshotAwsEksOperator(DbtAwsEksBaseOperator, DbtSnapshotKubernetesOperator):
     """
     Executes a dbt core snapshot command.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSourceAzureContainerInstanceOperator(DbtAwsEksBaseOperator, DbtSourceKubernetesOperator):
     """
     Executes a dbt source freshness command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtRunAwsEksOperator(DbtAwsEksBaseOperator, DbtRunKubernetesOperator):
@@ -132,9 +117,6 @@ class DbtRunAwsEksOperator(DbtAwsEksBaseOperator, DbtRunKubernetesOperator):
         DbtAwsEksBaseOperator.template_fields + DbtRunKubernetesOperator.template_fields  # type: ignore[operator]
     )
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtTestAwsEksOperator(DbtAwsEksBaseOperator, DbtTestKubernetesOperator):
     """
@@ -145,9 +127,6 @@ class DbtTestAwsEksOperator(DbtAwsEksBaseOperator, DbtTestKubernetesOperator):
         DbtAwsEksBaseOperator.template_fields + DbtTestKubernetesOperator.template_fields  # type: ignore[operator]
     )
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtRunOperationAwsEksOperator(DbtAwsEksBaseOperator, DbtRunOperationKubernetesOperator):
     """
@@ -157,6 +136,3 @@ class DbtRunOperationAwsEksOperator(DbtAwsEksBaseOperator, DbtRunOperationKubern
     template_fields: Sequence[str] = (
         DbtAwsEksBaseOperator.template_fields + DbtRunOperationKubernetesOperator.template_fields  # type: ignore[operator]
     )
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -82,9 +82,6 @@ class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceB
     Executes a dbt core ls command.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
     """
@@ -95,9 +92,6 @@ class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInsta
 
     template_fields: Sequence[str] = DbtAzureContainerInstanceBaseOperator.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
     """
@@ -105,17 +99,11 @@ class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContai
 
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSourceAzureContainerInstanceOperator(DbtSourceMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt source freshness command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
@@ -124,9 +112,6 @@ class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanc
     """
 
     template_fields: Sequence[str] = DbtAzureContainerInstanceBaseOperator.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtTestAzureContainerInstanceOperator(DbtTestMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
@@ -152,6 +137,3 @@ class DbtRunOperationAzureContainerInstanceOperator(DbtRunOperationMixin, DbtAzu
     template_fields: Sequence[str] = (
         DbtAzureContainerInstanceBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
     )
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -267,7 +267,7 @@ class AbstractDbtBaseOperator(BaseOperator, metaclass=ABCMeta):
         self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
 
 
-class DbtBuildMixin:
+class DbtBuildMixin(BaseOperator, metaclass=ABCMeta):
     """Mixin for dbt build command."""
 
     base_cmd = ["build"]
@@ -294,7 +294,7 @@ class DbtBuildMixin:
         return flags
 
 
-class DbtLSMixin:
+class DbtLSMixin(BaseOperator, metaclass=ABCMeta):
     """
     Executes a dbt core ls command.
     """
@@ -303,7 +303,7 @@ class DbtLSMixin:
     ui_color = "#DBCDF6"
 
 
-class DbtSeedMixin:
+class DbtSeedMixin(BaseOperator, metaclass=ABCMeta):
     """
     Mixin for dbt seed operation command.
 
@@ -334,14 +334,14 @@ class DbtSeedMixin:
         return flags
 
 
-class DbtSnapshotMixin:
+class DbtSnapshotMixin(BaseOperator, metaclass=ABCMeta):
     """Mixin for a dbt snapshot command."""
 
     base_cmd = ["snapshot"]
     ui_color = "#964B00"
 
 
-class DbtSourceMixin:
+class DbtSourceMixin(BaseOperator, metaclass=ABCMeta):
     """
     Executes a dbt source freshness command.
     """
@@ -350,7 +350,7 @@ class DbtSourceMixin:
     ui_color = "#34CCEB"
 
 
-class DbtRunMixin:
+class DbtRunMixin(BaseOperator, metaclass=ABCMeta):
     """
     Mixin for dbt run command.
 
@@ -382,26 +382,14 @@ class DbtRunMixin:
         return flags
 
 
-class DbtTestMixin:
+class DbtTestMixin(BaseOperator, metaclass=ABCMeta):
     """Mixin for dbt test command."""
 
     base_cmd = ["test"]
     ui_color = "#8194E0"
 
-    def __init__(
-        self,
-        exclude: str | None = None,
-        select: str | None = None,
-        selector: str | None = None,
-        **kwargs: Any,
-    ) -> None:
-        self.select = select
-        self.exclude = exclude
-        self.selector = selector
-        super().__init__(exclude=exclude, select=select, selector=selector, **kwargs)  # type: ignore
 
-
-class DbtRunOperationMixin:
+class DbtRunOperationMixin(BaseOperator, metaclass=ABCMeta):
     """
     Mixin for dbt run operation command.
 

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -69,17 +69,11 @@ class DbtBuildDockerOperator(DbtBuildMixin, DbtDockerBaseOperator):
 
     template_fields: Sequence[str] = DbtDockerBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtLSDockerOperator(DbtLSMixin, DbtDockerBaseOperator):
     """
     Executes a dbt core ls command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtSeedDockerOperator(DbtSeedMixin, DbtDockerBaseOperator):
@@ -91,26 +85,17 @@ class DbtSeedDockerOperator(DbtSeedMixin, DbtDockerBaseOperator):
 
     template_fields: Sequence[str] = DbtDockerBaseOperator.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSnapshotDockerOperator(DbtSnapshotMixin, DbtDockerBaseOperator):
     """
     Executes a dbt core snapshot command.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSourceDockerOperator(DbtSourceMixin, DbtDockerBaseOperator):
     """
     Executes a dbt source freshness command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtRunDockerOperator(DbtRunMixin, DbtDockerBaseOperator):
@@ -119,9 +104,6 @@ class DbtRunDockerOperator(DbtRunMixin, DbtDockerBaseOperator):
     """
 
     template_fields: Sequence[str] = DbtDockerBaseOperator.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtTestDockerOperator(DbtTestMixin, DbtDockerBaseOperator):
@@ -145,6 +127,3 @@ class DbtRunOperationDockerOperator(DbtRunOperationMixin, DbtDockerBaseOperator)
     """
 
     template_fields: Sequence[str] = DbtDockerBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -102,17 +102,11 @@ class DbtBuildKubernetesOperator(DbtBuildMixin, DbtKubernetesBaseOperator):
 
     template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtLSKubernetesOperator(DbtLSMixin, DbtKubernetesBaseOperator):
     """
     Executes a dbt core ls command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtSeedKubernetesOperator(DbtSeedMixin, DbtKubernetesBaseOperator):
@@ -122,26 +116,17 @@ class DbtSeedKubernetesOperator(DbtSeedMixin, DbtKubernetesBaseOperator):
 
     template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSnapshotKubernetesOperator(DbtSnapshotMixin, DbtKubernetesBaseOperator):
     """
     Executes a dbt core snapshot command.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSourceKubernetesOperator(DbtSourceMixin, DbtKubernetesBaseOperator):
     """
     Executes a dbt source freshness command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtRunKubernetesOperator(DbtRunMixin, DbtKubernetesBaseOperator):
@@ -150,9 +135,6 @@ class DbtRunKubernetesOperator(DbtRunMixin, DbtKubernetesBaseOperator):
     """
 
     template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtTestKubernetesOperator(DbtTestMixin, DbtKubernetesBaseOperator):
@@ -257,6 +239,3 @@ class DbtRunOperationKubernetesOperator(DbtRunOperationMixin, DbtKubernetesBaseO
     """
 
     template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -545,17 +545,11 @@ class DbtBuildLocalOperator(DbtBuildMixin, DbtLocalBaseOperator):
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtLSLocalOperator(DbtLSMixin, DbtLocalBaseOperator):
     """
     Executes a dbt core ls command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtSeedLocalOperator(DbtSeedMixin, DbtLocalBaseOperator):
@@ -565,26 +559,17 @@ class DbtSeedLocalOperator(DbtSeedMixin, DbtLocalBaseOperator):
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSnapshotLocalOperator(DbtSnapshotMixin, DbtLocalBaseOperator):
     """
     Executes a dbt core snapshot command.
     """
 
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
-
 
 class DbtSourceLocalOperator(DbtSourceMixin, DbtLocalBaseOperator):
     """
     Executes a dbt source freshness command.
     """
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtRunLocalOperator(DbtRunMixin, DbtLocalBaseOperator):
@@ -593,9 +578,6 @@ class DbtRunLocalOperator(DbtRunMixin, DbtLocalBaseOperator):
     """
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
@@ -658,9 +640,6 @@ class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
     """
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, **kwargs: Any) -> None:
-        super().__init__(**kwargs)
 
 
 class DbtDocsLocalOperator(DbtLocalBaseOperator):

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1522,7 +1522,7 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     hash_dir, hash_args = version.split(",")
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
-        assert hash_dir == "c1e25b0679b5ddcb636bcc30f2f85a06"
+        assert hash_dir == "6809189f3bfdaf2b4917fbe06ee3cdb1"
     else:
         assert hash_dir == "6f63493009733a7be34364a6ea3ffd3c"
 

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -154,7 +154,7 @@ def test_dbt_mixin_base_cmd(dbt_command, dbt_operator_class):
     "full_refresh, expected_flags", [("True", ["--full-refresh"]), (True, ["--full-refresh"]), (False, [])]
 )
 def test_dbt_mixin_add_cmd_flags_full_refresh(full_refresh, expected_flags, dbt_operator_class):
-    dbt_mixin = dbt_operator_class(full_refresh=full_refresh)
+    dbt_mixin = dbt_operator_class(task_id="test_task_id", full_refresh=full_refresh)
     flags = dbt_mixin.add_cmd_flags()
     assert flags == expected_flags
 
@@ -162,7 +162,7 @@ def test_dbt_mixin_add_cmd_flags_full_refresh(full_refresh, expected_flags, dbt_
 @pytest.mark.parametrize("args, expected_flags", [(None, []), ({"arg1": "val1"}, ["--args", "arg1: val1\n"])])
 def test_dbt_mixin_add_cmd_flags_run_operator(args, expected_flags):
     macro_name = "some_macro"
-    run_operation = DbtRunOperationMixin(macro_name=macro_name, args=args)
+    run_operation = DbtRunOperationMixin(task_id="test_task_id", macro_name=macro_name, args=args)
     assert run_operation.base_cmd == ["run-operation", "some_macro"]
 
     flags = run_operation.add_cmd_flags()


### PR DESCRIPTION
## Description

Fixes Airflow 2.10 regression / compat

## Related Issue(s)

This is a fix for #1161, and is designed to be a different proposal to the changes in #1162.

Ultimately the issue that popped up in 2.10 relates to how the MRO was impacted by the Mixin class.

The simplest, most robust fix to make the MRO work properly is to make each mixin a subclass of `BaseOperator`. This doesn't require the unintuitive hack of needing an `__init__()` call to shuffle the MRO around, and it makes things more easily maintainable going forward, I think.

A note: This PR is merging to `test-af-2.10`, not `main`.

Tested for 2.10.

I also removed an unnecessary `__init__` for the `DbtTestMixin` while I was at it.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
