### PR TITLE
Add 'virtualenv_dir' param to 'Execution Config' docs

### DIFF
--- a/docs/configuration/execution-config.rst
+++ b/docs/configuration/execution-config.rst
@@ -11,3 +11,4 @@ The ``ExecutionConfig`` class takes the following arguments:
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
 - ``dbt_project_path``: Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.
+- ``virtualenv_dir`` (new in v1.6): Directory path to locate the (cached) virtual env that should be used for execution when execution mode is set to ``ExecutionMode.VIRTUALENV``.


### PR DESCRIPTION
Add missing `virtualenv_dir` param introduced in PR #1079 
to the `Execution Config` docs. Also say that it's added in v1.6

closes: #1172 
 