### PR TITLE
Give credits to @LennartKloppenburg in CHANGELOG.rst

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ New Features
 
 * Add support for loading manifest from cloud stores using Airflow Object Storage by @pankajkoti in #1109
 * Cache ``package-lock.yml`` file by @pankajastro in #1086
-* Support persisting the ``LoadMode.VIRTUALENV`` directory by @lennart by @LennartKloppenburg and @tatiana in #1079 and #611
+* Support persisting the ``LoadMode.VIRTUALENV`` directory @LennartKloppenburg and @tatiana in #1079 and #611
 * Add support to store and fetch ``dbt ls`` cache in remote stores by @pankajkoti in #1147
 * Add default source nodes rendering by @arojasb3 in #1107
 * Add Teradata ``ProfileMapping`` by @sc250072 in #1077

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,7 @@ New Features
 
 * Add support for loading manifest from cloud stores using Airflow Object Storage by @pankajkoti in #1109
 * Cache ``package-lock.yml`` file by @pankajastro in #1086
-* Support persisting the ``LoadMode.VIRTUALENV`` directory by @tatiana in #1079
+* Support persisting the ``LoadMode.VIRTUALENV`` directory by @lennart by @LennartKloppenburg and @tatiana in #1079 and #611
 * Add support to store and fetch ``dbt ls`` cache in remote stores by @pankajkoti in #1147
 * Add default source nodes rendering by @arojasb3 in #1107
 * Add Teradata ``ProfileMapping`` by @sc250072 in #1077


### PR DESCRIPTION
We missed giving credit to Lennart, who did most of the work on persisting the virtual environment in Cosmos when using `ExecutionMode.` virtualenv`. This change to the changelog aims to make up on this.
