### PR TITLE
Fix CI issues - Upgrade actions/upload-artifact & actions/download-artifact to v4 and set min version for packaging

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main,upgrade-gh-action-artifact-upload-download]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -93,7 +93,7 @@ jobs:
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}:test-cov
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -177,7 +177,7 @@ jobs:
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -248,7 +248,7 @@ jobs:
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integration-expensive-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -315,7 +315,7 @@ jobs:
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integration-sqlite-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -391,7 +391,7 @@ jobs:
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integration-dbt-1-5-4-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -534,7 +534,7 @@ jobs:
           POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: coverage-integration-kubernetes-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}
           path: .coverage
@@ -559,7 +559,7 @@ jobs:
         run: |
           pip3 install coverage
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@v2
+        uses: actions/download-artifact@v4
         with:
           path: ./coverage
       - name: Combine coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main,upgrade-gh-action-artifact-upload-download]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",
     "msgpack",
-    "packaging",
+    "packaging>=22.0",
     "pydantic>=1.10.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
@@ -86,7 +86,7 @@ docs = [
     "apache-airflow-providers-cncf-kubernetes>=5.1.1",
 ]
 tests = [
-    "packaging",
+    "packaging>=22.0",
     "pytest>=6.0",
     "pytest-split",
     "pytest-dotenv",


### PR DESCRIPTION
I am observing that our CI [jobs](https://github.com/astronomer/astronomer-cosmos/actions/runs/10920015707/job/30308959677?pr=1207) are failing complaining that we're using deprecated version (v2) for `actions/upload-artifact` & `actions/download-artifact`. It is weird that the jobs directly are failed for using deprecating versions, but so is the case that's happening. Hence, to get the CI working I'm upgrading the versions to use v4.

Additionally, we are observing failures for packaging version as discussed in https://github.com/astronomer/astronomer-cosmos/pull/1201#discussion_r1754867454. Hence, also set the min packaging version to `22.0` as per the discussion in that thread

closes: https://github.com/astronomer/astronomer-cosmos/issues/1209