### PR TITLE
Ignore from Git possibly created symlink to 'dev/dags' for running 'airflow dags test' command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -160,3 +160,6 @@ webserver_config.py
 
 # VI
 *.sw[a-z]
+
+# Ignore possibly created symlink to `dev/dags` for running `airflow dags test` command.
+dags


### PR DESCRIPTION
For local development and testing, we create a symlink in the project root for the `dev/dags` directory
for the `airflow dags test` command to discover dags when the `AIRFLOW_HOME` is set to project dir.
This PR adds to `.gitignore` to ignore the symlink so that it does not show as unstaged change
while working with `git`