### PR TITLE
Consistently handle build and imports in cosmos/__init__.py

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -42,6 +42,7 @@ logger = get_logger(__name__)
 
 try:
     from cosmos.operators.docker import (
+        DbtBuildDockerOperator,
         DbtLSDockerOperator,
         DbtRunDockerOperator,
         DbtRunOperationDockerOperator,
@@ -62,6 +63,7 @@ except ImportError:
 
 try:
     from cosmos.operators.kubernetes import (
+        DbtBuildKubernetesOperator,
         DbtLSKubernetesOperator,
         DbtRunKubernetesOperator,
         DbtRunOperationKubernetesOperator,
@@ -71,6 +73,10 @@ try:
     )
 except ImportError:
     logger.debug("To import Kubernetes modules, install astronomer-cosmos[kubernetes].", stack_info=True)
+    DbtBuildKubernetesOperator = MissingPackage(
+        "cosmos.operators.kubernetes.DbtBuildKubernetesOperator",
+        "kubernetes",
+    )
     DbtLSKubernetesOperator = MissingPackage(
         "cosmos.operators.kubernetes.DbtLSKubernetesOperator",
         "kubernetes",
@@ -98,6 +104,7 @@ except ImportError:
 
 try:
     from cosmos.operators.azure_container_instance import (
+        DbtBuildAzureContainerInstanceOperator,
         DbtLSAzureContainerInstanceOperator,
         DbtRunAzureContainerInstanceOperator,
         DbtRunOperationAzureContainerInstanceOperator,
@@ -106,6 +113,9 @@ try:
         DbtTestAzureContainerInstanceOperator,
     )
 except ImportError:
+    DbtBuildAzureContainerInstanceOperator = MissingPackage(
+        "cosmos.operators.azure_container_instance.DbtBuildAzureContainerInstanceOperator", "azure-container-instance"
+    )
     DbtLSAzureContainerInstanceOperator = MissingPackage(
         "cosmos.operators.azure_container_instance.DbtLSAzureContainerInstanceOperator", "azure-container-instance"
     )
@@ -127,41 +137,42 @@ except ImportError:
         "cosmos.operators.azure_container_instance.DbtTestAzureContainerInstanceOperator", "azure-container-instance"
     )
 
+
+try:
+    from cosmos.operators.aws_eks import (
+        DbtBuildAwsEksOperator,
+        DbtLSAwsEksOperator,
+        DbtRunAwsEksOperator,
+        DbtRunOperationAwsEksOperator,
+        DbtSeedAwsEksOperator,
+        DbtSnapshotAwsEksOperator,
+        DbtTestAwsEksOperator,
+    )
+except ImportError:
+    DbtBuildAwsEksOperator = MissingPackage(
+        "cosmos.operators.azure_container_instance.DbtBuildAwsEksOperator", "aws_eks"
+    )
+    DbtLSAwsEksOperator = MissingPackage("cosmos.operators.azure_container_instance.DbtLSAwsEksOperator", "aws_eks")
+    DbtRunAwsEksOperator = MissingPackage("cosmos.operators.azure_container_instance.DbtRunAwsEksOperator", "aws_eks")
+    DbtRunOperationAwsEksOperator = MissingPackage(
+        "cosmos.operators.azure_container_instance.DbtRunOperationAwsEksOperator",
+        "aws_eks",
+    )
+    DbtSeedAwsEksOperator = MissingPackage("cosmos.operators.azure_container_instance.DbtSeedAwsEksOperator", "aws_eks")
+    DbtSnapshotAwsEksOperator = MissingPackage(
+        "cosmos.operators.azure_container_instance.DbtSnapshotAwsEksOperator",
+        "aws_eks",
+    )
+    DbtTestAwsEksOperator = MissingPackage("cosmos.operators.azure_container_instance.DbtTestAwsEksOperator", "aws_eks")
+
+
 __all__ = [
     "ProjectConfig",
     "ProfileConfig",
     "ExecutionConfig",
     "RenderConfig",
-    "DbtLSLocalOperator",
-    "DbtRunOperationLocalOperator",
-    "DbtRunLocalOperator",
-    "DbtSeedLocalOperator",
-    "DbtTestLocalOperator",
-    "DbtBuildLocalOperator",
-    "DbtDepsLocalOperator",
-    "DbtSnapshotLocalOperator",
     "DbtDag",
     "DbtTaskGroup",
-    "DbtLSDockerOperator",
-    "DbtRunOperationDockerOperator",
-    "DbtRunDockerOperator",
-    "DbtSeedDockerOperator",
-    "DbtTestDockerOperator",
-    "DbtBuildDockerOperator",
-    "DbtSnapshotDockerOperator",
-    "DbtLSKubernetesOperator",
-    "DbtRunOperationKubernetesOperator",
-    "DbtRunKubernetesOperator",
-    "DbtSeedKubernetesOperator",
-    "DbtTestKubernetesOperator",
-    "DbtBuildKubernetesOperator",
-    "DbtSnapshotKubernetesOperator",
-    "DbtLSAzureContainerInstanceOperator",
-    "DbtRunOperationAzureContainerInstanceOperator",
-    "DbtRunAzureContainerInstanceOperator",
-    "DbtSeedAzureContainerInstanceOperator",
-    "DbtTestAzureContainerInstanceOperator",
-    "DbtSnapshotAzureContainerInstanceOperator",
     "ExecutionMode",
     "LoadMode",
     "TestBehavior",
@@ -169,6 +180,47 @@ __all__ = [
     "TestIndirectSelection",
     "SourceRenderingBehavior",
     "DbtResourceType",
+    # Local Execution Mode
+    "DbtBuildLocalOperator",
+    "DbtDepsLocalOperator",  # deprecated, to be delete in Cosmos 2.x
+    "DbtLSLocalOperator",
+    "DbtRunLocalOperator",
+    "DbtRunOperationLocalOperator",
+    "DbtSeedLocalOperator",
+    "DbtSnapshotLocalOperator",
+    "DbtTestLocalOperator",
+    # Docker Execution Mode
+    "DbtBuildDockerOperator",
+    "DbtLSDockerOperator",
+    "DbtRunDockerOperator",
+    "DbtRunOperationDockerOperator",
+    "DbtSeedDockerOperator",
+    "DbtSnapshotDockerOperator",
+    "DbtTestDockerOperator",
+    # Kubernetes Execution Mode
+    "DbtBuildKubernetesOperator",
+    "DbtLSKubernetesOperator",
+    "DbtRunKubernetesOperator",
+    "DbtRunOperationKubernetesOperator",
+    "DbtSeedKubernetesOperator",
+    "DbtSnapshotKubernetesOperator",
+    "DbtTestKubernetesOperator",
+    # Azure Container Instance Execution Mode
+    "DbtBuildAzureContainerInstanceOperator",
+    "DbtLSAzureContainerInstanceOperator",
+    "DbtRunAzureContainerInstanceOperator",
+    "DbtRunOperationAzureContainerInstanceOperator",
+    "DbtSeedAzureContainerInstanceOperator",
+    "DbtSnapshotAzureContainerInstanceOperator",
+    "DbtTestAzureContainerInstanceOperator",
+    # AWS EKS Execution Mode
+    "DbtBuildAwsEksOperator",
+    "DbtLSAwsEksOperator",
+    "DbtRunAwsEksOperator",
+    "DbtRunOperationAwsEksOperator",
+    "DbtSeedAwsEksOperator",
+    "DbtSnapshotAwsEksOperator",
+    "DbtTestAwsEksOperator",
 ]
 
 """

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -7,6 +7,7 @@ from airflow.utils.context import Context
 from cosmos.config import ProfileConfig
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
+    DbtBuildMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -75,6 +76,17 @@ class DbtAzureContainerInstanceBaseOperator(AbstractDbtBaseOperator, AzureContai
         dbt_cmd, env_vars = self.build_cmd(context=context, cmd_flags=cmd_flags)
         self.environment_variables: dict[str, Any] = {**env_vars, **self.environment_variables}
         self.command: list[str] = dbt_cmd
+
+
+class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+    """
+    Executes a dbt core build command.
+    """
+
+    template_fields: Sequence[str] = DbtAzureContainerInstanceBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
 
 
 class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore

--- a/tests/operators/test_azure_container_instance.py
+++ b/tests/operators/test_azure_container_instance.py
@@ -6,6 +6,7 @@ from pendulum import datetime
 
 from cosmos.operators.azure_container_instance import (
     DbtAzureContainerInstanceBaseOperator,
+    DbtBuildAzureContainerInstanceOperator,
     DbtLSAzureContainerInstanceOperator,
     DbtRunAzureContainerInstanceOperator,
     DbtSeedAzureContainerInstanceOperator,
@@ -121,6 +122,7 @@ base_kwargs = {
 }
 
 result_map = {
+    "build": DbtBuildAzureContainerInstanceOperator(**base_kwargs),
     "ls": DbtLSAzureContainerInstanceOperator(**base_kwargs),
     "run": DbtRunAzureContainerInstanceOperator(**base_kwargs),
     "test": DbtTestAzureContainerInstanceOperator(**base_kwargs),


### PR DESCRIPTION
While reviewing #1153, I noticed we were inconsistent with Build operators, especially how we import and expose them in Cosmos `__init__.py` This PR addresses this.

These were the changes introduced:
* Add `DbtBuildAzureContainerInstanceOperator`
* Expose the build operators for all execution modes in Cosmos `__init__` (missing for most, except `ExecutionMode.LOCAL`)
* Be consistent with import error messages in `__init__` (we were missing AWS EKS)