### PR TITLE
[DOCS] Add scarf to readme and docs for website analytics

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -15,10 +15,6 @@
 
 .. image:: https://raw.githubusercontent.com/astronomer/astronomer-cosmos/main/docs/_static/cosmos-logo.svg
 
-.. raw:: html
-
-    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ac335a8b-a9f3-49e6-9e8e-a7ec614fb794" />
-
 
 ===========================================================
 

--- a/README.rst
+++ b/README.rst
@@ -15,6 +15,10 @@
 
 .. image:: https://raw.githubusercontent.com/astronomer/astronomer-cosmos/main/docs/_static/cosmos-logo.svg
 
+.. raw:: html
+
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ac335a8b-a9f3-49e6-9e8e-a7ec614fb794" />
+
 
 ===========================================================
 
@@ -77,3 +81,9 @@ License
 _______
 
 `Apache License 2.0 <https://github.com/astronomer/astronomer-cosmos/blob/main/LICENSE>`_
+
+
+Privacy Notice
+______________
+
+This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,3 +84,13 @@ License
 _______
 
 `Apache License 2.0 <https://github.com/astronomer/astronomer-cosmos/blob/main/LICENSE>`_
+
+Privacy Notice
+______________
+
+This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_
+
+.. Tracking pixel for Scarf
+.. raw:: html
+
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ac335a8b-a9f3-49e6-9e8e-a7ec614fb794" />


### PR DESCRIPTION
This adds a privacy notice and website analytics to the Cosmos readme and auto-generated docs. 

Note that while you cannot explicitly opt out of website analytics for the publicly hosted readme (and docs), Scarf respects browser DND. If that is set via the browser, telemetry for that user will not be sent to Scarf.

Scarf privacy policy: https://about.scarf.sh/privacy-policy
Astronomer privacy policy: https://www.astronomer.io/privacy/