### PR TITLE
Introduce ground work for `ExecutionMode.AIRFLOW_ASYNC`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
-  pull_request_target: # Also run on pull requests originated from forks
     branches: [main,poc-dbt-compile-task]
+  pull_request_target: # Also run on pull requests originated from forks
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push: # Run on pushes to the default branch
     branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
-    branches: [main]
+    branches: [main,poc-dbt-compile-task]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -176,6 +176,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -248,6 +250,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -316,6 +320,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -393,6 +399,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -537,6 +545,8 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -20,6 +20,7 @@ from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
+from cosmos.settings import dbt_compile_task_id
 
 logger = get_logger(__name__)
 
@@ -332,11 +333,22 @@ def build_airflow_graph(
         for leaf_node_id in leaves_ids:
             tasks_map[leaf_node_id] >> test_task
 
-    create_airflow_task_dependencies(nodes, tasks_map)
+    if execution_mode == ExecutionMode.AIRFLOW_ASYNC:
+        compile_task_metadata = TaskMetadata(
+            id=dbt_compile_task_id,
+            owner="",  # Set appropriate owner if needed
+            operator_class=f"cosmos.operators.airflow_async.DbtCompileAirflowAsyncOperator",
+            arguments=task_args,
+            extra_context={},
+        )
+        compile_airflow_task = create_airflow_task(compile_task_metadata, dag, task_group=None)
+        tasks_map[dbt_compile_task_id] = compile_airflow_task
+
+    create_airflow_task_dependencies(nodes, tasks_map, execution_mode)
 
 
 def create_airflow_task_dependencies(
-    nodes: dict[str, DbtNode], tasks_map: dict[str, Union[TaskGroup, BaseOperator]]
+    nodes: dict[str, DbtNode], tasks_map: dict[str, Union[TaskGroup, BaseOperator]], execution_mode: ExecutionMode
 ) -> None:
     """
     Create the Airflow task dependencies between non-test nodes.
@@ -344,6 +356,9 @@ def create_airflow_task_dependencies(
     :param tasks_map: Dictionary mapping dbt nodes (node.unique_id to Airflow task)
     """
     for node_id, node in nodes.items():
+        if not node.depends_on and execution_mode == ExecutionMode.AIRFLOW_ASYNC:
+            tasks_map[dbt_compile_task_id] >> tasks_map[node_id]
+
         for parent_node_id in node.depends_on:
             # depending on the node type, it will not have mapped 1:1 to tasks_map
             if (node_id in tasks_map) and (parent_node_id in tasks_map):

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -259,6 +259,7 @@ def _add_dbt_compile_task(
     execution_mode: ExecutionMode,
     task_args: dict[str, Any],
     tasks_map: dict[str, Any],
+    task_group: TaskGroup | None,
 ) -> None:
     if execution_mode != ExecutionMode.AIRFLOW_ASYNC:
         return
@@ -269,7 +270,7 @@ def _add_dbt_compile_task(
         arguments=task_args,
         extra_context={},
     )
-    compile_airflow_task = create_airflow_task(compile_task_metadata, dag, task_group=None)
+    compile_airflow_task = create_airflow_task(compile_task_metadata, dag, task_group=task_group)
     tasks_map[DBT_COMPILE_TASK_ID] = compile_airflow_task
 
     for node_id, node in nodes.items():
@@ -357,7 +358,7 @@ def build_airflow_graph(
         for leaf_node_id in leaves_ids:
             tasks_map[leaf_node_id] >> test_task
 
-    _add_dbt_compile_task(nodes, dag, execution_mode, task_args, tasks_map)
+    _add_dbt_compile_task(nodes, dag, execution_mode, task_args, tasks_map, task_group)
 
     create_airflow_task_dependencies(nodes, tasks_map)
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -8,6 +8,7 @@ from airflow.utils.task_group import TaskGroup
 
 from cosmos.config import RenderConfig
 from cosmos.constants import (
+    DBT_COMPILE_TASK_ID,
     DEFAULT_DBT_RESOURCES,
     TESTABLE_DBT_RESOURCES,
     DbtResourceType,
@@ -20,7 +21,6 @@ from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
-from cosmos.settings import dbt_compile_task_id
 
 logger = get_logger(__name__)
 
@@ -264,17 +264,17 @@ def _add_dbt_compile_task(
         return
 
     compile_task_metadata = TaskMetadata(
-        id=dbt_compile_task_id,
+        id=DBT_COMPILE_TASK_ID,
         operator_class="cosmos.operators.airflow_async.DbtCompileAirflowAsyncOperator",
         arguments=task_args,
         extra_context={},
     )
     compile_airflow_task = create_airflow_task(compile_task_metadata, dag, task_group=None)
-    tasks_map[dbt_compile_task_id] = compile_airflow_task
+    tasks_map[DBT_COMPILE_TASK_ID] = compile_airflow_task
 
     for node_id, node in nodes.items():
         if not node.depends_on and node_id in tasks_map:
-            tasks_map[dbt_compile_task_id] >> tasks_map[node_id]
+            tasks_map[DBT_COMPILE_TASK_ID] >> tasks_map[node_id]
 
 
 def build_airflow_graph(

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -265,7 +265,7 @@ def _add_dbt_compile_task(
 
     compile_task_metadata = TaskMetadata(
         id=dbt_compile_task_id,
-        operator_class=f"cosmos.operators.airflow_async.DbtCompileAirflowAsyncOperator",
+        operator_class="cosmos.operators.airflow_async.DbtCompileAirflowAsyncOperator",
         arguments=task_args,
         extra_context={},
     )

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -148,3 +148,5 @@ DEFAULT_DBT_RESOURCES = DbtResourceType.__members__.values()
 # It expects that you have already created those resources through the appropriate commands.
 # https://docs.getdbt.com/reference/commands/test
 TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtResourceType.SNAPSHOT, DbtResourceType.SEED}
+
+DBT_COMPILE_TASK_ID = "dbt_compile"

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -86,6 +86,7 @@ class ExecutionMode(Enum):
     """
 
     LOCAL = "local"
+    AIRFLOW_ASYNC = "airflow_async"
     DOCKER = "docker"
     KUBERNETES = "kubernetes"
     AWS_EKS = "aws_eks"

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -1,0 +1,91 @@
+from typing import Any
+
+from airflow.utils.context import Context
+
+from cosmos.operators.base import DbtCompileMixin
+from cosmos.operators.local import (
+    DbtBuildLocalOperator,
+    DbtDepsLocalOperator,
+    DbtDocsAzureStorageLocalOperator,
+    DbtDocsCloudLocalOperator,
+    DbtDocsGCSLocalOperator,
+    DbtDocsLocalOperator,
+    DbtDocsS3LocalOperator,
+    DbtLocalBaseOperator,
+    DbtLSLocalOperator,
+    DbtRunLocalOperator,
+    DbtRunOperationLocalOperator,
+    DbtSeedLocalOperator,
+    DbtSnapshotLocalOperator,
+    DbtSourceLocalOperator,
+    DbtTestLocalOperator,
+)
+
+
+class DbtBuildAirflowAsyncOperator(DbtBuildLocalOperator):
+    pass
+
+
+class DbtLSAirflowAsyncOperator(DbtLSLocalOperator):
+    pass
+
+
+class DbtSeedAirflowAsyncOperator(DbtSeedLocalOperator):
+    pass
+
+
+class DbtSnapshotAirflowAsyncOperator(DbtSnapshotLocalOperator):
+    pass
+
+
+class DbtSourceAirflowAsyncOperator(DbtSourceLocalOperator):
+    pass
+
+
+class DbtRunAirflowAsyncOperator(DbtRunLocalOperator):
+    pass
+
+
+class DbtTestAirflowAsyncOperator(DbtTestLocalOperator):
+    pass
+
+
+class DbtRunOperationAirflowAsyncOperator(DbtRunOperationLocalOperator):
+    pass
+
+
+class DbtDocsAirflowAsyncOperator(DbtDocsLocalOperator):
+    pass
+
+
+class DbtDocsCloudAirflowAsyncOperator(DbtDocsCloudLocalOperator):
+    pass
+
+
+class DbtDocsS3AirflowAsyncOperator(DbtDocsS3LocalOperator):
+    pass
+
+
+class DbtDocsAzureStorageAirflowAsyncOperator(DbtDocsAzureStorageLocalOperator):
+    pass
+
+
+class DbtDocsGCSAirflowAsyncOperator(DbtDocsGCSLocalOperator):
+    pass
+
+
+class DbtDepsAirflowAsyncOperator(DbtDepsLocalOperator):
+    pass
+
+
+class DbtCompileAirflowAsyncOperator(DbtCompileMixin, DbtLocalBaseOperator):
+    """
+    Executes a dbt core build command.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs["should_upload_compiled_sql"] = True
+        super().__init__(*args, **kwargs)
+
+    def execute(self, context: Context) -> None:
+        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -1,15 +1,10 @@
-from typing import Any
-
-from cosmos.operators.base import DbtCompileMixin
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
-    DbtDepsLocalOperator,
+    DbtCompileLocalOperator,
     DbtDocsAzureStorageLocalOperator,
-    DbtDocsCloudLocalOperator,
     DbtDocsGCSLocalOperator,
     DbtDocsLocalOperator,
     DbtDocsS3LocalOperator,
-    DbtLocalBaseOperator,
     DbtLSLocalOperator,
     DbtRunLocalOperator,
     DbtRunOperationLocalOperator,
@@ -56,10 +51,6 @@ class DbtDocsAirflowAsyncOperator(DbtDocsLocalOperator):
     pass
 
 
-class DbtDocsCloudAirflowAsyncOperator(DbtDocsCloudLocalOperator):
-    pass
-
-
 class DbtDocsS3AirflowAsyncOperator(DbtDocsS3LocalOperator):
     pass
 
@@ -72,15 +63,5 @@ class DbtDocsGCSAirflowAsyncOperator(DbtDocsGCSLocalOperator):
     pass
 
 
-class DbtDepsAirflowAsyncOperator(DbtDepsLocalOperator):
+class DbtCompileAirflowAsyncOperator(DbtCompileLocalOperator):
     pass
-
-
-class DbtCompileAirflowAsyncOperator(DbtCompileMixin, DbtLocalBaseOperator):
-    """
-    Executes a dbt core build command.
-    """
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        kwargs["should_upload_compiled_sql"] = True
-        super().__init__(*args, **kwargs)

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -1,7 +1,5 @@
 from typing import Any
 
-from airflow.utils.context import Context
-
 from cosmos.operators.base import DbtCompileMixin
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
@@ -86,6 +84,3 @@ class DbtCompileAirflowAsyncOperator(DbtCompileMixin, DbtLocalBaseOperator):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["should_upload_compiled_sql"] = True
         super().__init__(*args, **kwargs)
-
-    def execute(self, context: Context) -> None:
-        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -429,3 +429,12 @@ class DbtRunOperationMixin:
             flags.append("--args")
             flags.append(yaml.dump(self.args))
         return flags
+
+
+class DbtCompileMixin:
+    """
+    Mixin for dbt compile command.
+    """
+
+    base_cmd = ["compile"]
+    ui_color = "#877c7c"

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -9,6 +9,7 @@ from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Callable, Literal, Sequence
+from urllib.parse import urlparse
 
 import airflow
 import jinja2
@@ -288,7 +289,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
 
         remote_conn_id = remote_target_path_conn_id
         if not remote_conn_id:
-            target_path_schema = target_path_str.split("://")[0]
+            target_path_schema = urlparse(target_path_str).scheme
             remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)  # type: ignore[assignment]
         if remote_conn_id is None:
             return None, None

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -69,6 +69,7 @@ from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCompileMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -986,3 +987,9 @@ class DbtDepsLocalOperator(DbtLocalBaseOperator):
         raise DeprecationWarning(
             "The DbtDepsOperator has been deprecated. " "Please use the `install_deps` flag in dbt_args instead."
         )
+
+
+class DbtCompileLocalOperator(DbtCompileMixin, DbtLocalBaseOperator):
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        kwargs["should_upload_compiled_sql"] = True
+        super().__init__(*args, **kwargs)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -32,7 +32,7 @@ from cosmos.constants import FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, Invocation
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.dbt.project import get_partial_parse_path, has_non_empty_dependencies_file
 from cosmos.exceptions import AirflowCompatibilityError, CosmosValueError
-from cosmos.settings import AIRFLOW_IO_AVAILABLE, LINEAGE_NAMESPACE, remote_target_path, remote_target_path_conn_id
+from cosmos.settings import AIRFLOW_IO_AVAILABLE, remote_target_path, remote_target_path_conn_id
 
 try:
     from airflow.datasets import Dataset

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -276,10 +276,10 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
             self.log.info("Warning: ti is of type TaskInstancePydantic. Cannot update template_fields.")
 
     @staticmethod
-    def _configure_remote_target_path() -> Path | None:
+    def _configure_remote_target_path() -> tuple[Path, str] | tuple[None, None]:
         """Configure the remote target path if it is provided."""
         if not remote_target_path:
-            return None
+            return None, None
 
         _configured_target_path = None
 
@@ -290,7 +290,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
             target_path_schema = target_path_str.split("://")[0]
             remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)  # type: ignore[assignment]
         if remote_conn_id is None:
-            return _configured_target_path
+            return None, None
 
         if not AIRFLOW_IO_AVAILABLE:
             raise CosmosValueError(
@@ -306,7 +306,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         if not _configured_target_path.exists():  # type: ignore[no-untyped-call]
             _configured_target_path.mkdir(parents=True, exist_ok=True)
 
-        return _configured_target_path
+        return _configured_target_path, remote_conn_id
 
     def upload_compiled_sql(self, tmp_project_dir: str, context: Context) -> None:
         """
@@ -315,7 +315,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
         if not self.should_upload_compiled_sql:
             return
 
-        dest_target_dir = self._configure_remote_target_path()
+        dest_target_dir, dest_conn_id = self._configure_remote_target_path()
         if not dest_target_dir:
             raise CosmosValueError(
                 "You're trying to upload compiled SQL files, but the remote target path is not configured. "
@@ -323,9 +323,18 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
 
         from airflow.io.path import ObjectStoragePath
 
-        source_target_dir = ObjectStoragePath(Path(tmp_project_dir) / "target" / "compiled")
+        source_compiled_dir = Path(tmp_project_dir) / "target" / "compiled"
+        files = [str(file) for file in source_compiled_dir.rglob("*") if file.is_file()]
 
-        source_target_dir.copy(dest_target_dir, recursive=True)  # type: ignore[arg-type]
+        for file_path in files:
+            rel_path = os.path.relpath(file_path, source_compiled_dir)
+
+            dest_path = ObjectStoragePath(
+                f"{str(dest_target_dir).rstrip('/')}/{context['dag'].dag_id}/{rel_path.lstrip('/')}",
+                conn_id=dest_conn_id,
+            )
+            ObjectStoragePath(file_path).copy(dest_path)
+            self.log.debug("Copied %s to %s", file_path, dest_path)
 
     @provide_session
     def store_freshness_json(self, tmp_project_dir: str, context: Context, session: Session = NEW_SESSION) -> None:

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -35,6 +35,10 @@ virtualenv_max_retries_lock = conf.getint("cosmos", "virtualenv_max_retries_lock
 remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 
+dbt_compile_task_id = conf.get("cosmos", "dbt_compile_task_id", fallback="dbt_compile")
+remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
+remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
+
 try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
 except airflow.exceptions.AirflowConfigException:

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -35,7 +35,6 @@ virtualenv_max_retries_lock = conf.getint("cosmos", "virtualenv_max_retries_lock
 remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 
-dbt_compile_task_id = conf.get("cosmos", "dbt_compile_task_id", fallback="dbt_compile")
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
 

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -1,0 +1,36 @@
+import os
+from datetime import datetime
+from pathlib import Path
+
+from cosmos import DbtDag, ExecutionConfig, ExecutionMode, ProfileConfig, ProjectConfig
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+        disable_event_tracking=True,
+    ),
+)
+
+simple_dag_async = DbtDag(
+    # dbt/cosmos-specific parameters
+    project_config=ProjectConfig(
+        DBT_ROOT_PATH / "jaffle_shop",
+    ),
+    profile_config=profile_config,
+    execution_config=ExecutionConfig(
+        execution_mode=ExecutionMode.AIRFLOW_ASYNC,
+    ),
+    # normal dag parameters
+    schedule_interval=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="simple_dag_async",
+    tags=["simple"],
+)

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -33,4 +33,5 @@ simple_dag_async = DbtDag(
     catchup=False,
     dag_id="simple_dag_async",
     tags=["simple"],
+    operator_args={"install_deps": True},
 )

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -18,6 +18,7 @@ profile_config = ProfileConfig(
     ),
 )
 
+# [START airflow_async_execution_mode_example]
 simple_dag_async = DbtDag(
     # dbt/cosmos-specific parameters
     project_config=ProjectConfig(
@@ -35,3 +36,4 @@ simple_dag_async = DbtDag(
     tags=["simple"],
     operator_args={"install_deps": True},
 )
+# [END airflow_async_execution_mode_example]

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -126,6 +126,27 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``None``
     - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_CACHE_DIR_CONN_ID``
 
+.. _remote_target_path:
+
+`remote_target_path`_:
+    (Introduced since Cosmos 1.7.0) The path to the remote target directory. This is the directory designated to
+    remotely copy & store in the files generated and stored by dbt in the dbt project's target directory. The value
+    for the remote target path can be any of the schemes that are supported by the
+    `Airflow Object Store <https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/objectstorage.html>`_
+    feature introduced in Airflow 2.8.0 (e.g. ``s3://your_s3_bucket/cache_dir/``, ``gs://your_gs_bucket/cache_dir/``,
+    ``abfs://your_azure_container/cache_dir``, etc.)
+
+    - Default: ``None``
+    - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_TARGET_PATH``
+
+.. _remote_target_path_conn_id:
+
+`remote_target_path_conn_id`_:
+    (Introduced since Cosmos 1.7.0) The connection ID for the remote target path. If this is not set, the default
+    Airflow connection ID identified for the scheme will be used.
+
+    - Default: ``None``
+    - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID``
 
 [openlineage]
 ~~~~~~~~~~~~~

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -133,7 +133,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     remotely copy & store in the files generated and stored by dbt in the dbt project's target directory. The value
     for the remote target path can be any of the schemes that are supported by the
     `Airflow Object Store <https://airflow.apache.org/docs/apache-airflow/stable/core-concepts/objectstorage.html>`_
-    feature introduced in Airflow 2.8.0 (e.g. ``s3://your_s3_bucket/cache_dir/``, ``gs://your_gs_bucket/cache_dir/``,
+    feature introduced in Airflow 2.8.0 (e.g. ``s3://your_s3_bucket/target_dir/``, ``gs://your_gs_bucket/target_dir/``,
     ``abfs://your_azure_container/cache_dir``, etc.)
 
     - Default: ``None``

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -243,20 +243,19 @@ Each task will create a new Cloud Run Job execution, giving full isolation. The 
         },
     )
 
-Airflow Async
+Airflow Async (experimental)
 -------------
 
 .. versionadded:: 1.7.0
 
-(**Experimental**)
 
-The ``airflow_async`` execution mode is a way to run the dbt resources from your dbt project using Apache Airflow's
+(**Experimental**) The ``airflow_async`` execution mode is a way to run the dbt resources from your dbt project using Apache Airflow's
 `Deferrable operators <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__.
 This execution mode could be preferred when you've long running resources and you want to run them asynchronously by
 leveraging Airflow's deferrable operators. With that, you would be able to potentially observe higher throughput of tasks
 as more dbt nodes will be run in parallel since they won't be blocking Airflow's worker slots.
 
-In this mode, Cosmos adds a new operator, ``DbtCompileAirflowAsyncOperator``, as a root task in the DAG. The task runs
+In this mode, Cosmos adds a new operator, ``DbtCompileAirflowAsyncOperator``, as a root task in the DbtDag or DbtTaskGroup. The task runs
 the ``dbt compile`` command on your dbt project which then outputs compiled SQLs in the project's target directory.
 As part of the same task run, these compiled SQLs are then stored remotely to a remote path set using the
 :ref:`remote_target_path` configuration. The remote path is then used by the subsequent tasks in the DAG to

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -12,7 +12,7 @@ Cosmos can run ``dbt`` commands using five different approaches, called ``execut
 5. **aws_eks**: Run ``dbt`` commands from AWS EKS Pods managed by Cosmos (requires a pre-existing Docker image)
 6. **azure_container_instance**: Run ``dbt`` commands from Azure Container Instances managed by Cosmos (requires a pre-existing Docker image)
 7. **gcp_cloud_run_job**: Run ``dbt`` commands from GCP Cloud Run Job instances managed by Cosmos (requires a pre-existing Docker image)
-8. **airflow_async**: (Introduced since Cosmos 1.7.0) Run the dbt resources from your dbt project asynchronously, by submitting the corresponding compiled SQLs to Apache Airflow's `Deferrable operators <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__
+8. **airflow_async**: (Experimental and introduced since Cosmos 1.7.0) Run the dbt resources from your dbt project asynchronously, by submitting the corresponding compiled SQLs to Apache Airflow's `Deferrable operators <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__
 
 The choice of the ``execution mode`` can vary based on each user's needs and concerns. For more details, check each execution mode described below.
 
@@ -244,7 +244,7 @@ Each task will create a new Cloud Run Job execution, giving full isolation. The 
     )
 
 Airflow Async (experimental)
--------------
+----------------------------
 
 .. versionadded:: 1.7.0
 
@@ -260,7 +260,9 @@ the ``dbt compile`` command on your dbt project which then outputs compiled SQLs
 As part of the same task run, these compiled SQLs are then stored remotely to a remote path set using the
 :ref:`remote_target_path` configuration. The remote path is then used by the subsequent tasks in the DAG to
 fetch (from the remote path) and run the compiled SQLs asynchronously using e.g. the ``DbtRunAirflowAsyncOperator``.
-You may observe that the compile task takes a bit longer to run due to the latency of storing the compiled SQLs remotely,
+You may observe that the compile task takes a bit longer to run due to the latency of storing the compiled SQLs
+remotely (e.g. for the classic ``jaffle_shop`` dbt project, upon compiling it produces about 31 files measuring about 124KB in total, but on a local
+machine it took approximately 25 seconds for the task to compile & upload the compiled SQLs to the remote path).,
 however, it is still a win as it is one-time overhead and the subsequent tasks run asynchronously utilising the Airflow's
 deferrable operators and supplying to them those compiled SQLs.
 
@@ -268,6 +270,7 @@ Note that currently, the ``airflow_async`` execution mode has the following limi
 
 1. Only supports the ``dbt resource type`` models to be run asynchronously using Airflow deferrable operators. All other resources are executed synchronously using dbt commands as they are in the ``local`` execution mode.
 2. Only supports BigQuery as the target database. If a profile target other than BigQuery is specified, Cosmos will error out saying that the target database is not supported with this execution mode.
+3. Only works for ``full_refresh`` models. There is pending work to support other modes.
 
 Example DAG:
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -21,6 +21,7 @@ from cosmos.airflow.graph import (
 )
 from cosmos.config import ProfileConfig, RenderConfig
 from cosmos.constants import (
+    DBT_COMPILE_TASK_ID,
     DbtResourceType,
     ExecutionMode,
     SourceRenderingBehavior,
@@ -30,7 +31,6 @@ from cosmos.constants import (
 from cosmos.converter import airflow_kwargs
 from cosmos.dbt.graph import DbtNode
 from cosmos.profiles import PostgresUserPasswordProfileMapping
-from cosmos.settings import dbt_compile_task_id
 
 SAMPLE_PROJ_PATH = Path("/home/user/path/dbt-proj/")
 SOURCE_RENDERING_BEHAVIOR = SourceRenderingBehavior(os.getenv("SOURCE_RENDERING_BEHAVIOR", "none"))
@@ -258,8 +258,8 @@ def test_build_airflow_graph_with_dbt_compile_task():
         )
 
     task_ids = [task.task_id for task in dag.tasks]
-    assert dbt_compile_task_id in task_ids
-    assert dbt_compile_task_id in dag.tasks[0].upstream_task_ids
+    assert DBT_COMPILE_TASK_ID in task_ids
+    assert DBT_COMPILE_TASK_ID in dag.tasks[0].upstream_task_ids
 
 
 def test_calculate_operator_class():

--- a/tests/operators/test_airflow_async.py
+++ b/tests/operators/test_airflow_async.py
@@ -1,0 +1,82 @@
+from cosmos.operators.airflow_async import (
+    DbtBuildAirflowAsyncOperator,
+    DbtCompileAirflowAsyncOperator,
+    DbtDocsAirflowAsyncOperator,
+    DbtDocsAzureStorageAirflowAsyncOperator,
+    DbtDocsGCSAirflowAsyncOperator,
+    DbtDocsS3AirflowAsyncOperator,
+    DbtLSAirflowAsyncOperator,
+    DbtRunAirflowAsyncOperator,
+    DbtRunOperationAirflowAsyncOperator,
+    DbtSeedAirflowAsyncOperator,
+    DbtSnapshotAirflowAsyncOperator,
+    DbtSourceAirflowAsyncOperator,
+    DbtTestAirflowAsyncOperator,
+)
+from cosmos.operators.local import (
+    DbtBuildLocalOperator,
+    DbtCompileLocalOperator,
+    DbtDocsAzureStorageLocalOperator,
+    DbtDocsGCSLocalOperator,
+    DbtDocsLocalOperator,
+    DbtDocsS3LocalOperator,
+    DbtLSLocalOperator,
+    DbtRunLocalOperator,
+    DbtRunOperationLocalOperator,
+    DbtSeedLocalOperator,
+    DbtSnapshotLocalOperator,
+    DbtSourceLocalOperator,
+    DbtTestLocalOperator,
+)
+
+
+def test_dbt_build_airflow_async_operator_inheritance():
+    assert issubclass(DbtBuildAirflowAsyncOperator, DbtBuildLocalOperator)
+
+
+def test_dbt_ls_airflow_async_operator_inheritance():
+    assert issubclass(DbtLSAirflowAsyncOperator, DbtLSLocalOperator)
+
+
+def test_dbt_seed_airflow_async_operator_inheritance():
+    assert issubclass(DbtSeedAirflowAsyncOperator, DbtSeedLocalOperator)
+
+
+def test_dbt_snapshot_airflow_async_operator_inheritance():
+    assert issubclass(DbtSnapshotAirflowAsyncOperator, DbtSnapshotLocalOperator)
+
+
+def test_dbt_source_airflow_async_operator_inheritance():
+    assert issubclass(DbtSourceAirflowAsyncOperator, DbtSourceLocalOperator)
+
+
+def test_dbt_run_airflow_async_operator_inheritance():
+    assert issubclass(DbtRunAirflowAsyncOperator, DbtRunLocalOperator)
+
+
+def test_dbt_test_airflow_async_operator_inheritance():
+    assert issubclass(DbtTestAirflowAsyncOperator, DbtTestLocalOperator)
+
+
+def test_dbt_run_operation_airflow_async_operator_inheritance():
+    assert issubclass(DbtRunOperationAirflowAsyncOperator, DbtRunOperationLocalOperator)
+
+
+def test_dbt_docs_airflow_async_operator_inheritance():
+    assert issubclass(DbtDocsAirflowAsyncOperator, DbtDocsLocalOperator)
+
+
+def test_dbt_docs_s3_airflow_async_operator_inheritance():
+    assert issubclass(DbtDocsS3AirflowAsyncOperator, DbtDocsS3LocalOperator)
+
+
+def test_dbt_docs_azure_storage_airflow_async_operator_inheritance():
+    assert issubclass(DbtDocsAzureStorageAirflowAsyncOperator, DbtDocsAzureStorageLocalOperator)
+
+
+def test_dbt_docs_gcs_airflow_async_operator_inheritance():
+    assert issubclass(DbtDocsGCSAirflowAsyncOperator, DbtDocsGCSLocalOperator)
+
+
+def test_dbt_compile_airflow_async_operator_inheritance():
+    assert issubclass(DbtCompileAirflowAsyncOperator, DbtCompileLocalOperator)

--- a/tests/operators/test_base.py
+++ b/tests/operators/test_base.py
@@ -8,6 +8,7 @@ from airflow.utils.context import Context
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCompileMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -143,6 +144,7 @@ def test_dbt_base_operator_context_merge(
         ("seed", DbtSeedMixin),
         ("run", DbtRunMixin),
         ("build", DbtBuildMixin),
+        ("compile", DbtCompileMixin),
     ],
 )
 def test_dbt_mixin_base_cmd(dbt_command, dbt_operator_class):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1241,6 +1241,7 @@ def test_upload_compiled_sql_should_upload(mock_configure_remote, mock_object_st
         task_id="fake-task",
         profile_config=profile_config,
         project_dir="fake-dir",
+        dag=DAG("test_dag", start_date=datetime(2024, 4, 16)),
     )
 
     mock_configure_remote.return_value = ("mock_remote_path", "mock_conn_id")
@@ -1259,12 +1260,10 @@ def test_upload_compiled_sql_should_upload(mock_configure_remote, mock_object_st
     files = [file1, file2]
 
     with patch.object(Path, "rglob", return_value=files):
-        context = {"dag": MagicMock(dag_id="test_dag")}
-
-        operator.upload_compiled_sql(tmp_project_dir, context)
+        operator.upload_compiled_sql(tmp_project_dir, context={"task": operator})
 
         for file_path in files:
             rel_path = os.path.relpath(str(file_path), str(source_compiled_dir))
-            expected_dest_path = f"mock_remote_path/test_dag/{rel_path.lstrip('/')}"
+            expected_dest_path = f"mock_remote_path/test_dag/compiled/{rel_path.lstrip('/')}"
             mock_object_storage_path.assert_any_call(expected_dest_path, conn_id="mock_conn_id")
             mock_object_storage_path.return_value.copy.assert_any_call(mock_object_storage_path.return_value)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -28,7 +28,7 @@ KUBERNETES_DAGS = ["jaffle_shop_kubernetes"]
 
 MIN_VER_DAG_FILE: dict[str, list[str]] = {
     "2.4": ["cosmos_seed_dag.py"],
-    "2.8": ["cosmos_manifest_example.py"],
+    "2.8": ["cosmos_manifest_example.py", "simple_dag_async.py"],
 }
 
 IGNORED_DAG_FILES = ["performance_dag.py", "jaffle_shop_kubernetes.py"]


### PR DESCRIPTION
This PR is the groundwork for the implementation of ExecutionMode.AIRFLOW_ASYNC (https://github.com/astronomer/astronomer-cosmos/issues/1120), which - once all other epic tasks are completed - will enable asynchronous execution of dbt resources using Apache Airflow’s deferrable operators. As part of this work, this PR introduces a new option to the enum `ExecutionMode` : `AIRFLOW_ASYNC`. When this execution mode is used, Cosmos now creates a setup task that will pre-compile the dbt project SQL and make it available to the remaining dbt tasks. This PR, however, does not yet leverage Airflow's deferrable operators. If users use  `ExecutionMode.AIRFLOW_ASYNC` they will actually be running `ExecutionMode.LOCAL` operators with this change. The PR (#1230) has a first experimental version of using deferrable operators for task execution.

## Setup task as the ground work for a new Execution Mode: `ExecutionMode.AIRFLOW_ASYNC`:
- Adds a new operator, `DbtCompileAirflowAsyncOperator`, as a root task(analogous to a setup task) in the DAG, running the dbt compile command and uploading the compiled SQL files to a remote storage location for subsequent tasks that fetch these compiled SQL files from the remote storage and run them asynchronously using Airflow's deferrable operators.

## Airflow Configurations:
- `remote_target_path`: Introduces a configurable path to store dbt-generated files remotely, supporting any storage scheme that works with Airflow’s Object Store (e.g., S3, GCS, Azure Blob).
- `remote_target_path_conn_id`: Allows specifying a custom connection ID for the remote target path, defaulting to the scheme’s associated Airflow connection if not set.

## Example DAG for CI Testing:
Introduces an example DAG (`simple_dag_async.py`) demonstrating how to use the new execution mode(The execution like mentioned earlier would still run like Execution Mode LOCAL operators at the moment with this PR alone)
This DAG is integrated into the CI pipeline to run integration tests and aims at verifying the functionality of the `ExecutionMode.AIRFLOW_ASYNC` as and when implementation gets added starting with the experimental implementation in #1230 .

## Unit & Integration Tests:
- Adds comprehensive unit and integration tests to ensure correct behavior.
- Tests include validation for successful uploads, error handling for misconfigured remote paths, and scenarios where `remote_target_path` are not set.

## Documentation:
- Adds detailed documentation explaining how to configure and set the `ExecutionMode.AIRFLOW_ASYNC`.

## Scope & Limitations of the feature being introduced:
1. This feature is meant to be released as Experimental and is also marked so in the documentation.
2. Currently, it has been scoped for only  dbt models to be executed asynchronously (being worked upon in PR #1230), while other resource types would be run synchronously. 
3. `BigQuery` will be the only supported target database for this execution mode ((being worked upon in PR #1230).

Thus, this PR enhances Cosmos by providing the ground work for more efficient execution of long-running dbt resources

## Additional Notes:
- This feature is planned to be introduced in Cosmos v1.7.0.

related: #1134 