### PR TITLE
Remove PR branch added for testing a change in CI in #1224

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main,poc-dbt-compile-task]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 


### PR DESCRIPTION
We temporarily added a PR (#1224) branch to the CI test.yml to test a new example DAG, along with the necessary environment variables for the DAG. However, I missed adding a review comment to remove the branch after testing. This PR removes the temporarily added branch from the CI configuration.