### PR TITLE
Update GCP manifest file path based on new secret update

### DIFF
--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -74,7 +74,7 @@ def cosmos_manifest_example() -> None:
     gcp_gs_example = DbtTaskGroup(
         group_id="gcp_gs_example",
         project_config=ProjectConfig(
-            manifest_path="gs://cosmos-manifest-test/manifest.json",
+            manifest_path="gs://cosmos_remote_targe/manifest.json",
             manifest_conn_id="gcp_gs_conn",
             # `manifest_conn_id` is optional. If not provided, the default connection ID `google_cloud_default` is used.
             project_name="jaffle_shop",

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -74,7 +74,7 @@ def cosmos_manifest_example() -> None:
     gcp_gs_example = DbtTaskGroup(
         group_id="gcp_gs_example",
         project_config=ProjectConfig(
-            manifest_path="gs://cosmos_remote_targe/manifest.json",
+            manifest_path="gs://cosmos_remote_target/manifest.json",
             manifest_conn_id="gcp_gs_conn",
             # `manifest_conn_id` is optional. If not provided, the default connection ID `google_cloud_default` is used.
             project_name="jaffle_shop",


### PR DESCRIPTION
We recently updated our GCP GS connection secret in our CI & that points to a different account.
Update the bucket name available in that account in our example DAG so that it is able to find &
use the needed manifest file with the updated secret in CI.