### PR TITLE
Improve dbt Docs Hosting Debugging -- Update dbt_docs_not_set_up.html

### DIFF
--- a/cosmos/plugin/templates/dbt_docs_not_set_up.html
+++ b/cosmos/plugin/templates/dbt_docs_not_set_up.html
@@ -1,6 +1,6 @@
 {% extends base_template %}
 {% block content %}
-    <h1 style="display: block; padding-top: 15px; padding-bottom: 15px">⚠️ Your dbt docs are not set up yet! ⚠️</h1>
+    <h1 style="display: block; padding-top: 15px; padding-bottom: 15px">⚠️ Your dbt docs are not set up yet! dbt_docs_dir was not found!⚠️</h1>
 
     <p>
         Read the <a href="https://astronomer.github.io/astronomer-cosmos/configuration/hosting-docs.html">Astronomer Cosmos docs</a> for information on how to set up dbt docs.


### PR DESCRIPTION

## Description

[ dbt_docs_dir is None ] directly triggers the [ dbt_docs_net_set_up.html ] page via the cosmos plugin. I had a hard time figuring out why my dbt docs weren't hosting properly considering I had (incorrectly) tried setting up the dbt_docs_dir variable via the Airflow UI. Once I added the environment variable to my Dockerfile, the dbt Docs showed correctly in the airflow UI. I had to inspect the source code for the plugin to find out that cosmos was not correctly seeing the environment variables I had set up.

Adding a note that the "dbt_docs_dir was not found" would make this error page much more helpful from a debugging standpoint for me.

## Related Issue(s)

Related to #1245: Make it easier for end-users to create a DAG for creating/hosting dbt docs
Related to #1139: Write blog post dbt docs in Airflow with Cosmos 

## Breaking Change?

This is my first time creating a PR on a public github, but I think this is as low impact as you can get :)

## Checklist

- [NA ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works 

I don't know how to test this :( Just trying to save others some time if they have the same problem I had with correctly hosting dbt docs.
