### PR TITLE
fix: Replace login by user for clickhouse profile

### DIFF
--- a/cosmos/profiles/clickhouse/user_pass.py
+++ b/cosmos/profiles/clickhouse/user_pass.py
@@ -1,4 +1,4 @@
-"""Maps Airflow Postgres connections using user + password authentication to dbt profiles."""
+"""Maps Airflow Clickhouse connections using user + password authentication to dbt profiles."""
 
 from __future__ import annotations
 
@@ -20,7 +20,7 @@ class ClickhouseUserPasswordProfileMapping(BaseProfileMapping):
 
     required_fields = [
         "host",
-        "login",
+        "user",
         "schema",
         "clickhouse",
     ]
@@ -29,7 +29,7 @@ class ClickhouseUserPasswordProfileMapping(BaseProfileMapping):
     ]
     airflow_param_mapping = {
         "host": "host",
-        "login": "login",
+        "user": "login",
         "password": "password",
         "port": "port",
         "schema": "schema",

--- a/tests/profiles/clickhouse/test_clickhouse_userpass.py
+++ b/tests/profiles/clickhouse/test_clickhouse_userpass.py
@@ -83,7 +83,7 @@ def test_profile_args(mock_clickhouse_conn: Connection) -> None:
     assert profile_mapping.profile == {
         "type": "clickhouse",
         "schema": mock_clickhouse_conn.schema,
-        "login": mock_clickhouse_conn.login,
+        "user": mock_clickhouse_conn.login,
         "password": "{{ env_var('COSMOS_CONN_GENERIC_PASSWORD') }}",
         "driver": "native",
         "port": 9000,
@@ -102,7 +102,7 @@ def test_mock_profile() -> None:
     assert profile_mapping.mock_profile == {
         "type": "clickhouse",
         "schema": "mock_value",
-        "login": "mock_value",
+        "user": "mock_value",
         "driver": "native",
         "port": 9000,
         "host": "mock_value",


### PR DESCRIPTION
## Description

The clickhouse profile is currently not working. Changing the login parameter to user  

## Related Issue(s)

closes #1249

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
