### PR TITLE
[DOCS]: Add dedicated scarf tracking pixel to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -88,4 +88,3 @@ This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/pri
 .. raw:: html
 
     <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ae43a92a-5a21-4c77-af8b-99c2242adf93" />
-

--- a/README.rst
+++ b/README.rst
@@ -83,3 +83,9 @@ Privacy Notice
 ______________
 
 This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_
+
+.. Tracking pixel for Scarf
+.. raw:: html
+
+    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ae43a92a-5a21-4c77-af8b-99c2242adf93" />
+


### PR DESCRIPTION
This adds website analytics to the Cosmos readme.

Note that while you cannot explicitly opt out of website analytics for the publicly hosted readme (and docs), Scarf respects browser DND. If that is set via the browser, telemetry for that user will not be sent to Scarf.

Scarf privacy policy: https://about.scarf.sh/privacy-policy
Astronomer privacy policy: https://www.astronomer.io/privacy/