### PR TITLE
Update issue template bug.yml - cosmos version update in the dropdown

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -15,7 +15,7 @@ body:
       description: What version of Astronomer Cosmos are you running? If you do not see your version in the list, please (ideally) test on
         the latest release or main to see if the issue is fixed before reporting it.
       options:
-        - "1.4.1"
+        - "1.7.0"
         - "main (development)"
         - "Other Astronomer Cosmos version (please specify below)"
       multiple: false

--- a/.github/ISSUE_TEMPLATE/01-bug.yml
+++ b/.github/ISSUE_TEMPLATE/01-bug.yml
@@ -8,32 +8,23 @@ body:
     attributes:
       value: |
         Thanks for taking the time to fill out this bug report!
-  - type: dropdown
+  - type: input
     id: cosmos-version
     attributes:
       label: Astronomer Cosmos Version
-      description: What version of Astronomer Cosmos are you running? If you do not see your version in the list, please (ideally) test on
-        the latest release or main to see if the issue is fixed before reporting it.
-      options:
-        - "1.7.0"
-        - "main (development)"
-        - "Other Astronomer Cosmos version (please specify below)"
-      multiple: false
-    validations:
-      required: true
-  - type: input
-    attributes:
-      label: If "Other Astronomer Cosmos version" selected, which one?
       # yamllint disable rule:line-length
       description: >
         On what version of Astronomer Cosmos are you currently experiencing the issue? Remember, you are encouraged to
         test with the latest release or on the main branch to verify your issue still exists.
+      placeholder: e.g. 1.7.0
+    validations:
+      required: true
   - type: input
     id: dbt-core-version
     attributes:
       label: dbt-core version
       description: What version of dbt-core are you running?
-      placeholder: ex. 1.8.0
+      placeholder: e.g. 1.8.0
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
Housekeeping to use latest released version in the bug report template to select cosmos version.
Cosmos's latest released version in 1.7.0 and hence use the same as the first
dropdown item version that appears to the bug reporters.

