### PR TITLE
Fix release to PyPI after `raw` rst directive disabled

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -3,6 +3,7 @@ name: Deploy to PyPi
 on:
   release:
     types: [published]
+    branches: [fix-release]
 
 jobs:
   build:
@@ -37,7 +38,7 @@ jobs:
           path: dist
 
       - name: Push build artifacts to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.8.14
+        uses: pypa/gh-action-pypi-publish@v1.10.3
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,15 @@
 Changelog
 =========
 
+1.7.1a1 (2024-10-24)
+--------------------
+
+Others
+
+* Fix release to PyPI after rst directive disabled by @tatiana in #1281
+
+
+
 1.7.0 (2024-10-04)
 ------------------
 

--- a/README.rst
+++ b/README.rst
@@ -85,6 +85,6 @@ ______________
 This project follows `Astronomer's Privacy Policy <https://www.astronomer.io/privacy/>`_
 
 .. Tracking pixel for Scarf
-.. raw:: html
 
-    <img referrerpolicy="no-referrer-when-downgrade" src="https://static.scarf.sh/a.png?x-pxid=ae43a92a-5a21-4c77-af8b-99c2242adf93" />
+.. image:: https://static.scarf.sh/a.png?x-pxid=ae43a92a-5a21-4c77-af8b-99c2242adf93
+   :target: https://static.scarf.sh/a.png?x-pxid=ae43a92a-5a21-4c77-af8b-99c2242adf93

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.7.0"
+__version__ = "1.7.0a1"
 
 
 from cosmos.airflow.dag import DbtDag


### PR DESCRIPTION
We started facing the following error while trying to publish packages to PyPI:

```
ERROR    `long_description` has syntax errors in markup and would not be
         rendered on PyPI.
         line 88: Warning: "raw" directive disabled.
Checking dist/astronomer_cosmos-1.7.1a1.tar.gz: FAILED
```

As seen in https://github.com/astronomer/astronomer-cosmos/actions/runs/11485503895/job/31965756381

I was able to reproduce the Github action error by running:

```
rm -fr dist && python -m build --wheel && twine check dist/*
```

This PR aims to solve the issue without side effects on Scarf metrics.