### PR TITLE
Update the URL for sample dbt docs hosted in Astronomer S3 bucket

### DIFF
--- a/dev/docker-compose.yaml
+++ b/dev/docker-compose.yaml
@@ -10,7 +10,7 @@ x-airflow-common:
   environment:
     &airflow-common-env
     DB_BACKEND: postgres
-    AIRFLOW__COSMOS__DBT_DOCS_DIR: http://cosmos-docs.s3-website-us-east-1.amazonaws.com/
+    AIRFLOW__COSMOS__DBT_DOCS_DIR: http://cosmos-demo-dbt-docs.s3-website.eu-north-1.amazonaws.com/
     AIRFLOW__CORE__EXECUTOR: LocalExecutor
     AIRFLOW__DATABASE__SQL_ALCHEMY_CONN: postgresql+psycopg2://airflow:pg_password@postgres:5432/airflow
     AIRFLOW__CORE__FERNET_KEY: ''

--- a/docs/configuration/generating-docs.rst
+++ b/docs/configuration/generating-docs.rst
@@ -3,7 +3,7 @@
 Generating Docs
 ===============
 
-dbt allows you to generate static documentation on your models, tables, and more. You can read more about it in the `official dbt documentation <https://docs.getdbt.com/docs/building-a-dbt-project/documentation>`_. For an example of what the docs look like with the ``jaffle_shop`` project, check out `this site <http://cosmos-docs.s3-website-us-east-1.amazonaws.com/>`_.
+dbt allows you to generate static documentation on your models, tables, and more. You can read more about it in the `official dbt documentation <https://docs.getdbt.com/docs/building-a-dbt-project/documentation>`_. For an example of what the docs look like with the ``jaffle_shop`` project, check out `this site <http://cosmos-demo-dbt-docs.s3-website.eu-north-1.amazonaws.com/>`_.
 
 After generating the dbt docs, you can host them natively within Airflow via the Cosmos Airflow plugin; see `Hosting Docs <hosting-docs.html>`__ for more information.
 


### PR DESCRIPTION
It was observed by @tatiana that the previous URL 
http://cosmos-docs.s3-website-us-east-1.amazonaws.com/
is no longer functioning and she hosted the docs in an Astronomer S3
bucket available at http://cosmos-demo-dbt-docs.s3-website.eu-north-1.amazonaws.com/

Hence, this PR is quick follow-up to update the references for the newly
hosted docs.