### PR TITLE
Minor refactor on `VirtualenvOperators` & add test for PR #1253 & 

### DIFF
--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -11,6 +11,7 @@ import psutil
 from airflow.utils.python_virtualenv import prepare_virtualenv
 
 from cosmos import settings
+from cosmos.constants import InvocationMode
 from cosmos.exceptions import CosmosValueError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.log import get_logger
@@ -78,9 +79,16 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         self.is_virtualenv_dir_temporary = is_virtualenv_dir_temporary
         self.max_retries_lock = settings.virtualenv_max_retries_lock
         self._py_bin: str | None = None
+        kwargs["invocation_mode"] = InvocationMode.SUBPROCESS
         super().__init__(**kwargs)
         if not self.py_requirements:
             self.log.error("Cosmos virtualenv operators require the `py_requirements` parameter")
+
+    def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str) -> FullOutputSubprocessResult:
+        if self._py_bin is not None:
+            self.log.info(f"Using Python binary from virtualenv: {self._py_bin}")
+            command[0] = str(Path(self._py_bin).parent / "dbt")
+        return super().run_subprocess(command, env, cwd)
 
     def run_command(
         self,

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -82,20 +82,6 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         if not self.py_requirements:
             self.log.error("Cosmos virtualenv operators require the `py_requirements` parameter")
 
-    def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str) -> FullOutputSubprocessResult:
-        self.log.info("Trying to run the command:\n %s\nFrom %s", command, cwd)
-        if self._py_bin is not None:
-            self.log.info(f"Using Python binary from virtualenv: {self._py_bin}")
-            command[0] = str(Path(self._py_bin).parent / "dbt")
-        subprocess_result = self.subprocess_hook.run_command(
-            command=command,
-            env=env,
-            cwd=cwd,
-            output_encoding=self.output_encoding,
-        )
-        self.log.info(subprocess_result.output)
-        return subprocess_result
-
     def run_command(
         self,
         cmd: list[str],

--- a/dev/dags/example_virtualenv_mini.py
+++ b/dev/dags/example_virtualenv_mini.py
@@ -1,0 +1,35 @@
+import os
+from datetime import datetime
+from pathlib import Path
+
+from airflow.models import DAG
+
+from cosmos import ProfileConfig
+from cosmos.operators.virtualenv import DbtSeedVirtualenvOperator
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_PROJ_DIR = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH)) / "jaffle_shop"
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+    ),
+)
+
+with DAG("example_virtualenv_mini", start_date=datetime(2022, 1, 1)) as dag:
+    seed_operator = DbtSeedVirtualenvOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="seed",
+        dbt_cmd_flags=["--select", "raw_customers"],
+        install_deps=True,
+        append_env=True,
+        py_system_site_packages=False,
+        py_requirements=["dbt-postgres"],
+        virtualenv_dir=Path("/tmp/persistent-venv2"),
+    )
+    seed_operator

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -22,6 +22,7 @@ AIRFLOW_VERSION = Version(airflow.__version__)
 
 DBT_PROJ_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_shop"
 
+DAGS_FOLDER = Path(__file__).parent.parent.parent / "dev/dags/"
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -368,7 +369,7 @@ def test_integration_virtualenv_operator(caplog):
     """
     from airflow.models.dagbag import DagBag
 
-    dag_bag = DagBag(dag_folder=None, include_examples=False)
+    dag_bag = DagBag(dag_folder=DAGS_FOLDER, include_examples=False)
     dag = dag_bag.get_dag("example_virtualenv_mini")
 
     dag.test()

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -373,5 +373,5 @@ def test_integration_virtualenv_operator(caplog):
 
     dag.test()
 
-    assert "Trying to run the command:\n ['/tmp/persistent-venv2', 'deps'" in caplog.text
-    assert "Trying to run the command:\n ['/tmp/persistent-venv2', 'seed'" in caplog.text
+    assert "Trying to run the command:\n ['/tmp/persistent-venv2/bin/dbt', 'deps'" in caplog.text
+    assert "Trying to run the command:\n ['/tmp/persistent-venv2/bin/dbt', 'seed'" in caplog.text

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -13,14 +13,27 @@ from airflow.models.connection import Connection
 from cosmos.config import ProfileConfig
 from cosmos.constants import InvocationMode
 from cosmos.exceptions import CosmosValueError
-from cosmos.operators.virtualenv import DbtVirtualenvBaseOperator
+from cosmos.operators.virtualenv import DbtSeedVirtualenvOperator, DbtVirtualenvBaseOperator
 from cosmos.profiles import PostgresUserPasswordProfileMapping
+from tests.utils import test_dag as run_test_dag
+
+DBT_PROJ_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_shop"
+
 
 profile_config = ProfileConfig(
     profile_name="default",
     target_name="dev",
     profile_mapping=PostgresUserPasswordProfileMapping(
         conn_id="fake_conn",
+        profile_args={"schema": "public"},
+    ),
+)
+
+real_profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
         profile_args={"schema": "public"},
     ),
 )
@@ -339,3 +352,34 @@ def test__release_venv_lock_current_process(tmpdir):
     )
     assert venv_operator._release_venv_lock() is None
     assert not lockfile.exists()
+
+
+@pytest.mark.integration  # although we're not running dbt, we are still creating a virtualenv
+@patch("cosmos.operators.local.FullOutputSubprocessHook.run_command")
+@patch("cosmos.operators.local.DbtLocalBaseOperator.handle_exception_subprocess")
+def test_integration_virtualenv_operator(mock_handle_exception_subprocess, mock_run_command):
+    """
+    Confirm we're using the correct dbt command to run with virtualenv.
+    """
+
+    with DAG("test-id-virtualenv", start_date=datetime(2022, 1, 1)) as dag:
+        seed_operator = DbtSeedVirtualenvOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="seed",
+            dbt_cmd_flags=["--select", "raw_customers"],
+            install_deps=True,
+            append_env=True,
+            py_system_site_packages=False,
+            py_requirements=["dbt-postgres"],
+            virtualenv_dir=Path("/tmp/persistent-venv2"),
+        )
+        seed_operator
+
+    run_test_dag(dag)
+
+    assert len(mock_run_command.call_args_list) == 2
+    assert mock_run_command.call_args_list[0].kwargs["command"][0] == "/tmp/persistent-venv2/bin/dbt"
+    assert mock_run_command.call_args_list[0].kwargs["command"][1] == "deps"
+    assert mock_run_command.call_args_list[1].kwargs["command"][0] == "/tmp/persistent-venv2/bin/dbt"
+    assert mock_run_command.call_args_list[1].kwargs["command"][1] == "seed"


### PR DESCRIPTION
Cosmos virtualenv operators are using the system dbt instead of the virtualenv dbt.

Create a test case that illustrates issue #1246. This test fails with Cosmos 1.7 (and the current main branch) and passes when using PR #1252.

This PR also introduces two refactors:
- Reuse the parent class method where applicable, as opposed to re-writing it completely
- Force the Virtualenv invocation mode to be `SUBPROCESS ` since Airflow/Cosmos are not able to import dbt as a library if it is not part of the same Python virtualenv

