### PR TITLE
Release 1.7.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Bug fixes
 Enhancements
 
 * Improve dbt Docs Hosting Debugging -- Update dbt_docs_not_set_up.html by @johnmcochran in #1250
-* Minor refactor on VirtualenvOperators & add test for PR by @tatiana in #1253
+* Minor refactor on VirtualenvOperators & add test for PR #1253 by @tatiana in #1286
 
 Docs
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,21 +1,33 @@
 Changelog
 =========
 
-
-1.7.1a3 (2024-10-24)
+1.7.1 (2024-10-29)
 --------------------
 
 Bug fixes
 
+* Fix ``DbtVirtualenvBaseOperator`` to use correct virtualenv Python path by kesompochy in #1252
 * Fix displaying dbt docs as menu item in Astro by @tatiana in #1280
+* Fix: Replace login by user for clickhouse profile by @petershenri in #1255
+
+Enhancements
+
+* Improve dbt Docs Hosting Debugging -- Update dbt_docs_not_set_up.html by @johnmcochran in #1250
+* Minor refactor on VirtualenvOperators & add test for PR by @tatiana in #1253
 
 Docs
 
+* Add Welcome Section and "What Is Cosmos" Blurb to Home Page by @cmarteepants and @yanmastin-astro in #1251
 * Update the URL for sample dbt docs hosted in Astronomer S3 bucket by @pankajkoti in #1283
+* Add dedicated scarf tracking pixel to readme by @cmarteepants in #1256
+
 
 Others
 
-* Fix release after the raw rst directive disabled was disabled in PyPI by @tatiana in #1282
+* Update ``CODEOWNERS`` to track all files by @pankajkoti in #1284
+* Fix release after the ``raw`` rst directive disabled was disabled in PyPI by @tatiana in #1282
+* Update issue template ``bug.yml`` - cosmos version update in the dropdown by @pankajkoti in #1275
+* Pre-commit hook updates in #1285, #1274, #1254, #1244
 
 
 1.7.0 (2024-10-04)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -25,7 +25,7 @@ Docs
 Others
 
 * Update ``CODEOWNERS`` to track all files by @pankajkoti in #1284
-* Fix release after the ``raw`` rst directive disabled was disabled in PyPI by @tatiana in #1282
+* Fix release after the ``raw`` rst directive was disabled in PyPI by @tatiana in #1282
 * Update issue template ``bug.yml`` - cosmos version update in the dropdown by @pankajkoti in #1275
 * Pre-commit hook updates in #1285, #1274, #1254, #1244
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,7 +6,7 @@ Changelog
 
 Bug fixes
 
-* Fix ``DbtVirtualenvBaseOperator`` to use correct virtualenv Python path by kesompochy in #1252
+* Fix ``DbtVirtualenvBaseOperator`` to use correct virtualenv Python path by @kesompochy in #1252
 * Fix displaying dbt docs as menu item in Astro by @tatiana in #1280
 * Fix: Replace login by user for clickhouse profile by @petershenri in #1255
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.7.1a3"
+__version__ = "1.7.1"
 
 
 from cosmos.airflow.dag import DbtDag


### PR DESCRIPTION
Bug fixes

* Fix ``DbtVirtualenvBaseOperator`` to use correct virtualenv Python path by @kesompochy in #1252
* Fix displaying dbt docs as menu item in Astro by @tatiana in #1280
* Fix: Replace login by user for clickhouse profile by @petershenri in #1255

Enhancements

* Improve dbt Docs Hosting Debugging -- Update dbt_docs_not_set_up.html by @johnmcochran in #1250
* Minor refactor on VirtualenvOperators & add test for PR by @tatiana in #1253

Docs

* Add Welcome Section and "What Is Cosmos" Blurb to Home Page by @cmarteepants and @yanmastin-astro in #1251
* Update the URL for sample dbt docs hosted in Astronomer S3 bucket by @pankajkoti in #1283
* Add dedicated scarf tracking pixel to readme by @cmarteepants in #1256

Others

* Update ``CODEOWNERS`` to track all files by @pankajkoti in #1284
* Fix release after the ``raw`` rst directive disabled was disabled in PyPI by @tatiana in #1282
* Update issue template ``bug.yml`` - cosmos version update in the dropdown by @pankajkoti in #1275
* Pre-commit hook updates in #1285, #1274, #1254, #1244