### PR TITLE
Add stalebot to label/close stale PRs and issues

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/stale@v9
         with:
           days-before-issue-stale: 30
-          days-before-issue-close: -1
+          days-before-issue-close: -1  # Never closes issues, more information in https://github.com/actions/stale/
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           days-before-pr-stale: 30

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -19,7 +19,8 @@ jobs:
           stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
           days-before-pr-stale: 60
           days-before-pr-close: 120
-          stale-pr-label: "This PR is stale because it has been open for 60 days with no activity."
-          stale-pr-message: "This PR"
+          stale-pr-label: "stale"
+          stale-pr-message: "This PR is stale because it has been open for 60 days with no activity."
+          close-pr-label: "stale"
           close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,9 +18,8 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
           days-before-pr-stale: 60
-          days-before-pr-close: 120
+          days-before-pr-close: 60
           stale-pr-label: "stale"
           stale-pr-message: "This PR is stale because it has been open for 60 days with no activity."
-          close-pr-label: "stale"
           close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,25 @@
+name: Handle stale issues and PRs
+on:
+  schedule:
+    - cron: "0 11 * * *"
+  push:
+    branches: [stale-bot]
+jobs:
+  handle-stale:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - uses: actions/stale@v9
+        with:
+          days-before-issue-stale: 90
+          days-before-issue-close: -1
+          stale-issue-label: "stale"
+          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
+          days-before-pr-stale: 60
+          days-before-pr-close: 120
+          stale-pr-label: "This PR is stale because it has been open for 60 days with no activity."
+          stale-pr-message: "This PR"
+          close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -2,8 +2,6 @@ name: Handle stale issues and PRs
 on:
   schedule:
     - cron: "0 11 * * *"
-  push:
-    branches: [stale-bot]
 jobs:
   handle-stale:
     runs-on: ubuntu-latest

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -13,13 +13,13 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          days-before-issue-stale: 90
+          days-before-issue-stale: 30
           days-before-issue-close: -1
           stale-issue-label: "stale"
-          stale-issue-message: "This issue is stale because it has been open for 90 days with no activity."
-          days-before-pr-stale: 60
-          days-before-pr-close: 60
+          stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
+          days-before-pr-stale: 30
+          days-before-pr-close: 10
           stale-pr-label: "stale"
-          stale-pr-message: "This PR is stale because it has been open for 60 days with no activity."
-          close-pr-message: "This PR was closed because it has been inactive for 60 days since being marked as stale."
+          stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
+          close-pr-message: "This PR was closed because it has been inactive for 10 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
As Cosmos grows in popularity, it is important that we automate a few actions:
- labelling issues as stale
- labelling PRs as stale
- closing stale PRs

The goal of this PR is to accomplish this. As a starting point, my suggestion is that we don't mark issues as stale, but I'm open to changing this.

An example of a successful run:
https://github.com/astronomer/astronomer-cosmos/actions/runs/11590467421/job/32268097259

