### PR TITLE
Add missing attribute 'DbtSourceGcpCloudRunJobOperator' in module 'cosmos.operators.gcp_cloud_run_job'

### DIFF
--- a/cosmos/operators/gcp_cloud_run_job.py
+++ b/cosmos/operators/gcp_cloud_run_job.py
@@ -15,6 +15,7 @@ from cosmos.operators.base import (
     DbtRunOperationMixin,
     DbtSeedMixin,
     DbtSnapshotMixin,
+    DbtSourceMixin,
     DbtTestMixin,
 )
 
@@ -121,6 +122,15 @@ class DbtSeedGcpCloudRunJobOperator(DbtSeedMixin, DbtGcpCloudRunJobBaseOperator)
     """
 
     template_fields: Sequence[str] = DbtGcpCloudRunJobBaseOperator.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtSourceGcpCloudRunJobOperator(DbtSourceMixin, DbtGcpCloudRunJobBaseOperator):
+    """
+    Executes a dbt core source freshness command.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)


### PR DESCRIPTION

## Description

this PR add a missing attribute `DbtSourceGcpCloudRunJobOperator` in `cosmos.operators.gcp_cloud_run_job.py` to be able to use the source_rendering_behavior params in `cosmos.config.RenderConfig` class with the new GCP_CLOUD_RUN_JOB execution mode (available in 1.7.0) .

## Related Issue(s)

closes [#1276](https://github.com/astronomer/astronomer-cosmos/issues/1276)

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
