### PR TITLE
Fix security vulnerability, by not pinning Airflow 2.10.0

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 aenum
-apache-airflow==2.10.0
+apache-airflow==2.10.2
 PyAthena==3.9.0
 redshift-connector==2.1.3
 fsspec==2024.6.1


### PR DESCRIPTION
Solve these security vulnerabilities:
https://github.com/astronomer/astronomer-cosmos/security/dependabot/6
https://github.com/astronomer/astronomer-cosmos/security/dependabot/7

Introduced by #1294