### PR TITLE
Support building `DbtDag` without setting paths in `ProjectConfig`

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -91,6 +91,13 @@ class RenderConfig:
         # allows us to initiate this attribute from Path objects and str
         self.dbt_ls_path = Path(self.dbt_ls_path) if self.dbt_ls_path else None
 
+    @property
+    def project_name(self) -> str:
+        if self.project_path:
+            return Path(self.project_path).stem
+        else:
+            return ""
+
     def validate_dbt_command(self, fallback_cmd: str | Path = "") -> None:
         """
         When using LoadMode.DBT_LS, the dbt executable path is necessary for rendering.

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -158,7 +158,7 @@ def validate_initial_user_config(
         )
 
 
-def validate_adapted_user_config(
+def validate_changed_config_paths(
     execution_config: ExecutionConfig | None, project_config: ProjectConfig, render_config: RenderConfig | None
 ):
     """
@@ -226,7 +226,7 @@ class DbtToAirflowConverter:
             render_config.project_path = project_config.dbt_project_path
             execution_config.project_path = project_config.dbt_project_path
 
-        validate_adapted_user_config(execution_config, project_config, render_config)
+        validate_changed_config_paths(execution_config, project_config, render_config)
 
         env_vars = copy.deepcopy(project_config.env_vars or operator_args.get("env"))
         dbt_vars = copy.deepcopy(project_config.dbt_vars or operator_args.get("vars"))
@@ -298,7 +298,7 @@ class DbtToAirflowConverter:
             execution_mode=execution_config.execution_mode,
             task_args=task_args,
             test_indirect_selection=execution_config.test_indirect_selection,
-            dbt_project_name=project_config.project_name,
+            dbt_project_name=render_config.project_name,
             on_warning_callback=on_warning_callback,
             render_config=render_config,
         )


### PR DESCRIPTION
Previously, users were unable to run a DbtDag or DbtTask group where the following was used:
- `RenderMode.DBT_LS`
- `ExecutionConfig(dbt_project_path)`
- `RenderConfig(dbt_project_path)`

This scenario can be helpful when using ExecutionMode.KUBERNETES or other similar ones and was found out during: https://github.com/astronomer/astronomer-cosmos/pull/1297