### PR TITLE
Fix vulnerability issue on docs dependency

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 aenum
-apache-airflow==2.10.2
+apache-airflow==2.10
 PyAthena==3.9.0
 redshift-connector==2.1.3
 fsspec==2024.6.1

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 aenum
-apache-airflow==2.10
+apache-airflow~=2.10.3
 PyAthena==3.9.0
 redshift-connector==2.1.3
 fsspec==2024.6.1


### PR DESCRIPTION
Fix: https://github.com/astronomer/astronomer-cosmos/security/dependabot/8

More details about the vulnerability:
> Airflow versions before 2.10.3 have a vulnerability that allows authenticated users with audit log access to see sensitive values in audit logs which they should not see. When sensitive variables were set via airflow CLI, values of those variables appeared in the audit log and were stored unencrypted in the Airflow database. While this risk is limited to users with audit log access, upgrading to Airflow 2.10.3 or a later version is recommended, which addresses this issue. Users who previously used the CLI to set secret variables should manually delete entries with those variables from the log table.
