### PR TITLE
Add task timeout support.

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1,8 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Callable, Union
-
 from datetime import timedelta
+from typing import Any, Callable, Union
 
 from airflow.models import BaseOperator
 from airflow.models.dag import DAG
@@ -246,7 +245,7 @@ def generate_task_or_group(
         use_task_group=use_task_group,
         source_rendering_behavior=source_rendering_behavior,
         model_timeout=model_timeout,
-        model_sla=model_sla
+        model_sla=model_sla,
     )
 
     # In most cases, we'll  map one DBT node to one Airflow task

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -80,8 +80,6 @@ class RenderConfig:
     enable_mock_profile: bool = True
     source_rendering_behavior: SourceRenderingBehavior = SourceRenderingBehavior.NONE
     airflow_vars_to_purge_dbt_ls_cache: list[str] = field(default_factory=list)
-    model_timeout: bool = False
-    model_sla: bool = False
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         if self.env_vars:

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -80,6 +80,8 @@ class RenderConfig:
     enable_mock_profile: bool = True
     source_rendering_behavior: SourceRenderingBehavior = SourceRenderingBehavior.NONE
     airflow_vars_to_purge_dbt_ls_cache: list[str] = field(default_factory=list)
+    model_timeout: bool = False
+    model_sla: bool = False
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         if self.env_vars:

--- a/docs/configuration/index.rst
+++ b/docs/configuration/index.rst
@@ -27,3 +27,4 @@ Cosmos offers a number of configuration options to customize its behavior. For m
    Compiled SQL <compiled-sql>
    Logging <logging>
    Caching <caching>
+   Task Timeout <task-timeout>

--- a/docs/configuration/task-timeout.rst
+++ b/docs/configuration/task-timeout.rst
@@ -3,11 +3,8 @@
 Task Timeout
 ================
 
-In Airflow, the "execution_timeout" parameter allows you to set the maximum runtime for a Task.
-With Cosmos, you can specify an execution_timeout for each dbt model converted to a Task.
-This lets users set a threshold for the maximum runtime of a model, triggering a timeout error if the execution exceeds this limit.
-
-By adding cosmos_task_timeout to the config of a dbt model, Cosmos will automatically apply the specified timeout to the Task based on this value.
+In Airflow, the ``execution_timeout`` parameter allows you to set the maximum runtime for a Task.
+In Cosmos, you can apply an ``execution_timeout`` to each dbt model task by specifying a ``cosmos_task_timeout`` in the model’s configuration, which sets a runtime threshold to trigger a timeout error if exceeded.
 
 Example:
 

--- a/docs/configuration/task-timeout.rst
+++ b/docs/configuration/task-timeout.rst
@@ -1,0 +1,21 @@
+.. _task-timeout:
+
+Task Timeout
+================
+
+In Airflow, the "execution_timeout" parameter allows you to set the maximum runtime for a Task.
+With Cosmos, you can specify an execution_timeout for each dbt model converted to a Task.
+This lets users set a threshold for the maximum runtime of a model, triggering a timeout error if the execution exceeds this limit.
+
+By adding cosmos_task_timeout to the config of a dbt model, Cosmos will automatically apply the specified timeout to the Task based on this value.
+
+Example:
+
+.. code-block:: yaml
+
+    version: 2
+
+    models:
+    - name: my_model
+      config:
+        - cosmos_task_timeout: 600 # Specify in seconds.

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -1,5 +1,5 @@
 import os
-from datetime import datetime
+from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -566,6 +566,24 @@ def test_create_task_metadata_snapshot(caplog):
     assert metadata.id == "my_snapshot_snapshot"
     assert metadata.operator_class == "cosmos.operators.kubernetes.DbtSnapshotKubernetesOperator"
     assert metadata.arguments == {"models": "my_snapshot"}
+
+
+def test_create_task_metadata_timeout():
+    sample_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.my_folder.my_model",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path="",
+        tags=[],
+        config={
+            "cosmos_task_timeout": 1
+        },
+    )
+    metadata = create_task_metadata(
+        sample_node, execution_mode=ExecutionMode.LOCAL, args={}, dbt_dag_task_group_identifier=""
+    )
+    assert "execution_timeout" in metadata.arguments
+    assert metadata.arguments["execution_timeout"] == timedelta(seconds=1)
 
 
 @pytest.mark.parametrize(

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -575,9 +575,7 @@ def test_create_task_metadata_timeout():
         depends_on=[],
         file_path="",
         tags=[],
-        config={
-            "cosmos_task_timeout": 1
-        },
+        config={"cosmos_task_timeout": 1},
     )
     metadata = create_task_metadata(
         sample_node, execution_mode=ExecutionMode.LOCAL, args={}, dbt_dag_task_group_identifier=""


### PR DESCRIPTION
## Description

In Airflow, both DAGs and tasks can have timeout specified. Since dbt models likely have varying expected execution times for each layer, there could be cases where users want to apply timeout individually to each node.

How about having Cosmos retrieve timeout from the node metadata and apply them individually when rendering nodes?

Specifically, the expected time is specified in the model's config, which will be read accordingly.

```yml
version: 2
models:
  - name: stg_customers
    config:
      cosmos_task_timeout: 600 # Specify in seconds.
```

## Related Issue(s)

closes https://github.com/astronomer/astronomer-cosmos/issues/1316

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
