### PR TITLE
Add postgres pod status check for k8s tests in CI

### DIFF
--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -59,7 +59,6 @@ class DbtSourceAirflowAsyncOperator(DbtBaseAirflowAsyncOperator, DbtSourceLocalO
     pass
 
 
-# Test
 class DbtRunAirflowAsyncOperator(BigQueryInsertJobOperator):  # type: ignore
 
     template_fields: Sequence[str] = (

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -59,6 +59,7 @@ class DbtSourceAirflowAsyncOperator(DbtBaseAirflowAsyncOperator, DbtSourceLocalO
     pass
 
 
+# Test
 class DbtRunAirflowAsyncOperator(BigQueryInsertJobOperator):  # type: ignore
 
     template_fields: Sequence[str] = (

--- a/scripts/test/kubernetes-setup.sh
+++ b/scripts/test/kubernetes-setup.sh
@@ -43,10 +43,6 @@ while true; do
     sleep 5
   fi
 done
-#while [ "$(kubectl get pod "$POD_NAME" -n default -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ]; do
-#  echo "Pod $POD_NAME is not ready yet. Waiting..."
-#  sleep 5
-#done
 # Print the name of the PostgreSQL pod
 echo "$POD_NAME"
 

--- a/scripts/test/kubernetes-setup.sh
+++ b/scripts/test/kubernetes-setup.sh
@@ -26,6 +26,13 @@ kind load docker-image dbt-jaffle-shop:1.0.0
 # The output is filtered to get the first pod's name
 POD_NAME=$(kubectl get pods -n default -l app=postgres -o jsonpath='{.items[0].metadata.name}')
 
+# Wait for the PostgreSQL pod to be in the 'Running' and 'Ready' state
+echo "Waiting for PostgreSQL pod to be ready..."
+while [ "$(kubectl get pod "$POD_NAME" -n default -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ]; do
+  echo "Pod $POD_NAME is not ready yet. Waiting..."
+  sleep 5
+done
+
 # Print the name of the PostgreSQL pod
 echo "$POD_NAME"
 

--- a/scripts/test/kubernetes-setup.sh
+++ b/scripts/test/kubernetes-setup.sh
@@ -28,11 +28,25 @@ POD_NAME=$(kubectl get pods -n default -l app=postgres -o jsonpath='{.items[0].m
 
 # Wait for the PostgreSQL pod to be in the 'Running' and 'Ready' state
 echo "Waiting for PostgreSQL pod to be ready..."
-while [ "$(kubectl get pod "$POD_NAME" -n default -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ]; do
-  echo "Pod $POD_NAME is not ready yet. Waiting..."
-  sleep 5
-done
+while true; do
+  POD_STATUS=$(kubectl get pod "$POD_NAME" -n default -o jsonpath='{.status.phase}')
 
+  if [ "$POD_STATUS" = "Running" ] && [ "$(kubectl get pod "$POD_NAME" -n default -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" = "True" ]; then
+    echo "PostgreSQL pod is up and running!"
+    break
+  elif [ "$POD_STATUS" = "Error" ]; then
+    echo "Error: PostgreSQL pod failed to start. Exiting..."
+    kubectl describe pod "$POD_NAME" -n default  # Show details for debugging
+    exit 1
+  else
+    echo "Pod $POD_NAME is not ready yet (status: $POD_STATUS). Waiting..."
+    sleep 5
+  fi
+done
+#while [ "$(kubectl get pod "$POD_NAME" -n default -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}')" != "True" ]; do
+#  echo "Pod $POD_NAME is not ready yet. Waiting..."
+#  sleep 5
+#done
 # Print the name of the PostgreSQL pod
 echo "$POD_NAME"
 


### PR DESCRIPTION
It appears we have a flaky Kubernetes test that failed in PR #1313. As shown in the error log [here](https://github.com/astronomer/astronomer-cosmos/actions/runs/11796817624/job/32867560902?pr=1313#step:7:473), the PostgreSQL pod did not reach the ready state and instead entered an error status. Since the cause of the error status is unclear, this PR introduces a status check for the PostgreSQL pod to ensure it becomes fully running and healthy. If the pod enters an ERROR state, we now run a `kubectl describe` command on the pod to capture the event logs for debugging. The test will also exit with an error code of 1 to prevent further execution.

related: #1319 