### PR TITLE
Change the mock value of port in TrinoBaseProfileMapping to an integer

### DIFF
--- a/cosmos/profiles/trino/base.py
+++ b/cosmos/profiles/trino/base.py
@@ -41,6 +41,12 @@ class TrinoBaseProfileMapping(BaseProfileMapping):
         # remove any null values
         return self.filter_null(profile_vars)
 
+    @property
+    def mock_profile(self) -> dict[str, Any]:
+        mock_profile = super().mock_profile
+        mock_profile["port"] = 99999
+        return mock_profile
+
     def transform_host(self, host: str) -> str:
         """Replaces http:// or https:// with nothing."""
         return host.replace("http://", "").replace("https://", "")

--- a/tests/profiles/trino/test_trino_base.py
+++ b/tests/profiles/trino/test_trino_base.py
@@ -84,3 +84,19 @@ def test_profile_args_overrides() -> None:
             "user": "my_login",
             "session_properties": {"my_property": "my_value_override"},
         }
+
+
+def test_mock_profile() -> None:
+    """
+    Tests that the mock_profile values get set correctly. A non-integer value of port will crash dbt ls.
+    """
+    profile_mapping = TrinoBaseProfileMapping(conn_id="mock_conn_id")
+    
+    assert profile_mapping.mock_profile == {
+        "type": "trino",
+        "host": "mock_value",
+        "database": "mock_value",
+        "schema": "mock_value",
+        "port": 99999,
+        "user": "mock_value"
+        }

--- a/tests/profiles/trino/test_trino_base.py
+++ b/tests/profiles/trino/test_trino_base.py
@@ -91,12 +91,12 @@ def test_mock_profile() -> None:
     Tests that the mock_profile values get set correctly. A non-integer value of port will crash dbt ls.
     """
     profile_mapping = TrinoBaseProfileMapping(conn_id="mock_conn_id")
-    
+
     assert profile_mapping.mock_profile == {
         "type": "trino",
         "host": "mock_value",
         "database": "mock_value",
         "schema": "mock_value",
         "port": 99999,
-        "user": "mock_value"
-        }
+        "user": "mock_value",
+    }


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
The mock value of `port` in `TrinoBaseProfileMapping` has been changed to an integer.

## Related Issue(s)

Closes: #1315

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
