### PR TITLE
Add dbt clone operator

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -30,6 +30,7 @@ from cosmos.log import get_logger
 from cosmos.operators.lazy_load import MissingPackage
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
     DbtDepsLocalOperator,
     DbtLSLocalOperator,
     DbtRunLocalOperator,
@@ -44,6 +45,7 @@ logger = get_logger(__name__)
 try:
     from cosmos.operators.docker import (
         DbtBuildDockerOperator,
+        DbtCloneDockerOperator,
         DbtLSDockerOperator,
         DbtRunDockerOperator,
         DbtRunOperationDockerOperator,
@@ -65,6 +67,7 @@ except ImportError:
 try:
     from cosmos.operators.kubernetes import (
         DbtBuildKubernetesOperator,
+        DbtCloneKubernetesOperator,
         DbtLSKubernetesOperator,
         DbtRunKubernetesOperator,
         DbtRunOperationKubernetesOperator,
@@ -106,6 +109,7 @@ except ImportError:
 try:
     from cosmos.operators.azure_container_instance import (
         DbtBuildAzureContainerInstanceOperator,
+        DbtCloneAzureContainerInstanceOperator,
         DbtLSAzureContainerInstanceOperator,
         DbtRunAzureContainerInstanceOperator,
         DbtRunOperationAzureContainerInstanceOperator,
@@ -142,6 +146,7 @@ except ImportError:
 try:
     from cosmos.operators.aws_eks import (
         DbtBuildAwsEksOperator,
+        DbtCloneAwsEksOperator,
         DbtLSAwsEksOperator,
         DbtRunAwsEksOperator,
         DbtRunOperationAwsEksOperator,
@@ -170,6 +175,7 @@ except ImportError:
 try:
     from cosmos.operators.gcp_cloud_run_job import (
         DbtBuildGcpCloudRunJobOperator,
+        DbtCloneGcpCloudRunJobOperator,
         DbtLSGcpCloudRunJobOperator,
         DbtRunGcpCloudRunJobOperator,
         DbtRunOperationGcpCloudRunJobOperator,
@@ -217,6 +223,7 @@ __all__ = [
     "DbtResourceType",
     # Local Execution Mode
     "DbtBuildLocalOperator",
+    "DbtCloneLocalOperator",
     "DbtDepsLocalOperator",  # deprecated, to be delete in Cosmos 2.x
     "DbtLSLocalOperator",
     "DbtRunLocalOperator",
@@ -226,6 +233,7 @@ __all__ = [
     "DbtTestLocalOperator",
     # Docker Execution Mode
     "DbtBuildDockerOperator",
+    "DbtCloneDockerOperator",
     "DbtLSDockerOperator",
     "DbtRunDockerOperator",
     "DbtRunOperationDockerOperator",
@@ -234,6 +242,7 @@ __all__ = [
     "DbtTestDockerOperator",
     # Kubernetes Execution Mode
     "DbtBuildKubernetesOperator",
+    "DbtCloneKubernetesOperator",
     "DbtLSKubernetesOperator",
     "DbtRunKubernetesOperator",
     "DbtRunOperationKubernetesOperator",
@@ -242,6 +251,7 @@ __all__ = [
     "DbtTestKubernetesOperator",
     # Azure Container Instance Execution Mode
     "DbtBuildAzureContainerInstanceOperator",
+    "DbtCloneAzureContainerInstanceOperator",
     "DbtLSAzureContainerInstanceOperator",
     "DbtRunAzureContainerInstanceOperator",
     "DbtRunOperationAzureContainerInstanceOperator",
@@ -250,6 +260,7 @@ __all__ = [
     "DbtTestAzureContainerInstanceOperator",
     # AWS EKS Execution Mode
     "DbtBuildAwsEksOperator",
+    "DbtCloneAwsEksOperator",
     "DbtLSAwsEksOperator",
     "DbtRunAwsEksOperator",
     "DbtRunOperationAwsEksOperator",
@@ -258,6 +269,7 @@ __all__ = [
     "DbtTestAwsEksOperator",
     # GCP Cloud Run Job Execution Mode
     "DbtBuildGcpCloudRunJobOperator",
+    "DbtCloneGcpCloudRunJobOperator",
     "DbtLSGcpCloudRunJobOperator",
     "DbtRunGcpCloudRunJobOperator",
     "DbtRunOperationGcpCloudRunJobOperator",

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -14,6 +14,7 @@ from cosmos.exceptions import CosmosValueError
 from cosmos.operators.base import AbstractDbtBaseOperator
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
     DbtCompileLocalOperator,
     DbtLocalBaseOperator,
     DbtLSLocalOperator,
@@ -187,4 +188,8 @@ class DbtRunOperationAirflowAsyncOperator(DbtBaseAirflowAsyncOperator, DbtRunOpe
 
 
 class DbtCompileAirflowAsyncOperator(DbtBaseAirflowAsyncOperator, DbtCompileLocalOperator):  # type: ignore
+    pass
+
+
+class DbtCloneAirflowAsyncOperator(DbtBaseAirflowAsyncOperator, DbtCloneLocalOperator):
     pass

--- a/cosmos/operators/aws_eks.py
+++ b/cosmos/operators/aws_eks.py
@@ -8,6 +8,7 @@ from airflow.utils.context import Context
 
 from cosmos.operators.kubernetes import (
     DbtBuildKubernetesOperator,
+    DbtCloneKubernetesOperator,
     DbtKubernetesBaseOperator,
     DbtLSKubernetesOperator,
     DbtRunKubernetesOperator,
@@ -157,6 +158,15 @@ class DbtRunOperationAwsEksOperator(DbtAwsEksBaseOperator, DbtRunOperationKubern
     template_fields: Sequence[str] = (
         DbtAwsEksBaseOperator.template_fields + DbtRunOperationKubernetesOperator.template_fields  # type: ignore[operator]
     )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneAwsEksOperator(DbtAwsEksBaseOperator, DbtCloneKubernetesOperator):
+    """
+    Executes a dbt core clone command.
+    """
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -8,6 +8,7 @@ from cosmos.config import ProfileConfig
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCloneMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -166,4 +167,13 @@ class DbtRunOperationAzureContainerInstanceOperator(DbtRunOperationMixin, DbtAzu
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneAzureContainerInstanceOperator(DbtCloneMixin, DbtAzureContainerInstanceBaseOperator):
+    """
+    Executes a dbt core clone command.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -445,3 +445,21 @@ class DbtCloneMixin:
 
     base_cmd = ["clone"]
     ui_color = "#83a300"
+
+    def __init__(self, full_refresh: bool | str = False, **kwargs: Any) -> None:
+        self.full_refresh = full_refresh
+        super().__init__(**kwargs)
+
+    def add_cmd_flags(self) -> list[str]:
+        flags = []
+
+        if isinstance(self.full_refresh, str):
+            # Handle template fields when render_template_as_native_obj=False
+            full_refresh = to_boolean(self.full_refresh)
+        else:
+            full_refresh = self.full_refresh
+
+        if full_refresh is True:
+            flags.append("--full-refresh")
+
+        return flags

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -438,3 +438,10 @@ class DbtCompileMixin:
 
     base_cmd = ["compile"]
     ui_color = "#877c7c"
+
+
+class DbtCloneMixin:
+    """Mixin for dbt clone command."""
+
+    base_cmd = ["clone"]
+    ui_color = "#83a300"

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -7,6 +7,7 @@ from airflow.utils.context import Context
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCloneMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -147,4 +148,13 @@ class DbtRunOperationDockerOperator(DbtRunOperationMixin, DbtDockerBaseOperator)
     template_fields: Sequence[str] = DbtDockerBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneDockerOperator(DbtCloneMixin, DbtDockerBaseOperator):
+    """
+    Executes a dbt core clone command.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/gcp_cloud_run_job.py
+++ b/cosmos/operators/gcp_cloud_run_job.py
@@ -10,6 +10,7 @@ from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCloneMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -179,4 +180,13 @@ class DbtRunOperationGcpCloudRunJobOperator(DbtRunOperationMixin, DbtGcpCloudRun
     template_fields: Sequence[str] = DbtGcpCloudRunJobBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneGcpCloudRunJobOperator(DbtCloneMixin, DbtGcpCloudRunJobBaseOperator):
+    """
+    Executes a dbt core clone command.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -11,6 +11,7 @@ from cosmos.dbt.parser.output import extract_log_issues
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCloneMixin,
     DbtLSMixin,
     DbtRunMixin,
     DbtRunOperationMixin,
@@ -259,4 +260,11 @@ class DbtRunOperationKubernetesOperator(DbtRunOperationMixin, DbtKubernetesBaseO
     template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneKubernetesOperator(DbtCloneMixin, DbtKubernetesBaseOperator):
+    """Executes a dbt core clone command."""
+
+    def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -70,6 +70,7 @@ from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBaseOperator,
     DbtBuildMixin,
+    DbtCloneMixin,
     DbtCompileMixin,
     DbtLSMixin,
     DbtRunMixin,
@@ -1008,4 +1009,13 @@ class DbtDepsLocalOperator(DbtLocalBaseOperator):
 class DbtCompileLocalOperator(DbtCompileMixin, DbtLocalBaseOperator):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["should_upload_compiled_sql"] = True
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
+    """
+    Executes a dbt core clone command.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -17,6 +17,7 @@ from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.log import get_logger
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
     DbtDocsLocalOperator,
     DbtLocalBaseOperator,
     DbtLSLocalOperator,
@@ -282,6 +283,15 @@ class DbtDocsVirtualenvOperator(DbtVirtualenvBaseOperator, DbtDocsLocalOperator)
     """
     Executes `dbt docs generate` command within a Python Virtual Environment, that is created before running the dbt
     command and deleted just after.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+
+class DbtCloneVirtualenvOperator(DbtVirtualenvBaseOperator, DbtCloneLocalOperator):
+    """
+    Executes a dbt core clone command.
     """
 
     def __init__(self, *args: Any, **kwargs: Any):

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -22,3 +22,28 @@ postgres_profile:
       port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
       schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
+
+bigquery_dev:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: service-account
+      project: astronomer-dag-authoring
+      dataset: bq_dev
+      threads: 4 # Must be a value of 1 or greater
+      keyfile: /usr/local/airflow/include/key.json
+      location: US
+
+
+bigquery_clone:
+  target: dev
+  outputs:
+    dev:
+      type: bigquery
+      method: service-account
+      project: astronomer-dag-authoring
+      dataset: bq_clone
+      threads: 4 # Must be a value of 1 or greater
+      keyfile: /usr/local/airflow/include/key.json
+      location: US

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -35,7 +35,6 @@ bigquery_dev:
       keyfile: /usr/local/airflow/include/key.json
       location: US
 
-
 bigquery_clone:
   target: dev
   outputs:

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -22,27 +22,3 @@ postgres_profile:
       port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
       schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
-
-bigquery_dev:
-  target: dev
-  outputs:
-    dev:
-      type: bigquery
-      method: service-account
-      project: astronomer-dag-authoring
-      dataset: bq_dev
-      threads: 4 # Must be a value of 1 or greater
-      keyfile: /usr/local/airflow/include/key.json
-      location: US
-
-bigquery_clone:
-  target: dev
-  outputs:
-    dev:
-      type: bigquery
-      method: service-account
-      project: astronomer-dag-authoring
-      dataset: bq_clone
-      threads: 4 # Must be a value of 1 or greater
-      keyfile: /usr/local/airflow/include/key.json
-      location: US

--- a/dev/dags/example_clone.py
+++ b/dev/dags/example_clone.py
@@ -1,0 +1,51 @@
+from datetime import datetime
+
+from airflow import DAG
+
+from cosmos import DbtCloneLocalOperator, DbtRunLocalOperator, DbtSeedLocalOperator, ProfileConfig
+
+DBT_PROJ_DIR = "/usr/local/airflow/dbt/jaffle_shop"
+
+profile_config1 = ProfileConfig(
+    profile_name="bigquery_dev",
+    target_name="dev",
+    profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml",
+)
+
+profile_config2 = ProfileConfig(
+    profile_name="bigquery_clone",
+    target_name="dev",
+    profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml",
+)
+
+
+with DAG("test-id-1", start_date=datetime(2024, 1, 1), catchup=False) as dag:
+    seed_operator = DbtSeedLocalOperator(
+        profile_config=profile_config1,
+        project_dir=DBT_PROJ_DIR,
+        task_id="seed",
+        dbt_cmd_flags=["--select", "raw_customers"],
+        install_deps=True,
+        append_env=True,
+    )
+    run_operator = DbtRunLocalOperator(
+        profile_config=profile_config1,
+        project_dir=DBT_PROJ_DIR,
+        task_id="run",
+        dbt_cmd_flags=["--models", "stg_customers"],
+        install_deps=True,
+        append_env=True,
+    )
+
+    # [START clone_example]
+    clone_operator = DbtCloneLocalOperator(
+        profile_config=profile_config2,
+        project_dir=DBT_PROJ_DIR,
+        task_id="clone",
+        dbt_cmd_flags=["--models", "stg_customers", "--state", "/usr/local/airflow/dbt/jaffle_shop/target"],
+        install_deps=True,
+        append_env=True,
+    )
+    # [END clone_example]
+
+    seed_operator >> run_operator >> clone_operator

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -9,8 +9,8 @@ from cosmos import DbtCloneLocalOperator, DbtRunLocalOperator, DbtSeedLocalOpera
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
 DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
-DBT_PROFILE_PATH = DBT_ROOT_PATH / "profiles.yml"
-DBT_ARTIFACT = DBT_ROOT_PATH / "target"
+DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
+DBT_ARTIFACT = DBT_PROJ_DIR / "target"
 
 profile_config1 = ProfileConfig(
     profile_name="bigquery_dev",

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -12,22 +12,15 @@ DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
 DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
 DBT_ARTIFACT = DBT_PROJ_DIR / "target"
 
-profile_config1 = ProfileConfig(
-    profile_name="bigquery_dev",
+profile_config = ProfileConfig(
+    profile_name="postgres_profile",
     target_name="dev",
     profiles_yml_filepath=DBT_PROFILE_PATH,
 )
-
-profile_config2 = ProfileConfig(
-    profile_name="bigquery_clone",
-    target_name="dev",
-    profiles_yml_filepath=DBT_PROFILE_PATH,
-)
-
 
 with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as dag:
     seed_operator = DbtSeedLocalOperator(
-        profile_config=profile_config1,
+        profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="seed",
         dbt_cmd_flags=["--select", "raw_customers"],
@@ -35,7 +28,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         append_env=True,
     )
     run_operator = DbtRunLocalOperator(
-        profile_config=profile_config1,
+        profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="run",
         dbt_cmd_flags=["--models", "stg_customers"],
@@ -45,7 +38,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
 
     # [START clone_example]
     clone_operator = DbtCloneLocalOperator(
-        profile_config=profile_config2,
+        profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="clone",
         dbt_cmd_flags=["--models", "stg_customers", "--state", DBT_ARTIFACT],

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -13,7 +13,7 @@ DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
 DBT_ARTIFACT = DBT_PROJ_DIR / "target"
 
 profile_config = ProfileConfig(
-    profile_name="postgres_profile",
+    profile_name="default",
     target_name="dev",
     profiles_yml_filepath=DBT_PROFILE_PATH,
 )

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -1,21 +1,27 @@
+import os
 from datetime import datetime
+from pathlib import Path
 
 from airflow import DAG
 
 from cosmos import DbtCloneLocalOperator, DbtRunLocalOperator, DbtSeedLocalOperator, ProfileConfig
 
-DBT_PROJ_DIR = "/usr/local/airflow/dbt/jaffle_shop"
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
+DBT_PROFILE_PATH = DBT_ROOT_PATH / "profiles.yml"
+DBT_ARTIFACT = DBT_ROOT_PATH / "target"
 
 profile_config1 = ProfileConfig(
     profile_name="bigquery_dev",
     target_name="dev",
-    profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml",
+    profiles_yml_filepath=DBT_PROFILE_PATH,
 )
 
 profile_config2 = ProfileConfig(
     profile_name="bigquery_clone",
     target_name="dev",
-    profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml",
+    profiles_yml_filepath=DBT_PROFILE_PATH,
 )
 
 
@@ -42,7 +48,7 @@ with DAG("test-id-1", start_date=datetime(2024, 1, 1), catchup=False) as dag:
         profile_config=profile_config2,
         project_dir=DBT_PROJ_DIR,
         task_id="clone",
-        dbt_cmd_flags=["--models", "stg_customers", "--state", "/usr/local/airflow/dbt/jaffle_shop/target"],
+        dbt_cmd_flags=["--models", "stg_customers", "--state", DBT_ARTIFACT],
         install_deps=True,
         append_env=True,
     )

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -25,7 +25,7 @@ profile_config2 = ProfileConfig(
 )
 
 
-with DAG("test-id-1", start_date=datetime(2024, 1, 1), catchup=False) as dag:
+with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as dag:
     seed_operator = DbtSeedLocalOperator(
         profile_config=profile_config1,
         project_dir=DBT_PROJ_DIR,

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -14,6 +14,7 @@
    Azure Container Instance Execution Mode <azure-container-instance>
    GCP Cloud Run Job Execution Mode <gcp-cloud-run-job>
    dbt and Airflow Similar Concepts <dbt-airflow-concepts>
+   Operators <operators>
 
 
 Getting Started

--- a/docs/getting_started/operators.rst
+++ b/docs/getting_started/operators.rst
@@ -18,7 +18,7 @@ The ``DbtCloneLocalOperator`` implement `dbt clone <https://docs.getdbt.com/refe
 
 Example of how to use
 
-.. literalinclude:: ../../dev/dags/example_clone.py
+.. literalinclude:: ../../dev/dags/example_operators.py
     :language: python
     :start-after: [START clone_example]
     :end-before: [END clone_example]

--- a/docs/getting_started/operators.rst
+++ b/docs/getting_started/operators.rst
@@ -1,0 +1,24 @@
+.. _operators:
+
+Operators
+=========
+
+Cosmos exposes individual operators that correspond to specific dbt commands, which can be used just like traditional
+`Apache Airflow® <https://airflow.apache.org/>`_ operators. Cosmos names these operators using the format ``Dbt<dbt-command><execution-mode>Operator``. For example, ``DbtBuildLocalOperator``.
+
+Clone
+-----
+
+Requirement
+
+* Cosmos >= 1.8.0
+* dbt-core >= 1.6.0
+
+The ``DbtCloneLocalOperator`` implement `dbt clone <https://docs.getdbt.com/reference/commands/clone>`_ command.
+
+Example of how to use
+
+.. literalinclude:: ../../dev/dags/example_clone.py
+    :language: python
+    :start-after: [START clone_example]
+    :end-before: [END clone_example]

--- a/tests/operators/test_aws_eks.py
+++ b/tests/operators/test_aws_eks.py
@@ -5,6 +5,7 @@ from airflow.exceptions import AirflowException
 
 from cosmos.operators.aws_eks import (
     DbtBuildAwsEksOperator,
+    DbtCloneAwsEksOperator,
     DbtLSAwsEksOperator,
     DbtRunAwsEksOperator,
     DbtSeedAwsEksOperator,
@@ -44,6 +45,7 @@ def test_dbt_kubernetes_build_command():
         "test": DbtTestAwsEksOperator(**base_kwargs),
         "build": DbtBuildAwsEksOperator(**base_kwargs),
         "seed": DbtSeedAwsEksOperator(**base_kwargs),
+        "clone": DbtCloneAwsEksOperator(**base_kwargs),
     }
 
     for command_name, command_operator in result_map.items():

--- a/tests/operators/test_azure_container_instance.py
+++ b/tests/operators/test_azure_container_instance.py
@@ -7,6 +7,7 @@ from pendulum import datetime
 from cosmos.operators.azure_container_instance import (
     DbtAzureContainerInstanceBaseOperator,
     DbtBuildAzureContainerInstanceOperator,
+    DbtCloneAzureContainerInstanceOperator,
     DbtLSAzureContainerInstanceOperator,
     DbtRunAzureContainerInstanceOperator,
     DbtSeedAzureContainerInstanceOperator,
@@ -127,6 +128,7 @@ result_map = {
     "run": DbtRunAzureContainerInstanceOperator(**base_kwargs),
     "test": DbtTestAzureContainerInstanceOperator(**base_kwargs),
     "seed": DbtSeedAzureContainerInstanceOperator(**base_kwargs),
+    "clone": DbtCloneAzureContainerInstanceOperator(**base_kwargs),
 }
 
 

--- a/tests/operators/test_docker.py
+++ b/tests/operators/test_docker.py
@@ -7,6 +7,7 @@ from pendulum import datetime
 
 from cosmos.operators.docker import (
     DbtBuildDockerOperator,
+    DbtCloneDockerOperator,
     DbtLSDockerOperator,
     DbtRunDockerOperator,
     DbtSeedDockerOperator,
@@ -113,6 +114,7 @@ result_map = {
     "test": DbtTestDockerOperator(**base_kwargs),
     "build": DbtBuildDockerOperator(**base_kwargs),
     "seed": DbtSeedDockerOperator(**base_kwargs),
+    "clone": DbtCloneDockerOperator(**base_kwargs),
 }
 
 

--- a/tests/operators/test_gcp_cloud_run_job.py
+++ b/tests/operators/test_gcp_cloud_run_job.py
@@ -10,6 +10,7 @@ from pendulum import datetime
 try:
     from cosmos.operators.gcp_cloud_run_job import (
         DbtBuildGcpCloudRunJobOperator,
+        DbtCloneGcpCloudRunJobOperator,
         DbtGcpCloudRunJobBaseOperator,
         DbtLSGcpCloudRunJobOperator,
         DbtRunGcpCloudRunJobOperator,
@@ -173,6 +174,7 @@ def test_dbt_gcp_cloud_run_job_build_command():
         "build": DbtBuildGcpCloudRunJobOperator(**BASE_KWARGS),
         "snapshot": DbtSnapshotGcpCloudRunJobOperator(**BASE_KWARGS),
         "source": DbtSourceGcpCloudRunJobOperator(**BASE_KWARGS),
+        "clone": DbtCloneGcpCloudRunJobOperator(**BASE_KWARGS),
         "run-operation": DbtRunOperationGcpCloudRunJobOperator(macro_name="some-macro", **BASE_KWARGS),
     }
 

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -10,6 +10,7 @@ from pendulum import datetime
 
 from cosmos.operators.kubernetes import (
     DbtBuildKubernetesOperator,
+    DbtCloneKubernetesOperator,
     DbtLSKubernetesOperator,
     DbtRunKubernetesOperator,
     DbtSeedKubernetesOperator,
@@ -128,6 +129,7 @@ result_map = {
     "test": DbtTestKubernetesOperator(**base_kwargs),
     "build": DbtBuildKubernetesOperator(**base_kwargs),
     "seed": DbtSeedKubernetesOperator(**base_kwargs),
+    "clone": DbtCloneKubernetesOperator(**base_kwargs),
 }
 
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -29,6 +29,7 @@ from cosmos.exceptions import CosmosValueError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
     DbtCompileLocalOperator,
     DbtDocsAzureStorageLocalOperator,
     DbtDocsGCSLocalOperator,
@@ -1159,6 +1160,19 @@ def test_dbt_compile_local_operator_initialisation():
     )
     assert operator.should_upload_compiled_sql is True
     assert "compile" in operator.base_cmd
+
+
+def test_dbt_clone_local_operator_initialisation():
+    operator = DbtCloneLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="clone",
+        dbt_cmd_flags=["--state", "/usr/local/airflow/dbt/jaffle_shop/target"],
+        install_deps=True,
+        append_env=True,
+    )
+
+    assert "clone" in operator.base_cmd
 
 
 @patch("cosmos.operators.local.remote_target_path", new="s3://some-bucket/target")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -806,6 +806,11 @@ def test_store_compiled_sql() -> None:
             {"context": {}, "env": {}, "cmd_flags": ["run", "--full-refresh"]},
         ),
         (
+            DbtCloneLocalOperator,
+            {"full_refresh": True},
+            {"context": {}, "env": {}, "cmd_flags": ["clone", "--full-refresh"]},
+        ),
+        (
             DbtTestLocalOperator,
             {},
             {"context": {}, "env": {}, "cmd_flags": ["test"]},

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -15,7 +15,7 @@ from packaging.version import Version
 from cosmos.config import ProfileConfig
 from cosmos.constants import InvocationMode
 from cosmos.exceptions import CosmosValueError
-from cosmos.operators.virtualenv import DbtVirtualenvBaseOperator
+from cosmos.operators.virtualenv import DbtCloneVirtualenvOperator, DbtVirtualenvBaseOperator
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 AIRFLOW_VERSION = Version(airflow.__version__)
@@ -376,3 +376,16 @@ def test_integration_virtualenv_operator(caplog):
 
     assert "Trying to run the command:\n ['/tmp/persistent-venv2/bin/dbt', 'deps'" in caplog.text
     assert "Trying to run the command:\n ['/tmp/persistent-venv2/bin/dbt', 'seed'" in caplog.text
+
+
+def test_dbt_clone_virtualenv_operator_initialisation():
+    operator = DbtCloneVirtualenvOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="clone",
+        dbt_cmd_flags=["--state", "/usr/local/airflow/dbt/jaffle_shop/target"],
+        install_deps=True,
+        append_env=True,
+    )
+
+    assert "clone" in operator.base_cmd

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -79,6 +79,8 @@ def get_dag_bag() -> DagBag:
             file.writelines(["example_cosmos_sources.py\n"])
         if DBT_VERSION < Version("1.6.0"):
             file.writelines(["example_model_version.py\n"])
+            file.writelines(["example_clone.py\n"])
+
         if DBT_VERSION < Version("1.5.0"):
             file.writelines(["example_source_rendering.py\n"])
 

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -55,6 +55,7 @@ def get_dag_bag() -> DagBag:
 
         if DBT_VERSION < Version("1.6.0"):
             file.writelines(["example_model_version.py\n"])
+            file.writelines(["example_clone.py\n"])
         # cosmos_profile_mapping uses the automatic profile rendering from an Airflow connection.
         # so we can't parse that without live connections
         for file_name in ["cosmos_profile_mapping.py"]:


### PR DESCRIPTION
## Description

This PR introduces the DbtCloneOperator. For more details, refer to the dbt documentation: https://docs.getdbt.com/reference/commands/clone.

## Testing

**Airflow DAG**
```python
from datetime import datetime

from airflow import DAG
from cosmos import DbtSeedLocalOperator, DbtRunLocalOperator, DbtCloneLocalOperator, ProfileConfig

DBT_PROJ_DIR="/usr/local/airflow/dbt/jaffle_shop"

profile_config1=ProfileConfig(
profile_name="bigquery_dev",
target_name="dev",
profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml"
)

profile_config2=ProfileConfig(
profile_name="bigquery_clone",
target_name="dev",
profiles_yml_filepath="/usr/local/airflow/dbt/jaffle_shop/profiles.yml"
)


with DAG("test-id-1", start_date=datetime(2024, 1, 1), catchup=False) as dag:
    seed_operator = DbtSeedLocalOperator(
        profile_config=profile_config1,
        project_dir=DBT_PROJ_DIR,
        task_id="seed",
        dbt_cmd_flags=["--select", "raw_customers"],
        install_deps=True,
        append_env=True,
    )
    run_operator = DbtRunLocalOperator(
        profile_config=profile_config1,
        project_dir=DBT_PROJ_DIR,
        task_id="run",
        dbt_cmd_flags=["--models", "stg_customers"],
        install_deps=True,
        append_env=True,
    )

    clone_operator = DbtCloneLocalOperator(
        profile_config=profile_config2,
        project_dir=DBT_PROJ_DIR,
        task_id="clone",
        dbt_cmd_flags=["--models", "stg_customers", "--state", "/usr/local/airflow/dbt/jaffle_shop/target"],
        install_deps=True,
        append_env=True,
    )

    seed_operator >> run_operator >> clone_operator
``` 

**DBT Profile**
```
bigquery_dev:
  target: dev
  outputs:
    dev:
      type: bigquery
      method: service-account
      project: astronomer-dag-authoring
      dataset: bq_dev
      threads: 4 # Must be a value of 1 or greater
      keyfile: /usr/local/airflow/include/key.json
      location: US


bigquery_clone:
  target: dev
  outputs:
    dev:
      type: bigquery
      method: service-account
      project: astronomer-dag-authoring
      dataset: bq_clone
      threads: 4 # Must be a value of 1 or greater
      keyfile: /usr/local/airflow/include/key.json
      location: US
``` 

**Airflow DAG Run**

<img width="1660" alt="Screenshot 2024-11-15 at 6 06 50 PM" src="https://github.com/user-attachments/assets/4a3af37e-3f6c-4859-814f-aeff3a252ac6">


**BQ data WH**

<img width="1454" alt="Screenshot 2024-11-15 at 6 04 29 PM" src="https://github.com/user-attachments/assets/69b45f57-3ff5-43d9-a8f1-bb04e7ad5735">


## Related Issue(s)

closes: https://github.com/astronomer/astronomer-cosmos/issues/1268
closes: https://github.com/astronomer/astronomer-cosmos/issues/878

## Breaking Change?
No

## Limitation
- The `dbt clone` command was introduced in dbt-core 1.6.0, so this feature is only available to users with dbt-core version 1.6 or higher https://github.com/dbt-labs/dbt-core/blob/1.6.latest/CHANGELOG.md
- Users should ensure their database is supported for cloning operations.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
