### PR TITLE
Add exempt label option in GH action stale job

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -18,6 +18,8 @@ jobs:
           days-before-pr-stale: 30
           days-before-pr-close: 10
           stale-pr-label: "stale"
+          exempt-issue-labels: "do-not-stale"
+          exempt-pr-labels: "do-not-stale"
           stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
           close-pr-message: "This PR was closed because it has been inactive for 10 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
I’ve noticed that the "dosubot" and "stale" jobs are creating unnecessary noise by closing issues and PRs that were not intended to be closed. In this PR, I am introducing the exempt-issue-labels and exempt-pr-labels options for the stale job. These options will ensure that issues and PRs labeled with do-not-stale are excluded from being closed by the "dosubot" and "stale" jobs.
