### PR TITLE
Configure Airflow tasks using dbt model meta

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -119,6 +119,7 @@ def create_test_task_metadata(
     return TaskMetadata(
         id=test_task_name,
         owner=task_owner,
+        cosmos_custom=node.cosmos_custom,
         operator_class=calculate_operator_class(
             execution_mode=execution_mode,
             dbt_class="DbtTest",
@@ -191,6 +192,7 @@ def create_task_metadata(
         task_metadata = TaskMetadata(
             id=task_id,
             owner=node.owner,
+            cosmos_custom=node.cosmos_custom,
             operator_class=calculate_operator_class(
                 execution_mode=execution_mode, dbt_class=dbt_resource_to_class[node.resource_type]
             ),

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -32,6 +32,9 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
     if task.owner != "":
         task_kwargs["owner"] = task.owner
 
+    for k, v in task.cosmos_custom.items():
+        task_kwargs[k] = v
+
     airflow_task = Operator(
         task_id=task.id,
         dag=dag,

--- a/cosmos/core/graph/entities.py
+++ b/cosmos/core/graph/entities.py
@@ -58,6 +58,7 @@ class Task(CosmosEntity):
     """
 
     owner: str = ""
+    cosmos_custom: Dict[str, Any] = field(default_factory=dict)
     operator_class: str = "airflow.operators.empty.EmptyOperator"
     arguments: Dict[str, Any] = field(default_factory=dict)
     extra_context: Dict[str, Any] = field(default_factory=dict)

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -13,7 +13,7 @@ from dataclasses import dataclass, field
 from functools import cached_property
 from pathlib import Path
 from subprocess import PIPE, Popen
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Dict
 
 from airflow.models import Variable
 
@@ -66,6 +66,20 @@ class DbtNode:
     config: dict[str, Any] = field(default_factory=lambda: {})
     has_freshness: bool = False
     has_test: bool = False
+
+    @property
+    def cosmos_custom(self) -> Dict[str, Any]:
+        """
+        This method is designed to extend the dbt project's functionality by incorporating Airflow-related metadata into the dbt YAML configuration.
+        Since dbt projects are independent of Airflow, adding Airflow-specific information to the `meta` field within the dbt YAML allows Airflow tasks to
+        utilize this information during execution.
+
+        Examples: pool, pool_slots, queue, ...
+        Returns:
+            Dict[str, Any]: A dictionary containing custom metadata configurations for integration with Airflow.
+        """
+        return self.config.get("meta", {}).get("cosmos", {})
+
 
     @property
     def resource_name(self) -> str:


### PR DESCRIPTION
## Description
The various dbt models have unique characteristics, and some may require the use of custom pools, queues, or other specific configurations. To support such cases, this update introduces the ability to add necessary information in the meta section of the dbt model.yaml. This metadata is then passed as kwargs to the corresponding Airflow tasks, enabling model-specific customization and enhanced task configuration.


**here is sample**

DbtTaskGroup - default_args for all dbt models
```python
    dbt_task_group = DbtTaskGroup(
        project_config=,
        profile_config=ProfileConfig,
        default_args={'pool': dbt_pool}
    )
```


```yaml
version: 2

models:
  - name: name
    description: description
    meta:
      owner: 'jaegwon.seo@toss.im'
      cosmos:
        pool: abcd
```

**result**

general pool
![스크린샷 2024-11-25 오후 10 15 26](https://github.com/user-attachments/assets/ea492a19-488f-4dbb-b4b9-2be20dc191be)
custom pool
![스크린샷 2024-11-25 오후 10 15 40](https://github.com/user-attachments/assets/f6055cc0-94f6-4789-9b05-4e02e34bcd5f)



## Related Issue(s)
https://github.com/astronomer/astronomer-cosmos/issues/1325
## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
