### PR TITLE
[Docs] Remove extra ` char from docs

### DIFF
--- a/docs/contributing.rst
+++ b/docs/contributing.rst
@@ -166,7 +166,7 @@ This will run the docs server in a virtual environment with the right dependenci
 Building
 ________
 
-We use ```hatch``` to build the project. To build the project, run:
+We use ``hatch`` to build the project. To build the project, run:
 
 .. code-block:: bash
 
@@ -183,7 +183,7 @@ We use GitHub actions to create and deploy new releases. To create a new release
     hatch version minor
 
 
-```hatch``` will automatically update the version for you. Then, create a new release on GitHub with the new version. The release will be automatically deployed to PyPI.
+``hatch`` will automatically update the version for you. Then, create a new release on GitHub with the new version. The release will be automatically deployed to PyPI.
 
 .. note::
     You can update the version in a few different ways. Check out the `hatch docs <https://hatch.pypa.io/latest/version/#updating>`_ to learn more.


### PR DESCRIPTION
Remove extra ` char from docs

**Before**
<img width="813" alt="Screenshot 2024-11-28 at 1 33 55 AM" src="https://github.com/user-attachments/assets/4c676c45-ad0b-47d8-8ed4-ef5fe0ea4fb7">

**After**

<img width="829" alt="Screenshot 2024-11-28 at 1 39 31 AM" src="https://github.com/user-attachments/assets/0e5d99e3-35b8-4903-ac28-4761599c27b2">
