### PR TITLE
Remove dependency `eval_type_backport`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,6 @@ dependencies = [
     "types-requests",
     "types-python-dateutil",
     "Werkzeug<3.0.0",
-    "eval_type_backport", # TODO: https://github.com/astronomer/astronomer-cosmos/issues/1342
     "dbt-core<1.8.9"  # TODO: https://github.com/astronomer/astronomer-cosmos/issues/1343
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]


### PR DESCRIPTION
Sometimes, time is the best medicine. The CI issue that happened before no longer occurs, and we can remove the dependency `eval_type_backport` while seeing all the tests pass.

Closes: #1342