### PR TITLE
Remove 'dbt-core<1.8.9' pin

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, issue-1343]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 
@@ -134,12 +134,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      #- uses: actions/cache@v3
-      #  with:
-      #    path: |
-      #      ~/.cache/pip
-      #      .local/share/hatch/
-      #    key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -211,12 +211,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      #- uses: actions/cache@v3
-      #  with:
-      #    path: |
-      #      ~/.cache/pip
-      #      .local/share/hatch/
-      #    key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, issue-1343]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 
@@ -134,12 +134,12 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+      #- uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      ~/.cache/pip
+      #      .local/share/hatch/
+      #    key: integration-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4
@@ -211,12 +211,12 @@ jobs:
       - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
-      - uses: actions/cache@v3
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+      #- uses: actions/cache@v3
+      #  with:
+      #    path: |
+      #      ~/.cache/pip
+      #      .local/share/hatch/
+      #    key: integration-expensive-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ dependencies = [
     "types-requests",
     "types-python-dateutil",
     "Werkzeug<3.0.0",
-    "dbt-core<1.8.9"  # TODO: https://github.com/astronomer/astronomer-cosmos/issues/1343
+    "dbt-core"
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -6,9 +6,9 @@ set -e
 
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-pip uninstall -y dbt-postgres dbt-databricks dbt-vertica
+pip uninstall -y 'dbt-bigquery' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
 rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y
 airflow db init
-pip install 'dbt-core' 'dbt-bigquery' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
+pip install 'dbt-databricks' 'dbt-bigquery' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'


### PR DESCRIPTION
We were facing issues with conflicting dbt core and dbt-databricks when using the latest release of dbt-core:
```
File "<frozen importlib._bootstrap>", line 1204, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1176, in _find_and_load
  File "<frozen importlib._bootstrap>", line 1147, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 690, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line [940](https://github.com/astronomer/astronomer-cosmos/actions/runs/12018236731/job/33502297498?pr=1340#step:7:941), in exec_module
  File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.11-2.6/lib/python3.11/site-packages/dbt/adapters/databricks/__init__.py", line 1, in <module>
    from dbt.adapters.databricks.connections import DatabricksConnectionManager  # noqa
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.11-2.6/lib/python3.11/site-packages/dbt/adapters/databricks/connections.py", line 27, in <module>
    from dbt.adapters.base import Credentials
ImportError: cannot import name 'Credentials' from 'dbt.adapters.base' (/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.11-2.6/lib/python3.11/site-packages/dbt/adapters/base/__init__.py)
```

This PR solves this.

Closes: #1343
