### PR TITLE
Pin dbt-databricks version to < 1.9

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,9 +2,9 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
-  pull_request_target: # Also run on pull requests originated from forks
     branches: [main, fix-1375]
+  pull_request_target: # Also run on pull requests originated from forks
+    branches: [main]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        airflow-version: ["2.4", "2.5", "2.6", "2.7"] #, "2.8", "2.9", "2.10"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7"] #, "2.8", "2.9", "2.10"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -105,7 +105,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11"]
-        airflow-version: ["2.4", "2.5", "2.6", "2.7"] #, "2.8", "2.9", "2.10"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, fix-1375]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ on:
   push: # Run on pushes to the default branch
     branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
-    branches: [main]
+    branches: [main, fix-1375]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -39,7 +39,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
-        airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10"]
+        airflow-version: ["2.4", "2.5", "2.6", "2.7"] #, "2.8", "2.9", "2.10"]
         exclude:
           - python-version: "3.11"
             airflow-version: "2.4"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
     "Jinja2>=3.0.0",
     "msgpack",
     "packaging>=22.0",
-    "pydantic>=1.10.0",
+    # "pydantic>=1.10.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,6 +45,7 @@ dbt-all = [
     "dbt-athena",
     "dbt-bigquery",
     "dbt-clickhouse",
+    # TODO: https://github.com/astronomer/astronomer-cosmos/issues/1379
     "dbt-databricks<1.9",
     "dbt-exasol",
     "dbt-postgres",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,6 @@ dependencies = [
     "Jinja2>=3.0.0",
     "msgpack",
     "packaging>=22.0",
-    # "pydantic>=1.10.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]
@@ -65,7 +64,7 @@ dbt-redshift = ["dbt-redshift"]
 dbt-snowflake = ["dbt-snowflake"]
 dbt-spark = ["dbt-spark"]
 dbt-teradata = ["dbt-teradata"]
-dbt-vertica = ["dbt-vertica"]
+dbt-vertica = ["dbt-vertica<=1.5.4"]
 openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
 amazon = [
     "apache-airflow-providers-amazon[s3fs]>=3.0.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dbt-all = [
     "dbt-athena",
     "dbt-bigquery",
     "dbt-clickhouse",
-    "dbt-databricks",
+    "dbt-databricks<1.9",
     "dbt-exasol",
     "dbt-postgres",
     "dbt-redshift",
@@ -144,7 +144,7 @@ dependencies = [
     "types-requests",
     "types-python-dateutil",
     "Werkzeug<3.0.0",
-    "dbt-core"
+    "dbt-core",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,6 +35,7 @@ dependencies = [
     "Jinja2>=3.0.0",
     "msgpack",
     "packaging>=22.0",
+    "pydantic>=1.10.0",
     "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ dbt-redshift = ["dbt-redshift"]
 dbt-snowflake = ["dbt-snowflake"]
 dbt-spark = ["dbt-spark"]
 dbt-teradata = ["dbt-teradata"]
-dbt-vertica = ["dbt-vertica<=1.5.4"]
+dbt-vertica = ["dbt-vertica"]
 openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
 amazon = [
     "apache-airflow-providers-amazon[s3fs]>=3.0.0",
@@ -189,7 +189,6 @@ dependencies = [
     "apache-airflow-providers-microsoft-azure>=8.5.0",
     "msgpack",
     "openlineage-airflow",
-    "pydantic>=1.10.0",
     "pydata-sphinx-theme",
     "sphinx",
     "sphinx-autoapi",

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -6,9 +6,9 @@ set -e
 
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-pip uninstall -y 'dbt-bigquery' 'dbt-databricks<1.9' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
+pip uninstall -y 'dbt-bigquery' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
 rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y
 airflow db init
-pip install 'dbt-databricks' 'dbt-bigquery' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
+pip install 'dbt-databricks<1.9' 'dbt-bigquery' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -6,7 +6,7 @@ set -e
 
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
-pip uninstall -y 'dbt-bigquery' 'dbt-databricks' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
+pip uninstall -y 'dbt-bigquery' 'dbt-databricks<1.9' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
 rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y


### PR DESCRIPTION
Our CI is broken due to a `dbt-databricks` release with conflicting dependencies with `Airflow>=2.8`.

The latest release of`dbt-databricks` has pinned the Pydantic to `"pydantic>=1.10.0, <2"` https://github.com/databricks/dbt-databricks/blob/main/pyproject.toml#L33-L33

This change was added in PR: https://github.com/databricks/dbt-databricks/pull/843  and released on 9 December as part of `dbt-databricks==1.9.0` (https://pypi.org/project/dbt-databricks/1.9.0/).

The `debt-data bricks` conflicts with the neAirflow version, which that requires Pydantic 2.0.

For Airflow < 2.8, things work as expected: https://github.com/astronomer/astronomer-cosmos/actions/runs/12259335118/job/34201293598.

In this PR, I'm pinning dbt-databricks version to < 1.9 to make CI green again.

Follow-up PR: https://github.com/astronomer/astronomer-cosmos/issues/1379