### PR TITLE
Remove typing-extensions as dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,7 +36,6 @@ dependencies = [
     "msgpack",
     "packaging>=22.0",
     "pydantic>=1.10.0",
-    "typing-extensions; python_version < '3.8'",
     "virtualenv",
 ]
 


### PR DESCRIPTION
Since We do not support Python < 3.8 let's remove typing-extensions as dependency