### PR TITLE
Remove Pytest durations from tests scripts

### DIFF
--- a/scripts/test/integration-dbt-1-5-4.sh
+++ b/scripts/test/integration-dbt-1-5-4.sh
@@ -7,7 +7,6 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m integration  \
     --ignore=tests/perf \
     --ignore=tests/test_example_k8s_dags.py \

--- a/scripts/test/integration-expensive.sh
+++ b/scripts/test/integration-expensive.sh
@@ -3,7 +3,6 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m integration  \
     --ignore=tests/perf \
     --ignore=tests/test_example_k8s_dags.py \

--- a/scripts/test/integration-kubernetes.sh
+++ b/scripts/test/integration-kubernetes.sh
@@ -11,6 +11,5 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m integration \
     tests/test_example_k8s_dags.py

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -17,7 +17,6 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m 'integration'  \
     --ignore=tests/perf \
     --ignore=tests/test_example_k8s_dags.py \

--- a/scripts/test/unit-cov.sh
+++ b/scripts/test/unit-cov.sh
@@ -3,7 +3,6 @@ pytest \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations=0 \
     -m "not (integration or perf)" \
     --ignore=tests/perf \
     --ignore=tests/test_example_dags.py \

--- a/scripts/test/unit.sh
+++ b/scripts/test/unit.sh
@@ -1,6 +1,5 @@
 pytest \
     -vv \
-    --durations=0 \
     -m "not (integration or perf)" \
     --ignore=tests/perf \
     --ignore=tests/test_example_dags.py \


### PR DESCRIPTION
Even though the `--durations` flag can be very helpful in debugging and troubleshooting test durations, having it permanently adds overhead to the tests and obfuscates us seeing more relevant data, such as coverage reports.

As an example, it is currently hard to spot test coverage when running:
```
hatch run tests.py3.8-2.4:test-integration
```

Since the end of the terminal is filled up with duration information that we're not currently using:

```
============================================================= slowest durations ==============================================================
29.86s call     tests/test_example_dags.py::test_example_dag[example_model_version]
22.90s call     tests/test_example_dags.py::test_example_dag[example_cosmos_sources]
22.74s call     tests/test_example_dags.py::test_example_dag[source_rendering_dag]
22.68s call     tests/test_example_dags.py::test_example_dag[cosmos_profile_mapping]
22.38s call     tests/test_example_dags.py::test_example_dag[basic_cosmos_dag]
13.39s call     tests/operators/test_local.py::test_run_operator_caches_partial_parsing
12.12s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[True]
12.00s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[False]
11.94s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_uses_partial_parse_when_cache_is_disabled
11.67s call     tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets
11.65s call     tests/test_example_dags.py::test_example_dag[basic_cosmos_task_group]
11.09s call     tests/test_example_dags.py::test_example_dag[extract_dag]
10.25s call     tests/test_example_dags.py::test_example_dag[user_defined_profile]
9.29s call     tests/test_example_dags.py::test_example_dag[example_operators]
7.61s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_project_config_vars
7.57s call     tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.SUBPROCESS]
7.41s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_selector_arg
7.33s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir0-39]
7.20s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_via_dbt_ls]
7.20s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_exclude
6.98s call     tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_via_dbt_ls]
6.90s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages
5.87s call     tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.SUBPROCESS]
4.25s setup    tests/plugin/test_plugin.py::test_dbt_docs
4.24s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir1-28]
3.45s call     tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.DBT_RUNNER]
3.43s call     tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.DBT_RUNNER]
2.87s call     tests/operators/test_local.py::test_run_operator_dataset_url_encoded_names
2.26s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps
0.71s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/manifest.json]
0.23s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs]
0.10s call     tests/plugin/test_plugin.py::test_dbt_docs
0.07s call     tests/test_example_dags.py::test_example_dag[dataset_triggered_dag]
0.05s call     tests/test_example_dags.py::test_example_dag[example_cosmos_cleanup_dag]
0.04s call     tests/test_example_dags.py::test_example_dag[docs_dag]
0.03s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_selector_arg
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[False]
0.02s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[True]
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr
0.02s setup    tests/test_example_dags.py::test_example_dag[example_operators]
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps_and_preinstalled_dbt_packages
0.02s setup    tests/test_example_dags.py::test_example_dag[example_model_version]
0.02s setup    tests/test_example_dags.py::test_example_dag[user_defined_profile]
0.02s setup    tests/test_example_dags.py::test_example_dag[basic_cosmos_dag]
0.02s setup    tests/test_example_dags.py::test_example_dag[cosmos_profile_mapping]
0.02s setup    tests/test_example_dags.py::test_example_dag[basic_cosmos_task_group]
0.02s setup    tests/test_example_dags.py::test_example_dag[source_rendering_dag]
0.02s setup    tests/test_example_dags.py::test_example_dag[docs_dag]
0.02s setup    tests/test_example_dags.py::test_example_dag[example_cosmos_sources]
0.02s setup    tests/test_example_dags.py::test_example_dag[dataset_triggered_dag]
0.02s setup    tests/test_example_dags.py::test_example_dag[example_cosmos_cleanup_dag]
0.02s setup    tests/test_example_dags.py::test_example_dag[extract_dag]
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_uses_partial_parse_when_cache_is_disabled
0.02s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_runtime_error_in_stdout
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[True]
0.02s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[False]
0.02s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs]
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/manifest.json]
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/catalog.json]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_not_set_up
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs_index.html]
0.01s call     tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_all_cache_five_minutes_ago
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/manifest.json]
0.01s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_non_zero_returncode
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/catalog.json]
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[dbt_docs_index.html]
0.01s call     tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs_index.html]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[catalog.json]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[manifest.json]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[dbt_docs_index.html]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[manifest.json]
0.01s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[False]
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[catalog.json]
0.01s call     tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_a_week_ago_cache
0.01s setup    tests/dbt/test_graph.py::test_dbt_ls_cache_key_args_uses_airflow_vars_to_purge_dbt_ls_cache
0.01s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[True]
0.01s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr
0.01s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_from_dbt_manifest]
0.01s setup    tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.SUBPROCESS]
0.01s call     tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_from_dbt_manifest]
0.01s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[False]
0.01s call     tests/airflow/test_graph.py::test_build_airflow_graph_with_dbt_compile_task
0.01s setup    tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_a_week_ago_cache
0.01s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact[catalog.json]
0.01s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_caching_partial_parsing[True]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_uses_partial_parse_when_cache_is_disabled
0.00s setup    tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_all_cache_five_minutes_ago
0.00s teardown tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_a_week_ago_cache
0.00s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact[manifest.json]
0.00s call     tests/plugin/test_plugin.py::test_dbt_docs_artifact[dbt_docs_index.html]
0.00s teardown tests/test_cache.py::test_delete_unused_dbt_ls_cache_deletes_all_cache_five_minutes_ago
0.00s setup    tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.DBT_RUNNER]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[False]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_selector_arg
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_zero_returncode_and_non_empty_stderr
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[True]
0.00s setup    tests/dbt/test_graph.py::test_get_dbt_ls_cache_returns_empty_if_non_json_var
0.00s teardown tests/dbt/test_graph.py::test_dbt_ls_cache_key_args_uses_airflow_vars_to_purge_dbt_ls_cache
0.00s call     tests/airflow/test_graph.py::test_build_airflow_graph_with_after_each
0.00s teardown tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.DBT_RUNNER]
0.00s call     tests/dbt/test_graph.py::test_dbt_ls_cache_key_args_uses_airflow_vars_to_purge_dbt_ls_cache
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs_index.html]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/catalog.json]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/manifest.json]
0.00s teardown tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.SUBPROCESS]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/dbt_docs_index.html]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_in_astro_must_include_custom_menu[/cosmos/catalog.json]
0.00s teardown tests/dbt/test_graph.py::test_get_dbt_ls_cache_returns_empty_if_non_json_var
0.00s teardown tests/operators/test_local.py::test_run_operator_caches_partial_parsing
0.00s call     tests/airflow/test_graph.py::test_build_airflow_graph_with_after_all
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_operators]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_sources]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[dataset_triggered_dag]
0.00s call     tests/dbt/test_graph.py::test_load_via_dbt_ls_file
0.00s call     tests/dbt/test_graph.py::test_get_dbt_ls_cache_returns_empty_if_non_json_var
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[source_rendering_dag]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_model_version]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[user_defined_profile]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[docs_dag]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[simple_dag_async]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_task_group]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_dag]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[extract_dag]
0.00s call     tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_cleanup_dag]
0.00s setup    tests/operators/test_local.py::test_run_operator_caches_partial_parsing
0.00s setup    tests/airflow/test_graph.py::test_build_airflow_graph_with_after_each
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir0-39]
0.00s call     tests/operators/test_local.py::test_run_operator_emits_events
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_via_dbt_ls]
0.00s setup    tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets
0.00s teardown tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir1-28]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir0-39]
0.00s teardown tests/test_example_dags.py::test_example_dag[example_model_version]
0.00s setup    tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_from_dbt_manifest]
0.00s setup    tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_via_dbt_ls]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_without_exclude[project_dir1-28]
0.00s teardown tests/operators/test_local.py::test_run_operator_dataset_url_encoded_names
0.00s teardown tests/test_example_dags.py::test_example_dag[cosmos_profile_mapping]
0.00s teardown tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_via_dbt_ls]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps
0.00s teardown tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.SUBPROCESS]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_runtime_error_in_stdout
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_exclude
0.00s teardown tests/test_example_dags.py::test_example_dag[basic_cosmos_task_group]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_project_config_vars
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_without_dbt_deps
0.00s teardown tests/test_example_dags.py::test_example_dag[example_cosmos_sources]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_from_dbt_manifest]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_via_dbt_ls]
0.00s teardown tests/test_example_dags.py::test_example_dag[source_rendering_dag]
0.00s setup    tests/operators/test_local.py::test_run_operator_dataset_url_encoded_names
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact[dbt_docs_index.html]
0.00s teardown tests/test_example_dags.py::test_example_dag[example_operators]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[dataset_triggered_dag]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[catalog.json]
0.00s setup    tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.DBT_RUNNER]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[catalog.json]
0.00s setup    tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact[catalog.json]
0.00s teardown tests/test_example_dags.py::test_example_dag[dataset_triggered_dag]
0.00s teardown tests/test_example_dags.py::test_example_dag[extract_dag]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/catalog.json]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact[manifest.json]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[extract_dag]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_sources]
0.00s teardown tests/airflow/test_graph.py::test_build_airflow_graph_with_after_each
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_sources]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[manifest.json]
0.00s teardown tests/test_example_dags.py::test_example_dag[basic_cosmos_dag]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_operators]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[dbt_docs_index.html]
0.00s teardown tests/operators/test_local.py::test_run_operator_dataset_emission_is_skipped
0.00s setup    tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.SUBPROCESS]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs_index.html]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/manifest.json]
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[dbt_docs_index.html]
0.00s teardown tests/test_example_dags.py::test_example_dag[example_cosmos_cleanup_dag]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_exclude
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_runtime_error_in_stdout
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[manifest.json]
0.00s setup    tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[manifest.json]
0.00s teardown tests/test_example_dags.py::test_example_dag[user_defined_profile]
0.00s teardown tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.DBT_RUNNER]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[dataset_triggered_dag]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/catalog.json]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_non_zero_returncode
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[manifest.json]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact[dbt_docs_index.html]
0.00s teardown tests/dbt/test_graph.py::test_load_dbt_ls_and_manifest_with_model_version[load_from_dbt_manifest]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[catalog.json]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[simple_dag_async]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact[manifest.json]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[docs_dag]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[source_rendering_dag]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/manifest.json]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_non_zero_returncode
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_dag]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs]
0.00s teardown tests/test_example_dags.py::test_example_dag[docs_dag]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_cleanup_dag]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact[catalog.json]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_model_version]
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_with_sources[load_from_dbt_manifest]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_task_group]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_not_found[dbt_docs_index.html]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[user_defined_profile]
0.00s teardown tests/plugin/test_plugin.py::test_has_access_with_permissions_outside_astro_does_not_include_custom_menu[/cosmos/dbt_docs_index.html]
0.00s setup    tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[extract_dag]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[dbt_docs_index.html]
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_artifact_missing[catalog.json]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[source_rendering_dag]
0.00s setup    tests/operators/test_local.py::test_run_operator_dataset_emission_is_skipped
0.00s teardown tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards_disabled_via_envvar
0.00s teardown tests/dbt/test_graph.py::test_load_via_dbt_ls_file
0.00s setup    tests/airflow/test_graph.py::test_build_airflow_graph_with_after_all
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_file
0.00s setup    tests/plugin/test_plugin.py::test_dbt_docs_not_set_up
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_operators]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[user_defined_profile]
0.00s setup    tests/dbt/test_graph.py::test_load_via_dbt_ls_with_project_config_vars
0.00s teardown tests/plugin/test_plugin.py::test_dbt_docs_not_set_up
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_model_version]
0.00s setup    tests/operators/test_local.py::test_run_operator_emits_events
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[docs_dag]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[simple_dag_async]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_task_group]
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[example_cosmos_cleanup_dag]
0.00s setup    tests/airflow/test_graph.py::test_build_airflow_graph_with_dbt_compile_task
0.00s teardown tests/airflow/test_graph.py::test_build_airflow_graph_with_dbt_compile_task
0.00s setup    tests/operators/test_virtualenv.py::test_integration_virtualenv_operator
0.00s teardown tests/test_example_dags_no_connections.py::test_parse_dags_without_connections[basic_cosmos_dag]
0.00s teardown tests/airflow/test_graph.py::test_build_airflow_graph_with_after_all
0.00s setup    tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards_disabled_via_envvar
0.00s teardown tests/operators/test_local.py::test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards
0.00s teardown tests/operators/test_virtualenv.py::test_integration_virtualenv_operator
0.00s teardown tests/operators/test_local.py::test_run_operator_emits_events
========================================================== short test summary info ===========================================================

```