### PR TITLE
Improve dbt command execution logs to troubleshoot `None` values

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.8.0a2"
+__version__ = "1.7.1"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.8.0a1"
+__version__ = "1.8.0a2"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.7.1"
+__version__ = "1.8.0a1"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -133,7 +133,8 @@ def is_freshness_effective(freshness: Optional[dict[str, Any]]) -> bool:
 
 def run_command(command: list[str], tmp_dir: Path, env_vars: dict[str, str]) -> str:
     """Run a command in a subprocess, returning the stdout."""
-    logger.info("Running command: `%s`", " ".join(str(arg) if arg is not None else "<None>" for arg in command))
+    command = [str(arg) if arg is not None else "<None>" for arg in command]
+    logger.info("Running command: `%s`", " ".join(command))
     logger.debug("Environment variable keys: %s", env_vars.keys())
     process = Popen(
         command,

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -133,7 +133,7 @@ def is_freshness_effective(freshness: Optional[dict[str, Any]]) -> bool:
 
 def run_command(command: list[str], tmp_dir: Path, env_vars: dict[str, str]) -> str:
     """Run a command in a subprocess, returning the stdout."""
-    logger.info("Running command: `%s`", " ".join(command))
+    logger.info("Running command: `%s`", " ".join(str(arg) if arg is not None else "<None>" for arg in command))
     logger.debug("Environment variable keys: %s", env_vars.keys())
     process = Popen(
         command,

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1121,6 +1121,20 @@ def test_run_command(mock_popen, stdout, returncode):
     assert return_value == stdout
 
 
+@patch("cosmos.dbt.graph.Popen")
+def test_run_command_none_argument(mock_popen, caplog):
+    fake_command = ["invalid-cmd", None]
+    fake_dir = Path("fake_dir")
+    env_vars = {"fake": "env_var"}
+
+    mock_popen.return_value.communicate.return_value = ("Invalid None argument", None)
+    with pytest.raises(CosmosLoadDbtException) as exc_info:
+        run_command(fake_command, fake_dir, env_vars)
+
+    expected = "Unable to run ['invalid-cmd', '<None>'] due to the error:\nInvalid None argument"
+    assert str(exc_info.value) == expected
+
+
 def test_parse_dbt_ls_output_real_life_customer_bug(caplog):
     dbt_ls_output = """
 11:20:43  Running with dbt=1.7.6


### PR DESCRIPTION
Recently, an Astronomer customer reported they were facing the following error while trying to run Cosmos and couldn't troubleshoot it:
![type-error](https://github.com/user-attachments/assets/bfb15103-d6f8-425c-ae0e-25b40953d3d7)

The following log line was sub-optimal, since it errored if the value was None:
https://github.com/astronomer/astronomer-cosmos/blob/43998d246661b0f27580cf9f314d19aeef785b6a/cosmos/dbt/graph.py#L136

To change just the log line was not enough since the `None` would also break the subprocess command execution:
![type-error-2](https://github.com/user-attachments/assets/d8980b4e-eed1-4948-825f-3f219e84b1ee)

By changing both, the source problem became evident to the customer:
![unable-to-run](https://github.com/user-attachments/assets/80906ee0-8c17-4615-8ca2-b87a704db5e1)
