### PR TITLE
Fix releasing package to PyPI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ jobs:
           path: dist
 
       - name: Push build artifacts to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.10.3
+        uses: pypa/gh-action-pypi-publish@v1.12.3
         with:
           user: __token__
           password: ${{ secrets.PYPI_TOKEN }}


### PR DESCRIPTION
Fixes the error raised while trying to publish Cosmos 1.8.0a3:
```
Checking dist/astronomer_cosmos-1.8.0a3-py3-none-any.whl: ERROR    InvalidDistribution: Metadata is missing required fields: Name,
 Version.
 Make sure the distribution includes the files where those fields are
 specified, and is using a supported Metadata-Version: 1.0, 1.1, 1.2,
 2.0, 2.1, 2.2, 2.3.
```
https://github.com/astronomer/astronomer-cosmos/actions/runs/12374645486/job/34538056884

The fix was tested in the following branch and the release worked:
https://github.com/astronomer/astronomer-cosmos/pull/1395
https://github.com/astronomer/astronomer-cosmos/actions/runs/12374833970
