### PR TITLE
Add warning callback on source freshness

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -198,7 +198,6 @@ def create_task_metadata(
             else:
                 task_id = f"{node.name}_run"
         elif node.resource_type == DbtResourceType.SOURCE:
-            # if on_warning_callback is not None:
             extra_context["on_warning_callback"] = on_warning_callback
 
             if (source_rendering_behavior == SourceRenderingBehavior.NONE) or (

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -199,7 +199,7 @@ def create_task_metadata(
             else:
                 task_id = f"{node.name}_run"
         elif node.resource_type == DbtResourceType.SOURCE:
-            extra_context["on_warning_callback"] = on_warning_callback
+            args["on_warning_callback"] = on_warning_callback
 
             if (source_rendering_behavior == SourceRenderingBehavior.NONE) or (
                 source_rendering_behavior == SourceRenderingBehavior.WITH_TESTS_OR_FRESHNESS

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -177,7 +177,8 @@ def create_task_metadata(
     :param dbt_dag_task_group_identifier: Identifier to refer to the DbtDAG or DbtTaskGroup in the DAG.
     :param use_task_group: It determines whether to use the name as a prefix for the task id or not.
         If it is False, then use the name as a prefix for the task id, otherwise do not.
-    :param on_warning_callback:
+    :param on_warning_callback: A callback function called on warnings with additional Context variables “test_names”
+        and “test_results” of type List. This is param available for dbt test and dbt source freshness command.
     :returns: The metadata necessary to instantiate the source dbt node as an Airflow task.
     """
     dbt_resource_to_class = create_dbt_resource_to_class(test_behavior)

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -35,6 +35,12 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
     for k, v in task.airflow_task_config.items():
         task_kwargs[k] = v
 
+    # Set the on_warning_callback of source node in task_kwargs
+    on_warning_callback = task.extra_context.get("on_warning_callback")
+    if on_warning_callback is not None:
+        task_kwargs["on_warning_callback"] = on_warning_callback
+        del task.extra_context["on_warning_callback"]
+
     airflow_task = Operator(
         task_id=task.id,
         dag=dag,

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -35,11 +35,6 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
     for k, v in task.airflow_task_config.items():
         task_kwargs[k] = v
 
-    on_warning_callback = task.extra_context.get("on_warning_callback")
-    if on_warning_callback:
-        task_kwargs["on_warning_callback"] = on_warning_callback
-        task.extra_context.pop("on_warning_callback", None)
-
     airflow_task = Operator(
         task_id=task.id,
         dag=dag,

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -35,7 +35,6 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
     for k, v in task.airflow_task_config.items():
         task_kwargs[k] = v
 
-    # Set the on_warning_callback of source node in task_kwargs
     on_warning_callback = task.extra_context.get("on_warning_callback")
     if on_warning_callback:
         task_kwargs["on_warning_callback"] = on_warning_callback

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -37,9 +37,9 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
 
     # Set the on_warning_callback of source node in task_kwargs
     on_warning_callback = task.extra_context.get("on_warning_callback")
-    if on_warning_callback is not None:
+    if on_warning_callback:
         task_kwargs["on_warning_callback"] = on_warning_callback
-        del task.extra_context["on_warning_callback"]
+        task.extra_context.pop("on_warning_callback", None)
 
     airflow_task = Operator(
         task_id=task.id,

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -54,17 +54,17 @@ def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
 def extract_freshness_warn_msg(result: FullOutputSubprocessResult) -> Tuple[List[str], List[str]]:
     log_list = result.full_output
 
-    test_names = []
-    test_results = []
+    node_names = []
+    node_results = []
 
     for line in log_list:
 
         if DBT_FRESHNESS_WARN_MSG in line:
-            test_name = line.split(DBT_FRESHNESS_WARN_MSG)[1].split(" ")[1]
-            test_names.append(test_name)
-            test_results.append(line)
+            node_name = line.split(DBT_FRESHNESS_WARN_MSG)[1].split(" ")[1]
+            node_names.append(node_name)
+            node_results.append(line)
 
-    return test_names, test_results
+    return node_names, node_results
 
 
 def extract_log_issues(log_list: List[str]) -> Tuple[List[str], List[str]]:

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -40,10 +40,6 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     return num
 
 
-def parse_number_of_freshness_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
-    return sum(1 for line in result.full_output if DBT_FRESHNESS_WARN_MSG in line)
-
-
 def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
@@ -55,7 +51,8 @@ def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     return num
 
 
-def extract_freshness_warn_issue(log_list: List[str]) -> Tuple[List[str], List[str]]:
+def extract_freshness_warn_msg(result: FullOutputSubprocessResult) -> Tuple[List[str], List[str]]:
+    log_list = result.full_output
 
     test_names = []
     test_results = []

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -11,6 +11,7 @@ from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"
+DBT_FRESHNESS_WARN_MSG = "WARN freshness of"
 
 
 def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
@@ -39,6 +40,10 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     return num
 
 
+def parse_number_of_freshness_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
+    return sum(1 for line in result.full_output if DBT_FRESHNESS_WARN_MSG in line)
+
+
 def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
@@ -48,6 +53,21 @@ def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
         if run_result.status == "warn":
             num += 1
     return num
+
+
+def extract_freshness_warn_issue(log_list: List[str]) -> Tuple[List[str], List[str]]:
+
+    test_names = []
+    test_results = []
+
+    for line in log_list:
+
+        if DBT_FRESHNESS_WARN_MSG in line:
+            test_name = line.split(DBT_FRESHNESS_WARN_MSG)[1].split(" ")[1]
+            test_names.append(test_name)
+            test_results.append(line)
+
+    return test_names, test_results
 
 
 def extract_log_issues(log_list: List[str]) -> Tuple[List[str], List[str]]:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -57,9 +57,8 @@ from cosmos.constants import (
 )
 from cosmos.dbt.parser.output import (
     extract_dbt_runner_issues,
-    extract_freshness_warn_issue,
+    extract_freshness_warn_msg,
     extract_log_issues,
-    parse_number_of_freshness_warnings_subprocess,
     parse_number_of_warnings_dbt_runner,
     parse_number_of_warnings_subprocess,
 )
@@ -712,17 +711,6 @@ class DbtSourceLocalOperator(DbtSourceMixin, DbtLocalBaseOperator):
         super().__init__(*args, **kwargs)
         self.on_warning_callback = on_warning_callback
         self.extract_issues: Callable[..., tuple[list[str], list[str]]]
-        self.parse_number_of_warnings: Callable[..., int]
-
-    def _set_test_result_parsing_methods(self) -> None:
-        """Sets the extract_issues and parse_number_of_warnings methods based on the invocation mode."""
-        if self.invocation_mode == InvocationMode.SUBPROCESS:
-            self.extract_issues = extract_freshness_warn_issue
-            self.parse_number_of_warnings = parse_number_of_freshness_warnings_subprocess
-        # TODO: FIXME
-        # elif self.invocation_mode == InvocationMode.DBT_RUNNER:
-        #     self.extract_issues = extract_dbt_runner_issues
-        #     self.parse_number_of_warnings = parse_number_of_warnings_dbt_runner
 
     def _handle_warnings(self, result: FullOutputSubprocessResult | dbtRunnerResult, context: Context) -> None:
         """
@@ -732,7 +720,12 @@ class DbtSourceLocalOperator(DbtSourceMixin, DbtLocalBaseOperator):
         :param result: The result object from the build and run command.
         :param context: The original airflow context in which the build and run command was executed.
         """
-        test_names, test_results = self.extract_issues(result.full_output)
+        if self.invocation_mode == InvocationMode.SUBPROCESS:
+            self.extract_issues = extract_freshness_warn_msg
+        elif self.invocation_mode == InvocationMode.DBT_RUNNER:
+            self.extract_issues = extract_dbt_runner_issues
+
+        test_names, test_results = self.extract_issues(result)
 
         warning_context = dict(context)
         warning_context["test_names"] = test_names
@@ -742,9 +735,7 @@ class DbtSourceLocalOperator(DbtSourceMixin, DbtLocalBaseOperator):
 
     def execute(self, context: Context) -> None:
         result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
-        self._set_test_result_parsing_methods()
-        number_of_warnings = self.parse_number_of_warnings(result)  # type: ignore
-        if self.on_warning_callback and number_of_warnings > 0:
+        if self.on_warning_callback:
             self._handle_warnings(result, context)
 
 

--- a/dev/dags/example_source_rendering.py
+++ b/dev/dags/example_source_rendering.py
@@ -40,4 +40,5 @@ source_rendering_dag = DbtDag(
     catchup=False,
     dag_id="source_rendering_dag",
     default_args={"retries": 2},
+    on_warning_callback=lambda context: print(context),
 )

--- a/dev/dags/example_source_rendering.py
+++ b/dev/dags/example_source_rendering.py
@@ -23,6 +23,8 @@ profile_config = ProfileConfig(
     ),
 )
 
+# [START cosmos_source_node_example]
+
 source_rendering_dag = DbtDag(
     # dbt/cosmos-specific parameters
     project_config=ProjectConfig(
@@ -42,3 +44,4 @@ source_rendering_dag = DbtDag(
     default_args={"retries": 2},
     on_warning_callback=lambda context: print(context),
 )
+# [END cosmos_source_node_example]

--- a/docs/configuration/source-nodes-rendering.rst
+++ b/docs/configuration/source-nodes-rendering.rst
@@ -34,3 +34,16 @@ Example:
             source_rendering_behavior=SourceRenderingBehavior.WITH_TESTS_OR_FRESHNESS,
         )
     )
+
+
+on_warning_callback Callback
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The ``on_warning_callback`` is a callback parameter available on the ``DbtSourceLocalOperator``. This callback is triggered when a warning occurs during the execution of the ``dbt source freshness`` command. The callback accepts the task context, which includes additional parameters: test_names and test_results
+
+Example:
+
+.. literalinclude:: ../../dev/dags/example_source_rendering.py/
+    :language: python
+    :start-after: [START cosmos_source_node_example]
+    :end-before: [END cosmos_source_node_example]


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/914

This PR introduced `on_warning_callback` for `dbt source freshness` command i.e on operator `DbtSourceLocalOperator`.

Example DAG
```python
source_rendering_dag = DbtDag(
    # dbt/cosmos-specific parameters
    project_config=ProjectConfig(
        DBT_ROOT_PATH / "jaffle_shop",
    ),
    profile_config=profile_config,
    operator_args={
        "install_deps": True,  # install any necessary dependencies before running any dbt command
        "full_refresh": True,  # used only in dbt commands that support this flag
    },
    render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
    # normal dag parameters
    schedule_interval="@daily",
    start_date=datetime(2024, 1, 1),
    catchup=False,
    dag_id="source_rendering_dag",
    default_args={"retries": 2},
    on_warning_callback=lambda context: print(context),
)

``` 
