### PR TITLE
Mention in documentation that the callback functionality is supported in ExecutionMode.VIRTUALENV

### DIFF
--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -56,6 +56,16 @@ def example_virtualenv() -> None:
             "py_requirements": ["dbt-postgres"],
             "install_deps": True,
             "emit_datasets": False,  # Example of how to not set inlets and outlets
+            # --------------------------------------------------------------------------
+            # Callback function to upload files using Airflow Object storage and Cosmos remote_target_path setting on
+            # Airflow 2.8 and above
+            # "callback": upload_to_cloud_storage,
+            # --------------------------------------------------------------------------
+            # Callback function if you'd like to upload files from the target directory to remote store e.g. AWS S3 that
+            # works with Airflow < 2.8 too
+            # "callback": upload_to_aws_s3,
+            # "callback_args": {"aws_conn_id": "aws_s3_conn", "bucket_name": "cosmos-artifacts-upload"}
+            # --------------------------------------------------------------------------
         },
     )
 

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -57,6 +57,9 @@ def example_virtualenv() -> None:
             "install_deps": True,
             "emit_datasets": False,  # Example of how to not set inlets and outlets
             # --------------------------------------------------------------------------
+            # For the sake of avoiding additional latency observed while uploading files for each of the tasks, the
+            # below callback functions to be executed are commented, but you can uncomment them if you'd like to
+            # enable callback execution.
             # Callback function to upload files using Airflow Object storage and Cosmos remote_target_path setting on
             # Airflow 2.8 and above
             # "callback": upload_to_cloud_storage,

--- a/docs/configuration/callbacks.rst
+++ b/docs/configuration/callbacks.rst
@@ -3,7 +3,8 @@
 Callbacks
 =========
 
-Cosmos supports callback functions that execute at the end of a task's execution when using ``ExecutionMode.LOCAL``.
+Cosmos supports callback functions that execute at the end of a task's execution when using ``ExecutionMode.LOCAL`` and
+``ExecutionMode.VIRTUALENV``.
 These callbacks can be used for various purposes, such as uploading files from the target directory to remote
 storage. While this feature has been available for some time, users may not be fully aware of its capabilities.
 
@@ -46,6 +47,6 @@ metadata.
 Limitations and Contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Currently, callback support is available only when using ``ExecutionMode.LOCAL``. Contributions to extend this
-functionality to other execution modes are welcome and encouraged. You can reference the implementation for
-``ExecutionMode.LOCAL`` to add support for other modes.
+Currently, callback support is available only when using ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``.
+Contributions to extend this functionality to other execution modes are welcome and encouraged. You can reference the
+implementation for ``ExecutionMode.LOCAL`` to add support for other modes.


### PR DESCRIPTION
Following up on PR #1389 wherein we add helper functions to demonstrate how to 
utilise the callback functionality in `ExecutionMode.LOCAL`, I also tested this functionality
with `ExecutionMode.VIRTUALENV` since the VirtualEnv mode operators inherit the Local
mode operators and it does seem to support the callback functionality well. I was well able
to test this by adding the callback arg to the VirtualEnv example DAG we have and see that
the files do get uploaded to remote store. I have added the argument in comments in the example
DAG so that users could take a reference of that, however I have left the argument as commented
so that we do not always keep on uploading the files in our CI runs and given that we already this
in the `example_operators.py` DAG.

The PR also updates the documentation to reflect that the callback functionality is supported in 
the `ExecutionMode.VIRTUALENV` too.

closes: #1399 