### PR TITLE
Increase performance tests models

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,7 +354,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
         airflow-version: ["2.8"]
-        num-models: [1, 10, 50, 100]
+        num-models: [1, 10, 50, 100, 500, 1000]
     services:
       postgres:
         image: postgres
@@ -401,7 +401,7 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 180.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
           POSTGRES_HOST: localhost


### PR DESCRIPTION
Previously, we ran performance tests for DAGs with 1, 10, 50, and 100 dbt models.

This PR also extends to creating DAGs with 500 and 1000 dbt models.