### PR TITLE
Unpin dbt-databricks version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,8 +44,7 @@ dbt-all = [
     "dbt-athena",
     "dbt-bigquery",
     "dbt-clickhouse",
-    # TODO: https://github.com/astronomer/astronomer-cosmos/issues/1379
-    "dbt-databricks<1.9",
+    "dbt-databricks!=1.9.0",
     "dbt-exasol",
     "dbt-postgres",
     "dbt-redshift",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,9 @@ dbt-all = [
     "dbt-athena",
     "dbt-bigquery",
     "dbt-clickhouse",
+    # The dbt-databricks:1.9.0 version causes a dependency conflict with
+    # the Pydantic version required by Airflow (version > 2.7)
+    # See: https://github.com/astronomer/astronomer-cosmos/issues/1379
     "dbt-databricks!=1.9.0",
     "dbt-exasol",
     "dbt-postgres",

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -11,4 +11,4 @@ rm -rf airflow.*
 pip freeze | grep airflow
 airflow db reset -y
 airflow db init
-pip install 'dbt-databricks<1.9' 'dbt-bigquery' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'
+pip install 'dbt-databricks!=1.9.0' 'dbt-bigquery' 'dbt-postgres' 'dbt-vertica' 'openlineage-airflow'


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1379

A new version of dbt-databricks (v1.9.1) has been released, [release notes](https://github.com/databricks/dbt-databricks/releases/tag/v1.9.1). It is expected that PR: https://github.com/databricks/dbt-databricks/pull/874 will resolve the existing dependency issue.
