### PR TITLE
Drop running 1000 models in the CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -354,7 +354,7 @@ jobs:
       matrix:
         python-version: ["3.11"]
         airflow-version: ["2.8"]
-        num-models: [1, 10, 50, 100, 500, 1000]
+        num-models: [1, 10, 50, 100, 500]
     services:
       postgres:
         image: postgres


### PR DESCRIPTION
With PR #1403 , we added to the matrix to run tests on 500 & 1000 models. Although the job for
500 models completes in under 15 mins, the job for 1000 models is taking significantly longer ~40+ mins as can be seen here https://github.com/astronomer/astronomer-cosmos/actions/runs/12400943145/job/34619249671. 

I suggest we drop running 1000 models and later add it to the matrix to conditionally run only when a certain label is added to the PR i.e. when we would actually like to benchmark on specific PRs. I have created a follow-up issue for this https://github.com/astronomer/astronomer-cosmos/issues/1410

related: #1410 