### PR TITLE
Enable Docs DAG in CI leveraging existing CI connections

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -503,19 +503,9 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
                 self.store_freshness_json(tmp_project_dir, context)
                 self.store_compiled_sql(tmp_project_dir, context)
                 self.upload_compiled_sql(tmp_project_dir, context)
-                print("Result is", result)
-                dirlist = os.listdir(tmp_project_dir)
-                print("Before: Files and directories in '", tmp_project_dir, "' :")
-                print("\t", dirlist)
                 if self.callback:
-                    dirlist = os.listdir(f"{tmp_project_dir}/target")
-                    print("Before: Files and directories in '", tmp_project_dir, "' :")
-                    print("\t", dirlist)
                     self.callback_args.update({"context": context})
                     self.callback(tmp_project_dir, **self.callback_args)
-                    dirlist = os.listdir(f"{tmp_project_dir}/target")
-                    print("After: Files and directories in '", tmp_project_dir, "' :")
-                    print("\t", dirlist)
                 self.handle_exception(result)
 
                 return result
@@ -909,9 +899,6 @@ class DbtDocsS3LocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to S3 using S3Hook("%s")',
             self.connection_id,
         )
-        dirlist = os.listdir(f"{project_dir}/target")
-        print("Files and directories in '", project_dir, "' :")
-        print("\t", dirlist)
 
         from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
@@ -978,9 +965,6 @@ class DbtDocsAzureStorageLocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to Azure Blob Storage using WasbHook(conn_id="%s")',
             self.connection_id,
         )
-        dirlist = os.listdir(f"{project_dir}/target")
-        print("Files and directories in '", project_dir, "' :")
-        print("\t", dirlist)
 
         from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
@@ -1025,9 +1009,6 @@ class DbtDocsGCSLocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to Storage using GCSHook(conn_id="%s")',
             self.connection_id,
         )
-        dirlist = os.listdir(f"{project_dir}/target")
-        print("Files and directories in '", project_dir, "' :")
-        print("\t", dirlist)
 
         from airflow.providers.google.cloud.hooks.gcs import GCSHook
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -503,6 +503,10 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
                 self.store_freshness_json(tmp_project_dir, context)
                 self.store_compiled_sql(tmp_project_dir, context)
                 self.upload_compiled_sql(tmp_project_dir, context)
+                print("Result is", result)
+                dirlist = os.listdir(tmp_project_dir)
+                print("Before: Files and directories in '", tmp_project_dir, "' :")
+                print("\t", dirlist)
                 if self.callback:
                     dirlist = os.listdir(f"{tmp_project_dir}/target")
                     print("Before: Files and directories in '", tmp_project_dir, "' :")

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -504,8 +504,14 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
                 self.store_compiled_sql(tmp_project_dir, context)
                 self.upload_compiled_sql(tmp_project_dir, context)
                 if self.callback:
+                    dirlist = os.listdir(f"{tmp_project_dir}/target")
+                    print("Before: Files and directories in '", tmp_project_dir, "' :")
+                    print("\t", dirlist)
                     self.callback_args.update({"context": context})
                     self.callback(tmp_project_dir, **self.callback_args)
+                    dirlist = os.listdir(f"{tmp_project_dir}/target")
+                    print("After: Files and directories in '", tmp_project_dir, "' :")
+                    print("\t", dirlist)
                 self.handle_exception(result)
 
                 return result
@@ -899,6 +905,9 @@ class DbtDocsS3LocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to S3 using S3Hook("%s")',
             self.connection_id,
         )
+        dirlist = os.listdir(f"{project_dir}/target")
+        print("Files and directories in '", project_dir, "' :")
+        print("\t", dirlist)
 
         from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
@@ -965,6 +974,9 @@ class DbtDocsAzureStorageLocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to Azure Blob Storage using WasbHook(conn_id="%s")',
             self.connection_id,
         )
+        dirlist = os.listdir(f"{project_dir}/target")
+        print("Files and directories in '", project_dir, "' :")
+        print("\t", dirlist)
 
         from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
@@ -1009,6 +1021,9 @@ class DbtDocsGCSLocalOperator(DbtDocsCloudLocalOperator):
             'Attempting to upload generated docs to Storage using GCSHook(conn_id="%s")',
             self.connection_id,
         )
+        dirlist = os.listdir(f"{project_dir}/target")
+        print("Files and directories in '", project_dir, "' :")
+        print("\t", dirlist)
 
         from airflow.providers.google.cloud.hooks.gcs import GCSHook
 

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -56,7 +56,7 @@ with DAG(
         task_id="generate_dbt_docs_azure",
         project_dir=DBT_ROOT_PATH / "jaffle_shop",
         profile_config=profile_config,
-        connection_id="azure_wasb_conn",
+        connection_id="azure_abfs_conn",
         bucket_name="cosmos-ci-docs",
         install_deps=True,
     )

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -49,6 +49,7 @@ with DAG(
         profile_config=profile_config,
         connection_id="aws_s3_conn",
         bucket_name="cosmos-ci-docs",
+        install_deps=True,
     )
 
     generate_dbt_docs_azure = DbtDocsAzureStorageOperator(
@@ -57,6 +58,7 @@ with DAG(
         profile_config=profile_config,
         connection_id="azure_wasb_conn",
         bucket_name="cosmos-ci-docs",
+        install_deps=True,
     )
 
     generate_dbt_docs_gcs = DbtDocsGCSOperator(
@@ -65,4 +67,5 @@ with DAG(
         profile_config=profile_config,
         connection_id="gcp_gs_conn",
         bucket_name="cosmos-ci-docs",
+        install_deps=True,
     )

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -24,9 +24,6 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
 
-S3_CONN_ID = "aws_s3_conn"
-AZURE_CONN_ID = "azure_wasb_conn"
-GCS_CONN_ID = "gcp_gs_conn"
 
 profile_config = ProfileConfig(
     profile_name="default",


### PR DESCRIPTION
It seems that the dbt docs DAG in our example DAGs suite was silently failing to run because the specified connections in the DAG were not present in our CI environment. I am removing the connection checks, allowing the previously skipped tasks to execute even when the remote Airflow connections are unavailable. Additionally, I’ve updated the DAG to use our existing CI credentials and Airflow connections, as well as updated the bucket name to the ones I created in our object stores. This change will help catch issues like #1420 earlier. While fix #1422 has already addressed #1420, this PR will now validate that the fix is functioning as expected.

closes: #1420 