### PR TITLE
Docs: Fix broken links and rendering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -46,7 +46,7 @@ https://github.com/astronomer/astronomer-cosmos/blob/24aa38e528e299ef51ca6baf32f
 
 This will generate an Airflow DAG that looks like this:
 
-.. figure:: /docs/_static/jaffle_shop_dag.png
+.. figure:: https://github.com/astronomer/astronomer-cosmos/blob/main/docs/_static/jaffle_shop_dag.png
 
 
 Community

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -73,7 +73,7 @@ This example DAG:
 ..
    The following renders in Sphinx but not Github:
 
-.. literalinclude:: ./../dev/dags/basic_cosmos_dag.py
+.. literalinclude:: ../../dev/dags/basic_cosmos_dag.py
     :language: python
     :start-after: [START local_example]
     :end-before: [END local_example]

--- a/docs/getting_started/azure-container-instance.rst
+++ b/docs/getting_started/azure-container-instance.rst
@@ -3,6 +3,7 @@
 Azure Container Instance Execution Mode
 =======================================
 .. versionadded:: 1.4
+
 This tutorial will guide you through the steps required to use Azure Container Instance as the Execution Mode for your dbt code with Astronomer Cosmos. Schematically, the guide will walk you through the steps required to build the following architecture:
 
 .. figure:: https://github.com/astronomer/astronomer-cosmos/raw/main/docs/_static/cosmos_aci_schematic.png
@@ -54,6 +55,7 @@ You will need a postgres database running to be used as the database for the dbt
 In order to run a container in Azure Container Instance, it needs access to the container image. In our setup, we will use Azure Container Registry for this. To set an Azure Container Registry up, you can use the following bash command:
 
 .. code-block:: bash
+
     az acr create --name <<<YOUR_REGISTRY_NAME>>> --resource-group <<<YOUR_RG>>> --sku Basic --admin-enabled
 
 **Build the dbt Docker image**
@@ -82,6 +84,7 @@ After this, the image needs to be pushed to the registry of your choice. Note th
 
     You may need to ensure docker knows to use the right credentials. If using Azure Container Registry, this can be done by running the following command:
     .. code-block:: bash
+
         az acr login
 
 .. note::

--- a/docs/getting_started/index.rst
+++ b/docs/getting_started/index.rst
@@ -15,6 +15,7 @@
    GCP Cloud Run Job Execution Mode <gcp-cloud-run-job>
    dbt and Airflow Similar Concepts <dbt-airflow-concepts>
    Operators <operators>
+   Custom Airflow Properties <custom-airflow-properties>
 
 
 Getting Started


### PR DESCRIPTION
1. Link docs/custom-airflow-properties.rst in index
2. Fix syntax warning of docs/getting_started/azure-container-instance.rst
3. Fix the example broken link at: https://astronomer.github.io/astronomer-cosmos/configuration/scheduling.html#examples 
4. [Pypi](https://pypi.org/project/astronomer-cosmos/) is not loading image correctly

<img width="769" alt="Screenshot 2024-12-31 at 6 02 38 PM" src="https://github.com/user-attachments/assets/c0167df0-08cd-4c30-a0c5-700428e8298c" />
