### PR TITLE
Upgrade GitHub action artifacts upload-artifact & download-artifact to v4

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Build source distribution
         run: python -m build
 
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: artifacts
           path: dist/*
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: dist


### PR DESCRIPTION
Since `upload-artifact@v3` & `download-artifact@v3` are not going to be usable from January 30th, 2025, upgrade them to v4.

Ref: https://astronomer.slack.com/archives/C07DCAVK7TR/p1736358249600619

related: https://github.com/astronomer/oss-integrations-private/issues/64