### PR TITLE
Enable Depandabot to scan outdated Github Actions dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels:
+      - "dependencies"
+    reviewers:
+      - "@astronomer/oss-integrations"


### PR DESCRIPTION
Recently, a high manager at Astronomer received a message saying "Subject: [Action required] Actions artifacts v3 is closing down", with a list of repos within the org that had outdated dependencies.

To avoid this in the future, we're enabling Github's Depandabot, which will automatically create PRs suggesting these fixes proactively - so this situation does not happen again.
