### PR TITLE
update openlineage to avoid deprecation warning

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -46,7 +46,7 @@ else:
 if TYPE_CHECKING:
     from airflow.datasets import Dataset  # noqa: F811
     from dbt.cli.main import dbtRunner, dbtRunnerResult
-    from openlineage.client.run import RunEvent
+    from openlineage.client.event_v2 import RunEvent
 
 
 from sqlalchemy.orm import Session


### PR DESCRIPTION
## Description

openlineage suggests using event_v2 as the new import call. This can be seen in the source code of openlineage itself for the [run](https://github.com/OpenLineage/OpenLineage/blob/main/client/python/openlineage/client/run.py) method.


## Related Issue(s)

UserWarning: {message : DeprecationWarning('This module is deprecated. Please use `openlineage.client.event_v2`.'), category : 'DeprecationWarning', filename : '/home/airflow/.local/lib/python3.10/site-packages/openlineage/client/filter.py', lineno : 9, line : None}

## Breaking Change?

No

## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
