### PR TITLE
Docs: Update `operator args` docs to include `install_deps`

### DIFF
--- a/docs/configuration/operator-args.rst
+++ b/docs/configuration/operator-args.rst
@@ -55,6 +55,7 @@ dbt-related
 - ``vars``: (Deprecated since Cosmos 1.3 use ``ProjectConfig.dbt_vars`` instead) Supply variables to the project. This argument overrides variables defined in the ``dbt_project.yml``.
 - ``warn_error``: convert ``dbt`` warnings into errors.
 - ``full_refresh``: If True, then full refresh the node. This only applies to model and seed nodes.
+- ``install_deps``: When using ``ExecutionMode.LOCAL`` or ``ExecutionMode.VIRTUALENV``, run ``dbt deps`` every time a task is executed.
 
 Airflow-related
 ...............


### PR DESCRIPTION
Although Cosmos has had this feature for a while, we missed documenting it.