### PR TITLE
Fix detached test tasks names so they do not exceed 250 chars

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -431,18 +431,23 @@ def identify_detached_nodes(
                     detached_from_parent[parent_id].append(node)
 
 
-def calculate_detached_node_name(node: DbtNode, counter: list[int] = [0]) -> str:
+_counter = 0
+
+
+def calculate_detached_node_name(node: DbtNode) -> str:
     """
     Given a detached test node, calculate its name. It will either be:
      - the name of the test with a "_test" suffix, if this is smaller than 250
      - or detached_{an incremental number}_test
     """
+    # Note: this implementation currently relies on the fact that Airflow creates a new process
+    # to parse each DAG both in the scheduler and also in the worker nodes. We logged a ticket to improved this:
+    # https://github.com/astronomer/astronomer-cosmos/issues/1469
     node_name = f"{node.resource_name.split('.')[0]}_test"
-
     if not len(node_name) < AIRFLOW_MAX_ID_LENGTH:
-        node_name = f"detached_{counter[0]}_test"
-        counter[0] += 1
-
+        global _counter
+        node_name = f"detached_{_counter}_test"
+        _counter += 1
     return node_name
 
 

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -13,4 +13,11 @@ airflow db check
 
 
 rm -rf dbt/jaffle_shop/dbt_packages;
-pytest -vv tests/test_converter.py::test_converter_creates_dag_with_test_with_multiple_parents
+pytest -vv \
+    --cov=cosmos \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    -m 'integration'  \
+    --ignore=tests/perf \
+    --ignore=tests/test_example_k8s_dags.py \
+    -k 'not ( example_cosmos_python_models or example_virtualenv or jaffle_shop_kubernetes)'

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -13,11 +13,4 @@ airflow db check
 
 
 rm -rf dbt/jaffle_shop/dbt_packages;
-pytest -vv \
-    --cov=cosmos \
-    --cov-report=term-missing \
-    --cov-report=xml \
-    -m 'integration'  \
-    --ignore=tests/perf \
-    --ignore=tests/test_example_k8s_dags.py \
-    -k 'not ( example_cosmos_python_models or example_virtualenv or jaffle_shop_kubernetes)'
+pytest -vv tests/test_converter.py::test_converter_creates_dag_with_test_with_multiple_parents

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -13,6 +13,7 @@ from packaging import version
 from cosmos.airflow.graph import (
     _snake_case_to_camelcase,
     build_airflow_graph,
+    calculate_detached_node_name,
     calculate_leaves,
     calculate_operator_class,
     create_task_metadata,
@@ -76,6 +77,32 @@ child2_node = DbtNode(
 
 sample_nodes_list = [parent_seed, parent_node, test_parent_node, child_node, child2_node]
 sample_nodes = {node.unique_id: node for node in sample_nodes_list}
+
+
+def test_calculate_datached_node_name_under_is_under_250():
+    node = DbtNode(
+        unique_id="model.my_dbt_project.a_very_short_name",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path="",
+    )
+    assert calculate_detached_node_name(node) == "a_very_short_name_test"
+
+    node = DbtNode(
+        unique_id="model.my_dbt_project." + "this_is_a_very_long_name" * 20,  # 24 x 20 = 480 characters
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path="",
+    )
+    assert calculate_detached_node_name(node) == "detached_0_test"
+
+    node = DbtNode(
+        unique_id="model.my_dbt_project." + "this_is_another_very_long_name" * 20,
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path="",
+    )
+    assert calculate_detached_node_name(node) == "detached_1_test"
 
 
 @pytest.mark.skipif(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -203,6 +203,10 @@ def test_converter_creates_dag_with_test_with_multiple_parents():
     # We should have a task dedicated to run the test with multiple parents
     args = tasks["test.my_dbt_project.custom_test_combined_model_combined_model_.c6e4587380"].build_cmd({})[0]
     assert args[1:] == ["test", "--select", "custom_test_combined_model_combined_model_.c6e4587380"]
+    assert (
+        tasks["test.my_dbt_project.custom_test_combined_model_combined_model_.c6e4587380"].task_id
+        == "custom_test_combined_model_combined_model__test"
+    )
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Since we introduced detached test tasks in #1433 (released in 1.8.0), users started facing issues due to very long task names exceeding Airflow's limits.
    
Example of Python traceback reported by user:
```
     Traceback (most recent call last):
      File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 968, in __init__
        validate_key(task_id)
      File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/helpers.py", line 55, in validate_key
        raise AirflowException(f"The key has to be less than {max_length} characters")
    airflow.exceptions.AirflowException: The key has to be less than 250 characters
```
    
This PR fixes this issue. In case the name exceeds Airflow's limit (250 ATM), it will name the detached test using:
- "detached_{incremental unique number}_test"

We also considered naming the new test using:
- "parent1_parent2_..._test" - but that may not solve the issue, especially in circumstances where the same parents may have multiple detached nodes. Perhaps in future, we could bundle them in a single task.

Closes: #1440