### PR TITLE
Move `DbtRunner` related functions into `dbt/runner.py` module

### DIFF
--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -4,9 +4,12 @@ import logging
 import re
 from typing import TYPE_CHECKING, List, Tuple
 
+import deprecation
+
 if TYPE_CHECKING:
     from dbt.cli.main import dbtRunnerResult
 
+from cosmos import __version__ as cosmos_version  # type: ignore[attr-defined]
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
 DBT_NO_TESTS_MSG = "Nothing to do"
@@ -40,7 +43,14 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     return num
 
 
-def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
+# Python 3.13 exposes a deprecated operator, we can replace it in the future
+@deprecation.deprecated(
+    deprecated_in="1.9",
+    removed_in="2.0",
+    current_version=cosmos_version,
+    details="Use the `cosmos.dbt.runner.parse_number_of_warnings` instead.",
+)  # type: ignore[misc]
+def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:  # type: ignore[misc]
     """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
@@ -105,9 +115,16 @@ def extract_log_issues(log_list: List[str]) -> Tuple[List[str], List[str]]:
     return test_names, test_results
 
 
+# Python 3.13 exposes a deprecated operator, we can replace it in the future
+@deprecation.deprecated(
+    deprecated_in="1.9",
+    removed_in="2.0",
+    current_version=cosmos_version,
+    details="Use the `cosmos.dbt.runner.extract_message_by_status` instead.",
+)  # type: ignore[misc]
 def extract_dbt_runner_issues(
     result: dbtRunnerResult, status_levels: list[str] = ["warn"]
-) -> Tuple[List[str], List[str]]:
+) -> Tuple[List[str], List[str]]:  # type: ignore[misc]
     """
     Extracts messages from the dbt runner result and returns them as a formatted string.
 

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -1,0 +1,119 @@
+from __future__ import annotations
+
+import sys
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+from cosmos.dbt.project import change_working_directory, environ
+from cosmos.exceptions import CosmosDbtRunError
+from cosmos.log import get_logger
+
+if "pytest" in sys.modules:
+    # We set the cache limit to 0, so nothing gets cached by default when
+    # running tests
+    cache = lru_cache(maxsize=0)
+else:  # pragma: no cover
+    try:
+        # Available since Python 3.9
+        from functools import cache
+    except ImportError:
+        cache = lru_cache(maxsize=None)
+
+
+logger = get_logger(__name__)
+
+if TYPE_CHECKING:  # pragma: no cover
+    from dbt.cli.main import dbtRunner, dbtRunnerResult
+
+
+# TODO: Change operators/local.py invoke_dbt to use this
+# TODO: Change operators/local.py _discover_invocation_mode to use this
+@cache
+def is_available() -> bool:
+    """
+    Checks if the dbt runner is available (if dbt-core is installed in the same Python virtualenv as Airflow."
+    """
+    try:
+        from dbt.cli.main import dbtRunner  # noqa
+    except ImportError:
+        return False
+    return True
+
+
+# TODO: Change operators/local.py to use this in run_dbt_runner
+@cache
+def get_runner() -> dbtRunner:
+    """
+    Retrieves a dbtRunner instance.
+    """
+    from dbt.cli.main import dbtRunner
+
+    return dbtRunner()
+
+
+# TODO: Change operators/local.py run_dbt_runner to use this
+def run_command(command: list[str], env: dict[str, str], cwd: str) -> dbtRunnerResult:
+    """
+    Invokes the dbt command programmatically.
+    """
+    # Exclude the dbt executable path from the command
+    cli_args = command[1:]
+    with change_working_directory(cwd), environ(env):
+        logger.info("Trying to run dbtRunner with:\n %s\n in %s", cli_args, cwd)
+        runner = get_runner()
+        result = runner.invoke(cli_args)
+    return result
+
+
+# TODO: check any occurrences of extract_dbt_runner_issues and move it out from cosmos/dbt/parser/output.py
+def extract_message_by_status(
+    result: dbtRunnerResult, status_levels: list[str] = ["warn"]
+) -> tuple[list[str], list[str]]:
+    """
+    Extracts messages from the dbt runner result and returns them as a formatted string.
+
+    This function iterates over dbtRunnerResult messages in dbt run. It extracts results that match the
+    status levels provided and appends them to a list of issues.
+
+    :param result: dbtRunnerResult object containing the output to be parsed.
+    :param status_levels: List of strings, where each string is a result status level. Default is ["warn"].
+    :return: two lists of strings, the first one containing the node names and the second one
+        containing the node result message.
+    """
+    node_names = []
+    node_results = []
+
+    for node_result in result.result.results:  # type: ignore
+        if node_result.status in status_levels:
+            node_names.append(str(node_result.node.name))
+            node_results.append(str(node_result.message))
+
+    return node_names, node_results
+
+
+# TODO: check any occurrences of parse_number_of_warnings_dbt_runner and move it out from cosmos/dbt/parser/output.py
+def parse_number_of_warnings(result: dbtRunnerResult) -> int:
+    """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
+    from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
+    """
+    num = 0
+    for run_result in result.result.results:  # type: ignore
+        if run_result.status == "warn":
+            num += 1
+    return num
+
+
+# TODO: Change operators/local.py handle_exception_dbt_runner to use this
+def handle_exception_if_needed(result: dbtRunnerResult) -> None:
+    """
+    Given a dbtRunnerResult, identify if it failed and handle the exception, if necessary.
+    """
+    # dbtRunnerResult has an attribute `success` that is False if the command failed.
+    if not result.success:
+        if result.exception:
+            raise CosmosDbtRunError(f"dbt invocation did not complete with unhandled error: {result.exception}")
+        else:
+            node_names, node_results = extract_message_by_status(result, ["error", "fail", "runtime error"])
+            error_message = "\n".join([f"{name}: {result}" for name, result in zip(node_names, node_results)])
+            raise CosmosDbtRunError(f"dbt invocation completed with errors: {error_message}")
+

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -52,7 +52,9 @@ def run_command(command: list[str], env: dict[str, str], cwd: str) -> dbtRunnerR
     """
     Invokes the dbt command programmatically.
     """
-    # Exclude the dbt executable path from the command
+    # Exclude the dbt executable path from the command. This step is necessary because we are using the same
+    # command that is used by `InvocationMode.SUBPROCESS`, and in that scenario the first command is necessarily the path
+    # to the dbt executable.
     cli_args = command[1:]
     with change_working_directory(cwd), environ(env):
         logger.info("Trying to run dbtRunner with:\n %s\n in %s", cli_args, cwd)

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -26,8 +26,6 @@ if TYPE_CHECKING:  # pragma: no cover
     from dbt.cli.main import dbtRunner, dbtRunnerResult
 
 
-# TODO: Change operators/local.py invoke_dbt to use this
-# TODO: Change operators/local.py _discover_invocation_mode to use this
 @cache
 def is_available() -> bool:
     """
@@ -40,7 +38,6 @@ def is_available() -> bool:
     return True
 
 
-# TODO: Change operators/local.py to use this in run_dbt_runner
 @cache
 def get_runner() -> dbtRunner:
     """
@@ -51,7 +48,6 @@ def get_runner() -> dbtRunner:
     return dbtRunner()
 
 
-# TODO: Change operators/local.py run_dbt_runner to use this
 def run_command(command: list[str], env: dict[str, str], cwd: str) -> dbtRunnerResult:
     """
     Invokes the dbt command programmatically.
@@ -65,7 +61,6 @@ def run_command(command: list[str], env: dict[str, str], cwd: str) -> dbtRunnerR
     return result
 
 
-# TODO: check any occurrences of extract_dbt_runner_issues and move it out from cosmos/dbt/parser/output.py
 def extract_message_by_status(
     result: dbtRunnerResult, status_levels: list[str] = ["warn"]
 ) -> tuple[list[str], list[str]]:
@@ -91,7 +86,6 @@ def extract_message_by_status(
     return node_names, node_results
 
 
-# TODO: check any occurrences of parse_number_of_warnings_dbt_runner and move it out from cosmos/dbt/parser/output.py
 def parse_number_of_warnings(result: dbtRunnerResult) -> int:
     """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
@@ -103,7 +97,6 @@ def parse_number_of_warnings(result: dbtRunnerResult) -> int:
     return num
 
 
-# TODO: Change operators/local.py handle_exception_dbt_runner to use this
 def handle_exception_if_needed(result: dbtRunnerResult) -> None:
     """
     Given a dbtRunnerResult, identify if it failed and handle the exception, if necessary.

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -116,4 +116,3 @@ def handle_exception_if_needed(result: dbtRunnerResult) -> None:
             node_names, node_results = extract_message_by_status(result, ["error", "fail", "runtime error"])
             error_message = "\n".join([f"{name}: {result}" for name, result in zip(node_names, node_results)])
             raise CosmosDbtRunError(f"dbt invocation completed with errors: {error_message}")
-

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -29,7 +29,7 @@ if TYPE_CHECKING:  # pragma: no cover
 @cache
 def is_available() -> bool:
     """
-    Checks if the dbt runner is available (if dbt-core is installed in the same Python virtualenv as Airflow."
+    Checks if the dbt runner is available (if dbt-core is installed in the same Python virtualenv as Airflow)."
     """
     try:
         from dbt.cli.main import dbtRunner  # noqa

--- a/cosmos/exceptions.py
+++ b/cosmos/exceptions.py
@@ -5,5 +5,9 @@ class CosmosValueError(ValueError):
     """Raised when a Cosmos config value is invalid."""
 
 
+class CosmosDbtRunError(Exception):
+    """Raised when there are exceptions running DbtRunner"""
+
+
 class AirflowCompatibilityError(Exception):
     """Raised when Cosmos features are limited for Airflow version being used."""

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -31,7 +31,7 @@ from cosmos.cache import (
 from cosmos.constants import FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, InvocationMode
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.dbt.project import get_partial_parse_path, has_non_empty_dependencies_file
-from cosmos.exceptions import AirflowCompatibilityError, CosmosValueError
+from cosmos.exceptions import AirflowCompatibilityError, CosmosDbtRunError, CosmosValueError
 from cosmos.settings import remote_target_path, remote_target_path_conn_id
 
 try:
@@ -385,7 +385,7 @@ class DbtLocalBaseOperator(AbstractDbtBaseOperator):
     def run_dbt_runner(self, command: list[str], env: dict[str, str], cwd: str) -> dbtRunnerResult:
         """Invokes the dbt command programmatically."""
         if not dbt_runner.is_available():
-            raise ImportError(
+            raise CosmosDbtRunError(
                 "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
             )
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -61,7 +61,7 @@ from cosmos.dbt.parser.output import (
     extract_log_issues,
     parse_number_of_warnings_subprocess,
 )
-from cosmos.dbt.project import change_working_directory, create_symlinks, environ
+from cosmos.dbt.project import create_symlinks
 from cosmos.hooks.subprocess import (
     FullOutputSubprocessHook,
     FullOutputSubprocessResult,
@@ -1030,4 +1030,3 @@ class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
-

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,4 +1,5 @@
 aenum
+deprecation
 msgpack
 apache-airflow
 pydantic

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,7 @@ dependencies = [
     "aenum",
     "attrs",
     "apache-airflow>=2.4.0",
+    "deprecation",  # Python 3.13 exposes a deprecated operator, we can remove this dependency in the future
     "importlib-metadata; python_version < '3.8'",
     "Jinja2>=3.0.0",
     "msgpack",

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -1,0 +1,110 @@
+import os
+import shutil
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+
+import cosmos.dbt.runner as dbt_runner
+from cosmos.exceptions import CosmosDbtRunError
+
+DBT_PROJECT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_shop"
+
+
+@pytest.fixture
+def valid_dbt_project_dir():
+    """
+    Creates a plain dbt project structure, which does not contain logs or target folders.
+    """
+    tmp_dir = Path(tempfile.mkdtemp())
+    source_proj_dir = DBT_PROJECT_PATH
+    target_proj_dir = tmp_dir / "jaffle_shop"
+    shutil.copytree(source_proj_dir, target_proj_dir)
+    shutil.rmtree(target_proj_dir / "logs", ignore_errors=True)
+    shutil.rmtree(target_proj_dir / "target", ignore_errors=True)
+    yield target_proj_dir
+
+    shutil.rmtree(tmp_dir, ignore_errors=True)  # delete directory
+
+
+@pytest.fixture
+def invalid_dbt_project_dir(valid_dbt_project_dir):
+    """
+    Create an invalid dbt project dir, that will raise exceptions if attempted to be run.
+    """
+    file_to_be_deleted = valid_dbt_project_dir / "packages.yml"
+    file_to_be_deleted.unlink()
+
+    file_to_be_changed = valid_dbt_project_dir / "models/staging/stg_orders.sql"
+    open(str(file_to_be_changed), "w").close()
+
+    return valid_dbt_project_dir
+
+
+@patch.dict(sys.modules, {"dbt.cli.main": None})
+def test_is_available_is_false():
+    assert not dbt_runner.is_available()
+
+
+@pytest.mark.integration
+def test_is_available_is_true():
+    assert dbt_runner.is_available()
+
+
+@pytest.mark.integration
+def test_get_runner():
+    from dbt.cli.main import dbtRunner
+
+    runner = dbt_runner.get_runner()
+    assert isinstance(runner, dbtRunner)
+
+
+@pytest.mark.integration
+def test_run_command(valid_dbt_project_dir):
+    from dbt.cli.main import dbtRunnerResult
+
+    response = dbt_runner.run_command(command=["dbt", "deps"], env=os.environ, cwd=valid_dbt_project_dir)
+    assert isinstance(response, dbtRunnerResult)
+    assert response.success
+    assert response.exception is None
+    assert response.result is None
+
+    assert dbt_runner.handle_exception_if_needed(response) is None
+
+
+@pytest.mark.integration
+def test_handle_exception_if_needed_after_exception(valid_dbt_project_dir):
+    # THe following command will fail because we didn't run `dbt deps` in advance
+    response = dbt_runner.run_command(command=["dbt", "ls"], env=os.environ, cwd=valid_dbt_project_dir)
+    assert not response.success
+    assert response.exception
+
+    with pytest.raises(CosmosDbtRunError) as exc_info:
+        dbt_runner.handle_exception_if_needed(response)
+
+    err_msg = str(exc_info.value)
+    expected1 = "dbt invocation did not complete with unhandled error: Compilation Error"
+    expected2 = "dbt found 1 package(s) specified in packages.yml, but only 0 package(s) installed"
+    assert expected1 in err_msg
+    assert expected2 in err_msg
+
+
+@pytest.mark.integration
+def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
+    # THe following command will fail because we didn't run `dbt deps` in advance
+    response = dbt_runner.run_command(command=["dbt", "run"], env=os.environ, cwd=invalid_dbt_project_dir)
+    assert not response.success
+    assert response.exception is None
+    assert response.result
+
+    with pytest.raises(CosmosDbtRunError) as exc_info:
+        dbt_runner.handle_exception_if_needed(response)
+
+    err_msg = str(exc_info.value)
+    expected1 = "dbt invocation completed with errors:"
+    expected2 = "stg_payments: Database Error in model stg_payments"
+    assert expected1 in err_msg
+    assert expected2 in err_msg
+

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -107,4 +107,3 @@ def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
     expected2 = "stg_payments: Database Error in model stg_payments"
     assert expected1 in err_msg
     assert expected2 in err_msg
-

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -254,7 +254,7 @@ def test_dbt_base_operator_run_dbt_runner_cannot_import():
     )
     expected_error_message = "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
     with patch.dict(sys.modules, {"dbt.cli.main": None}):
-        with pytest.raises(ImportError, match=expected_error_message):
+        with pytest.raises(CosmosDbtRunError, match=expected_error_message):
             dbt_base_operator.run_dbt_runner(command=["cmd"], env={}, cwd="some-project")
 
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -17,15 +17,15 @@ from airflow.utils.context import Context
 from packaging import version
 from pendulum import datetime
 
+import cosmos.dbt.runner as dbt_runner
 from cosmos import cache
 from cosmos.config import ProfileConfig
 from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS, InvocationMode
 from cosmos.dbt.parser.output import (
-    extract_dbt_runner_issues,
     parse_number_of_warnings_dbt_runner,
     parse_number_of_warnings_subprocess,
 )
-from cosmos.exceptions import CosmosValueError
+from cosmos.exceptions import CosmosValueError, CosmosDbtRunError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
@@ -290,24 +290,6 @@ def test_dbt_base_operator_run_dbt_runner(mock_chdir, mock_environ):
     assert mock_environ.update.call_args[0][0] == env_vars
 
 
-@patch("cosmos.dbt.project.os.chdir")
-def test_dbt_base_operator_run_dbt_runner_is_cached(mock_chdir):
-    """Tests that if run_dbt_runner is called multiple times a cached runner is used."""
-    dbt_base_operator = ConcreteDbtLocalBaseOperator(
-        profile_config=profile_config,
-        task_id="my-task",
-        project_dir="my/dir",
-        invocation_mode=InvocationMode.DBT_RUNNER,
-    )
-    mock_dbt = MagicMock()
-    with patch.dict(sys.modules, {"dbt.cli.main": mock_dbt}):
-        for _ in range(3):
-            dbt_base_operator.run_dbt_runner(command=["cmd"], env={}, cwd="some-project")
-    mock_dbt_runner = mock_dbt.dbtRunner
-    assert mock_dbt_runner.call_count == 1
-    assert dbt_base_operator._dbt_runner is not None
-
-
 @pytest.mark.parametrize(
     ["skip_exception", "exception_code_returned", "expected_exception"],
     [
@@ -349,11 +331,11 @@ def test_dbt_base_operator_handle_exception_dbt_runner_unhandled_error():
     result.exception = "some exception"
     expected_error_message = "dbt invocation did not complete with unhandled error: some exception"
 
-    with pytest.raises(AirflowException, match=expected_error_message):
+    with pytest.raises(CosmosDbtRunError, match=expected_error_message):
         operator.handle_exception_dbt_runner(result)
 
 
-@patch("cosmos.operators.local.extract_dbt_runner_issues", return_value=(["node1", "node2"], ["error1", "error2"]))
+@patch("cosmos.dbt.runner.extract_message_by_status", return_value=(["node1", "node2"], ["error1", "error2"]))
 def test_dbt_base_operator_handle_exception_dbt_runner_handled_error(mock_extract_dbt_runner_issues):
     """Tests that an AirflowException is raised if the dbtRunner result is not successful and with handled errors."""
     operator = ConcreteDbtLocalBaseOperator(
@@ -367,7 +349,7 @@ def test_dbt_base_operator_handle_exception_dbt_runner_handled_error(mock_extrac
 
     expected_error_message = "dbt invocation completed with errors: node1: error1\nnode2: error2"
 
-    with pytest.raises(AirflowException, match=expected_error_message):
+    with pytest.raises(CosmosDbtRunError, match=expected_error_message):
         operator.handle_exception_dbt_runner(result)
 
     mock_extract_dbt_runner_issues.assert_called_once()
@@ -424,8 +406,8 @@ def test_dbt_test_local_operator_invocation_mode_methods(mock_extract_log_issues
         project_dir="my/dir",
     )
     operator._set_test_result_parsing_methods()
-    assert operator.extract_issues == extract_dbt_runner_issues
-    assert operator.parse_number_of_warnings == parse_number_of_warnings_dbt_runner
+    assert operator.extract_issues == dbt_runner.extract_message_by_status
+    assert operator.parse_number_of_warnings == dbt_runner.parse_number_of_warnings
 
 
 @pytest.mark.skipif(
@@ -1162,8 +1144,8 @@ def test_store_freshness_not_store_compiled_sql(mock_context, mock_session):
 @pytest.mark.parametrize(
     "invocation_mode, expected_extract_function",
     [
-        (InvocationMode.SUBPROCESS, "extract_freshness_warn_msg"),
-        (InvocationMode.DBT_RUNNER, "extract_dbt_runner_issues"),
+        (InvocationMode.SUBPROCESS, "cosmos.operators.local.extract_freshness_warn_msg"),
+        (InvocationMode.DBT_RUNNER, "cosmos.dbt.runner.extract_message_by_status"),
     ],
 )
 def test_handle_warnings(invocation_mode, expected_extract_function, mock_context):
@@ -1177,7 +1159,7 @@ def test_handle_warnings(invocation_mode, expected_extract_function, mock_contex
         invocation_mode=invocation_mode,
     )
 
-    with patch(f"cosmos.operators.local.{expected_extract_function}") as mock_extract_issues, patch.object(
+    with patch(expected_extract_function) as mock_extract_issues, patch.object(
         instance, "on_warning_callback"
     ) as mock_on_warning_callback:
         mock_extract_issues.return_value = (["test_name1", "test_name2"], ["test_name1", "test_name2"])

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -22,10 +22,9 @@ from cosmos import cache
 from cosmos.config import ProfileConfig
 from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS, InvocationMode
 from cosmos.dbt.parser.output import (
-    parse_number_of_warnings_dbt_runner,
     parse_number_of_warnings_subprocess,
 )
-from cosmos.exceptions import CosmosValueError, CosmosDbtRunError
+from cosmos.exceptions import CosmosDbtRunError, CosmosValueError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.operators.local import (
     DbtBuildLocalOperator,


### PR DESCRIPTION
Previously, @jbandoro added support for Cosmos to use `dbtRunner` to execute dbt commands in the Airflow worker nodes when using `ExecutionMode.LOCAL` instead of Python's subprocess #850. This change significantly improved Cosmos resource utilisation in worker nodes.

The first step to implementing support to use `dbtRunner` during DAG parsing (ticket #865) when using `LoadMode.DBT_LS` is to extract `dbtRunner` methods somewhere it can be reused by `graph.py` and is not specific to `operators.py`.

This PR does the following:
- Create `dbt/runner.py`
- Move all `dbtRunner`related functions to this module, refactoring them as needed
- Refactor `operators/local.py` to use the newly introduced methods

Related: #865