### PR TITLE
Use `dbtRunner` in the DAG Processor when using `LoadMode.DBT_LS` if `dbt-core` is available

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -648,10 +648,10 @@ class DbtGraph:
                 ]
 
                 self.target_dir = Path(env.get(DBT_TARGET_PATH_ENVVAR) or tmpdir_path / DBT_TARGET_DIR_NAME)
-                env[DBT_LOG_PATH_ENVVAR] = str(self.log_dir)
                 env[DBT_TARGET_PATH_ENVVAR] = str(self.target_dir)
 
                 self.log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir_path / DBT_LOG_DIR_NAME)
+                env[DBT_LOG_PATH_ENVVAR] = str(self.log_dir)
 
                 if self.render_config.dbt_deps and has_non_empty_dependencies_file(self.project_path):
                     if is_cache_package_lockfile_enabled(project_path):

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -317,6 +317,7 @@ class DbtGraph:
             self.dbt_ls_cache_key = ""
         self.dbt_vars = dbt_vars or {}
         self.operator_args = operator_args or {}
+        self.log_dir: Path | None = None
 
     @cached_property
     def env_vars(self) -> dict[str, str]:
@@ -647,7 +648,7 @@ class DbtGraph:
                 env[DBT_LOG_PATH_ENVVAR] = str(self.log_dir)
                 env[DBT_TARGET_PATH_ENVVAR] = str(self.target_dir)
 
-                self.log_dir: Path = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir_path / DBT_LOG_DIR_NAME)
+                self.log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir_path / DBT_LOG_DIR_NAME)
 
                 if self.render_config.dbt_deps and has_non_empty_dependencies_file(self.project_path):
                     if is_cache_package_lockfile_enabled(project_path):

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -198,6 +198,7 @@ def run_command_with_dbt_runner(command: list[str], tmp_dir: Path, env_vars: dic
         if response.exception:
             raise CosmosLoadDbtException(response.exception)
         elif response.result:
+            # TODO: check if the following works as expected
             stdout = "\n".join(response.result)
             node_names, node_results = dbt_runner.extract_message_by_status(response, ["err"])
             err_msgs = [f"Error processing node {node}: {msg}" for node, msg in zip(node_names, node_results)]

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1176,7 +1176,7 @@ def test_run_command(mock_popen, stdout, returncode):
 def test_run_command_success_with_log(tmp_dbt_project_dir):
     project_dir = tmp_dbt_project_dir / DBT_PROJECT_NAME
     (project_dir / DBT_LOG_FILENAME).touch()
-    response = run_command(command=["dbt", "deps"], env_vars=os.environ, tmp_dir=project_dir)
+    response = run_command(command=["dbt", "deps"], env_vars=os.environ, tmp_dir=project_dir, log_dir=project_dir)
     assert "Installing dbt-labs/dbt_utils" in response
 
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1575,7 +1575,7 @@ def test_run_dbt_deps(run_command_mock):
     graph = DbtGraph(project=project_config)
     graph.local_flags = []
     graph.run_dbt_deps("dbt", "/some/path", {})
-    run_command_mock.assert_called_with(["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {})
+    run_command_mock.assert_called_with(["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {}, None)
 
 
 @pytest.fixture()

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1104,6 +1104,7 @@ def test_load_via_dbt_ls_file():
     ],
 )
 @patch("cosmos.dbt.graph.Popen")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_run_command(mock_popen, stdout, returncode):
     fake_command = ["fake", "command"]
     fake_dir = Path("fake_dir")
@@ -1122,6 +1123,7 @@ def test_run_command(mock_popen, stdout, returncode):
 
 
 @patch("cosmos.dbt.graph.Popen")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_run_command_none_argument(mock_popen, caplog):
     fake_command = ["invalid-cmd", None]
     fake_dir = Path("fake_dir")
@@ -1232,6 +1234,7 @@ def test_parse_dbt_ls_output_with_json_without_tags_or_config():
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_load_via_dbt_ls_project_config_env_vars(
     mock_validate, mock_update_nodes, mock_popen, mock_enable_cache, tmp_dbt_project_dir
 ):
@@ -1267,6 +1270,7 @@ def test_load_via_dbt_ls_project_config_env_vars(
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_profile_created_correctly_with_profile_mapping(
     mock_validate,
     mock_update_nodes,
@@ -1300,6 +1304,7 @@ def test_profile_created_correctly_with_profile_mapping(
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_load_via_dbt_ls_project_config_dbt_vars(
     mock_validate, mock_update_nodes, mock_popen, mock_use_case, tmp_dbt_project_dir
 ):
@@ -1334,6 +1339,7 @@ def test_load_via_dbt_ls_project_config_dbt_vars(
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_load_via_dbt_ls_render_config_selector_arg_is_used(
     mock_validate, mock_update_nodes, mock_popen, mock_enable_cache, tmp_dbt_project_dir
 ):
@@ -1370,6 +1376,7 @@ def test_load_via_dbt_ls_render_config_selector_arg_is_used(
 @patch("cosmos.dbt.graph.Popen")
 @patch("cosmos.dbt.graph.DbtGraph.update_node_dependency")
 @patch("cosmos.config.RenderConfig.validate_dbt_command")
+@patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_load_via_dbt_ls_render_config_no_partial_parse(
     mock_validate, mock_update_nodes, mock_popen, mock_enable_cache, tmp_dbt_project_dir
 ):

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -96,7 +96,7 @@ def test_handle_exception_if_needed_after_exception(valid_dbt_project_dir):
 
 @pytest.mark.integration
 def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
-    # The following command
+    # The following command fails, but has no exceptions - only results
     response = dbt_runner.run_command(command=["dbt", "run"], env=os.environ, cwd=invalid_dbt_project_dir)
     assert not response.success
     assert response.exception is None

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -107,6 +107,4 @@ def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
 
     err_msg = str(exc_info.value)
     expected1 = "dbt invocation completed with errors:"
-    expected2 = "orders: Database Error in model orders (models/orders.sql)"
     assert expected1 in err_msg
-    assert expected2 in err_msg

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -5,6 +5,8 @@ import tempfile
 from pathlib import Path
 from unittest.mock import patch
 
+sys.modules.pop("dbt.cli.main", None)
+
 import pytest
 
 import cosmos.dbt.runner as dbt_runner
@@ -38,7 +40,8 @@ def invalid_dbt_project_dir(valid_dbt_project_dir):
     file_to_be_deleted.unlink()
 
     file_to_be_changed = valid_dbt_project_dir / "models/staging/stg_orders.sql"
-    open(str(file_to_be_changed), "w").close()
+    with open(str(file_to_be_changed), "w") as fp:
+        fp.writelines("select 1 as id")
 
     return valid_dbt_project_dir
 
@@ -76,7 +79,7 @@ def test_run_command(valid_dbt_project_dir):
 
 @pytest.mark.integration
 def test_handle_exception_if_needed_after_exception(valid_dbt_project_dir):
-    # THe following command will fail because we didn't run `dbt deps` in advance
+    # The following command will fail because we didn't run `dbt deps` in advance
     response = dbt_runner.run_command(command=["dbt", "ls"], env=os.environ, cwd=valid_dbt_project_dir)
     assert not response.success
     assert response.exception
@@ -93,7 +96,7 @@ def test_handle_exception_if_needed_after_exception(valid_dbt_project_dir):
 
 @pytest.mark.integration
 def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
-    # THe following command will fail because we didn't run `dbt deps` in advance
+    # The following command
     response = dbt_runner.run_command(command=["dbt", "run"], env=os.environ, cwd=invalid_dbt_project_dir)
     assert not response.success
     assert response.exception is None
@@ -104,6 +107,6 @@ def test_handle_exception_if_needed_after_error(invalid_dbt_project_dir):
 
     err_msg = str(exc_info.value)
     expected1 = "dbt invocation completed with errors:"
-    expected2 = "stg_payments: Database Error in model stg_payments"
+    expected2 = "orders: Database Error in model orders (models/orders.sql)"
     assert expected1 in err_msg
     assert expected2 in err_msg


### PR DESCRIPTION
This PR significantly improves Cosmos resource utilisation in the scheduler DAG Processor and in the worker nodes when dynamically converting dbt workflows into Airflow DAGs using the `LoadMode.DBT_LS`. 

It introduces support to use `dbtRunner` during DAG parsing if `dbt-core` and its adaptors are in the same Python virtualenv as Airflow.

This change is particularly relevant given the way Airflow (2.x) parses DAGs not only as part of the scheduler loop but also whenever a task executes:

<img width="845" alt="Screenshot 2025-01-23 at 13 51 40" src="https://github.com/user-attachments/assets/90398307-a26c-4cbd-ae44-a6a5c1e0e98e" />

> Diagram extracted from the talk @pankajkoti and I gave at Airflow Summit 2024
> https://airflowsummit.org/sessions/2024/overcoming-performance-hurdles-in-integrating-dbt-with-airflow/)

When using `LoadMode.DBT_LS`, Cosmos runs `dbt ls` whenever Airflow parses the DAG (in case of a cache miss).

Suppose there is a Cosmos `DbtDag` with 200 concurrent tasks. If the dbt project changes, when Airflow and Cosmos attempt to parse the `DbtDag`, they will invalidate the dbt ls cache. If 200 Cosmos tasks execute concurrently when there is a cache miss, they will all run the same `dbt ls` command. Until Cosmos 1.8, Cosmos would always create a subprocess for each command. If 200 tasks execute in a worker node, this would represent 400 processes attempting to run concurrently, leading to a vast resource CPU - and potentially memory - spike and Out of Memory (OOM) errors. While this change does not avoid the 200 tasks attempting to run `dbt ls` concurrently, it avoids each of them creating an additional subprocess - optimising the resource utilisation.

This change is heavily influenced by changes (#850) previously made by @jbandoro, who added support for Cosmos to use `dbtRunner` to execute dbt commands in the Airflow worker nodes when using `ExecutionMode.LOCAL` instead of Python's subprocess.

Closes: #865