### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -51,7 +51,7 @@ This will generate an Airflow DAG that looks like this:
 
 Community
 _________
-- Join us on the Airflow `Slack <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ at #airflow-dbt
+- Join us on the Airflow `Slack <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ at #dbt-deployment-and-orchestration
 
 
 Changelog


### PR DESCRIPTION
#airflow-dbt channel no longer exists

The link to Slack is also broken. New channel ID is CMZ2Q9MA9.