### PR TITLE
Allow users to opt-out `dbtRunner` during DAG parsing

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,18 @@ Changelog
 1.9.0a1 (2025-01-20)
 --------------------
 
+Breaking changes
+
+* When using ``LoadMode.DBT_LS``, Cosmos will now attempt to use the ``dbtRunner`` as opposed to subprocess to run ``dbt ls``.
+  While this represents significant performance improvements (half the vCPU usage and some memory consumption improvement), this may not work in
+  scenarios where users had multiple Python virtual environments to manage different versions of dbt and its adaptors. In those cases,
+  please, set ``RenderConfig(invocation_mode=InvocationMode.SUBPROCESS)`` to have the same behaviour Cosmos had in previous versions.
+
+Features
+
+* Use ``dbtRunner`` in the DAG Processor when using ``LoadMode.DBT_LS`` if dbt-core is available by @tatiana in #1484
+* Allow users to opt-out of ``dbtRunner`` during DAG parsing with ``InvocationMode.SUBPROCESS`` by @tatiana in #1495
+
 Bug Fixes
 
 * Fix select complex intersection of three tag-based graph selectors by @tatiana in #1466

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -70,6 +70,7 @@ class RenderConfig:
     emit_datasets: bool = True
     test_behavior: TestBehavior = TestBehavior.AFTER_EACH
     load_method: LoadMode = LoadMode.AUTOMATIC
+    invocation_mode: InvocationMode = InvocationMode.DBT_RUNNER
     select: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     selector: str | None = None

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -51,6 +51,7 @@ class RenderConfig:
     dependencies. Defaults to True
     :param test_behavior: The behavior for running tests. Defaults to after each (model)
     :param load_method: The parsing method for loading the dbt model. Defaults to AUTOMATIC
+    :param invocation_mode: If `LoadMode.DBT_LS` is used, define how dbt ls should be run: using dbtRunner (default) or Python subprocess.
     :param select: A list of dbt select arguments (e.g. 'config.materialized:incremental')
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
     :param selector: Name of a dbt YAML selector to use for parsing. Only supported when using ``load_method=LoadMode.DBT_LS``.

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -103,9 +103,6 @@ If you don't have a ``manifest.json`` file, Cosmos will attempt to generate one 
 
 When Cosmos runs ``dbt ls``, it also passes your ``select`` and ``exclude`` arguments to the command. This means that Cosmos will only generate a manifest for the models you want to run.
 
-Starting in Cosmos 1.5, Cosmos will cache the output of the ``dbt ls`` command, to improve the performance of this
-parsing method. Learn more `here <./caching.html>`_.
-
 To use this:
 
 .. code-block:: python
@@ -116,6 +113,28 @@ To use this:
         )
         # ...,
     )
+
+Starting in Cosmos 1.5, Cosmos will cache the output of the ``dbt ls`` command, to improve the performance of this
+parsing method. Learn more `here <./caching.html>`_.
+
+Since Cosmos 1.9, it will attempt to use dbt as a library, and run ``dbt ls`` using the ``dbtRunner``  that is available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__. This mode requires dbt version 1.5.0 or higher.
+This mode,  named ``InvocationMode.DBT_RUNNER``, also depends on dbt being installed in the same Python virtual environment as Airflow.
+In previous Cosmos versions, Cosmos would always run ``dbt ls`` using the  Python ``subprocess`` module, which can lead to significant CPU and memory usage.
+
+Users can force Cosmos to run ``dbt ls`` with subprocess and not ``dbtRunner``, by setting:
+
+.. code-block:: python
+
+    DbtDag(
+        render_config=RenderConfig(
+            load_method=LoadMode.DBT_LS, invocation_mode=InvocationMode.SUBPROCESS
+        )
+        # ...,
+    )
+
+
+For more information, check the `RenderConfig docs <./render-config.html>`_.
+
 
 ``dbt_ls_file``
 ----------------

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -36,13 +36,14 @@ In previous Cosmos versions, Cosmos would always run ``dbt ls`` using the  Pytho
 
 Although ``InvocationMode.DBT_RUNNER`` is the default behaviour in Cosmos 1.9, users can still specify which mode they would like to use:
 
-1. ``InvocationMode.SUBPROCESS``: In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
+1. ``InvocationMode.SUBPROCESS``: (behaviour before Cosmos 1.9) In this mode, Cosmos runs dbt cli commands using the Python ``subprocess`` module and parses the output to capture logs and to raise exceptions.
 
-2. ``InvocationMode.DBT_RUNNER``: In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
+2. ``InvocationMode.DBT_RUNNER``: (default since Cosmos 1.9) In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
    In order to use this mode, dbt must be installed in the same local environment. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and is faster than ``InvocationMode.SUBPROCESS``. \
    This mode requires dbt version 1.5.0 or higher. It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
 
-This may be particularly necessary in case users have multiple Python virtual environments with different versions of dbt and its adaptors.
+Users may opt to use ``InvocationMode.SUBPROCESS`` when they have multiple Python virtual environments with different versions of dbt and its adaptors,
+and do not want Cosmos to use the dbt version installed in the same Python Virtualenv as Airflow to parse the DAG.
 
 
 Customizing how nodes are rendered (experimental)

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1177,7 +1177,13 @@ def test_run_command(mock_popen, stdout, returncode):
 def test_run_command_success_with_log(tmp_dbt_project_dir):
     project_dir = tmp_dbt_project_dir / DBT_PROJECT_NAME
     (project_dir / DBT_LOG_FILENAME).touch()
-    response = run_command(command=["dbt", "deps"], env_vars=os.environ, tmp_dir=project_dir, log_dir=project_dir)
+    response = run_command(
+        command=["dbt", "deps"],
+        env_vars=os.environ,
+        tmp_dir=project_dir,
+        invocation_mode=InvocationMode.SUBPROCESS,
+        log_dir=project_dir,
+    )
     assert "Installing dbt-labs/dbt_utils" in response
 
 
@@ -1214,7 +1220,12 @@ def test_run_command_forcing_dbt_runner(mock_dbt_runner, mock_subprocess, tmp_db
 @pytest.mark.integration
 def test_run_command_with_dbt_runner_exception(tmp_dbt_project_dir):
     with pytest.raises(CosmosLoadDbtException) as err_info:
-        run_command(command=["dbt", "ls"], env_vars=os.environ, tmp_dir=tmp_dbt_project_dir / DBT_PROJECT_NAME)
+        run_command(
+            command=["dbt", "ls"],
+            env_vars=os.environ,
+            invocation_mode=InvocationMode.DBT_RUNNER,
+            tmp_dir=tmp_dbt_project_dir / DBT_PROJECT_NAME,
+        )
     err_msg = "Unable to run dbt ls command due to missing dbt_packages"
     assert err_msg in str(err_info.value)
 
@@ -1230,7 +1241,9 @@ def test_run_command_with_dbt_runner_error(tmp_dbt_project_dir):
         fp.writelines("select 1 as id")
 
     with pytest.raises(CosmosLoadDbtException) as err_info:
-        run_command(command=["dbt", "run"], env_vars=os.environ, tmp_dir=project_dir)
+        run_command(
+            command=["dbt", "run"], env_vars=os.environ, invocation_mode=InvocationMode.DBT_RUNNER, tmp_dir=project_dir
+        )
     assert "Unable to run ['dbt', 'run']" in str(err_info.value)
 
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -22,6 +22,7 @@ from cosmos.constants import (
     DBT_TARGET_DIR_NAME,
     DbtResourceType,
     ExecutionMode,
+    InvocationMode,
     SourceRenderingBehavior,
 )
 from cosmos.dbt.graph import (
@@ -1162,7 +1163,7 @@ def test_run_command(mock_popen, stdout, returncode):
     mock_popen.return_value.communicate.return_value = (stdout, "")
     mock_popen.return_value.returncode = returncode
 
-    return_value = run_command(fake_command, fake_dir, env_vars)
+    return_value = run_command(fake_command, fake_dir, env_vars, InvocationMode.DBT_RUNNER)
     args, kwargs = mock_popen.call_args
     assert args[0] == fake_command
     assert kwargs["cwd"] == fake_dir
@@ -1178,6 +1179,36 @@ def test_run_command_success_with_log(tmp_dbt_project_dir):
     (project_dir / DBT_LOG_FILENAME).touch()
     response = run_command(command=["dbt", "deps"], env_vars=os.environ, tmp_dir=project_dir, log_dir=project_dir)
     assert "Installing dbt-labs/dbt_utils" in response
+
+
+@patch("cosmos.dbt.graph.run_command_with_subprocess")
+@patch("cosmos.dbt.graph.run_command_with_dbt_runner")
+def test_run_command_forcing_subprocess(mock_dbt_runner, mock_subprocess, tmp_dbt_project_dir):
+    project_dir = tmp_dbt_project_dir / DBT_PROJECT_NAME
+    run_command(
+        command=["dbt", "deps"],
+        env_vars=os.environ,
+        tmp_dir=project_dir,
+        invocation_mode=InvocationMode.SUBPROCESS,
+        log_dir=project_dir,
+    )
+    assert mock_subprocess.called
+    assert not mock_dbt_runner.called
+
+
+@patch("cosmos.dbt.graph.run_command_with_subprocess")
+@patch("cosmos.dbt.graph.run_command_with_dbt_runner")
+def test_run_command_forcing_dbt_runner(mock_dbt_runner, mock_subprocess, tmp_dbt_project_dir):
+    project_dir = tmp_dbt_project_dir / DBT_PROJECT_NAME
+    run_command(
+        command=["dbt", "deps"],
+        env_vars=os.environ,
+        tmp_dir=project_dir,
+        invocation_mode=InvocationMode.DBT_RUNNER,
+        log_dir=project_dir,
+    )
+    assert not mock_subprocess.called
+    assert mock_dbt_runner.called
 
 
 @pytest.mark.integration
@@ -1212,7 +1243,7 @@ def test_run_command_none_argument(mock_popen, caplog):
 
     mock_popen.return_value.communicate.return_value = ("Invalid None argument", None)
     with pytest.raises(CosmosLoadDbtException) as exc_info:
-        run_command(fake_command, fake_dir, env_vars)
+        run_command(fake_command, fake_dir, env_vars, InvocationMode.SUBPROCESS)
 
     expected = "Unable to run ['invalid-cmd', '<None>'] due to the error:\nstderr: None\nstdout: Invalid None argument"
     assert str(exc_info.value) == expected
@@ -1656,7 +1687,9 @@ def test_run_dbt_deps(run_command_mock):
     graph = DbtGraph(project=project_config)
     graph.local_flags = []
     graph.run_dbt_deps("dbt", "/some/path", {})
-    run_command_mock.assert_called_with(["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {}, None)
+    run_command_mock.assert_called_with(
+        ["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {}, InvocationMode.DBT_RUNNER, None
+    )
 
 
 @pytest.fixture()


### PR DESCRIPTION
While speaking to a customer about #1484, they mentioned they have the following setup:
- `dbt-databricks` installed in the same Python virtualenv as Cosmos/Airflow
- `dbt-bigquery` installed in a separate Python virtualenv using Astro Dockerfile

And run DAGs using both with the same image. This means 1.9.0a3 breaks them since they use `LoadMode.DBT_LS` and only `debt-data bricks` can be parsed. This means that we have to add support to allow users to opt-in / out of using the `dbtRunner` during DAG parsing - similar to what was done for task execution, in `ExecutionConfig`.