### PR TITLE
Ignore dbt package tests when running Cosmos tests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,6 +177,7 @@ test-performance-setup = 'sh scripts/test/performance-setup.sh'
 type-check = "pre-commit run mypy --files cosmos/**/*"
 
 [tool.pytest.ini_options]
+addopts = "--ignore-glob=**/dbt_packages/*"
 filterwarnings = ["ignore::DeprecationWarning"]
 minversion = "6.0"
 markers = ["integration", "perf"]


### PR DESCRIPTION
Avoid errors raised by Pytest, such as the below, because we had installed `dbt deps` in one of Cosmos example dbt projects:
```
====================================================================== short test summary info =======================================================================
ERROR dags/dbt/altered_jaffle_shop/dbt_packages/dbt_utils/tests - _pytest.pathlib.ImportPathMismatchError: ('tests.conftest', '/Users/tati/Code/cosmos-fresh/astronomer-cosmos/tests/conftest.py', PosixPath('/Users/tati/Code/cosmos-fresh/astronomer-cosmos/dags/dbt/altered_jaffle_shop/dbt_packages/dbt_utils/tests/conftest.py'))
ERROR dev/dags/dbt/altered_jaffle_shop/dbt_packages/dbt_utils/tests - _pytest.pathlib.ImportPathMismatchError: ('tests.conftest', '/Users/tati/Code/cosmos-fresh/astronomer-cosmos/tests/conftest.py', PosixPath('/Users/tati/Code/cosmos-fresh/astronomer-cosmos/dev/dags/dbt/altered_jaffle_shop/dbt_packages/dbt_utils/tests/conftest.py'))
!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Interrupted: 2 errors during collection !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
============================================================ 81 deselected, 5 warnings, 2 errors in 4.93s ============================================================

```

When running Cosmos test commands such as:

```
hatch run tests.py3.9-2.9:test-cov
```

