### PR TITLE
Add Support for Running DbtSourceOperator Individually

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -19,8 +19,8 @@ SUPPORTED_CONFIG = ["materialized", "schema", "tags"]
 PATH_SELECTOR = "path:"
 TAG_SELECTOR = "tag:"
 CONFIG_SELECTOR = "config."
-SOURCE_SELECTOR = 'source:'
-RESOURCE_TYPE_SELECTOR = 'resource_type:'
+SOURCE_SELECTOR = "source:"
+RESOURCE_TYPE_SELECTOR = "resource_type:"
 PLUS_SELECTOR = "+"
 AT_SELECTOR = "@"
 GRAPH_SELECTOR_REGEX = r"^(@|[0-9]*\+)?([^\+]+)(\+[0-9]*)?$|"
@@ -179,12 +179,18 @@ class GraphSelector:
         elif TAG_SELECTOR in self.node_name:
             tag_selection = self.node_name[len(TAG_SELECTOR) :]
             root_nodes.update({node_id for node_id, node in nodes.items() if tag_selection in node.tags})
-        
+
         elif SOURCE_SELECTOR in self.node_name:
             source_selection = self.node_name[len(SOURCE_SELECTOR) :]
-            
+
             # match node.resource_type == SOURCE, node.name == source_selection
-            root_nodes.update({node_id for node_id, node in nodes.items() if node.resource_type == DbtResourceType.SOURCE and node.name == source_selection})
+            root_nodes.update(
+                {
+                    node_id
+                    for node_id, node in nodes.items()
+                    if node.resource_type == DbtResourceType.SOURCE and node.name == source_selection
+                }
+            )
 
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
@@ -288,7 +294,15 @@ class SelectorConfig:
 
     @property
     def is_empty(self) -> bool:
-        return not (self.paths or self.tags or self.config or self.graph_selectors or self.other or self.sources or self.resource_types)
+        return not (
+            self.paths
+            or self.tags
+            or self.config
+            or self.graph_selectors
+            or self.other
+            or self.sources
+            or self.resource_types
+        )
 
     def load_from_statement(self, statement: str) -> None:
         """

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -327,7 +327,7 @@ class SelectorConfig:
                     self._parse_unknown_selector(item)
                 else:
                     self._handle_no_precursors_or_descendants(item, node_name)
-    
+
     def _handle_no_precursors_or_descendants(self, item: str, node_name: str) -> None:
         if node_name.startswith(PATH_SELECTOR):
             self._parse_path_selector(item)
@@ -472,7 +472,7 @@ class NodeSelector:
             return False
 
         if self.config.resource_types and not self._is_resource_type_matching(node):
-                return False
+            return False
 
         if self.config.sources and not self._is_source_matching(node):
             return False
@@ -484,7 +484,7 @@ class NodeSelector:
         if node.resource_type.value not in self.config.resource_types:
             return False
         return True
-    
+
     def _is_source_matching(self, node: DbtNode) -> bool:
         """Checks if the node's source is a subset of the config's source."""
         if node.resource_type != DbtResourceType.SOURCE:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -177,6 +177,12 @@ class GraphSelector:
         elif TAG_SELECTOR in self.node_name:
             tag_selection = self.node_name[len(TAG_SELECTOR) :]
             root_nodes.update({node_id for node_id, node in nodes.items() if tag_selection in node.tags})
+        
+        elif SOURCE_SELECTOR in self.node_name:
+            source_selection = self.node_name[len(SOURCE_SELECTOR) :]
+            
+            # match node.resource_type == SOURCE, node.name == source_selection
+            root_nodes.update({node_id for node_id, node in nodes.items() if node.resource_type == DbtResourceType.SOURCE and node.name == source_selection})
 
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
@@ -353,7 +359,7 @@ class SelectorConfig:
         self.sources.append(source_name)
 
     def __repr__(self) -> str:
-        return f"SelectorConfig(paths={self.paths}, tags={self.tags}, config={self.config}, other={self.other}, graph_selectors={self.graph_selectors})"
+        return f"SelectorConfig(paths={self.paths}, tags={self.tags}, config={self.config}, sources={self.sources}, resource={self.resource_types}, other={self.other}, graph_selectors={self.graph_selectors})"
 
 
 class NodeSelector:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -474,9 +474,8 @@ class NodeSelector:
         if self.config.sources:
             if node.resource_type != DbtResourceType.SOURCE:
                 return False
-
-        if node.resource_name not in self.config.sources:
-            return False
+            if node.resource_name not in self.config.sources:
+                return False
 
         return True
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -183,12 +183,12 @@ class GraphSelector:
         elif SOURCE_SELECTOR in self.node_name:
             source_selection = self.node_name[len(SOURCE_SELECTOR) :]
 
-            # match node.resource_type == SOURCE, node.name == source_selection
+            # match node.resource_type == SOURCE, node.resource_name == source_selection
             root_nodes.update(
                 {
                     node_id
                     for node_id, node in nodes.items()
-                    if node.resource_type == DbtResourceType.SOURCE and node.name == source_selection
+                    if node.resource_type == DbtResourceType.SOURCE and node.resource_name == source_selection
                 }
             )
 
@@ -475,7 +475,7 @@ class NodeSelector:
             if node.resource_type != DbtResourceType.SOURCE:
                 return False
 
-        if node.name not in self.config.sources:
+        if node.resource_name not in self.config.sources:
             return False
 
         return True

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -288,7 +288,7 @@ class SelectorConfig:
 
     @property
     def is_empty(self) -> bool:
-        return not (self.paths or self.tags or self.config or self.graph_selectors or self.other)
+        return not (self.paths or self.tags or self.config or self.graph_selectors or self.other or self.sources or self.resource_types)
 
     def load_from_statement(self, statement: str) -> None:
         """

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -605,6 +605,8 @@ def validate_filters(exclude: list[str], select: list[str]) -> None:
             if (
                 filter_parameter.startswith(PATH_SELECTOR)
                 or filter_parameter.startswith(TAG_SELECTOR)
+                or filter_parameter.startswith(RESOURCE_TYPE_SELECTOR)
+                or filter_parameter.startswith(SOURCE_SELECTOR)
                 or PLUS_SELECTOR in filter_parameter
                 or any([filter_parameter.startswith(CONFIG_SELECTOR + config + ":") for config in SUPPORTED_CONFIG])
             ):

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -43,6 +43,8 @@ class GraphSelector:
         path:/path/to/model_h+
         +tag:nightly
         +config.materialized:view
+        resource_type:resource_name
+        source:source_name
 
     https://docs.getdbt.com/reference/node-selection/graph-operators
     """

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -23,6 +23,10 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``@node_name`` (@ operator): include/exclude the node with name ``node_name``, all its descendants, and all ancestors of those descendants. This is useful in CI environments where you want to build a model and all its descendants, but you need the ancestors of those descendants to exist first.
 - ``tag:my_tag,+node_name`` (intersection): include/exclude ``node_name`` and its parents if they have the tag ``my_tag`` (`dbt set operator docs <https://docs.getdbt.com/reference/node-selection/set-operators>`_)
 - ``['tag:first_tag', 'tag:second_tag']`` (union): include/exclude nodes that have either ``tag:first_tag`` or ``tag:second_tag``
+- ``resource_type:<resource>``: include/exclude nodes with the resource type ``seed, snapshots, model, test, source``. For example, ``resource_type:source`` returns only nodes where resource_type == SOURCE
+- ``source:my_source``: include/exclude nodes that have the source ``my_source`` and are of resource_type ``source``
+- ``source:my_source+``: include/exclude nodes that have the source ``my_source`` and their children
+- ``source:my_source.my_table``: include/exclude nodes that have the source ``my_source`` and the table ``my_table``
 
 .. note::
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -764,6 +764,7 @@ def test_exclude_nodes_with_period_with_at_operator():
     expected = ["model.dbt-proj.child", "model.dbt-proj.orphaned", "model.dbt-proj.sibling1", "model.dbt-proj.sibling2"]
     assert sorted(selected.keys()) == expected
 
+
 def test_select_nodes_by_resource_type_source():
     """
     Test that 'resource_type:source' picks up only nodes with resource_type == SOURCE,
@@ -799,6 +800,8 @@ def test_select_nodes_by_resource_type_source():
         source_node.unique_id: source_node,
     }
     assert selected == expected
+
+
 def test_select_nodes_by_source_name():
     """
     Test selecting a single source node by exact name 'source:my_source.my_table'.
@@ -823,6 +826,8 @@ def test_select_nodes_by_source_name():
     )
     expected = {source_node.unique_id: source_node}
     assert selected == expected
+
+
 def test_exclude_nodes_by_resource_type_source():
     """
     Test excluding any seed node via 'resource_type:seed'.

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -848,6 +848,7 @@ def test_exclude_nodes_by_resource_type_seed():
     for model_id in sample_nodes.keys():
         assert model_id in selected
 
+
 def test_source_selector():
     """
     Covers:

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -828,7 +828,7 @@ def test_select_nodes_by_source_name():
     assert selected == expected
 
 
-def test_exclude_nodes_by_resource_type_source():
+def test_exclude_nodes_by_resource_type_seed():
     """
     Test excluding any seed node via 'resource_type:seed'.
     """

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -779,7 +779,6 @@ def test_select_nodes_by_resource_type_source():
         tags=[],
         config={},
     )
-    source_node.name = "my_source.my_table"
 
     local_nodes[source_node.unique_id] = source_node
     model_node = DbtNode(
@@ -790,7 +789,6 @@ def test_select_nodes_by_resource_type_source():
         tags=["depends_on_source"],
         config={"materialized": "table", "tags": ["depends_on_source"]},
     )
-    model_node.name = "model_from_source"
 
     local_nodes[model_node.unique_id] = model_node
     selected = select_nodes(
@@ -819,7 +817,6 @@ def test_select_nodes_by_source_name():
         tags=[],
         config={},
     )
-    source_node.name = "my_source.my_table"
 
     local_nodes[source_node.unique_id] = source_node
     selected = select_nodes(
@@ -844,7 +841,6 @@ def test_exclude_nodes_by_resource_type_source():
         config={},
         file_path=SAMPLE_PROJ_PATH / "seeds/seed.yml",
     )
-    seed_node.name = "my_seed"
 
     local_nodes[seed_node.unique_id] = seed_node
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=local_nodes, exclude=["resource_type:seed"])

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -780,7 +780,7 @@ def test_select_nodes_by_resource_type_source():
         config={},
     )
     source_node.name = "my_source.my_table"
-    
+
     local_nodes[source_node.unique_id] = source_node
     model_node = DbtNode(
         unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.model_from_source",
@@ -791,7 +791,7 @@ def test_select_nodes_by_resource_type_source():
         config={"materialized": "table", "tags": ["depends_on_source"]},
     )
     model_node.name = "model_from_source"
-    
+
     local_nodes[model_node.unique_id] = model_node
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH,
@@ -820,7 +820,7 @@ def test_select_nodes_by_source_name():
         config={},
     )
     source_node.name = "my_source.my_table"
-    
+
     local_nodes[source_node.unique_id] = source_node
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH,
@@ -845,7 +845,7 @@ def test_exclude_nodes_by_resource_type_source():
         file_path=SAMPLE_PROJ_PATH / "seeds/seed.yml",
     )
     seed_node.name = "my_seed"
-    
+
     local_nodes[seed_node.unique_id] = seed_node
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=local_nodes, exclude=["resource_type:seed"])
     assert seed_node.unique_id not in selected

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -778,8 +778,9 @@ def test_select_nodes_by_resource_type_source():
         file_path=SAMPLE_PROJ_PATH / "sources/my_source.yml",
         tags=[],
         config={},
-        name="my_source.my_table",
     )
+    source_node.name = "my_source.my_table"
+    
     local_nodes[source_node.unique_id] = source_node
     model_node = DbtNode(
         unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.model_from_source",
@@ -788,8 +789,9 @@ def test_select_nodes_by_resource_type_source():
         file_path=SAMPLE_PROJ_PATH / "models/model_from_source.sql",
         tags=["depends_on_source"],
         config={"materialized": "table", "tags": ["depends_on_source"]},
-        name="model_from_source",
     )
+    model_node.name = "model_from_source"
+    
     local_nodes[model_node.unique_id] = model_node
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH,
@@ -816,8 +818,9 @@ def test_select_nodes_by_source_name():
         file_path=SAMPLE_PROJ_PATH / "sources/my_source.yml",
         tags=[],
         config={},
-        name="my_source.my_table",
     )
+    source_node.name = "my_source.my_table"
+    
     local_nodes[source_node.unique_id] = source_node
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH,
@@ -833,17 +836,18 @@ def test_exclude_nodes_by_resource_type_source():
     Test excluding any seed node via 'resource_type:seed'.
     """
     local_nodes = dict(sample_nodes)
-    source_node = DbtNode(
+    seed_node = DbtNode(
         unique_id=f"{DbtResourceType.SEED.value}.{SAMPLE_PROJ_PATH.stem}.my_seed",
         resource_type=DbtResourceType.SEED,
         depends_on=[],
         tags=[],
         config={},
         file_path=SAMPLE_PROJ_PATH / "seeds/seed.yml",
-        name="my_seed",
     )
-    local_nodes[source_node.unique_id] = source_node
+    seed_node.name = "my_seed"
+    
+    local_nodes[seed_node.unique_id] = seed_node
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=local_nodes, exclude=["resource_type:seed"])
-    assert source_node.unique_id not in selected
+    assert seed_node.unique_id not in selected
     for model_id in sample_nodes.keys():
         assert model_id in selected


### PR DESCRIPTION
## Description

This pull request adds two new types of selectors to Cosmos’s dbt-like node selection logic:

1. **`resource_type:`** – Allows filtering nodes by their resource type.  
   - Example: `resource_type:source` returns only nodes where `resource_type == SOURCE`.  
   - Useful for running freshness tests or filtering all sources.

2. **`source:`** – Enables selecting a specific dbt source node by name.  
   - Example: `source:my_source.my_table` matches a source node named `"my_source.my_table"`.

## Related Issue(s)

Closes #1494 
Closes #1496

## Breaking Change?

No, this is an additive feature. Existing selector behavior remains unchanged.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works


