### PR TITLE
Add setup task for async executions

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.9.0a5"
+__version__ = "1.9.0a6"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -117,6 +117,7 @@ def create_test_task_metadata(
     test_task_name: str,
     execution_mode: ExecutionMode,
     test_indirect_selection: TestIndirectSelection,
+    dbt_dag_task_group_identifier: str,
     task_args: dict[str, Any],
     on_warning_callback: Callable[..., Any] | None = None,
     node: DbtNode | None = None,
@@ -151,7 +152,10 @@ def create_test_task_metadata(
         else:  # tested with node.resource_type == DbtResourceType.SEED or DbtResourceType.SNAPSHOT
             task_args["select"] = node.resource_name
 
-        extra_context = {"dbt_node_config": node.context_dict}
+        extra_context = {
+            "dbt_node_config": node.context_dict,
+            "dbt_dag_task_group_identifier": dbt_dag_task_group_identifier,
+        }
         task_owner = node.owner
 
     elif render_config is not None:  # TestBehavior.AFTER_ALL
@@ -377,6 +381,7 @@ def generate_task_or_group(
                     "test",
                     execution_mode,
                     test_indirect_selection,
+                    dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
                     task_args=task_args,
                     node=node,
                     on_warning_callback=on_warning_callback,
@@ -567,6 +572,7 @@ def build_airflow_graph(
             f"{dbt_project_name}_test",
             execution_mode,
             test_indirect_selection,
+            dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
             task_args=task_args,
             on_warning_callback=on_warning_callback,
             render_config=render_config,
@@ -583,6 +589,7 @@ def build_airflow_graph(
                 datached_node_name,
                 execution_mode,
                 test_indirect_selection,
+                dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
                 task_args=task_args,
                 on_warning_callback=on_warning_callback,
                 render_config=render_config,

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -588,6 +588,7 @@ def build_airflow_graph(
             tasks_map[node_id] = test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)
+    _add_dbt_compile_task(nodes, dag, execution_mode, task_args, tasks_map, task_group)
     return tasks_map
 
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -139,7 +139,6 @@ def create_test_task_metadata(
     task_args["on_warning_callback"] = on_warning_callback
     extra_context = {}
     detached_from_parent = detached_from_parent or {}
-
     task_owner = ""
 
     if test_indirect_selection != TestIndirectSelection.EAGER:

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -25,6 +25,7 @@ from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
+from cosmos.settings import enable_setup_task
 
 logger = get_logger(__name__)
 
@@ -599,7 +600,8 @@ def build_airflow_graph(
             tasks_map[node_id] = test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)
-    _add_dbt_compile_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
+    if enable_setup_task:
+        _add_dbt_compile_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
     return tasks_map
 
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -118,7 +118,6 @@ def create_test_task_metadata(
     test_task_name: str,
     execution_mode: ExecutionMode,
     test_indirect_selection: TestIndirectSelection,
-    dbt_dag_task_group_identifier: str,
     task_args: dict[str, Any],
     on_warning_callback: Callable[..., Any] | None = None,
     node: DbtNode | None = None,
@@ -153,10 +152,7 @@ def create_test_task_metadata(
         else:  # tested with node.resource_type == DbtResourceType.SEED or DbtResourceType.SNAPSHOT
             task_args["select"] = node.resource_name
 
-        extra_context = {
-            "dbt_node_config": node.context_dict,
-            "dbt_dag_task_group_identifier": dbt_dag_task_group_identifier,
-        }
+        extra_context = {"dbt_node_config": node.context_dict}
         task_owner = node.owner
 
     elif render_config is not None:  # TestBehavior.AFTER_ALL
@@ -382,7 +378,6 @@ def generate_task_or_group(
                     "test",
                     execution_mode,
                     test_indirect_selection,
-                    dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
                     task_args=task_args,
                     node=node,
                     on_warning_callback=on_warning_callback,
@@ -573,7 +568,6 @@ def build_airflow_graph(
             f"{dbt_project_name}_test",
             execution_mode,
             test_indirect_selection,
-            dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
             task_args=task_args,
             on_warning_callback=on_warning_callback,
             render_config=render_config,
@@ -590,7 +584,6 @@ def build_airflow_graph(
                 datached_node_name,
                 execution_mode,
                 test_indirect_selection,
-                dbt_dag_task_group_identifier=_get_dbt_dag_task_group_identifier(dag, task_group),
                 task_args=task_args,
                 on_warning_callback=on_warning_callback,
                 render_config=render_config,

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -161,7 +161,7 @@ SUPPORTED_BUILD_RESOURCES = [
 # https://docs.getdbt.com/reference/commands/test
 TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtResourceType.SNAPSHOT, DbtResourceType.SEED}
 
-DBT_COMPILE_TASK_ID = "dbt_compile"
+DBT_SETUP_ASYNC_TASK_ID = "dbt_setup_async"
 
 TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}"
 TELEMETRY_VERSION = "v1"

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -9,7 +9,12 @@ from cosmos.settings import enable_setup_task
 
 
 class SetupAsyncOperator(DbtRunOperator):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
     def execute(self, context: Context, **kwargs: Any) -> None:
         # TODO: Fix hardcoded values
         async_context = {"enable_setup_task": enable_setup_task, "profile_type": "bigquery"}
-        self.build_and_run_cmd(context=context, run_as_async=True, async_context=async_context)
+        self.build_and_run_cmd(
+            context=context, cmd_flags=self.dbt_cmd_flags, run_as_async=True, async_context=async_context
+        )

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -5,7 +5,6 @@ from typing import Any
 from airflow.utils.context import Context
 
 from cosmos.operators.local import DbtRunLocalOperator as DbtRunOperator
-from cosmos.settings import enable_setup_task
 
 
 class SetupAsyncOperator(DbtRunOperator):
@@ -13,8 +12,7 @@ class SetupAsyncOperator(DbtRunOperator):
         super().__init__(*args, **kwargs)
 
     def execute(self, context: Context, **kwargs: Any) -> None:
-        # TODO: Fix hardcoded values
-        async_context = {"enable_setup_task": enable_setup_task, "profile_type": "bigquery"}
+        async_context = {"profile_type": self.profile_config.get_profile_type()}
         self.build_and_run_cmd(
             context=context, cmd_flags=self.dbt_cmd_flags, run_as_async=True, async_context=async_context
         )

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -1,0 +1,15 @@
+from __future__ import annotations
+
+from typing import Any
+
+from airflow.utils.context import Context
+
+from cosmos.operators.local import DbtRunLocalOperator as DbtRunOperator
+from cosmos.settings import enable_setup_task
+
+
+class SetupAsyncOperator(DbtRunOperator):
+    def execute(self, context: Context, **kwargs: Any) -> None:
+        # TODO: Fix hardcoded values
+        async_context = {"enable_setup_task": enable_setup_task, "profile_type": "bigquery"}
+        self.build_and_run_cmd(context=context, run_as_async=True, async_context=async_context)

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -9,6 +9,7 @@ from cosmos.operators.local import DbtRunLocalOperator as DbtRunOperator
 
 class SetupAsyncOperator(DbtRunOperator):
     def __init__(self, *args: Any, **kwargs: Any):
+        kwargs["emit_datasets"] = False
         super().__init__(*args, **kwargs)
 
     def execute(self, context: Context, **kwargs: Any) -> None:

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -104,9 +104,8 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             raise CosmosValueError(f"Cosmos async support is only available starting in Airflow 2.8 or later.")
         from airflow.io.path import ObjectStoragePath
 
-        # TODO: FixMe
-        file_path = self.extra_context["dbt_node_config"]["file_path"]  # type: ignore
-        dbt_dag_task_group_identifier = self.extra_context["dbt_dag_task_group_identifier"]
+        file_path = self.async_context["dbt_node_config"]["file_path"]  # type: ignore
+        dbt_dag_task_group_identifier = self.async_context["dbt_dag_task_group_identifier"]
 
         remote_target_path_str = str(remote_target_path).rstrip("/")
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -100,7 +100,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         return ["run"]
 
     def get_remote_sql(self) -> str:
-        if not settings.AIRFLOW_IO_AVAILABLE:
+        if not settings.AIRFLOW_IO_AVAILABLE:  # pragma: no cover
             raise CosmosValueError(f"Cosmos async support is only available starting in Airflow 2.8 or later.")
         from airflow.io.path import ObjectStoragePath
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -13,7 +13,7 @@ from cosmos.config import ProfileConfig
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators.local import AbstractDbtLocalBase
-from cosmos.settings import enable_setup_task, remote_target_path, remote_target_path_conn_id
+from cosmos.settings import enable_setup_async_task, remote_target_path, remote_target_path_conn_id
 
 AIRFLOW_VERSION = Version(airflow.__version__)
 
@@ -121,7 +121,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             return fp.read()  # type: ignore
 
     def execute(self, context: Context, **kwargs: Any) -> None:
-        if enable_setup_task:
+        if enable_setup_async_task:
             self.configuration = {
                 "query": {
                     "query": self.get_remote_sql(),

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
-from typing import Any, Sequence
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Sequence
 
 import airflow
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
@@ -12,6 +13,7 @@ from cosmos.config import ProfileConfig
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators.local import AbstractDbtLocalBase
+from cosmos.settings import enable_setup_task, remote_target_path, remote_target_path_conn_id
 
 AIRFLOW_VERSION = Version(airflow.__version__)
 
@@ -97,5 +99,36 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     def base_cmd(self) -> list[str]:
         return ["run"]
 
+    def get_remote_sql(self) -> str:
+        if not settings.AIRFLOW_IO_AVAILABLE:
+            raise CosmosValueError(f"Cosmos async support is only available starting in Airflow 2.8 or later.")
+        from airflow.io.path import ObjectStoragePath
+
+        # TODO: FixMe
+        file_path = self.extra_context["dbt_node_config"]["file_path"]  # type: ignore
+        dbt_dag_task_group_identifier = self.extra_context["dbt_dag_task_group_identifier"]
+
+        remote_target_path_str = str(remote_target_path).rstrip("/")
+
+        if TYPE_CHECKING:  # pragma: no cover
+            assert self.project_dir is not None
+
+        project_dir_parent = str(Path(self.project_dir).parent)
+        relative_file_path = str(file_path).replace(project_dir_parent, "").lstrip("/")
+        remote_model_path = f"{remote_target_path_str}/{dbt_dag_task_group_identifier}/run/{relative_file_path}"
+
+        object_storage_path = ObjectStoragePath(remote_model_path, conn_id=remote_target_path_conn_id)
+        with object_storage_path.open() as fp:  # type: ignore
+            return fp.read()  # type: ignore
+
     def execute(self, context: Context, **kwargs: Any) -> None:
-        self.build_and_run_cmd(context=context, run_as_async=True, async_context=self.async_context)
+        if enable_setup_task:
+            self.configuration = {
+                "query": {
+                    "query": self.get_remote_sql(),
+                    "useLegacySql": False,
+                }
+            }
+            super().execute(context=context)
+        else:
+            self.build_and_run_cmd(context=context, run_as_async=True, async_context=self.async_context)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -455,7 +455,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _handle_post_execution(self, tmp_project_dir: str, context: Context) -> None:
         self.store_freshness_json(tmp_project_dir, context)
         self.store_compiled_sql(tmp_project_dir, context)
-        self._upload_sql_files(tmp_project_dir, "compiled")
+        if self.should_upload_compiled_sql:
+            self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
             self.callback(tmp_project_dir, **self.callback_args)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -305,10 +305,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         return _configured_target_path, remote_conn_id
 
     def _construct_dest_file_path(
-        self,
-        dest_target_dir: Path,
-        file_path: str,
-        source_compiled_dir: Path,
+        self, dest_target_dir: Path, file_path: str, source_compiled_dir: Path, resource_type: str
     ) -> str:
         """
         Construct the destination path for the compiled SQL files to be uploaded to the remote store.
@@ -317,28 +314,22 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         dag_task_group_identifier = self.extra_context["dbt_dag_task_group_identifier"]
         rel_path = os.path.relpath(file_path, source_compiled_dir).lstrip("/")
 
-        return f"{dest_target_dir_str}/{dag_task_group_identifier}/compiled/{rel_path}"
+        return f"{dest_target_dir_str}/{dag_task_group_identifier}/{resource_type}/{rel_path}"
 
-    def upload_compiled_sql(self, tmp_project_dir: str, context: Context) -> None:
-        """
-        Uploads the compiled SQL files from the dbt compile output to the remote store.
-        """
-        if not self.should_upload_compiled_sql:
-            return
-
+    def _upload_sql_files(self, tmp_project_dir: str, resource_type: str) -> None:
         dest_target_dir, dest_conn_id = self._configure_remote_target_path()
 
         if not dest_target_dir:
             raise CosmosValueError(
-                "You're trying to upload compiled SQL files, but the remote target path is not configured. "
+                "You're trying to upload run SQL files, but the remote target path is not configured. "
             )
 
         from airflow.io.path import ObjectStoragePath
 
-        source_compiled_dir = Path(tmp_project_dir) / "target" / "compiled"
-        files = [str(file) for file in source_compiled_dir.rglob("*") if file.is_file()]
+        source_run_dir = Path(tmp_project_dir) / f"target/{resource_type}"
+        files = [str(file) for file in source_run_dir.rglob("*") if file.is_file()]
         for file_path in files:
-            dest_file_path = self._construct_dest_file_path(dest_target_dir, file_path, source_compiled_dir)
+            dest_file_path = self._construct_dest_file_path(dest_target_dir, file_path, source_run_dir, resource_type)
             dest_object_storage_path = ObjectStoragePath(dest_file_path, conn_id=dest_conn_id)
             ObjectStoragePath(file_path).copy(dest_object_storage_path)
             self.log.debug("Copied %s to %s", file_path, dest_object_storage_path)
@@ -466,19 +457,22 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _handle_post_execution(self, tmp_project_dir: str, context: Context) -> None:
         self.store_freshness_json(tmp_project_dir, context)
         self.store_compiled_sql(tmp_project_dir, context)
-        self.upload_compiled_sql(tmp_project_dir, context)
+        self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
             self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
-        sql = self._read_run_sql_from_target_dir(tmp_project_dir, async_context)
-        profile_type = async_context["profile_type"]
-        module_path = f"cosmos.operators._asynchronous.{profile_type}"
-        method_name = f"_configure_{profile_type}_async_op_args"
-        async_op_configurator = load_method_from_module(module_path, method_name)
-        async_op_configurator(self, sql=sql)
-        async_context["async_operator"].execute(self, context)
+        if async_context.get("enable_setup_task"):
+            self._upload_sql_files(tmp_project_dir, "run")
+        else:
+            sql = self._read_run_sql_from_target_dir(tmp_project_dir, async_context)
+            profile_type = async_context["profile_type"]
+            module_path = f"cosmos.operators._asynchronous.{profile_type}"
+            method_name = f"_configure_{profile_type}_async_op_args"
+            async_op_configurator = load_method_from_module(module_path, method_name)
+            async_op_configurator(self, sql=sql)
+            async_context["async_operator"].execute(self, context)
 
     def run_command(
         self,

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -430,8 +430,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _mock_dbt_adapter(async_context: dict[str, Any] | None) -> None:
         if not async_context:
             raise CosmosValueError("`async_context` is necessary for running the model asynchronously")
-        if "async_operator" not in async_context:
-            raise CosmosValueError("`async_operator` needs to be specified in `async_context` when running as async")
+        # if "async_operator" not in async_context:
+        #     raise CosmosValueError("`async_operator` needs to be specified in `async_context` when running as async")
         if "profile_type" not in async_context:
             raise CosmosValueError("`profile_type` needs to be specified in `async_context` when running as async")
         profile_type = async_context["profile_type"]

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -35,7 +35,7 @@ from cosmos.constants import FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, Invocation
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.dbt.project import get_partial_parse_path, has_non_empty_dependencies_file
 from cosmos.exceptions import AirflowCompatibilityError, CosmosDbtRunError, CosmosValueError
-from cosmos.settings import remote_target_path, remote_target_path_conn_id
+from cosmos.settings import enable_setup_task, remote_target_path, remote_target_path_conn_id
 
 try:
     from airflow.datasets import Dataset
@@ -430,8 +430,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _mock_dbt_adapter(async_context: dict[str, Any] | None) -> None:
         if not async_context:
             raise CosmosValueError("`async_context` is necessary for running the model asynchronously")
-        # if "async_operator" not in async_context:
-        #     raise CosmosValueError("`async_operator` needs to be specified in `async_context` when running as async")
         if "profile_type" not in async_context:
             raise CosmosValueError("`profile_type` needs to be specified in `async_context` when running as async")
         profile_type = async_context["profile_type"]
@@ -463,7 +461,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
-        if async_context.get("enable_setup_task"):
+        if enable_setup_task:
             self._upload_sql_files(tmp_project_dir, "run")
         else:
             sql = self._read_run_sql_from_target_dir(tmp_project_dir, async_context)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -455,7 +455,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _handle_post_execution(self, tmp_project_dir: str, context: Context) -> None:
         self.store_freshness_json(tmp_project_dir, context)
         self.store_compiled_sql(tmp_project_dir, context)
-        if self.should_upload_compiled_sql:
+        if self.should_upload_compiled_sql:  # pragma: no cover
             self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -37,6 +37,9 @@ remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallba
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
 
+# Related to async operators
+enable_setup_task = conf.getboolean("cosmos", "enable_setup_task", fallback=True)
+
 AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 
 # The following environment variable is populated in Astro Cloud

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -38,7 +38,7 @@ remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
 
 # Related to async operators
-enable_setup_task = conf.getboolean("cosmos", "enable_setup_task", fallback=True)
+enable_setup_async_task = conf.getboolean("cosmos", "enable_setup_async_task", fallback=True)
 
 AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -155,7 +155,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 .. _enable_setup_async_task:
 
 `enable_setup_async_task`_:
-    (Introduced in Cosmos 1.9.0): Enables a setup task for ``ExecutionMode.AIRFLOW_ASYNC`` to generate SQL files and upload them to a remote location (S3/GCS), preventing the ``run`` command from being executed on every node.
+    (Introduced in Cosmos 1.9.0): Enables a setup task for ``ExecutionMode.AIRFLOW_ASYNC`` to generate SQL files and upload them to a remote location (S3/GCS), preventing the ``run`` command from being executed on every node. You need to specify ``remote_target_path_conn_id`` and ``remote_target_path`` configuration to upload the artifact to the remote location.
 
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_SETUP_ASYNC_TASK``

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -152,6 +152,14 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``None``
     - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID``
 
+.. _enable_setup_task:
+
+`enable_setup_task`_:
+    (Introduced in Cosmos 1.9.0): Enables a setup task for ``ExecutionMode.AIRFLOW_ASYNC`` to generate SQL files and upload them to a remote location (S3/GCS), preventing the ``run`` command from being executed on every node.
+
+    - Default: ``True``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_SETUP_TASK``
+
 [openlineage]
 ~~~~~~~~~~~~~
 

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -152,13 +152,13 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``None``
     - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID``
 
-.. _enable_setup_task:
+.. _enable_setup_async_task:
 
-`enable_setup_task`_:
+`enable_setup_async_task`_:
     (Introduced in Cosmos 1.9.0): Enables a setup task for ``ExecutionMode.AIRFLOW_ASYNC`` to generate SQL files and upload them to a remote location (S3/GCS), preventing the ``run`` command from being executed on every node.
 
     - Default: ``True``
-    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_SETUP_TASK``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_SETUP_ASYNC_TASK``
 
 [openlineage]
 ~~~~~~~~~~~~~

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -295,11 +295,11 @@ This execution mode could be preferred when you've long running resources and yo
 leveraging Airflow's deferrable operators. With that, you would be able to potentially observe higher throughput of tasks
 as more dbt nodes will be run in parallel since they won't be blocking Airflow's worker slots.
 
-In this mode, Cosmos adds a new operator, ``DbtCompileAirflowAsyncOperator``, as a root task in the DbtDag or DbtTaskGroup. The task runs
-the ``dbt compile`` command on your dbt project which then outputs compiled SQLs in the project's target directory.
+In this mode, Cosmos adds a new operator, ``SetupAsyncOperator``, as a root task in the DbtDag or DbtTaskGroup. The task runs
+the mocked ``dbt run`` command on your dbt project which then outputs compiled SQLs in the project's target directory.
 As part of the same task run, these compiled SQLs are then stored remotely to a remote path set using the
 :ref:`remote_target_path` configuration. The remote path is then used by the subsequent tasks in the DAG to
-fetch (from the remote path) and run the compiled SQLs asynchronously using e.g. the ``DbtRunAirflowAsyncOperator``.
+fetch (from the remote path) and run the compiled SQLs asynchronously using e.g. the ``SetupAsyncOperator``.
 You may observe that the compile task takes a bit longer to run due to the latency of storing the compiled SQLs
 remotely (e.g. for the classic ``jaffle_shop`` dbt project, upon compiling it produces about 31 files measuring about 124KB in total, but on a local
 machine it took approximately 25 seconds for the task to compile & upload the compiled SQLs to the remote path).,
@@ -312,9 +312,7 @@ Note that currently, the ``airflow_async`` execution mode has the following limi
 2. **Limited to dbt models**: Only dbt resource type models are run asynchronously using Airflow deferrable operators. Other resource types are executed synchronously, similar to the local execution mode.
 3. **BigQuery support only**: This mode only supports BigQuery as the target database. If a different target is specified, Cosmos will throw an error indicating the target database is unsupported in this mode.
 4. **ProfileMapping parameter required**: You need to specify the ``ProfileMapping`` parameter in the ``ProfileConfig`` for your DAG. Refer to the example DAG below for details on setting this parameter.
-5. **Supports only full_refresh models**: Currently, only ``full_refresh`` models are supported. To enable this, pass ``full_refresh=True`` in the ``operator_args`` of the ``DbtDag`` or ``DbtTaskGroup``. Refer to the example DAG below for details on setting this parameter.
 6. **location parameter required**: You must specify the location of the BigQuery dataset in the ``operator_args`` of the ``DbtDag`` or ``DbtTaskGroup``. The example DAG below provides guidance on this.
-7. **No dataset emission**: The async run operators do not currently emit datasets, meaning that :ref:`data-aware-scheduling` is not supported at this time. Future releases will address this limitation.
 
 To start leveraging async execution mode that is currently supported for the BigQuery profile type targets you need to install Cosmos with the below additional dependencies:
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -852,6 +852,7 @@ def test_create_test_task_metadata(node_type, node_unique_id, test_indirect_sele
         test_task_name="test_no_nulls",
         execution_mode=ExecutionMode.LOCAL,
         test_indirect_selection=test_indirect_selection,
+        dbt_dag_task_group_identifier="test_tg",
         task_args={"task_arg": "value"},
         on_warning_callback=True,
         node=sample_node,

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -852,7 +852,6 @@ def test_create_test_task_metadata(node_type, node_unique_id, test_indirect_sele
         test_task_name="test_no_nulls",
         execution_mode=ExecutionMode.LOCAL,
         test_indirect_selection=test_indirect_selection,
-        dbt_dag_task_group_identifier="test_tg",
         task_args={"task_arg": "value"},
         on_warning_callback=True,
         node=sample_node,

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -56,7 +56,7 @@ def test_dbt_run_airflow_async_bigquery_operator_base_cmd(profile_config_mock):
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "build_and_run_cmd")
 def test_dbt_run_airflow_async_bigquery_operator_execute(mock_build_and_run_cmd, profile_config_mock, monkeypatch):
     """Test execute calls build_and_run_cmd with correct parameters."""
-    monkeypatch.setattr("cosmos.operators._asynchronous.bigquery.enable_setup_task", False)
+    monkeypatch.setattr("cosmos.operators._asynchronous.bigquery.enable_setup_async_task", False)
     operator = DbtRunAirflowAsyncBigqueryOperator(
         task_id="test_task",
         project_dir="/path/to/project",

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -54,8 +54,9 @@ def test_dbt_run_airflow_async_bigquery_operator_base_cmd(profile_config_mock):
 
 
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "build_and_run_cmd")
-def test_dbt_run_airflow_async_bigquery_operator_execute(mock_build_and_run_cmd, profile_config_mock):
+def test_dbt_run_airflow_async_bigquery_operator_execute(mock_build_and_run_cmd, profile_config_mock, monkeypatch):
     """Test execute calls build_and_run_cmd with correct parameters."""
+    monkeypatch.setattr("cosmos.operators._asynchronous.bigquery.enable_setup_task", False)
     operator = DbtRunAirflowAsyncBigqueryOperator(
         task_id="test_task",
         project_dir="/path/to/project",

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1296,16 +1296,16 @@ def test_configure_remote_target_path(mock_object_storage_path):
     mock_object_storage_path.return_value.mkdir.assert_called_with(parents=True, exist_ok=True)
 
 
-@patch.object(DbtLocalBaseOperator, "_configure_remote_target_path")
-def test_no_compiled_sql_upload_for_other_operators(mock_configure_remote_target_path):
-    operator = DbtSeedLocalOperator(
-        task_id="fake-task",
-        profile_config=profile_config,
-        project_dir="fake-dir",
-    )
-    assert operator.should_upload_compiled_sql is False
-    operator._upload_sql_files("fake-dir", "compiled")
-    mock_configure_remote_target_path.assert_not_called()
+# @patch.object(DbtLocalBaseOperator, "_configure_remote_target_path")
+# def test_no_compiled_sql_upload_for_other_operators(mock_configure_remote_target_path):
+#     operator = DbtSeedLocalOperator(
+#         task_id="fake-task",
+#         profile_config=profile_config,
+#         project_dir="fake-dir",
+#     )
+#     assert operator.should_upload_compiled_sql is False
+#     operator._upload_sql_files("fake-dir", "compiled")
+#     mock_configure_remote_target_path.assert_not_called()
 
 
 @patch("cosmos.operators.local.DbtCompileLocalOperator._configure_remote_target_path")
@@ -1354,7 +1354,7 @@ def test_upload_compiled_sql_should_upload(mock_configure_remote, mock_object_st
     files = [file1, file2]
 
     with patch.object(Path, "rglob", return_value=files):
-        operator.upload_compiled_sql(tmp_project_dir, context={"task": operator})
+        operator._upload_sql_files(tmp_project_dir, "compiled")
 
         for file_path in files:
             rel_path = os.path.relpath(str(file_path), str(source_compiled_dir))
@@ -1391,22 +1391,6 @@ def test_mock_dbt_adapter_missing_async_context():
     operator = AbstractDbtLocalBase(task_id="test_task", project_dir="test_project", profile_config=MagicMock())
     with pytest.raises(CosmosValueError, match="`async_context` is necessary for running the model asynchronously"):
         operator._mock_dbt_adapter(None)
-
-
-def test_mock_dbt_adapter_missing_async_operator():
-    """
-    Test that the _mock_dbt_adapter method raises a CosmosValueError
-    when async_operator is missing in async_context.
-    """
-    async_context = {
-        "profile_type": "snowflake",
-    }
-    AbstractDbtLocalBase.__abstractmethods__ = set()
-    operator = AbstractDbtLocalBase(task_id="test_task", project_dir="test_project", profile_config=MagicMock())
-    with pytest.raises(
-        CosmosValueError, match="`async_operator` needs to be specified in `async_context` when running as async"
-    ):
-        operator._mock_dbt_adapter(async_context)
 
 
 def test_mock_dbt_adapter_missing_profile_type():

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1304,7 +1304,7 @@ def test_no_compiled_sql_upload_for_other_operators(mock_configure_remote_target
         project_dir="fake-dir",
     )
     assert operator.should_upload_compiled_sql is False
-    operator.upload_compiled_sql("fake-dir", MagicMock())
+    operator._upload_sql_files("fake-dir", "compiled")
     mock_configure_remote_target_path.assert_not_called()
 
 
@@ -1319,10 +1319,9 @@ def test_upload_compiled_sql_no_remote_path_raises_error(mock_configure_remote):
     mock_configure_remote.return_value = (None, None)
 
     tmp_project_dir = "/fake/tmp/project"
-    context = {"dag": MagicMock(dag_id="test_dag")}
 
     with pytest.raises(CosmosValueError, match="remote target path is not configured"):
-        operator.upload_compiled_sql(tmp_project_dir, context)
+        operator._upload_sql_files(tmp_project_dir, "compiled")
 
 
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1434,7 +1434,7 @@ def test_mock_dbt_adapter_unsupported_profile_type():
 def test_async_execution_without_start_task(mock_read_sql, mock_bq_execute, monkeypatch):
     from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 
-    monkeypatch.setattr("cosmos.operators.local.enable_setup_task", False)
+    monkeypatch.setattr("cosmos.operators.local.enable_setup_async_task", False)
     mock_read_sql.return_value = "select * from 1;"
     operator = DbtRunLocalOperator(
         task_id="test",

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1227,6 +1227,22 @@ def test_dbt_compile_local_operator_initialisation():
     assert "compile" in operator.base_cmd
 
 
+@patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_compiled_sql")
+def test_dbt_compile_local_operator_execute(store_compiled_sql, _upload_sql_files):
+    operator = DbtCompileLocalOperator(
+        task_id="fake-task",
+        profile_config=profile_config,
+        project_dir="fake-dir",
+    )
+
+    operator._handle_post_execution("fake-dir", {})
+
+    assert operator.should_upload_compiled_sql is True
+    _upload_sql_files.assert_called_once()
+    store_compiled_sql.assert_called_once()
+
+
 def test_dbt_clone_local_operator_initialisation():
     operator = DbtCloneLocalOperator(
         profile_config=profile_config,

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -983,6 +983,7 @@ def test_dbt_docs_gcs_local_operator():
         mock_hook.upload.assert_has_calls(expected_upload_calls)
 
 
+@patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.store_compiled_sql")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.handle_exception_subprocess")
 @patch("cosmos.config.ProfileConfig.ensure_profile")
@@ -997,6 +998,7 @@ def test_operator_execute_deps_parameters(
     mock_ensure_profile,
     mock_exception_handling,
     mock_store_compiled_sql,
+    mock_upload_sql_files,
     invocation_mode,
     tmp_path,
 ):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1296,18 +1296,6 @@ def test_configure_remote_target_path(mock_object_storage_path):
     mock_object_storage_path.return_value.mkdir.assert_called_with(parents=True, exist_ok=True)
 
 
-# @patch.object(DbtLocalBaseOperator, "_configure_remote_target_path")
-# def test_no_compiled_sql_upload_for_other_operators(mock_configure_remote_target_path):
-#     operator = DbtSeedLocalOperator(
-#         task_id="fake-task",
-#         profile_config=profile_config,
-#         project_dir="fake-dir",
-#     )
-#     assert operator.should_upload_compiled_sql is False
-#     operator._upload_sql_files("fake-dir", "compiled")
-#     mock_configure_remote_target_path.assert_not_called()
-
-
 @patch("cosmos.operators.local.DbtCompileLocalOperator._configure_remote_target_path")
 def test_upload_compiled_sql_no_remote_path_raises_error(mock_configure_remote):
     operator = DbtCompileLocalOperator(

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -50,8 +50,7 @@ class ConcreteDbtVirtualenvBaseOperator(DbtVirtualenvBaseOperator):
         return ["cmd"]
 
 
-# @patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
-# @patch("cosmos.operators.local.AbstractDbtLocalBase._clone_project")
+@patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
 @patch("airflow.utils.python_virtualenv.execute_in_subprocess")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.calculate_openlineage_events_completes")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.store_compiled_sql")
@@ -65,8 +64,7 @@ def test_run_command_without_virtualenv_dir(
     mock_store_compiled_sql,
     mock_calculate_openlineage_events_completes,
     mock_execute,
-    # _clone_project,
-    # _upload_sql_files,
+    _upload_sql_files,
 ):
     mock_get_connection.return_value = Connection(
         conn_id="fake_conn",

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -50,6 +50,8 @@ class ConcreteDbtVirtualenvBaseOperator(DbtVirtualenvBaseOperator):
         return ["cmd"]
 
 
+# @patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
+# @patch("cosmos.operators.local.AbstractDbtLocalBase._clone_project")
 @patch("airflow.utils.python_virtualenv.execute_in_subprocess")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.calculate_openlineage_events_completes")
 @patch("cosmos.operators.virtualenv.DbtLocalBaseOperator.store_compiled_sql")
@@ -63,6 +65,8 @@ def test_run_command_without_virtualenv_dir(
     mock_store_compiled_sql,
     mock_calculate_openlineage_events_completes,
     mock_execute,
+    # _clone_project,
+    # _upload_sql_files,
 ):
     mock_get_connection.return_value = Connection(
         conn_id="fake_conn",
@@ -107,6 +111,7 @@ def test_run_command_without_virtualenv_dir(
     assert len(cosmos_venv_dirs) == 0
 
 
+@patch("cosmos.operators.local.AbstractDbtLocalBase._upload_sql_files")
 @patch("cosmos.operators.virtualenv.DbtVirtualenvBaseOperator._is_lock_available")
 @patch("time.sleep")
 @patch("cosmos.operators.virtualenv.DbtVirtualenvBaseOperator._release_venv_lock")
@@ -126,6 +131,7 @@ def test_run_command_with_virtualenv_dir(
     mock_release_venv_lock,
     mock_sleep,
     mock_is_lock_available,
+    _upload_sql_files,
     caplog,
 ):
     mock_is_lock_available.side_effect = [False, False, True]


### PR DESCRIPTION
This PR reintroduces the setup task for ExecutionMode.AIRFLOW_ASYNC,
This will prevent the execution of the dbt command for each Airflow task node
for run operator and will only run the dbt command mock version for start job node.

Additionally, a new configuration, `enable_setup_task`, has been introduced to 
enable or disable this feature.

**With enable_setup_task**

<img width="1686" alt="Screenshot 2025-02-08 at 9 53 35 PM" src="https://github.com/user-attachments/assets/cb9daf76-2bd6-4bcf-8219-b64562c4151a" />


**Without enable_setup_task**

<img width="1668" alt="Screenshot 2025-02-08 at 10 23 49 PM" src="https://github.com/user-attachments/assets/4ac99c3b-15df-484e-b9e4-cc7b1022ea31" />



Related-to: https://github.com/astronomer/astronomer-cosmos/issues/1477



