### PR TITLE
Fix typo in selecting & excluding docs

### DIFF
--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -3,7 +3,7 @@
 Selecting & Excluding
 =======================
 
-Cosmos allows you to filter to a subset of your dbt project in each ``DbtDag`` / ``DbtTaskGroup`` using the ``select `` and ``exclude`` parameters in the ``RenderConfig`` class.
+Cosmos allows you to filter to a subset of your dbt project in each ``DbtDag`` / ``DbtTaskGroup`` using the ``select`` and ``exclude`` parameters in the ``RenderConfig`` class.
 
  Since Cosmos 1.3, the ``selector`` parameter is also available in ``RenderConfig`` when using the ``LoadMode.DBT_LS`` to parse the dbt project into Airflow.
 


### PR DESCRIPTION
Fix the `` rendering in docs
https://astronomer.github.io/astronomer-cosmos/configuration/selecting-excluding.html#selecting-excluding

<img width="823" alt="Screenshot 2025-02-08 at 8 50 38 AM" src="https://github.com/user-attachments/assets/8afe00cc-6f46-443e-9355-f83288ca5e04" />
