### PR TITLE
Add teardown task

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -26,7 +26,7 @@ from cosmos.core.airflow import get_airflow_task as create_airflow_task
 from cosmos.core.graph.entities import Task as TaskMetadata
 from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
-from cosmos.settings import enable_setup_async_task, enable_teardown_task
+from cosmos.settings import enable_setup_async_task, enable_teardown_async_task
 
 logger = get_logger(__name__)
 
@@ -627,7 +627,7 @@ def build_airflow_graph(
     create_airflow_task_dependencies(nodes, tasks_map)
     if enable_setup_async_task:
         _add_dbt_setup_async_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
-    if enable_teardown_task:
+    if enable_teardown_async_task:
         _add_teardown_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
     return tasks_map
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -27,7 +27,6 @@ from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
 from cosmos.settings import enable_setup_async_task
 
-
 logger = get_logger(__name__)
 
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -27,6 +27,7 @@ from cosmos.dbt.graph import DbtNode
 from cosmos.log import get_logger
 from cosmos.settings import enable_setup_async_task
 
+
 logger = get_logger(__name__)
 
 
@@ -487,6 +488,37 @@ def calculate_detached_node_name(node: DbtNode) -> str:
     return node_name
 
 
+def _add_teardown_task(
+    dag: DAG,
+    execution_mode: ExecutionMode,
+    task_args: dict[str, Any],
+    tasks_map: dict[str, Any],
+    task_group: TaskGroup | None,
+    render_config: RenderConfig | None = None,
+) -> None:
+    if execution_mode != ExecutionMode.AIRFLOW_ASYNC:
+        return
+
+    if render_config is not None:  # TestBehavior.AFTER_ALL
+        task_args["select"] = render_config.select
+        task_args["selector"] = render_config.selector
+        task_args["exclude"] = render_config.exclude
+
+    compile_task_metadata = TaskMetadata(
+        id="teardown",
+        operator_class="cosmos.operators._asynchronous.TeardownAsyncOperator",
+        arguments=task_args,
+        extra_context={"dbt_dag_task_group_identifier": _get_dbt_dag_task_group_identifier(dag, task_group)},
+    )
+    compile_airflow_task = create_airflow_task(compile_task_metadata, dag, task_group=task_group)
+
+    for task_id, task in tasks_map.items():
+        if len(task.downstream_list) == 0:
+            task >> compile_airflow_task
+
+    tasks_map["teardown"] = compile_airflow_task
+
+
 def build_airflow_graph(
     nodes: dict[str, DbtNode],
     dag: DAG,  # Airflow-specific - parent DAG where to associate tasks and (optional) task groups
@@ -595,6 +627,7 @@ def build_airflow_graph(
     create_airflow_task_dependencies(nodes, tasks_map)
     if enable_setup_async_task:
         _add_dbt_setup_async_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
+        _add_teardown_task(dag, execution_mode, task_args, tasks_map, task_group, render_config=render_config)
     return tasks_map
 
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -162,6 +162,7 @@ SUPPORTED_BUILD_RESOURCES = [
 TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtResourceType.SNAPSHOT, DbtResourceType.SEED}
 
 DBT_SETUP_ASYNC_TASK_ID = "dbt_setup_async"
+DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 
 TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}"
 TELEMETRY_VERSION = "v1"

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -21,6 +21,7 @@ class SetupAsyncOperator(DbtRunOperator):
 
 class TeardownAsyncOperator(DbtRunOperator):
     def __init__(self, *args: Any, **kwargs: Any):
+        kwargs["emit_datasets"] = False
         super().__init__(*args, **kwargs)
 
     def execute(self, context: Context, **kwargs: Any) -> Any:

--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -17,3 +17,14 @@ class SetupAsyncOperator(DbtRunOperator):
         self.build_and_run_cmd(
             context=context, cmd_flags=self.dbt_cmd_flags, run_as_async=True, async_context=async_context
         )
+
+
+class TeardownAsyncOperator(DbtRunOperator):
+    def __init__(self, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
+
+    def execute(self, context: Context, **kwargs: Any) -> Any:
+        async_context = {"profile_type": self.profile_config.get_profile_type(), "teardown_task": True}
+        self.build_and_run_cmd(
+            context=context, cmd_flags=self.dbt_cmd_flags, run_as_async=True, async_context=async_context
+        )

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -339,7 +339,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             dest_object_storage_path = ObjectStoragePath(dest_file_path, conn_id=dest_conn_id)
             ObjectStoragePath(file_path).copy(dest_object_storage_path)
             self.log.debug("Copied %s to %s", file_path, dest_object_storage_path)
-        
         elapsed_time = time.time() - start_time
         self.log.info("SQL files upload completed in %.2f seconds.", elapsed_time)
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -37,7 +37,7 @@ from cosmos.dbt.project import get_partial_parse_path, has_non_empty_dependencie
 from cosmos.exceptions import AirflowCompatibilityError, CosmosDbtRunError, CosmosValueError
 from cosmos.settings import (
     enable_setup_async_task,
-    enable_teardown_task,
+    enable_teardown_async_task,
     remote_target_path,
     remote_target_path_conn_id,
 )
@@ -477,7 +477,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
-        if async_context.get("teardown_task") and enable_teardown_task:
+        if async_context.get("teardown_task") and enable_teardown_async_task:
             self._delete_sql_files(Path(tmp_project_dir), "run")
             return
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -339,6 +339,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             dest_object_storage_path = ObjectStoragePath(dest_file_path, conn_id=dest_conn_id)
             ObjectStoragePath(file_path).copy(dest_object_storage_path)
             self.log.debug("Copied %s to %s", file_path, dest_object_storage_path)
+
         elapsed_time = time.time() - start_time
         self.log.info("SQL files upload completed in %.2f seconds.", elapsed_time)
 

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -46,7 +46,6 @@ AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 # The following environment variable is populated in Astro Cloud
 in_astro_cloud = os.getenv("ASTRONOMER_ENVIRONMENT") == "cloud"
 
-
 try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
 except airflow.exceptions.AirflowConfigException:

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -45,6 +45,9 @@ AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 # The following environment variable is populated in Astro Cloud
 in_astro_cloud = os.getenv("ASTRONOMER_ENVIRONMENT") == "cloud"
 
+# Related to async operators
+enable_setup_task = conf.getboolean("cosmos", "enable_setup_task", fallback=True)
+
 try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")
 except airflow.exceptions.AirflowConfigException:

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -39,14 +39,13 @@ remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fa
 
 # Related to async operators
 enable_setup_async_task = conf.getboolean("cosmos", "enable_setup_async_task", fallback=True)
+enable_teardown_task = conf.getboolean("cosmos", "", fallback=True)
 
 AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 
 # The following environment variable is populated in Astro Cloud
 in_astro_cloud = os.getenv("ASTRONOMER_ENVIRONMENT") == "cloud"
 
-# Related to async operators
-enable_setup_task = conf.getboolean("cosmos", "enable_setup_task", fallback=True)
 
 try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -39,7 +39,7 @@ remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fa
 
 # Related to async operators
 enable_setup_async_task = conf.getboolean("cosmos", "enable_setup_async_task", fallback=True)
-enable_teardown_task = conf.getboolean("cosmos", "", fallback=True)
+enable_teardown_async_task = conf.getboolean("cosmos", "enable_teardown_async_task", fallback=True)
 
 AIRFLOW_IO_AVAILABLE = Version(airflow_version) >= Version("2.8.0")
 

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -160,6 +160,14 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_SETUP_ASYNC_TASK``
 
+.. _enable_teardown_async_task:
+
+`enable_teardown_async_task`_:
+    (Introduced in Cosmos 1.9.0): Enables a teardown task for ``ExecutionMode.AIRFLOW_ASYNC`` to delete the SQL files from remote location (S3/GCS). You need to specify ``remote_target_path_conn_id`` and ``remote_target_path`` configuration to delete the artifact from the remote location.
+
+    - Default: ``True``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_TEARDOWN_ASYNC_TASK``
+
 [openlineage]
 ~~~~~~~~~~~~~
 

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -1,10 +1,11 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 
 from cosmos.config import ProfileConfig
+from cosmos.operators._asynchronous import TeardownAsyncOperator
 from cosmos.operators._asynchronous.base import DbtRunAirflowAsyncFactoryOperator, _create_async_operator_class
 from cosmos.operators._asynchronous.bigquery import DbtRunAirflowAsyncBigqueryOperator
 from cosmos.operators.local import DbtRunLocalOperator
@@ -68,3 +69,14 @@ def test_dbt_run_airflow_async_factory_operator_init(mock_create_class, profile_
 
     assert operator is not None
     assert isinstance(operator, MockAsyncOperator)
+
+
+@patch("cosmos.operators.local.DbtRunLocalOperator.build_and_run_cmd")
+def test_teardown_execute(mock_build_and_run_cmd):
+    operator = TeardownAsyncOperator(
+        task_id="fake-task",
+        profile_config=Mock(),
+        project_dir="fake-dir",
+    )
+    operator.execute({})
+    mock_build_and_run_cmd.assert_called_once()

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1329,6 +1329,7 @@ def test_upload_compiled_sql_no_remote_path_raises_error(mock_configure_remote):
 
 
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
+@pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("airflow.io.path.ObjectStoragePath.copy")
 @patch("airflow.io.path.ObjectStoragePath")
 @patch("cosmos.operators.local.DbtCompileLocalOperator._configure_remote_target_path")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1329,7 +1329,6 @@ def test_upload_compiled_sql_no_remote_path_raises_error(mock_configure_remote):
 
 
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
-@pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("airflow.io.path.ObjectStoragePath.copy")
 @patch("airflow.io.path.ObjectStoragePath")
 @patch("cosmos.operators.local.DbtCompileLocalOperator._configure_remote_target_path")
@@ -1448,6 +1447,7 @@ def test_async_execution_without_start_task(mock_read_sql, mock_bq_execute, monk
     mock_bq_execute.assert_called_once()
 
 
+@pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("pathlib.Path.rglob")
 @patch("cosmos.operators.local.AbstractDbtLocalBase._construct_dest_file_path")
 @patch("airflow.io.path.ObjectStoragePath.unlink")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1445,3 +1445,17 @@ def test_async_execution_without_start_task(mock_read_sql, mock_bq_execute, monk
         "/tmp", {}, {"profile_type": "bigquery", "async_operator": BigQueryInsertJobOperator}
     )
     mock_bq_execute.assert_called_once()
+
+
+@patch("cosmos.operators.local.AbstractDbtLocalBase._construct_dest_file_path")
+@patch("airflow.io.path.ObjectStoragePath.unlink")
+def test_async_execution_teardown_delete_files(unlink, _construct_dest_file_path):
+
+    project_dir = Path(__file__).parent.parent.parent / "dev/dags/dbt/altered_jaffle_shop"
+    operator = DbtRunLocalOperator(
+        task_id="test",
+        project_dir=project_dir,
+        profile_config=profile_config,
+    )
+    operator._handle_async_execution(project_dir, {}, {"profile_type": "bigquery", "teardown_task": True})
+    unlink.assert_called()


### PR DESCRIPTION
This PR introduces a teardown node in the Cosmos DAG that deletes SQL files from the remote location that were uploaded by the setup task. This ensures proper cleanup of resources after the task execution.

### Key Changes:
**Teardown Node Addition:**

A new teardown task is added to the Cosmos DAG that deletes the SQL files from the remote location. The files deleted are the ones uploaded by the setup task earlier in the DAG.
New Config: enable_teardown_async_task:

**A configuration option** ``enable_teardown_async_task``, is introduced to enable or disable this feature. This config is enabled by default.
Setting this config to False will skip the teardown step, while setting it to True will ensure the deletion task runs after the setup.

**Applicable Only for AIRFLOW_ASYNC Execution Mode:**

This feature is only triggered when the DAG is running in AIRFLOW_ASYNC execution mode

<img width="1685" alt="Screenshot 2025-02-12 at 6 17 08 PM" src="https://github.com/user-attachments/assets/3be02abe-1dce-4f8a-8eb5-2d859b6c4603" />

closes: https://github.com/astronomer/astronomer-cosmos/issues/1232