### PR TITLE
fix-1506: fix on_warning_callback on DbtSourceGcpCloudRunJobOperator and DbtTestGcpCloudRunJobOperator

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -265,7 +265,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
     def build_and_run_cmd(
         self,
         context: Context,
-        cmd_flags: list[str],
+        cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
     ) -> Any:


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
This PR initially fix the DbtSourceGcpCloudRunJobOperator bug with missing argument for on_warning_callback.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
closes #1506

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
This PR also add logs from dbt commands to Airflow logs. Initially there were only available in Google Cloud Run console and Google Cloud Logging.
We can now use this logs in the _handle_warnings function as we did in the LocalOperator.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
