### PR TITLE
Log elapsed_time for sql file upload/download

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -4,6 +4,7 @@ import inspect
 import json
 import os
 import tempfile
+import time
 import urllib.parse
 import warnings
 from abc import ABC, abstractmethod
@@ -317,6 +318,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         return f"{dest_target_dir_str}/{dag_task_group_identifier}/{resource_type}/{rel_path}"
 
     def _upload_sql_files(self, tmp_project_dir: str, resource_type: str) -> None:
+        start_time = time.time()
+
         dest_target_dir, dest_conn_id = self._configure_remote_target_path()
 
         if not dest_target_dir:
@@ -331,6 +334,9 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             dest_object_storage_path = ObjectStoragePath(dest_file_path, conn_id=dest_conn_id)
             ObjectStoragePath(file_path).copy(dest_object_storage_path)
             self.log.debug("Copied %s to %s", file_path, dest_object_storage_path)
+
+        elapsed_time = time.time() - start_time
+        self.log.info("SQL file upload completed in %.2f seconds.", elapsed_time)
 
     @provide_session
     def store_freshness_json(self, tmp_project_dir: str, context: Context, session: Session = NEW_SESSION) -> None:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -336,7 +336,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.log.debug("Copied %s to %s", file_path, dest_object_storage_path)
 
         elapsed_time = time.time() - start_time
-        self.log.info("SQL file upload completed in %.2f seconds.", elapsed_time)
+        self.log.info("SQL files upload completed in %.2f seconds.", elapsed_time)
 
     @provide_session
     def store_freshness_json(self, tmp_project_dir: str, context: Context, session: Session = NEW_SESSION) -> None:


### PR DESCRIPTION
Add logs to records the upload and download time for the SQL files on the remote storage

**Upload logs**

```
[2025-02-12, 14:40:48 UTC] {logging_mixin.py:190} INFO - 14:40:48  Completed successfully
[2025-02-12, 14:40:48 UTC] {logging_mixin.py:190} INFO - 14:40:48
[2025-02-12, 14:40:48 UTC] {logging_mixin.py:190} INFO - 14:40:48  Done. PASS=5 WARN=0 ERROR=0 SKIP=0 TOTAL=5
[2025-02-12, 14:40:50 UTC] {local.py:196} WARNING - Artifact schema version: https://schemas.getdbt.com/dbt/manifest/v12.json is above dbt-ol supported version 7. This might cause errors.
[2025-02-12, 14:40:50 UTC] {connection.py:277} WARNING - Connection schemes (type: google_cloud_platform) shall not contain '_' according to RFC3986.
[2025-02-12, 14:40:50 UTC] {base.py:84} INFO - Retrieving connection 'gcp_gs_conn'
[2025-02-12, 14:41:03 UTC] {local.py:339} INFO - SQL file upload completed in 12.52 seconds.
```

**Download logs:**

```
[2025-02-12, 14:41:25 UTC] {connection.py:277} WARNING - Connection schemes (type: google_cloud_platform) shall not contain '_' according to RFC3986.
[2025-02-12, 14:41:25 UTC] {base.py:84} INFO - Retrieving connection 'gcp_gs_conn'
[2025-02-12, 14:41:27 UTC] {bigquery.py:126} INFO - SQL file download completed in 2.43 seconds.
[2025-02-12, 14:41:27 UTC] {baseoperator.py:416} WARNING - DbtRunAirflowAsyncOperator.execute cannot be called outside TaskInstance!
[2025-02-12, 14:41:27 UTC] {connection.py:277} WARNING - Connection schemes (type: google_cloud_platform) shall not contain '_' according to RFC3986.
[2025-02-12, 14:41:27 UTC] {base.py:84} INFO - Retrieving connection 'gcp_gs_conn'
```

closes: https://github.com/astronomer/astronomer-cosmos/issues/1522
