### PR TITLE
Fix import error in dbt bigquery adapter mock for `dbt-bigquery<1.8` for `ExecutionMode.AIRFLOW_ASYNC`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,14 @@
 Changelog
 =========
 
+1.9.1a1 (2025-02-20)
+--------------------
+
+Bug Fixes
+
+* Fix import error in dbt bigquery adapter mock for ``dbt-bigquery<1.8`` for ``ExecutionMode.AIRFLOW_ASYNC`` by @pankajkoti in #1548
+
+
 1.9.0 (2025-02-19)
 --------------------
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.9.0"
+__version__ = "1.9.1a1"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -28,7 +28,11 @@ def _mock_bigquery_adapter() -> None:
 
     import agate
     from dbt.adapters.bigquery.connections import BigQueryAdapterResponse, BigQueryConnectionManager
-    from dbt_common.clients.agate_helper import empty_table
+
+    try:
+        from dbt_common.clients.agate_helper import empty_table
+    except (ModuleNotFoundError, ImportError):  # pragma: no cover
+        from dbt.clients.agate_helper import empty_table
 
     def execute(  # type: ignore[no-untyped-def]
         self, sql, auto_begin=False, fetch=None, limit: Optional[int] = None


### PR DESCRIPTION
A user has reported after testing the `astronomer-cosmos==1.9.0a5` that they are getting the below error
```
    from dbt_common.clients.agate_helper import empty_table
ModuleNotFoundError: No module named 'dbt_common'
```

They are using `dbt-bigquery==1.7.2`

Upon debugging, I observed that the `dbt_common` module that we rely on in the current mocking interface is available only in dbt bigquery adapterversion >= 1.8. For previous versions, to achieve the same, the helper seems to be available in `dbt.clients`. I tested this on dbt-bigquery versions 1.5, 1.6, 1.7 and 1.7.2 and the fix in this PR seems to solve the issue.

closes: #1547 
