### PR TITLE
Bugfix ProjectConfig install_dbt_deps (#1555)

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -152,6 +152,7 @@ class ProjectConfig:
     :param snapshots_relative_path: The relative path to the dbt snapshots directory within the project. Defaults to
     snapshots
     :param manifest_path: The absolute path to the dbt manifest file. Defaults to None
+    :param manifest_conn_id: Name of the Airflow connection used to access the manifest file if it is not stored locally. Defaults to None
     :param project_name: Allows the user to define the project name.
     Required if dbt_project_path is not defined. Defaults to the folder name of dbt_project_path.
     :param env_vars: Dictionary of environment variables that are used for both rendering and execution. Rendering with
@@ -175,6 +176,7 @@ class ProjectConfig:
     def __init__(
         self,
         dbt_project_path: str | Path | None = None,
+        install_dbt_deps: bool = True,
         models_relative_path: str | Path = "models",
         seeds_relative_path: str | Path = "seeds",
         snapshots_relative_path: str | Path = "snapshots",
@@ -228,6 +230,7 @@ class ProjectConfig:
         self.env_vars = env_vars
         self.dbt_vars = dbt_vars
         self.partial_parse = partial_parse
+        self.install_dbt_deps = install_dbt_deps
 
     def validate_project(self) -> None:
         """

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -28,6 +28,15 @@ def test_init_with_project_path_only():
     assert project_config.snapshots_path == Path("path/to/dbt/project/snapshots")
     assert project_config.project_name == "project"
     assert project_config.manifest_path is None
+    assert project_config.install_dbt_deps is True
+
+
+def test_init_with_project_path_and_install_dbt_deps_succeeds():
+    """
+    Passing only dbt_project_path and install_dbt_deps should succeed and set install_dbt_deps to the value defined
+    """
+    project_config = ProjectConfig(dbt_project_path="path/to/dbt/project", install_dbt_deps=False)
+    assert project_config.install_dbt_deps is False
 
 
 def test_init_with_manifest_path_and_project_path_succeeds():


### PR DESCRIPTION
## Description

`install_dbt_deps` is missing from the `ProjectConfig` `__init__` method, which is inconsistent with the [documentation](https://astronomer.github.io/astronomer-cosmos/configuration/project-config.html)
and does not make sense.

## Related Issue(s)

Closes #1555 

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
