### PR TITLE
Bugfix `operator_args` override configuration

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -223,7 +223,7 @@ def override_configuration(
     if execution_config.invocation_mode:
         operator_args["invocation_mode"] = execution_config.invocation_mode
 
-    if execution_config in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
+    if execution_config.execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
         if "install_deps" not in operator_args:
             operator_args["install_deps"] = project_config.install_dbt_deps
 


### PR DESCRIPTION
## Description

The function `cosmos.converter.override_configuration` had a small logical issue: the condition to override `install_deps`
could never be reached. This seems to be the root cause of #1557 

## Related Issue(s)

Closes #1557 

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
