### PR TITLE
Implement `no_retries_on_test_failure` on `DbtTestLocalOperator`

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -929,8 +929,10 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
             result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
         except CosmosDbtRunError as e:
             if self.no_retries_on_test_failure:
-                self.log.error("DBT test failed and `no_retries_on_test_failure=True`, "
-                               "raising AirflowFailException to prevent retries.")
+                self.log.error(
+                    "DBT test failed and `no_retries_on_test_failure=True`, "
+                    "raising AirflowFailException to prevent retries."
+                )
                 raise AirflowFailException(e)
             raise
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -16,7 +16,7 @@ from urllib.parse import urlparse
 import airflow
 import jinja2
 from airflow import DAG
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
 from airflow.models import BaseOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.context import Context
@@ -882,6 +882,7 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
     Executes a dbt core test command.
     :param on_warning_callback: A callback function called on warnings with additional Context variables "test_names"
         and "test_results" of type `List`. Each index in "test_names" corresponds to the same index in "test_results".
+    :param no_retries_on_test_failure: If True, raises AirflowFailException on test failure to prevent retries.
     """
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
@@ -889,10 +890,12 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
     def __init__(
         self,
         on_warning_callback: Callable[..., Any] | None = None,
+        no_retries_on_test_failure: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
         self.on_warning_callback = on_warning_callback
+        self.no_retries_on_test_failure = no_retries_on_test_failure
         self.extract_issues: Callable[..., tuple[list[str], list[str]]]
         self.parse_number_of_warnings: Callable[..., int]
 
@@ -922,7 +925,15 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
             self.parse_number_of_warnings = dbt_runner.parse_number_of_warnings
 
     def execute(self, context: Context, **kwargs: Any) -> None:
-        result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
+        try:
+            result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
+        except CosmosDbtRunError as e:
+            if self.no_retries_on_test_failure:
+                self.log.error("DBT test failed and `no_retries_on_test_failure=True`, "
+                               "raising AirflowFailException to prevent retries.")
+                raise AirflowFailException(e)
+            raise
+
         self._set_test_result_parsing_methods()
         number_of_warnings = self.parse_number_of_warnings(result)  # type: ignore
         if self.on_warning_callback and number_of_warnings > 0:

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -10,7 +10,7 @@ from unittest.mock import MagicMock, call, patch
 import pytest
 from airflow import DAG
 from airflow import __version__ as airflow_version
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException, AirflowFailException, AirflowSkipException
 from airflow.hooks.subprocess import SubprocessResult
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.context import Context
@@ -703,6 +703,23 @@ def test_run_test_operator_without_callback(invocation_mode):
         run_operator >> test_operator
     run_test_dag(dag)
     assert not on_warning_callback.called
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("invocation_mode", [InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
+def test_run_test_operator_with_no_retries_on_failure(invocation_mode, failing_test_dbt_project):
+    with DAG("test-id-4", start_date=datetime(2025, 1, 1)) as dag:
+        _ = DbtTestLocalOperator(
+            profile_config=mini_profile_config,
+            project_dir=failing_test_dbt_project,
+            task_id="test",
+            append_env=True,
+            invocation_mode=invocation_mode,
+            no_retries_on_test_failure=True,
+        )
+
+    with pytest.raises(AirflowFailException):
+        run_test_dag(dag)
 
 
 @pytest.mark.integration


### PR DESCRIPTION
## Description
Added `no_retries_on_test_failure` parameter to `DbtTestLocalOperator` with a default value of `True`.
This parameter raises `AirflowFailException`, ensuring that failed DBT tests are not retried unnecessarily, even if a common retries value of 1 or more is set in `DbtDag`/`DbtTaskGroup`.

Unlike the `on_warning_callback` parameter, it does not seem necessary to propagate `no_retries_on_test_failure` through the `converter` and `airflow/graph` modules. Instead, similar to the `callback` parameter in `AbstractDbtLocalBase`, it can be passed via `operator_args` when needed.

## Related Issue(s)
closes https://github.com/astronomer/astronomer-cosmos/issues/1537

## Breaking Change?
Nope.

## Checklist
- [] I have made corresponding changes to the documentation (if required) -> Not needed in this case.
- [x] I have added tests that prove my fix is effective or that my feature works
