### PR TITLE
fix: container_name is null for ecs integration

### DIFF
--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -72,7 +72,6 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         )
         logger.info('Container name: {}'.format(self.container_name))
         super().__init__(
-            container_name=self.container_name,
             **kwargs)
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
         # and eliminated the super().__init__() call. This change was made to resolve conflicts in parent class
@@ -116,7 +115,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.overrides = {
             "containerOverrides": [
                 {
-                    "name": self.container_name,
+                    "name": self.container_name or 'main',
                     "command": self.command,
                     "environment": [{"name": key, "value": value} for key, value in self.environment_variables.items()],
                 }

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -40,7 +40,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
     """
 
     template_fields: Sequence[str] = tuple(
-        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields) + 'dbt_container_name'
+        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields) + list("dbt_container_name")
     )
 
     intercept_flag = False
@@ -50,7 +50,6 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # arguments required by EcsRunTaskOperator
         cluster: str,
         task_definition: str,
-
         dbt_container_name: str,
         #
         aws_conn_id: str = DEFAULT_CONN_ID,
@@ -105,7 +104,6 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # For the first round, we're going to assume that the command is dbt
         # This means that we don't have openlineage support, but we will create a ticket
         # to add that in the future
-        logger.debug('Container name: {}'.format(self.dbt_container_name))
         self.dbt_executable_path = "dbt"
         dbt_cmd, env_vars = self.build_cmd(context=context, cmd_flags=cmd_flags)
         self.environment_variables = {**env_vars, **self.environment_variables}
@@ -120,6 +118,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
                 }
             ]
         }
+
 
 class DbtBuildAwsEcsOperator(DbtBuildMixin, DbtAwsEcsBaseOperator):
     """

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -70,6 +70,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
                 "overrides": None,
             }
         )
+        logger.info('Container name: {}'.format(self.container_name))
         super().__init__(
             container_name=self.container_name,
             **kwargs)

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -62,6 +62,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.profile_config = profile_config
         self.command = command
         self.environment_variables = environment_variables or DEFAULT_ENVIRONMENT_VARIABLES
+        self.container_name = container_name
         kwargs.update(
             {
                 "aws_conn_id": aws_conn_id,

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -22,6 +22,7 @@ from cosmos.operators.base import (
 logger = get_logger(__name__)
 
 DEFAULT_CONN_ID = "aws_default"
+DEFAULT_CONTAINER_NAME = "dbt"
 DEFAULT_ENVIRONMENT_VARIABLES: dict[str, str] = {}
 
 try:
@@ -50,7 +51,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # arguments required by EcsRunTaskOperator
         cluster: str,
         task_definition: str,
-        container_name: str,
+        container_name: str = DEFAULT_CONTAINER_NAME,
         #
         aws_conn_id: str = DEFAULT_CONN_ID,
         profile_config: ProfileConfig | None = None,

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -50,7 +50,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # arguments required by EcsRunTaskOperator
         cluster: str,
         task_definition: str,
-        container_name: str,
+        dbt_container_name: str,
         #
         aws_conn_id: str = DEFAULT_CONN_ID,
         profile_config: ProfileConfig | None = None,
@@ -61,7 +61,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.profile_config = profile_config
         self.command = command
         self.environment_variables = environment_variables or DEFAULT_ENVIRONMENT_VARIABLES
-        self.container_name = container_name
+        self.dbt_container_name = dbt_container_name
         kwargs.update(
             {
                 "aws_conn_id": aws_conn_id,
@@ -70,9 +70,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
                 "overrides": None,
             }
         )
-        logger.info('Container name: {}'.format(self.container_name))
-        super().__init__(
-            **kwargs)
+        super().__init__(**kwargs)
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
         # and eliminated the super().__init__() call. This change was made to resolve conflicts in parent class
         # initializations while adding support for ExecutionMode.AIRFLOW_ASYNC. Operators under this mode inherit
@@ -106,7 +104,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # For the first round, we're going to assume that the command is dbt
         # This means that we don't have openlineage support, but we will create a ticket
         # to add that in the future
-        logger.info('Container name: {}'.format(self.container_name))
+        logger.info('Container name: {}'.format(self.dbt_container_name))
         self.dbt_executable_path = "dbt"
         dbt_cmd, env_vars = self.build_cmd(context=context, cmd_flags=cmd_flags)
         self.environment_variables = {**env_vars, **self.environment_variables}
@@ -115,7 +113,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.overrides = {
             "containerOverrides": [
                 {
-                    "name": self.container_name or 'main',
+                    "name": self.dbt_container_name,
                     "command": self.command,
                     "environment": [{"name": key, "value": value} for key, value in self.environment_variables.items()],
                 }

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -52,8 +52,8 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         cluster: str,
         task_definition: str,
         container_name: str = DEFAULT_CONTAINER_NAME,
-        #
         aws_conn_id: str = DEFAULT_CONN_ID,
+        #
         profile_config: ProfileConfig | None = None,
         command: list[str] | None = None,
         environment_variables: dict[str, Any] | None = None,

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -40,7 +40,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
     """
 
     template_fields: Sequence[str] = tuple(
-        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields)
+        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields) + 'dbt_container_name'
     )
 
     intercept_flag = False
@@ -50,6 +50,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # arguments required by EcsRunTaskOperator
         cluster: str,
         task_definition: str,
+
         dbt_container_name: str,
         #
         aws_conn_id: str = DEFAULT_CONN_ID,
@@ -104,7 +105,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # For the first round, we're going to assume that the command is dbt
         # This means that we don't have openlineage support, but we will create a ticket
         # to add that in the future
-        logger.info('Container name: {}'.format(self.dbt_container_name))
+        logger.debug('Container name: {}'.format(self.dbt_container_name))
         self.dbt_executable_path = "dbt"
         dbt_cmd, env_vars = self.build_cmd(context=context, cmd_flags=cmd_flags)
         self.environment_variables = {**env_vars, **self.environment_variables}

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -50,7 +50,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         # arguments required by EcsRunTaskOperator
         cluster: str,
         task_definition: str,
-        dbt_container_name: str,
+        container_name: str,
         #
         aws_conn_id: str = DEFAULT_CONN_ID,
         profile_config: ProfileConfig | None = None,
@@ -61,13 +61,13 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.profile_config = profile_config
         self.command = command
         self.environment_variables = environment_variables or DEFAULT_ENVIRONMENT_VARIABLES
-        self.dbt_container_name = dbt_container_name
         kwargs.update(
             {
                 "aws_conn_id": aws_conn_id,
                 "task_definition": task_definition,
                 "cluster": cluster,
                 "overrides": None,
+                "container_name": container_name,
             }
         )
         super().__init__(**kwargs)
@@ -112,7 +112,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         self.overrides = {
             "containerOverrides": [
                 {
-                    "name": self.dbt_container_name,
+                    "name": self.container_name,
                     "command": self.command,
                     "environment": [{"name": key, "value": value} for key, value in self.environment_variables.items()],
                 }

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -40,7 +40,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
     """
 
     template_fields: Sequence[str] = tuple(
-        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields) + list("dbt_container_name")
+        list(AbstractDbtBase.template_fields) + list(EcsRunTaskOperator.template_fields)
     )
 
     intercept_flag = False
@@ -66,8 +66,8 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
                 "aws_conn_id": aws_conn_id,
                 "task_definition": task_definition,
                 "cluster": cluster,
-                "overrides": None,
                 "container_name": container_name,
+                "overrides": None,
             }
         )
         super().__init__(**kwargs)

--- a/tests/operators/test_aws_ecs.py
+++ b/tests/operators/test_aws_ecs.py
@@ -30,7 +30,7 @@ def test_dbt_aws_ecs_operator_add_global_flags() -> None:
         aws_conn_id="my-aws-conn-id",
         cluster="my-ecs-cluster",
         task_definition="my-dbt-task-definition",
-        container_name="my-dbt-container-name",
+        dbt_container_name="my-dbt-container-name",
         project_dir="my/dir",
         vars={
             "start_time": "{{ data_interval_start.strftime('%Y%m%d%H%M%S') }}",
@@ -185,6 +185,7 @@ def test_dbt_aes_ecs_overrides_parameter():
 
     assert "containerOverrides" in actual_overrides
     actual_container_overrides = actual_overrides["containerOverrides"][0]
+    assert actual_container_overrides["name"] == "my-dbt-container-name"
     assert isinstance(actual_container_overrides["command"], list), "`command` should be of type list"
 
     assert "environment" in actual_container_overrides

--- a/tests/operators/test_aws_ecs.py
+++ b/tests/operators/test_aws_ecs.py
@@ -30,7 +30,7 @@ def test_dbt_aws_ecs_operator_add_global_flags() -> None:
         aws_conn_id="my-aws-conn-id",
         cluster="my-ecs-cluster",
         task_definition="my-dbt-task-definition",
-        dbt_container_name="my-dbt-container-name",
+        container_name="my-dbt-container-name",
         project_dir="my/dir",
         vars={
             "start_time": "{{ data_interval_start.strftime('%Y%m%d%H%M%S') }}",


### PR DESCRIPTION
## Description

### TL/DR
* pas `container_name` to kwargs
* use a default value for **aws_conn_id**

### Long version

The current implementation of ECS integration implies passing the `container_name` as part of the operator_args.
e.g. 
```
operator_args = {
   "container_name": "main",
   ...
}
```
Anyhow, this lead to errors like this:
```
[2025-03-07, 16:40:34 UTC] {ecs.py:515} INFO - EcsOperator overrides: {'containerOverrides': [{'name': None, 'command': ['dbt', '--no-partial-parse', 'run', '--models', 'my_first_dbt_model'], 'environment': [{'name': 'AIRFLOW_CTX_DAG_OWNER', 'value': '***'}, {'name': 'AIRFLOW_CTX_DAG_ID', 'value': 'example_cosmos'}, {'name': 'AIRFLOW_CTX_TASK_ID', 'value': 'dbt_task_group.my_first_dbt_model.run'}, {'name': 'AIRFLOW_CTX_EXECUTION_DATE', 'value': '2025-03-07T16:40:31.716155+00:00'}, {'name': 'AIRFLOW_CTX_TRY_NUMBER', 'value': '1'}, {'name': 'AIRFLOW_CTX_DAG_RUN_ID', 'value': 'manual__2025-03-07T16:40:31.716155+00:00'}, {'name': 'EXTRA_VAR', 'value': 'extra_value'}]}]}
```
The container name is None, leading to a failure in how boto3 invokes the container.

The issue was due to the fact that `container_name` was not passed to the kwargs, therefore, the container_name was not set properly to the value that was set to cosmos.


### Full logs
<pre>
2025-03-10, 12:49:41 UTC] {ecs.py:512} INFO - Running ECS Task - Task definition: dbt - on cluster dbt
[2025-03-10, 12:49:41 UTC] {ecs.py:515} INFO - EcsOperator overrides: {'containerOverrides': [{'name': None, 'command': ['dbt', '--no-partial-parse', 'run', '--models', 'my_first_dbt_model'], 'environment': [{'name': 'AIRFLOW_CTX_DAG_OWNER', 'value': '***'}, {'name': 'AIRFLOW_CTX_DAG_ID', 'value': 'example_cosmos'}, {'name': 'AIRFLOW_CTX_TASK_ID', 'value': 'dbt_task_group.my_first_dbt_model.run'}, {'name': 'AIRFLOW_CTX_EXECUTION_DATE', 'value': '2025-03-10T12:49:28.878404+00:00'}, {'name': 'AIRFLOW_CTX_TRY_NUMBER', 'value': '1'}, {'name': 'AIRFLOW_CTX_DAG_RUN_ID', 'value': 'manual__2025-03-10T12:49:28.878404+00:00'}, {'name': 'EXTRA_VAR', 'value': 'extra_value'}]}]}
[2025-03-10, 12:49:41 UTC] {base.py:84} INFO - Retrieving connection 'aws_default'
[2025-03-10, 12:49:44 UTC] {credentials.py:1147} INFO - Found credentials in environment variables.
[2025-03-10, 12:49:44 UTC] {taskinstance.py:3313} ERROR - Task failed with exception
Traceback (most recent call last):
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 768, in _execute_task
    result = _execute_callable(context=context, **execute_callable_kwargs)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/taskinstance.py", line 734, in _execute_callable
    return ExecutionCallableRunner(
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/utils/operator_helpers.py", line 252, in run
    return self.func(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/cosmos/operators/base.py", line 278, in execute
    self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
  File "/home/airflow/.local/lib/python3.12/site-packages/cosmos/operators/aws_ecs.py", line 98, in build_and_run_cmd
    result = EcsRunTaskOperator.execute(self, context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/models/baseoperator.py", line 424, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 526, in execute
    self._start_task()
  File "/home/airflow/.local/lib/python3.12/site-packages/airflow/providers/amazon/aws/operators/ecs.py", line 626, in _start_task
    response = self.client.run_task(**run_opts)
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/botocore/client.py", line 569, in _api_call
    return self._make_api_call(operation_name, kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/botocore/client.py", line 980, in _make_api_call
    request_dict = self._convert_to_request_dict(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/botocore/client.py", line 1047, in _convert_to_request_dict
    request_dict = self._serializer.serialize_to_request(
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/airflow/.local/lib/python3.12/site-packages/botocore/validate.py", line 381, in serialize_to_request
    raise ParamValidationError(report=report.generate_report())
botocore.exceptions.ParamValidationError: Parameter validation failed:
Invalid type for parameter overrides.containerOverrides[0].name, value: None, type: <class 'NoneType'>, valid types: <class 'str'>
</pre>
  

## Related Issue(s)
I didn't created any issue - but I just thought to propose a fix.


## Breaking Change?

It does because user have to use `dbt_container_name` with ECS, but it's currently broken.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
