### PR TITLE
Improve BQ async error handling

### DIFF
--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -11,7 +11,7 @@ try:
 except ImportError:
     raise ImportError(
         "Could not import BigQueryInsertJobOperator. Ensure you've installed the Google Cloud provider separately or "
-        "with with `pip install apache-airflow-providers-bigquery`."
+        "with with `pip install apache-airflow-providers-google`."
     )
 
 from airflow.utils.context import Context

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -5,7 +5,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, Sequence
 
 import airflow
-from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+
+try:
+    from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+except ImportError:
+    raise ImportError(
+        "Could not import BigQueryInsertJobOperator. Ensure you've installed the Google Cloud provider separately or "
+        "with with `pip install apache-airflow-providers-bigquery`."
+    )
+
 from airflow.utils.context import Context
 from airflow.utils.session import NEW_SESSION, provide_session
 from packaging.version import Version
@@ -158,7 +166,12 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.log.debug("Executed SQL is: %s", sql)
         self.compiled_sql = sql
 
-        profile = self.profile_config.profile_mapping.profile
+        if self.profile_config.profile_mapping is not None:
+            profile = self.profile_config.profile_mapping.profile
+        else:
+            raise CosmosValueError(
+                "The `profile_config.profile`_mapping attribute must be defined to use `ExecutionMode.AIRFLOW_ASYNC`"
+            )
         self.gcp_project = profile["project"]
         self.dataset = profile["dataset"]
 


### PR DESCRIPTION
Currently, if someone attempts to run `simple_dag_async` without previously installing `apache-airflow-providers-google`, they will face this very ugly error:

```
Traceback (most recent call last):
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv/lib/python3.9/site-packages/airflow/models/dagbag.py", line 383, in parse
    loader.exec_module(new_module)
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/dags/simple_dag_async.py", line 21, in <module>
    simple_dag_async = DbtDag(
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/airflow/dag.py", line 26, in __init__
    DbtToAirflowConverter.__init__(self, *args, **specific_kwargs(**kwargs))
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/converter.py", line 328, in __init__
    self.tasks_map = build_airflow_graph(
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/airflow/graph.py", line 591, in build_airflow_graph
    task_or_group = conversion_function(  # type: ignore
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/airflow/graph.py", line 379, in generate_task_or_group
    task = create_airflow_task(task_meta, dag, task_group=model_task_group)
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/core/airflow.py", line 36, in get_airflow_task
    airflow_task = Operator(
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv/lib/python3.9/site-packages/airflow/models/baseoperator.py", line 506, in apply_defaults
    result = func(self, **kwargs, default_args=default_args)
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/airflow_async.py", line 75, in __init__
    super().__init__(
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv/lib/python3.9/site-packages/airflow/models/baseoperator.py", line 506, in apply_defaults
    result = func(self, **kwargs, default_args=default_args)
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/_asynchronous/base.py", line 50, in __init__
    async_operator_class = self.create_async_operator()
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/_asynchronous/base.py", line 69, in create_async_operator
    async_class_operator = _create_async_operator_class(profile_type, "DbtRun")
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/_asynchronous/base.py", line 34, in _create_async_operator_class
    raise ImportError(f"Error in loading class: {class_path}. Unable to find the specified operator class.") from e
ImportError: Error in loading class: cosmos.operators._asynchronous.bigquery.DbtRunAirflowAsyncBigqueryOperator. Unable to find the specified operator class.
```

The goal with this ticket is to give the same error handling as other parts of Cosmos by raising a more graceful error message.