### PR TITLE
Improve unit tests speed from 89s to 14s

### DIFF
--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -8,7 +8,6 @@ from urllib.parse import urlparse
 from cosmos import settings
 from cosmos.constants import DEFAULT_TARGET_PATH, FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP
 from cosmos.exceptions import CosmosValueError
-from cosmos.settings import remote_target_path, remote_target_path_conn_id
 
 
 def upload_to_aws_s3(
@@ -136,14 +135,14 @@ def _configure_remote_target_path() -> tuple[Path, str] | tuple[None, None]:
     """Configure the remote target path if it is provided."""
     from airflow.version import version as airflow_version
 
-    if not remote_target_path:
+    if not settings.remote_target_path:
         return None, None
 
     _configured_target_path = None
 
-    target_path_str = str(remote_target_path)
+    target_path_str = str(settings.remote_target_path)
 
-    remote_conn_id = remote_target_path_conn_id
+    remote_conn_id = settings.remote_target_path_conn_id
     if not remote_conn_id:
         target_path_schema = urlparse(target_path_str).scheme
         remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)  # type: ignore[assignment]

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1851,7 +1851,7 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     hash_dir, hash_args = version.split(",")
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
-        assert hash_dir == "afbced719302d5b1efdfb191c617e349"
+        assert hash_dir == "391db5c7e1fb90214d829dd0476059a1"
     else:
         assert hash_dir == "0148da6f5f7fd260c9fa55c3b3c45168"
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1457,6 +1457,7 @@ def test_async_execution_without_start_task(mock_read_sql, mock_bq_execute, monk
     mock_bq_execute.assert_called_once()
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("pathlib.Path.rglob")
 @patch("cosmos.operators.local.AbstractDbtLocalBase._construct_dest_file_path")

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -66,6 +66,7 @@ def test_upload_artifacts_to_azure_wasb(dummy_kwargs):
         assert hook_instance.load_file.call_count == 2
 
 
+@pytest.mark.integration
 def test_configure_remote_target_path_no_remote_target():
     """Test _configure_remote_target_path when no remote target path is set."""
     with patch("cosmos.settings.remote_target_path", None):
@@ -119,6 +120,7 @@ def test_upload_artifacts_to_cloud_storage_success(dummy_kwargs):
         assert mock_copy.call_count == 2
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("cosmos.io.remote_target_path")
 def test_configure_remote_target_path_no_conn_id(mock_remote_target_path):
@@ -135,6 +137,7 @@ def test_configure_remote_target_path_no_conn_id(mock_remote_target_path):
             assert result == (mock_object_storage.return_value, _default_s3_conn)
 
 
+@pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("cosmos.io.remote_target_path")
 def test_configure_remote_target_path_conn_id_is_none(mock_remote_target_path):

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -67,12 +67,13 @@ def test_upload_artifacts_to_azure_wasb(dummy_kwargs):
 
 
 @pytest.mark.integration
+@patch("cosmos.io.settings.remote_target_path", None)
+@patch("cosmos.io.settings.remote_target_path_conn_id", None)
 def test_configure_remote_target_path_no_remote_target():
     """Test _configure_remote_target_path when no remote target path is set."""
-    with patch("cosmos.settings.remote_target_path", None):
-        from cosmos.io import _configure_remote_target_path
+    from cosmos.io import _configure_remote_target_path
 
-        assert _configure_remote_target_path() == (None, None)
+    assert _configure_remote_target_path() == (None, None)
 
 
 def test_construct_dest_file_path(dummy_kwargs):
@@ -120,52 +121,52 @@ def test_upload_artifacts_to_cloud_storage_success(dummy_kwargs):
         assert mock_copy.call_count == 2
 
 
-@pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
-@patch("cosmos.io.remote_target_path")
-def test_configure_remote_target_path_no_conn_id(mock_remote_target_path):
+@patch("cosmos.io.settings.remote_target_path", "s3://bucket/path/to/file")
+@patch("cosmos.io.settings.remote_target_path_conn_id", None)
+@patch("airflow.io.path.ObjectStoragePath")
+@patch("cosmos.io.urlparse")
+def test_configure_remote_target_path_no_conn_id(mock_urlparse, mock_object_storage):
     """Test when no remote_conn_id is provided, but conn_id is resolved from scheme."""
-    mock_remote_target_path.return_value = "s3://bucket/path/to/file"
+    mock_urlparse.return_value.scheme = "s3"
     mock_storage_path = MagicMock()
-    with patch("cosmos.io.urlparse") as mock_urlparse:
-        mock_urlparse.return_value.scheme = "s3"
-        with patch("airflow.io.path.ObjectStoragePath") as mock_object_storage:
-            mock_object_storage.return_value = mock_storage_path
-            mock_storage_path.exists.return_value = True
+    mock_storage_path.exists.return_value = True
+    mock_object_storage.return_value = mock_storage_path
+    result = _configure_remote_target_path()
 
-            result = _configure_remote_target_path()
-            assert result == (mock_object_storage.return_value, _default_s3_conn)
+    assert result == (mock_object_storage.return_value, _default_s3_conn)
 
 
-@pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
-@patch("cosmos.io.remote_target_path")
-def test_configure_remote_target_path_conn_id_is_none(mock_remote_target_path):
+@patch("cosmos.io.settings.remote_target_path", "abcd://bucket/path/to/file")
+@patch("cosmos.io.settings.remote_target_path_conn_id", None)
+@patch("airflow.io.path.ObjectStoragePath")
+@patch("cosmos.io.urlparse")
+def test_configure_remote_target_path_conn_id_is_none(mock_urlparse, mock_object_storage):
     """Test when conn_id cannot be resolved and is None."""
-    mock_remote_target_path.return_value = "abcd://bucket/path/to/file"
     mock_storage_path = MagicMock()
-    with patch("cosmos.io.urlparse") as mock_urlparse:
-        mock_urlparse.return_value.scheme = "abcd"
-        with patch("airflow.io.path.ObjectStoragePath") as mock_object_storage:
-            mock_object_storage.return_value = mock_storage_path
-            mock_storage_path.exists.return_value = True
 
-            result = _configure_remote_target_path()
-            assert result == (None, None)
+    mock_urlparse.return_value.scheme = "abcd"
+    mock_storage_path.exists.return_value = True
+
+    result = _configure_remote_target_path()
+    assert result == (None, None)
 
 
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("cosmos.settings.AIRFLOW_IO_AVAILABLE", False)
-@patch("cosmos.io.remote_target_path")
-def test_configure_remote_target_path_airflow_io_unavailable(mock_remote_target_path):
+@patch("cosmos.io.settings.remote_target_path", "s3://bucket/path/to/file")
+@patch("airflow.io.path.ObjectStoragePath")
+@patch("cosmos.io.urlparse")
+def test_configure_remote_target_path_airflow_io_unavailable(mock_urlparse, mock_object_storage):
     """Test when AIRFLOW_IO_AVAILABLE is False."""
-    mock_remote_target_path.return_value = "s3://bucket/path/to/file"
+    mock_urlparse.return_value.scheme = "s3"
+
     mock_storage_path = MagicMock()
-    with patch("cosmos.io.urlparse") as mock_urlparse:
-        mock_urlparse.return_value.scheme = "s3"
-        with patch("airflow.io.path.ObjectStoragePath") as mock_object_storage:
-            mock_object_storage.return_value = mock_storage_path
-            mock_storage_path.exists.return_value = True
-            with pytest.raises(CosmosValueError) as exc_info:
-                _configure_remote_target_path()
+    mock_storage_path.exists.return_value = True
+    mock_object_storage.return_value = mock_storage_path
+
+    with pytest.raises(CosmosValueError) as exc_info:
+        _configure_remote_target_path()
+
     assert "Object Storage feature is unavailable" in str(exc_info.value)

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -66,7 +66,6 @@ def test_upload_artifacts_to_azure_wasb(dummy_kwargs):
         assert hook_instance.load_file.call_count == 2
 
 
-@pytest.mark.integration
 @patch("cosmos.io.settings.remote_target_path", None)
 @patch("cosmos.io.settings.remote_target_path_conn_id", None)
 def test_configure_remote_target_path_no_remote_target():


### PR DESCRIPTION
A few tests, such as `test_configure_remote_target_path_no_remote_target`, were taking a long time when using `hatch run tests.py3.9-2.9:test-cov`.

Time to run this command before these changes: 89.34s
Time to run this command after these changes: 14.50s

Also fix unittest that was failing locally.