### PR TITLE
Fix path selector when `manifest.json` was created in MS Windows

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -46,6 +46,13 @@ from cosmos.log import get_logger
 logger = get_logger(__name__)
 
 
+def _normalize_path(path: str) -> str:
+    """
+    Converts a potentially Windows path string into a Posix-friendly path.
+    """
+    return Path(path.replace("\\", "/")).as_posix()
+
+
 class CosmosLoadDbtException(Exception):
     """
     Exception raised while trying to load a `dbt` project as a `DbtGraph` instance.
@@ -823,7 +830,7 @@ class DbtGraph:
                     unique_id=unique_id,
                     resource_type=DbtResourceType(node_dict["resource_type"]),
                     depends_on=node_dict.get("depends_on", {}).get("nodes", []),
-                    file_path=self.execution_config.project_path / Path(node_dict["original_file_path"]),
+                    file_path=self.execution_config.project_path / _normalize_path(node_dict["original_file_path"]),
                     tags=node_dict["tags"],
                     config=node_dict["config"],
                     has_freshness=(

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -30,6 +30,7 @@ from cosmos.dbt.graph import (
     DbtGraph,
     DbtNode,
     LoadMode,
+    _normalize_path,
     parse_dbt_ls_output,
     run_command,
 )
@@ -2023,3 +2024,13 @@ def test_get_dbt_ls_cache_remote_cache_dir(
     }
 
     assert result == expected_result
+
+
+def test__normalize_path():
+    """
+    This normalizes the path (e.g. declared inside a manifest.json file) when it was created using MS Windows instead
+    of GNU Linux.
+    """
+    original_value = "seeds\\seed_ifs_util_manual_event_id.csv"
+    expected_value = "seeds/seed_ifs_util_manual_event_id.csv"
+    assert _normalize_path(original_value) == expected_value


### PR DESCRIPTION
Users who generated the `manifest.json` using MS Windows and attempted to use Cosmos path selectors after, such as `path:models/edr/run_results' were unable to do so, because the paths in Windows were different from the selector:

```
    "model.elementary.model_run_results": {
      "database": "FDH_DEV_DB",
      "schema": "MONITORING",
      "name": "model_run_results",
      "resource_type": "model",
      "package_name": "elementary",
      "path": "edr\\run_results\\model_run_results.sql",
      "original_file_path": "models\\edr\\run_results\\model_run_results.sql",
      "unique_id": "model.elementary.model_run_results",
      "fqn": [
        "elementary",
        "edr",
        "run_results",
        "model_run_results"
      ],
```

As observed in this example, the property `original_file_path` used the `\\` character as a divider in the path, but the selector checked using the Posix notation.

Since Cosmos implements path selectors using: path_selection in str(node.file_path), we have to normalize the input for the filter to work.

This issue only happened when using `LoadMode.DBT_MANIFEST` and not `LoadMode.DBT_LS` since dbt normalizes this internally when handling selectors as part of this command line.