### PR TITLE
Fix select behaviour using `LoadMode.MANIFEST` and a path with star

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -175,7 +175,7 @@ class GraphSelector:
         # Index nodes by name, we can improve performance by doing this once
         # for multiple GraphSelectors
         if PATH_SELECTOR in self.node_name:
-            path_selection = self.node_name[len(PATH_SELECTOR) :]
+            path_selection = self.node_name[len(PATH_SELECTOR) :].rstrip("*")
             root_nodes.update({node_id for node_id, node in nodes.items() if path_selection in str(node.file_path)})
 
         elif TAG_SELECTOR in self.node_name:
@@ -372,7 +372,7 @@ class SelectorConfig:
     def _parse_path_selector(self, item: str) -> None:
         index = len(PATH_SELECTOR)
         if self.project_dir:
-            self.paths.append(self.project_dir / Path(item[index:]))
+            self.paths.append(self.project_dir / Path(item[index:].rstrip("*")))
         else:
             self.paths.append(Path(item[index:]))
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -284,9 +284,28 @@ def test_select_nodes_with_test_by_intersection_and_tag_ancestry():
 
 
 def test_select_nodes_by_select_path():
+    # Path without star or graph selector
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models"])
     expected = {
         parent_node.unique_id: parent_node,
+    }
+    assert selected == expected
+
+    # Path with star
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models/*"])
+    expected = {
+        parent_node.unique_id: parent_node,
+    }
+    assert selected == expected
+
+    # Path with star and graph selector that retrieves descendants
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["path:gen2/models/*+"])
+    expected = {
+        child_node.unique_id: child_node,
+        parent_node.unique_id: parent_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
+        sibling3_node.unique_id: sibling3_node,
     }
     assert selected == expected
 


### PR DESCRIPTION
Let's say the dbt project has a file_path "gen2/models/parent.sql"
```
parent_node = DbtNode(
    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.parent",
    resource_type=DbtResourceType.MODEL,
    depends_on=[grandparent_node.unique_id, another_grandparent_node.unique_id],
    file_path=SAMPLE_PROJ_PATH / "gen2/models/parent.sql",
    tags=["has_child", "is_child"],
    config={"materialized": "view", "tags": ["has_child", "is_child"]},
)
```

When using Cosmos 1.9.0 with `LoadMode.MANIFEST` and trying to use:

```
RenderConfig(select="gen2/models/*")
```

The selector would not return any results.

It would still work with `LoadMode.DBT_LS`.

The goal of this PR is to solve this issue.
