### PR TITLE
Fix log that prints 'Total filtered nodes'

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -530,7 +530,7 @@ class DbtGraph:
         self.update_node_dependency()
 
         logger.info("Total nodes: %i", len(self.nodes))
-        logger.info("Total filtered nodes: %i", len(self.nodes))
+        logger.info("Total filtered nodes: %i", len(self.filtered_nodes))
 
     def run_dbt_ls(
         self, dbt_cmd: str, project_path: Path, tmp_dir: Path, env_vars: dict[str, str]


### PR DESCRIPTION
The log that prints 'Total filtered nodes' printed the incorrect value (the total nodes instead of the actual filtered nodes).