### PR TITLE
Detach dbt vars used to render DAGs from the operator args'

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -268,9 +268,6 @@ class DbtToAirflowConverter:
         override_configuration(project_config, render_config, execution_config, operator_args)
         validate_changed_config_paths(execution_config, project_config, render_config)
 
-        env_vars = project_config.env_vars or operator_args.get("env")
-        dbt_vars = project_config.dbt_vars or operator_args.get("vars")
-
         if execution_config.execution_mode != ExecutionMode.VIRTUALENV and execution_config.virtualenv_dir is not None:
             logger.warning(
                 "`ExecutionConfig.virtualenv_dir` is only supported when \
@@ -291,7 +288,7 @@ class DbtToAirflowConverter:
             profile_config=profile_config,
             cache_dir=cache_dir,
             cache_identifier=cache_identifier,
-            dbt_vars=dbt_vars,
+            dbt_vars=project_config.dbt_vars,
             airflow_metadata=cache._get_airflow_metadata(dag, task_group),
         )
         self.dbt_graph.load(method=render_config.load_method, execution_mode=execution_config.execution_mode)
@@ -303,6 +300,8 @@ class DbtToAirflowConverter:
         )
         previous_time = current_time
 
+        env_vars = project_config.env_vars or operator_args.get("env")
+        dbt_vars = project_config.dbt_vars or operator_args.get("vars")
         task_args = {
             **operator_args,
             "project_dir": execution_config.project_path,

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -161,16 +161,6 @@ def validate_initial_user_config(
             DeprecationWarning,
         )
 
-    if "vars" in operator_args:
-        # TODO: remove the following in a separate PR
-        warn(
-            "operator_args with 'vars' is deprecated since Cosmos 1.3 and will be removed in Cosmos 2.0. Use ProjectConfig.vars instead.",
-            DeprecationWarning,
-        )
-        if project_config.dbt_vars:
-            raise CosmosValueError(
-                "ProjectConfig.dbt_vars and operator_args with 'vars' are mutually exclusive and only one can be used."
-            )
     # Cosmos 2.0 will remove the ability to pass RenderConfig.env_vars in place of ProjectConfig.env_vars, check that both are not set.
     if project_config.env_vars and render_config.env_vars:
         raise CosmosValueError(
@@ -300,8 +290,8 @@ class DbtToAirflowConverter:
         )
         previous_time = current_time
 
-        env_vars = project_config.env_vars or operator_args.get("env")
-        dbt_vars = project_config.dbt_vars or operator_args.get("vars")
+        env_vars = operator_args.get("env") or project_config.env_vars
+        dbt_vars = operator_args.get("vars") or project_config.dbt_vars
         task_args = {
             **operator_args,
             "project_dir": execution_config.project_path,

--- a/docs/configuration/operator-args.rst
+++ b/docs/configuration/operator-args.rst
@@ -92,7 +92,7 @@ dbt-related
 - ``models``: Specifies which nodes to include.
 - ``no_version_check``: If set, skip ensuring ``dbt``'s version matches the one specified in the ``dbt_project.yml``.
 - ``quiet``: run ``dbt`` in silent mode, only displaying its error logs.
-- ``vars``: Supply dbt variables to run the task using dbt project. This argument overrides variables defined in the ``dbt_project.yml`` and any values set in ``ProjectConfig.dbt_vars``.
+- ``vars``: Supply dbt variables to run the task using dbt project. This argument overrides variables defined in the ``dbt_project.yml`` and any values set in ``ProjectConfig.dbt_vars``. Arguments set as dbt ``vars`` in ``operators_args`` will not be used to render the DAG when using `LoadMode.DBT_LS`. Use  ``ProjectConfig.dbt_vars`` instead for this use-case.
 - ``warn_error``: convert ``dbt`` warnings into errors.
 - ``full_refresh``: If True, then full refresh the node. This only applies to model and seed nodes.
 - ``install_deps``: (deprecated in v1.9, use ``ProjectConfig.install_dbt_deps`` onwards) When using ``ExecutionMode.LOCAL`` or ``ExecutionMode.VIRTUALENV``, run ``dbt deps`` every time a task is executed.

--- a/docs/configuration/operator-args.rst
+++ b/docs/configuration/operator-args.rst
@@ -92,7 +92,7 @@ dbt-related
 - ``models``: Specifies which nodes to include.
 - ``no_version_check``: If set, skip ensuring ``dbt``'s version matches the one specified in the ``dbt_project.yml``.
 - ``quiet``: run ``dbt`` in silent mode, only displaying its error logs.
-- ``vars``: Supply dbt variables to run the task using dbt project. This argument overrides variables defined in the ``dbt_project.yml`` and any values set in ``ProjectConfig.dbt_vars``. Arguments set as dbt ``vars`` in ``operators_args`` will not be used to render the DAG when using `LoadMode.DBT_LS`. Use  ``ProjectConfig.dbt_vars`` instead for this use-case.
+- ``vars``: Supply dbt variables to run the task using dbt project. This argument overrides variables defined in the ``dbt_project.yml`` and any values set in ``ProjectConfig.dbt_vars``. Arguments set as dbt ``vars`` in ``operators_args`` will not be used to render the DAG when using ``LoadMode.DBT_LS``. Use  ``ProjectConfig.dbt_vars`` instead for this use-case.
 - ``warn_error``: convert ``dbt`` warnings into errors.
 - ``full_refresh``: If True, then full refresh the node. This only applies to model and seed nodes.
 - ``install_deps``: (deprecated in v1.9, use ``ProjectConfig.install_dbt_deps`` onwards) When using ``ExecutionMode.LOCAL`` or ``ExecutionMode.VIRTUALENV``, run ``dbt deps`` every time a task is executed.

--- a/docs/configuration/operator-args.rst
+++ b/docs/configuration/operator-args.rst
@@ -92,7 +92,7 @@ dbt-related
 - ``models``: Specifies which nodes to include.
 - ``no_version_check``: If set, skip ensuring ``dbt``'s version matches the one specified in the ``dbt_project.yml``.
 - ``quiet``: run ``dbt`` in silent mode, only displaying its error logs.
-- ``vars``: (Deprecated since Cosmos 1.3 use ``ProjectConfig.dbt_vars`` instead) Supply variables to the project. This argument overrides variables defined in the ``dbt_project.yml``.
+- ``vars``: Supply dbt variables to run the task using dbt project. This argument overrides variables defined in the ``dbt_project.yml`` and any values set in ``ProjectConfig.dbt_vars``.
 - ``warn_error``: convert ``dbt`` warnings into errors.
 - ``full_refresh``: If True, then full refresh the node. This only applies to model and seed nodes.
 - ``install_deps``: (deprecated in v1.9, use ``ProjectConfig.install_dbt_deps`` onwards) When using ``ExecutionMode.LOCAL`` or ``ExecutionMode.VIRTUALENV``, run ``dbt deps`` every time a task is executed.


### PR DESCRIPTION
A DAG that used Jinja templated `operator_args` vars values, that used to work in Cosmos 1.9.0, stopped working in Cosmos 1.9.1. The DAG looked like this:
```
cosmos_dag = DbtDag(
    (...)
    operator_args={
        "vars": """\
            {"execution_date_nodash": {{ (triggering_dataset_events.values() | first | first).source_dag_run.execution_date.strftime('%Y%m%d') }}, \
                "execution_date": {{ (triggering_dataset_events.values() | first | first).source_dag_run.execution_date.strftime('%Y-%m-%d') }} }""",
```

Cosmos 1.9.1 was trying to use `operator_args` `dbt_vars` as dbt vars to during DAG rendering when using `LoadMode.DBT_LS`. This is an example of a error raised:
```
Broken DAG: [/usr/local/airflow/dags/dbt/dbt_firebase.py]
Traceback (most recent call last): |
File "/usr/local/lib/python3.12/site-packages/cosmos/dbt/graph.py", line 266, in run_command
stdout = run_command_with_subprocess(command, tmp_dir, env_vars)
File "/usr/local/lib/python3.12/site-packages/cosmos/dbt/graph.py", line 210, in run_command_with_subprocess raise CosmosLoadDbtException(f'Unable to run {command) due to the error:\n{details]")
cosmos.dbt.graph.CosmosLoadDbtException: Unable to run [/usr/local/airflow/dbt_venv/bin/dbt*, 'Is', '--output', 'json', '--project-dir', '/tmp/tmpvqh98105', '--profiles-dir', '/tmp/cosmos/profile/a430297fc6403bddbfac273a7a67d1ddd676e0e8406 stderr: Usage: dbt Is [OPTIONS]
Try 'dbt Is -h' for help.
Error: Invalid value for '-vars': String "*
(\'execution _date_nodash\": {{ (triggering_dataset_events.values) | first | first).source_dag_run.execution_date.strftime('%Y%m%d*) }}.
l'execution _date\': f{ (triggering_dataset_events.value
stdout: [0m14:12:45 The YAML provided in the --vars argument is not valid.
```

This change may be perceived as breaking, but it is primarily a bug fix. Users can still use `ProjectConfig(dbt_vars)` to set dbt variables that should be used for rendering the DAG when using `LoadMode.DBT_LS`.

We're also making it possible to use different values of `operator_args' vars`, and `RenderConfig` (via `ProjectConfig.dbt_vars`).

Closes: #1618