### PR TITLE
Support filtering by config meta nested properties

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -231,9 +231,9 @@ class GraphSelector:
 
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
-            # currently tags, materialized, and schema are the only supported config keys
+            # currently tags, materialized, schema and meta are the only supported config keys
             # logic is separated into two conditions because the config 'tags' contains a
-            # list of tags, but the config 'materialized', and 'schema' contain strings
+            # list of tags, the config 'materialized' & 'schema' contain strings and meta contains dictionaries
             if config_selection_key == "tags":
                 root_nodes.update(
                     {

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -258,7 +258,7 @@ class GraphSelector:
                     {
                         node_id
                         for node_id, node in nodes.items()
-                        if _check_nested_value_in_dict(node.config, config_selection_key)
+                        if _check_nested_value_in_dict(node.config, f"{config_selection_key}:{config_selection_value}")
                     }
                 )
             else:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -504,7 +504,7 @@ class NodeSelector:
                 config.pop(key)
         return True
 
-    def _should_include_based_on_config(self, node: DbtNode, config: dict[Any, Any]) -> bool:
+    def _should_include_based_on_non_meta_and_non_tag_config(self, node: DbtNode, config: dict[Any, Any]) -> bool:
         node_non_meta_or_tag_config = {
             key: value
             for key, value in node.config.items()
@@ -548,9 +548,9 @@ class NodeSelector:
         config_copy.pop("tags", None)
 
         # Handle other config attributes, including meta and general config
-        if not self._should_include_based_on_meta(node, config_copy) or not self._should_include_based_on_config(
+        if not self._should_include_based_on_meta(
             node, config_copy
-        ):
+        ) or not self._should_include_based_on_non_meta_and_non_tag_config(node, config_copy):
             return False
 
         if self.config.paths and not self._is_path_matching(node):

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -15,7 +15,8 @@ if TYPE_CHECKING:
     from cosmos.dbt.graph import DbtNode
 
 
-SUPPORTED_CONFIG = ["materialized", "schema", "tags"]
+CONFIG_META_PATH = "meta"
+SUPPORTED_CONFIG = ["materialized", "schema", "tags", CONFIG_META_PATH]
 PATH_SELECTOR = "path:"
 TAG_SELECTOR = "tag:"
 CONFIG_SELECTOR = "config."
@@ -27,6 +28,39 @@ AT_SELECTOR = "@"
 GRAPH_SELECTOR_REGEX = r"^(@|[0-9]*\+)?([^\+]+)(\+[0-9]*)?$|"
 
 logger = get_logger(__name__)
+
+
+def _check_nested_value_in_dict(dict_: dict[Any, Any], pattern: str) -> bool:
+    """
+    Given a dictionary dict_, identify if the pattern defined in pattern happens on the dictionary.
+
+    :param dict_: a dictionary
+    :param pattern: a string containing a dotted path that reference dictionary keys and a value (e.g.  "config.meta.frequency:daily")
+    :return: True/False if the desired pattern happens or not in the dictionary
+
+
+    Example:
+        dict_ = {
+            "config": {
+                "meta": {
+                    "frequency": "daily"
+                }
+            }
+        pattern = "config.meta.frequency:daily"
+        assert self._check_nested_value_in_dict(dict_, pattern)
+
+    """
+    keys, expected_value = pattern.split(":")
+    keys_values = keys.split(".")
+
+    current: dict[Any, Any] | str = dict_
+    for key in keys_values:
+        if isinstance(current, dict) and key in current:
+            current = current[key]
+        elif isinstance(current, str) and current == expected_value:
+            return True
+
+    return False  # Key path doesn't exist or doesn't have the expected value
 
 
 @dataclass
@@ -196,13 +230,10 @@ class GraphSelector:
 
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
-            if config_selection_key not in SUPPORTED_CONFIG:
-                logger.warning("Unsupported config key selector: %s", config_selection_key)
-
             # currently tags, materialized, and schema are the only supported config keys
             # logic is separated into two conditions because the config 'tags' contains a
             # list of tags, but the config 'materialized', and 'schema' contain strings
-            elif config_selection_key == "tags":
+            if config_selection_key == "tags":
                 root_nodes.update(
                     {
                         node_id
@@ -221,7 +252,16 @@ class GraphSelector:
                         if config_selection_value == node.config.get(config_selection_key, "")
                     }
                 )
-
+            elif config_selection_key.startswith(CONFIG_META_PATH):
+                root_nodes.update(
+                    {
+                        node_id
+                        for node_id, node in nodes.items()
+                        if _check_nested_value_in_dict(node.config, config_selection_key)
+                    }
+                )
+            else:
+                logger.warning("Unsupported config key selector: %s", config_selection_key)
         else:
             node_by_name = {}
             for node_id, node in nodes.items():
@@ -362,7 +402,8 @@ class SelectorConfig:
     def _parse_config_selector(self, item: str) -> None:
         index = len(CONFIG_SELECTOR)
         key, value = item[index:].split(":")
-        if key in SUPPORTED_CONFIG:
+
+        if key in SUPPORTED_CONFIG or key.startswith(CONFIG_META_PATH):
             self.config[key] = value
 
     def _parse_tag_selector(self, item: str) -> None:
@@ -451,6 +492,17 @@ class NodeSelector:
         self.selected_nodes = selected_nodes
         return selected_nodes
 
+    def _should_include_based_on_meta(self, node: DbtNode, config: dict[Any, Any]) -> bool:
+
+        # Deal with meta properties
+        selector_meta_patterns = {key: value for key, value in config.items() if key.startswith(CONFIG_META_PATH)}
+        if selector_meta_patterns:
+            for key, value in selector_meta_patterns.items():
+                if not _check_nested_value_in_dict(node.config, f"{key}:{value}"):
+                    return False
+                config.pop(key)
+        return True
+
     def _should_include_node(self, node_id: str, node: DbtNode) -> bool:
         """
         Checks if a single node should be included. Only runs once per node with caching."""
@@ -476,17 +528,21 @@ class NodeSelector:
             logger.debug("Excluding node <%s>", node_id)
             return False
 
-        node_config = {key: value for key, value in node.config.items() if key in SUPPORTED_CONFIG}
-
-        if not self._is_config_subset(node_config):
-            return False
-
         # Remove 'tags' as they've already been filtered for
         config_copy = copy.deepcopy(self.config.config)
         config_copy.pop("tags", None)
-        node_config.pop("tags", None)
 
-        if not (config_copy.items() <= node_config.items()):
+        if not self._should_include_based_on_meta(node, config_copy):
+            return False
+
+        # Handle config that is not tags nor meta
+        node_non_meta_or_tag_config = {
+            key: value
+            for key, value in node.config.items()
+            if key in SUPPORTED_CONFIG and key != "tag" and not key.startswith(CONFIG_META_PATH)
+        }
+
+        if not (config_copy.items() <= node_non_meta_or_tag_config.items()):
             return False
 
         if self.config.paths and not self._is_path_matching(node):
@@ -525,13 +581,11 @@ class NodeSelector:
         """Checks if the node's tags are a subset of the config's tags."""
         if not (set(self.config.tags) <= set(node.tags)):
             return False
-        return True
 
-    def _is_config_subset(self, node_config: dict[str, Any]) -> bool:
-        """Checks if the node's config is a subset of the config's config."""
         config_tags = self.config.config.get("tags")
-        if config_tags and config_tags not in node_config.get("tags", []):
+        if config_tags and not set(config_tags) <= set(node.config.get("tags", [])):
             return False
+
         return True
 
     def _is_path_matching(self, node: DbtNode) -> bool:
@@ -650,7 +704,7 @@ def validate_filters(exclude: list[str], select: list[str]) -> None:
                 or filter_parameter.startswith(EXCLUDE_RESOURCE_TYPE_SELECTOR)
                 or filter_parameter.startswith(SOURCE_SELECTOR)
                 or PLUS_SELECTOR in filter_parameter
-                or any([filter_parameter.startswith(CONFIG_SELECTOR + config + ":") for config in SUPPORTED_CONFIG])
+                or any([filter_parameter.startswith(CONFIG_SELECTOR + config) for config in SUPPORTED_CONFIG])
             ):
                 continue
             elif ":" in filter_parameter:

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -14,6 +14,7 @@ Using ``select`` and ``exclude``
 The ``select`` and ``exclude`` parameters are lists, with values like the following:
 
 - ``tag:my_tag``: include/exclude models with the tag ``my_tag``
+- ``config.meta.some_key:some_value``: include/exclude models with ``config.meta_some_key: some_value``
 - ``config.materialized:table``: include/exclude models with the config ``materialized: table``
 - ``path:analytics/tables``: include/exclude models in the ``analytics/tables`` directory. In this example, ``analytics/table`` is a relative path, but absolute paths are also supported.
 - ``+node_name+1`` (graph operators): include/exclude the node with name ``node_name``, all its parents, and its first generation of children (`dbt graph selector docs <https://docs.getdbt.com/reference/node-selection/graph-operators>`_)

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -214,6 +214,15 @@ def test_select_nodes_by_select_union_config_test_tags():
     assert selected == expected
 
 
+def test_select_nodes_by_invalid_config(caplog):
+    select_nodes(
+        project_dir=SAMPLE_PROJ_PATH,
+        nodes=sample_nodes,
+        select=["config.invalid_config:test+"],
+    )
+    assert "Unsupported config key selector: invalid_config" in caplog.messages
+
+
 def test_select_nodes_by_select_intersection_tag():
     selected = select_nodes(
         project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["tag:is_child,config.materialized:view"]

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -52,7 +52,7 @@ another_grandparent_node = DbtNode(
     depends_on=[],
     file_path=SAMPLE_PROJ_PATH / "gen1/models/another_grandparent_node.sql",
     tags=[],
-    config={},
+    config={"meta": {"frequency": "daily"}},
 )
 
 parent_node = DbtNode(
@@ -136,6 +136,12 @@ def test_select_nodes_by_select_config():
         sibling2_node.unique_id: sibling2_node,
         sibling3_node.unique_id: sibling3_node,
     }
+    assert selected == expected
+
+
+def test_select_nodes_by_select_config_meta_nested_property():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.meta.frequency:daily"])
+    expected = {another_grandparent_node.unique_id: another_grandparent_node}
     assert selected == expected
 
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -145,6 +145,39 @@ def test_select_nodes_by_select_config_meta_nested_property():
     assert selected == expected
 
 
+def test_select_nodes_by_select_config_meta_nested_property_with_children():
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.meta.frequency:daily+"])
+    expected = {
+        another_grandparent_node.unique_id: another_grandparent_node,
+        parent_node.unique_id: parent_node,
+        child_node.unique_id: child_node,
+        sibling1_node.unique_id: sibling1_node,
+        sibling2_node.unique_id: sibling2_node,
+        sibling3_node.unique_id: sibling3_node,
+    }
+    assert selected == expected
+
+
+def test_select_nodes_by_select_config_meta_nested_property_two_meta_values():
+    local_nodes = dict(sample_nodes)
+    someone_else_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.someone_else",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        file_path=SAMPLE_PROJ_PATH / "gen1/models/someone_else.sql",
+        tags=[],
+        config={"meta": {"frequency": "daily", "dbt_environment": "dev"}},
+    )
+    local_nodes[someone_else_node.unique_id] = someone_else_node
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH,
+        nodes=local_nodes,
+        select=["config.meta.frequency:daily,config.meta.dbt_environment:dev"],
+    )
+    expected = {someone_else_node.unique_id: someone_else_node}
+    assert selected == expected
+
+
 def test_select_nodes_by_select_config_tag():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["config.tags:is_child"])
     expected = {


### PR DESCRIPTION
Allow users to use `select` and `exclude` based on `config.meta` when using `LoadMode.MANIFEST`.

An Astro Customer request reported in: https://astronomer.slack.com/archives/C027CNLBGG7/p1741967575692289?thread_ts=1741881283.263679&cid=C027CNLBGG7.

> For the selector issue, it has to do with the model tagging I mentioned above. Right now, with tags, if a user set the following tags in the `dbt_project.yml`:
> ```
> models:
>   +tags=["core_models", "daily"]
> ```
> but they have a model under models/ that needs to run monthly, so they set the following in the model config block:
> ```
> {{
>   config(
>    tags=["monthly"]
>  )
>}}
>```
> That specific model ends up with the following tags: ["core_models", "daily", "monthly"] . This is because tags are additive when applied this way. With the way our Cosmos configs are setup (daily dag provided as an example):
>```render_config=RenderConfig(
>  load_method=LoadMode.DBT_MANIFEST,
>  select=["tag:core_models", "tag:daily"],
>  exclude=[
>    "tag:hourly",
>    "tag:weekly",
>    "tag:monthly",
>    "tag:static",
>    "tag:analyst_scheduled",
>  ],
>)
> ```
> This would prevent the task that's supposed to run monthly from ever being scheduled.
> Since selects are additive, we can't just have:
>
> ```render_config=RenderConfig(
>  load_method=LoadMode.DBT_MANIFEST,
>  select=["tag:core_models", "tag:daily"],
>)
>```
> as this would pull all models with either core_models or daily tags, which isn't our desired goal.
> In order to resolve this, we are discussing avenues to define the dbt_environment and frequency in a more unique way. Our current thought process is to utilize the meta section of the model config and set the following for models:
>
>```models:
>  <model-dir>:
>    +meta: {
>      "dbt_environment": "<dbt_environment>",
>      "frequency": "<frequency>"
>    }
>```
>This way, we can define defaults in the dbt_project.yml, but then override at a lower granularity when need be. However, in order for this to work with cosmos, we need the ability to select models based on this config, something like config:meta.dbt_environment and config:meta.frequency. Based on our limited testing, this didn't seem possible with `DBT_MANIFEST` load method, but did seem possible with `DBT_LS`

Closes: #1619