### PR TITLE
Kubernetes Operator argument fix

### DIFF
--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -41,13 +41,11 @@ with DAG(
     schedule_interval="@daily",
     doc_md=__doc__,
     catchup=False,
-    default_args={
-        "retries": 2,
-        "project_dir": DBT_ROOT_PATH / "jaffle_shop",
-    },
+    default_args={"retries": 2},
 ) as dag:
     generate_dbt_docs_aws = DbtDocsS3Operator(
         task_id="generate_dbt_docs_aws",
+        project_dir=DBT_ROOT_PATH / "jaffle_shop",
         profile_config=profile_config,
         connection_id="aws_s3_conn",
         bucket_name="cosmos-ci-docs",

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -41,11 +41,13 @@ with DAG(
     schedule_interval="@daily",
     doc_md=__doc__,
     catchup=False,
-    default_args={"retries": 2},
+    default_args={
+        "retries": 2,
+        "project_dir": DBT_ROOT_PATH / "jaffle_shop",
+    },
 ) as dag:
     generate_dbt_docs_aws = DbtDocsS3Operator(
         task_id="generate_dbt_docs_aws",
-        project_dir=DBT_ROOT_PATH / "jaffle_shop",
         profile_config=profile_config,
         connection_id="aws_s3_conn",
         bucket_name="cosmos-ci-docs",


### PR DESCRIPTION
## Description
Cosmos 1.9.0 introduced a change such that `AbstractDbtBase` no longer inherits from airflow `BaseOperator` and I believe this introduced two bugs.

- In the past you could give arguments using airflows `default_args` and these would end up being passed to cosmos.  So for example we were specifying the `project_dir` as a default arg, and in 1.9.0 these projects were broken because AbstractDbtBase was not longer getting a project_dir specified.   So the first change is to check both kwargs and default_args for the values AbstractDbtBase requires.  I've only made this change for the kubernetes operator, but I'd argue it should be done for the local a docker ones too.
- The existing code tries to inspect `KubernetesPodOperator` for the args that it requires, but notably this approach misses arguments that are required by `BaseOperator`, e.g. the task_group.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
