### PR TITLE
Support rendering DbtDag in Airflow 3

### DIFF
--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 import importlib
 from copy import deepcopy
 
-from airflow.models import BaseOperator
+try:  # Airflow 3
+    from airflow.sdk.bases.operator import BaseOperator
+except ImportError:  # Airflow 2
+    from airflow.models import BaseOperator
 from airflow.models.dag import DAG
 from airflow.utils.task_group import TaskGroup
 

--- a/cosmos/operators/_asynchronous/databricks.py
+++ b/cosmos/operators/_asynchronous/databricks.py
@@ -3,11 +3,14 @@ from __future__ import annotations
 
 from typing import Any
 
-from airflow.models.baseoperator import BaseOperator
+try:  # Airflow 3
+    from airflow.sdk.bases.operator import BaseOperator
+except ImportError:  # Airflow 2
+    from airflow.models import BaseOperator
 from airflow.utils.context import Context
 
 
-class DbtRunAirflowAsyncDatabricksOperator(BaseOperator):
+class DbtRunAirflowAsyncDatabricksOperator(BaseOperator):  # type: ignore[misc]
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -17,7 +17,11 @@ import airflow
 import jinja2
 from airflow import DAG
 from airflow.exceptions import AirflowException, AirflowSkipException
-from airflow.models import BaseOperator
+
+try:  # Airflow 3
+    from airflow.sdk.bases.operator import BaseOperator
+except ImportError:  # Airflow 2
+    from airflow.models import BaseOperator
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.context import Context
 from airflow.version import version as airflow_version
@@ -735,7 +739,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.subprocess_hook.send_sigterm()
 
 
-class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
+class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[misc]
 
     template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields  # type: ignore[operator]
 

--- a/scripts/airflow3/dags/basic_cosmos_dag.py
+++ b/scripts/airflow3/dags/basic_cosmos_dag.py
@@ -1,0 +1,45 @@
+"""
+An example DAG that uses Cosmos to render a dbt project into an Airflow DAG.
+"""
+
+import os
+from datetime import datetime
+from pathlib import Path
+
+from cosmos import DbtDag, ProfileConfig, ProjectConfig
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent.parent.parent.parent / "dev/dags/dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
+DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
+DBT_ARTIFACT = DBT_PROJ_DIR / "target"
+MANIFEST_PATH = DBT_ARTIFACT / "manifest.json"
+
+project_config = ProjectConfig(
+    dbt_project_path=DBT_PROJ_DIR,
+    project_name="jaffle_shop",
+)
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profiles_yml_filepath=DBT_PROFILE_PATH,
+)
+
+# [START local_example]
+basic_cosmos_dag = DbtDag(
+    # dbt/cosmos-specific parameters
+    project_config=project_config,
+    profile_config=profile_config,
+    operator_args={
+        "install_deps": True,  # install any necessary dependencies before running any dbt command
+        "full_refresh": True,  # used only in dbt commands that support this flag
+    },
+    # normal dag parameters
+    schedule="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="basic_cosmos_dag",
+    default_args={"retries": 2},
+)
+# [END local_example]


### PR DESCRIPTION
Add necessary changes so we can render Cosmos `DbtDag` using `LoadMode.DBT_LS` when using Airflow 3 main branch  (commit 9d6bebe9690a3f21a00044c0aeceaded86484a0c).

Previously, we were unable to run the DAG:
```
import os
from datetime import datetime
from pathlib import Path
from airflow.models import Variable

from cosmos import DbtDag, ExecutionConfig, LoadMode, ProfileConfig, ProjectConfig, RenderConfig, TestBehavior

DEFAULT_DBT_ROOT_PATH = Path(__file__).parent.parent.parent.parent / "dev/dags/dbt"
DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
DBT_ARTIFACT = DBT_PROJ_DIR / "target"

project_config = ProjectConfig(
    dbt_project_path=DBT_PROJ_DIR,
    project_name="jaffle_shop",
)

profile_config = ProfileConfig(
    profile_name="default",
    target_name="dev",
    profiles_yml_filepath=DBT_PROFILE_PATH,
)

basic_cosmos_dag = DbtDag(
    # dbt/cosmos-specific parameters
    project_config=project_config,
    profile_config=profile_config,
    operator_args={
        "install_deps": True,  # install any necessary dependencies before running any dbt command
        "full_refresh": True,  # used only in dbt commands that support this flag
    },
    # normal dag parameters
    schedule="@daily",
    start_date=datetime(2023, 1, 1),
    catchup=False,
    dag_id="basic_cosmos_dag",
    default_args={
```

It would raise the following exception when we attempted to run `airflow dags reserialize`:
```
i  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/airflow/graph.py", line 592, in build_airflow_graph
    task_or_group = conversion_function(  # type: ignore
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/airflow/graph.py", line 391, in generate_task_or_group
    task >> test_task
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv-af3-main/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/mixins.py", line 97, in __rshift__
    self.set_downstream(other)
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv-af3-main/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/node.py", line 216, in set_downstream
    self._set_relatives(task_or_task_list, upstream=False, edge_modifier=edge_modifier)
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/venv-af3-main/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/node.py", line 186, in _set_relatives
    raise ValueError(
ValueError: Tried to create relationships between tasks that don't have DAGs yet. Set the DAG for at least one task and try again: [<Task(DbtRunLocalOperator): run>, <Task(DbtTestLocalOperator): test>]
```

This issue happened due to an interface change in Airflow 3's `BaseOperator`, that would lead the line:
```
base_operator_args = set(inspect.signature(BaseOperator.__init__).parameters.keys())
```

To return zero arguments.

This was solved by changing the import path:

```
try:  # Airflow 3
    from airflow.sdk.bases.operator import BaseOperator
except ImportError:  # Airflow 2
    from airflow.models import BaseOperator
```

After these changes, we were able to successfully run:
- `airflow dags reserialize`
- `airflow dags test basic_cosmos_dag`

Co-authored-by: Ash Berlin-Taylor <ash@astronomer.io>