### PR TITLE
Add .gitignore file for the scripts/airflow3 directory

### DIFF
--- a/scripts/airflow3/.gitignore
+++ b/scripts/airflow3/.gitignore
@@ -1,0 +1,4 @@
+airflow.db-shm
+airflow.db-wal
+simple_auth_manager_passwords.json.generated
+venv-af3


### PR DESCRIPTION
Upon running few airflow cli commands in the airflow3 setup, I see a few files getting created along with the virtual env directory which I believe we don't need to checkin. Hence, adding a .gitignore for the same