### PR TITLE
Skip associating 'openlineage_events_completes' to 'ti' in AF3

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -559,7 +559,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                     env=env,
                     cwd=tmp_project_dir,
                 )
-                if is_openlineage_available:
+                if is_openlineage_available and AIRFLOW_VERSION.major < _AIRFLOW3_VERSION.major:
+                    # Airflow 3 does not support associating 'openlineage_events_completes' with task_instance. The
+                    # support for this is expected to be worked upon while addressing issue:
+                    # https://github.com/astronomer/astronomer-cosmos/issues/1635
                     self.calculate_openlineage_events_completes(env, tmp_dir_path)
                     context[
                         "task_instance"


### PR DESCRIPTION
Airflow 3 raises an error when attempting to associate openlineage_events_completes with the task instance, saying that the attribute does not exist on `ti`. The intended functionality to support the requirements is expected to be worked around  while addressing issue #1635.

In the meantime, to avoid compatibility issues, this block of code is conditionally skipped when running on Airflow 3.