### PR TITLE
Check only major version until AF3 stable release

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -168,4 +168,4 @@ TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetr
 TELEMETRY_VERSION = "v1"
 TELEMETRY_TIMEOUT = 1.0
 
-_AIRFLOW3_VERSION = Version("3.0.0a1")
+_AIRFLOW3_MAJOR_VERSION = 3

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -35,7 +35,7 @@ from cosmos.cache import (
     _get_latest_cached_package_lockfile,
     is_cache_package_lockfile_enabled,
 )
-from cosmos.constants import _AIRFLOW3_VERSION, FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, InvocationMode
+from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, InvocationMode
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.dbt.project import get_partial_parse_path, has_non_empty_dependencies_file
 from cosmos.exceptions import AirflowCompatibilityError, CosmosDbtRunError, CosmosValueError
@@ -481,7 +481,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         outlets = self.get_datasets("outputs")
         self.log.info("Inlets: %s", inlets)
         self.log.info("Outlets: %s", outlets)
-        if AIRFLOW_VERSION < _AIRFLOW3_VERSION:
+        if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
             self.register_dataset(inlets, outlets, context)
 
     def _update_partial_parse_cache(self, tmp_dir_path: Path) -> None:
@@ -492,7 +492,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             cache._update_partial_parse_cache(partial_parse_file, self.cache_dir)
 
     def _handle_post_execution(self, tmp_project_dir: str, context: Context) -> None:
-        if AIRFLOW_VERSION < _AIRFLOW3_VERSION:
+        if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
             self.store_freshness_json(tmp_project_dir, context)
             self.store_compiled_sql(tmp_project_dir, context)
         if self.should_upload_compiled_sql:
@@ -559,7 +559,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                     env=env,
                     cwd=tmp_project_dir,
                 )
-                if is_openlineage_available and AIRFLOW_VERSION.major < _AIRFLOW3_VERSION.major:
+                if is_openlineage_available and AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
                     # Airflow 3 does not support associating 'openlineage_events_completes' with task_instance. The
                     # support for this is expected to be worked upon while addressing issue:
                     # https://github.com/astronomer/astronomer-cosmos/issues/1635
@@ -766,7 +766,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
             if arg_key in base_operator_args:
                 base_operator_kwargs[arg_key] = arg_value
         AbstractDbtLocalBase.__init__(self, **abstract_dbt_local_base_kwargs)
-        if AIRFLOW_VERSION < _AIRFLOW3_VERSION:
+        if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
             if (
                 kwargs.get("emit_datasets", True)
                 and settings.enable_dataset_alias


### PR DESCRIPTION
When running the Cosmos DAG with runtime-image AF 3 using astro-cli, it seems to be trying to access the database because some condition checks are unintentionally returning true

```python
>>> from packaging.version import Version
>>> _AIRFLOW3_VERSION1 = Version("3.0.0a1")
>>> _AIRFLOW3_VERSION2 = Version("3.0.0.dev202504070002")
>>> _AIRFLOW3_VERSION2 < _AIRFLOW3_VERSION1
True
>>>
```