### PR TITLE
Fix prepare_env top-level import for AF3

### DIFF
--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -8,7 +8,11 @@ from tempfile import TemporaryDirectory
 from typing import TYPE_CHECKING, Any, Callable, Sequence
 
 import psutil
-from airflow.utils.python_virtualenv import prepare_virtualenv
+
+try:  # Airflow 3
+    from airflow.providers.standard.utils.python_virtualenv import prepare_virtualenv
+except ImportError:  # Airflow 2
+    from airflow.utils.python_virtualenv import prepare_virtualenv
 
 from cosmos import settings
 from cosmos.constants import InvocationMode


### PR DESCRIPTION
main is currently failing for AF3 after merging PR #1674, with the following error:
```
 File "<frozen importlib._bootstrap>", line 241, in _call_with_frames_removed
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/airflow_async.py", line 8, in <module>
    from cosmos.operators._asynchronous.base import DbtRunAirflowAsyncFactoryOperator
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/_asynchronous/__init__.py", line 12, in <module>
    from cosmos.operators.virtualenv import DbtRunVirtualenvOperator
  File "/Users/tati/Code/cosmos-fresh/astronomer-cosmos/cosmos/operators/virtualenv.py", line 11, in <module>
    from airflow.utils.python_virtualenv import prepare_virtualenv
ModuleNotFoundError: No module named 'airflow.utils.python_virtualenv'
```

(as reported by @tatiana)

It looks like we need to update the import path for the python_virtualenv module. I had the necessary fix locally but didn’t commit it, as I didn’t realize it would break after removing the setup task. However, since it’s a top-level import, it seems we do need to include the fix after all.

