### PR TITLE
Allowing for correct name in select clause in the case of detached tests

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -151,6 +151,8 @@ def create_test_task_metadata(
             task_args["models"] = node.resource_name
         elif node.resource_type == DbtResourceType.SOURCE:
             task_args["select"] = f"source:{node.resource_name}"
+        elif is_detached_test(node):
+            task_args["select"] = node.resource_name.split(".")[0]
         else:  # tested with node.resource_type == DbtResourceType.SEED or DbtResourceType.SNAPSHOT
             task_args["select"] = node.resource_name
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -248,7 +248,7 @@ def test_converter_creates_dag_with_test_with_multiple_parents():
 
     # We should have a task dedicated to run the test with multiple parents
     args = tasks["test.my_dbt_project.custom_test_combined_model_combined_model_.c6e4587380"].build_cmd({})[0]
-    assert args[1:] == ["test", "--select", "custom_test_combined_model_combined_model_.c6e4587380"]
+    assert args[1:] == ["test", "--select", "custom_test_combined_model_combined_model_"]
     assert (
         tasks["test.my_dbt_project.custom_test_combined_model_combined_model_.c6e4587380"].task_id
         == "custom_test_combined_model_combined_model__test"
@@ -420,7 +420,7 @@ def test_converter_creates_dag_with_test_with_multiple_parents_and_build():
 
     # We should have a task dedicated to run the test with multiple parents
     args = tasks["test.my_dbt_project.custom_test_combined_model_combined_model_.c6e4587380"].build_cmd({})[0]
-    assert args[1:] == ["test", "--select", "custom_test_combined_model_combined_model_.c6e4587380"]
+    assert args[1:] == ["test", "--select", "custom_test_combined_model_combined_model_"]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

The select wasn't taking into account the ".{id}" appended to detached schema tests like some other functions were, so the tests weren't actually running.  

Log before fix:
```
[2025-04-18, 20:08:08 UTC] {runner.py:60} INFO - Trying to run dbtRunner with:
 ['--no-partial-parse', 'test', '--select', 'relationships_model_2__id___id__ref_model_1_.f3f13d987e', '--exclude', 'resource_type:unit_test', '--project-dir', '/tmp/tmp28m6jm0w', '--profiles-dir', '/tmp/cosmos/profile/850783cbc19c58b0833e4e41dfbea8c4640ee8833a0c0f8a647eadb98d09321b', '--profile', 'test_profile', '--target', 'local']
 in /tmp/tmp28m6jm0w
[2025-04-18, 20:08:08 UTC] {logging_mixin.py:190} INFO - 20:08:08  Running with dbt=1.8.4
[2025-04-18, 20:08:09 UTC] {logging_mixin.py:190} INFO - 20:08:09  Registered adapter: bigquery=1.8.2
[2025-04-18, 20:08:10 UTC] {logging_mixin.py:190} INFO - 20:08:10  Found 2 models, 5 data tests, 484 macros
[2025-04-18, 20:08:10 UTC] {logging_mixin.py:190} INFO - 20:08:10  The selection criterion 'relationships_model_2__id___id__ref_model_1_.f3f13d987e' does not match any enabled nodes
[2025-04-18, 20:08:10 UTC] {logging_mixin.py:190} INFO - 20:08:10  The selection criterion 'resource_type:unit_test' does not match any enabled nodes
[2025-04-18, 20:08:10 UTC] {logging_mixin.py:190} INFO - 20:08:10
[2025-04-18, 20:08:10 UTC] {logging_mixin.py:190} INFO - 20:08:10  Nothing to do. Try checking your model configs and model specification args
```

Log after fix:
```
[2025-04-18, 20:15:01 UTC] {runner.py:60} INFO - Trying to run dbtRunner with:
 ['--no-partial-parse', 'test', '--select', 'relationships_model_2__id___id__ref_model_1_', '--exclude', 'resource_type:unit_test', '--project-dir', '/tmp/tmpm5sshv22', '--profiles-dir', '/tmp/cosmos/profile/850783cbc19c58b0833e4e41dfbea8c4640ee8833a0c0f8a647eadb98d09321b', '--profile', 'test_profile', '--target', 'local']
 in /tmp/tmpm5sshv22
[2025-04-18, 20:15:01 UTC] {logging_mixin.py:190} INFO - 20:15:01  Running with dbt=1.8.4
[2025-04-18, 20:15:01 UTC] {logging_mixin.py:190} INFO - 20:15:01  Registered adapter: bigquery=1.8.2
[2025-04-18, 20:15:02 UTC] {logging_mixin.py:190} INFO - 20:15:02  Found 2 models, 5 data tests, 484 macros
[2025-04-18, 20:15:02 UTC] {logging_mixin.py:190} INFO - 20:15:02  The selection criterion 'resource_type:unit_test' does not match any enabled nodes
[2025-04-18, 20:15:02 UTC] {logging_mixin.py:190} INFO - 20:15:02
[2025-04-18, 20:15:03 UTC] {logging_mixin.py:190} INFO - 20:15:03  Concurrency: 1 threads (target='local')
[2025-04-18, 20:15:03 UTC] {logging_mixin.py:190} INFO - 20:15:03
[2025-04-18, 20:15:03 UTC] {logging_mixin.py:190} INFO - 20:15:03  1 of 1 START test relationships_model_2__id___id__ref_model_1_ ................. [RUN]
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04  1 of 1 PASS relationships_model_2__id___id__ref_model_1_ ....................... [PASS in 1.29s]
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04  Finished running 1 test in 0 hours 0 minutes and 1.87 seconds (1.87s).
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04  Completed successfully
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04
[2025-04-18, 20:15:04 UTC] {logging_mixin.py:190} INFO - 20:15:04  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 TOTAL=1
```

## Related Issue(s)

Closes #1679

## Breaking Change?

N/A

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
