### PR TITLE
Allow multiple callbacks

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -160,7 +160,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         invocation_mode: InvocationMode | None = None,
         install_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
-        callback: Callable[[str], None] | None = None,
+        callback: Callable[[str], None] | list[Callable[[str], None]] | None = None,
         callback_args: dict[str, Any] | None = None,
         should_store_compiled_sql: bool = True,
         should_upload_compiled_sql: bool = False,
@@ -508,7 +508,12 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
-            self.callback(tmp_project_dir, **self.callback_args)
+            # handle the scenario where callback is a list of functions instead of a single function
+            if isinstance(self.callback, list):
+                for callback_fn in self.callback:
+                    callback_fn(tmp_project_dir, **self.callback_args)
+            else:
+                self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if async_context.get("teardown_task") and settings.enable_teardown_async_task:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -508,7 +508,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
-            # handle the scenario where callback is a list of functions instead of a single function
             if isinstance(self.callback, list):
                 for callback_fn in self.callback:
                     callback_fn(tmp_project_dir, **self.callback_args)

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1562,3 +1562,23 @@ def test_test_clone_project(create_symlinks_mock, copy_dbt_packages_mock, caplog
     assert f"Cloning project to writable temp directory {tmp_dir_path} from {project_dir}" in caplog.text
     assert "Copying dbt packages to temporary folder." in caplog.text
     assert "Completed copying dbt packages to temporary folder." in caplog.text
+
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_freshness_json")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_compiled_sql")
+@patch("cosmos.operators.local.AbstractDbtLocalBase._override_rtif")
+def test_handle_post_execution_with_multiple_callbacks(mock_override_rtif, mock_store_compiled_sql, mock_store_freshness_json):
+
+    multiple_callbacks = [MagicMock(), MagicMock(), MagicMock()]
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config,
+        task_id="my-task",
+        project_dir="my/dir",
+        callback=multiple_callbacks,
+        callback_args={"arg1": "value1"}
+    )
+
+    context = {"dag_run": MagicMock(), "task": MagicMock()}
+    operator._handle_post_execution("/tmp/project_dir", context)
+
+    for callback_fn in multiple_callbacks:
+        callback_fn.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1563,10 +1563,13 @@ def test_test_clone_project(create_symlinks_mock, copy_dbt_packages_mock, caplog
     assert "Copying dbt packages to temporary folder." in caplog.text
     assert "Completed copying dbt packages to temporary folder." in caplog.text
 
+
 @patch("cosmos.operators.local.AbstractDbtLocalBase.store_freshness_json")
 @patch("cosmos.operators.local.AbstractDbtLocalBase.store_compiled_sql")
 @patch("cosmos.operators.local.AbstractDbtLocalBase._override_rtif")
-def test_handle_post_execution_with_multiple_callbacks(mock_override_rtif, mock_store_compiled_sql, mock_store_freshness_json):
+def test_handle_post_execution_with_multiple_callbacks(
+    mock_override_rtif, mock_store_compiled_sql, mock_store_freshness_json
+):
 
     multiple_callbacks = [MagicMock(), MagicMock(), MagicMock()]
     operator = ConcreteDbtLocalBaseOperator(
@@ -1574,7 +1577,7 @@ def test_handle_post_execution_with_multiple_callbacks(mock_override_rtif, mock_
         task_id="my-task",
         project_dir="my/dir",
         callback=multiple_callbacks,
-        callback_args={"arg1": "value1"}
+        callback_args={"arg1": "value1"},
     )
 
     context = {"dag_run": MagicMock(), "task": MagicMock()}


### PR DESCRIPTION
## Description

During some experimentation with [callbacks](https://astronomer.github.io/astronomer-cosmos/configuration/callbacks.html#example-using-callbacks-with-a-single-operator) I have noticed that we can only use a single callback per time, which can be very limiting if I want to add custom callbacks together with the default ones provided by cosmos.

This PR is very simple and aims to allow multiple callbacks to be passed as a list of functions, that will then be executed sequentially. 

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

Should not be

## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
