### PR TITLE
add MonteCarlo callback example in documentation for importing dbt artifacts

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -160,7 +160,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         invocation_mode: InvocationMode | None = None,
         install_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
-        callback: Callable[[str], None] | list[Callable[[str], None]] | None = None,
+        callback: Callable[[str], None] | None = None,
         callback_args: dict[str, Any] | None = None,
         should_store_compiled_sql: bool = True,
         should_upload_compiled_sql: bool = False,
@@ -508,11 +508,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
-            if isinstance(self.callback, list):
-                for callback_fn in self.callback:
-                    callback_fn(tmp_project_dir, **self.callback_args)
-            else:
-                self.callback(tmp_project_dir, **self.callback_args)
+            self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if async_context.get("teardown_task") and settings.enable_teardown_async_task:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -508,7 +508,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self._upload_sql_files(tmp_project_dir, "compiled")
         if self.callback:
             self.callback_args.update({"context": context})
-            # handle the scenario where callback is a list of functions instead of a single function
             if isinstance(self.callback, list):
                 for callback_fn in self.callback:
                     callback_fn(tmp_project_dir, **self.callback_args)

--- a/docs/configuration/callbacks.rst
+++ b/docs/configuration/callbacks.rst
@@ -102,6 +102,77 @@ Below, find an example of a callback method that raises an exception if the quer
 
 Users can use the same approach to call the data observability platform `montecarlo <https://docs.getmontecarlo.com/docs/dbt-core>`_ or other services.
 
+.. code-block:: python
+
+    from pycarlo.core import Client, Session, Query
+    from pycarlo.features.dbt.dbt_importer import DbtImporter
+    from cosmos.log import get_logger
+    from cosmos.exceptions import CosmosValueError
+
+    logger = get_logger(__name__)
+
+    def get_resource_id(client):
+        """Get the resource ID of the first warehouse connected to the user's account"""
+        query = Query()
+        query.get_user().account.warehouses.__fields__("name", "connection_type", "uuid")
+        warehouses = client(query).get_user.account.warehouses
+        warehouse_list = []
+        if len(warehouses) > 0:
+            for val in warehouses:
+                warehouse_list.append(val.uuid)
+        else:
+            logger.error("no warehouses connected ! Please check your Monte Carlo account.")
+        return warehouse_list
+
+    def montecarlo_import_artifacts(
+            project_dir: str,
+            mcd_id: str,
+            mcd_token: str,
+            job_name: str,
+            project_name: str = "default-project",
+            resource_id: str = None,
+            **kwargs
+    ):
+        """
+         An example of a custom callback that import dbt artifacts to Monte Carlo.
+
+        Args:
+        :param project_dir: Path of the project directory used by Cosmos to run the dbt command
+        :param mcd_id: Monte Carlo token user ID
+        :param mcd_token: Monte Carlo token value
+        :param job_name: Job name (required - perhaps a logical sequence of dbt executions)
+        :param project_name: Project name (perhaps a logical group of dbt models)
+        :param resource_id: UUID of the warehouse as described by MonteCarlo. If not specified, the
+                    first warehouse connected to the user's account will be used
+        """
+
+        if not mcd_id or not mcd_token:
+            raise CosmosValueError("Monte Carlo credentials are required to authenticate with MonteCarlo!")
+
+        # create a client with the provided credentials
+        client = Client(session=Session(mcd_id=mcd_id, mcd_token=mcd_token))
+
+        dbt_importer = DbtImporter(mc_client=client)
+
+        target_path = f"{project_dir}/target"
+
+        import_options = {
+            "manifest_path": f"{target_path}/manifest.json",
+            "run_results_path": f"{target_path}/run_results.json",
+            "project_name": project_name,
+            "job_name": job_name
+        }
+
+        if resource_id:
+            import_options["resource_id"] = resource_id
+        else:
+            first_resource_id = get_resource_id(client)[0]
+            import_options["resource_id"] = first_resource_id
+
+        dbt_importer.import_run(**import_options)
+        logger.info("Successfully sent dbt run artifacts to Monte Carlo")
+
+
 Limitations and Contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/configuration/callbacks.rst
+++ b/docs/configuration/callbacks.rst
@@ -138,7 +138,7 @@ Users can use the same approach to call the data observability platform `monteca
                     warehouse_list.append(val.uuid)
             else:
                 raise Exception("no warehouses connected ! Please check your Monte Carlo account.")
-            return warehouse_list
+            return warehouse_list[0]
 
         if not mcd_id or not mcd_token:
             raise Exception("Monte Carlo credentials are required to authenticate with MonteCarlo!")
@@ -159,7 +159,7 @@ Users can use the same approach to call the data observability platform `monteca
         if resource_id:
             import_options["resource_id"] = resource_id
         else:
-            first_resource_id = get_resource_id(client)[0]
+            first_resource_id = get_resource_id(client)
             import_options["resource_id"] = first_resource_id
 
         dbt_importer.import_run(**import_options)

--- a/docs/configuration/callbacks.rst
+++ b/docs/configuration/callbacks.rst
@@ -104,13 +104,13 @@ Users can use the same approach to call the data observability platform `monteca
 
 .. code-block:: python
     def montecarlo_import_artifacts(
-            project_dir: str,
-            mcd_id: str,
-            mcd_token: str,
-            job_name: str,
-            project_name: str = "default-project",
-            resource_id: str = None,
-            **kwargs
+        project_dir: str,
+        mcd_id: str,
+        mcd_token: str,
+        job_name: str,
+        project_name: str = "default-project",
+        resource_id: str = None,
+        **kwargs,
     ):
         """
          An example of a custom callback that import dbt artifacts to Monte Carlo.
@@ -128,20 +128,26 @@ Users can use the same approach to call the data observability platform `monteca
         from pycarlo.features.dbt.dbt_importer import DbtImporter
 
         def get_resource_id(client):
-        """Get the resource ID of the first warehouse connected to the user's account"""
+            """Get the resource ID of the first warehouse connected to the user's account"""
             query = Query()
-            query.get_user().account.warehouses.__fields__("name", "connection_type", "uuid")
+            query.get_user().account.warehouses.__fields__(
+                "name", "connection_type", "uuid"
+            )
             warehouses = client(query).get_user.account.warehouses
             warehouse_list = []
             if len(warehouses) > 0:
                 for val in warehouses:
                     warehouse_list.append(val.uuid)
             else:
-                raise Exception("no warehouses connected ! Please check your Monte Carlo account.")
+                raise Exception(
+                    "no warehouses connected ! Please check your Monte Carlo account."
+                )
             return warehouse_list[0]
 
         if not mcd_id or not mcd_token:
-            raise Exception("Monte Carlo credentials are required to authenticate with MonteCarlo!")
+            raise Exception(
+                "Monte Carlo credentials are required to authenticate with MonteCarlo!"
+            )
 
         client = Client(session=Session(mcd_id=mcd_id, mcd_token=mcd_token))
 
@@ -153,7 +159,7 @@ Users can use the same approach to call the data observability platform `monteca
             "manifest_path": f"{target_path}/manifest.json",
             "run_results_path": f"{target_path}/run_results.json",
             "project_name": project_name,
-            "job_name": job_name
+            "job_name": job_name,
         }
 
         if resource_id:


### PR DESCRIPTION
## Description

Added an extra example on how to import dbt artifacts using montecarlo integration with dbt-core as a callback. The implementation is quite challenging considering the lack of documentation provided by montecarlo itself for the python SDK and after struggling to implement something functional, I believe it is worth having it in the cosmos documentation since the line above the code-block  mentions montecarlo, suggesting that many users would be interested in that.

## Related Issue(s)

## Breaking Change?

No

## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
