### PR TITLE
Set CosmosPlugin to None for airflow 3

### DIFF
--- a/cosmos/plugin/__init__.py
+++ b/cosmos/plugin/__init__.py
@@ -1,11 +1,19 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
 from airflow import __version__ as airflow_version
 from packaging import version
 
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
 
+if TYPE_CHECKING:
+    from .plugin_impl import CosmosPlugin as _CosmosPluginType
+
+CosmosPlugin: _CosmosPluginType | None = None
 # The plugin is only loaded if the Airflow version is less than 3.0. This is because the plugin is incompatible with
 # Airflow 3.0 and above. Once the compatibility issue is resolved as part of
 # https://github.com/astronomer/astronomer-cosmos/issues/1587, the import statement can be moved outside of the
 # conditional block.
 if version.parse(airflow_version).major < _AIRFLOW3_MAJOR_VERSION:
-    from .plugin_impl import CosmosPlugin as CosmosPlugin
+    from .plugin_impl import CosmosPlugin as CosmosPlugin  # type: ignore[assignment]

--- a/cosmos/plugin/__init__.py
+++ b/cosmos/plugin/__init__.py
@@ -7,7 +7,7 @@ from packaging import version
 
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from .plugin_impl import CosmosPlugin as _CosmosPluginType
 
 CosmosPlugin: _CosmosPluginType | None = None

--- a/tests/plugin/test_plugin.py
+++ b/tests/plugin/test_plugin.py
@@ -380,3 +380,7 @@ def test_has_access_with_permissions_in_astro_must_include_custom_menu(url_path,
     mock_check_auth = cosmos.plugin.plugin_impl.dbt_docs_view.appbuilder.sm.check_authorization
     app.get(url_path)
     assert mock_check_auth.call_args[0][0] == [("menu_access", "Custom Menu"), ("can_read", "Website")]
+
+
+def test_cosmos_plugin_enabled_on_airflow2():
+    assert cosmos.plugin.CosmosPlugin is not None

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -1,0 +1,16 @@
+# This module is added specifically to test that the plugin is disabled in Airflow 3.x.
+# Currently, we skip the entire test_plugin.py module since it contains multiple tests that are only compatible with Airflow 2.x.
+# Adding this test to that file would require selectively applying pytest.mark.skipif to each individual test,
+# which would add unnecessary complexity.
+# To keep things straightforward, we isolate the one relevant test for Airflow 3 here,
+# while continuing to skip the existing plugin test module entirely for Airflow 3.x.
+import pytest
+from airflow import __version__ as airflow_version
+from packaging import version
+
+import cosmos.plugin
+
+
+@pytest.mark.skipif(version.parse(airflow_version).major == 2, reason="Plugin is available in Airflow 2.x")
+def test_cosmos_plugin_disabled_on_airflow3():
+    assert cosmos.plugin.CosmosPlugin is None


### PR DESCRIPTION
Interestingly, while working on PR #1692, I didn’t encounter the following error initially. However, something in my environment must have changed—possibly related to the Airflow 3 setup—because I’m now seeing a plugin load error in the `airflow standalone` logs when using a Hatch-managed Airflow 3 environment:

```
dag-processor | [2025-04-25T18:51:24.537+0530] {plugins_manager.py:262} ERROR - Failed to import plugin cosmos
dag-processor | Traceback (most recent call last):
dag-processor | File "/Users/pankajkoti/Library/Application Support/hatch/env/virtual/astronomer-cosmos/D9FI7Men/tests.py3.9-3.0-1.9/lib/python3.9/site-packages/airflow/plugins_manager.py", line 254, in load_entrypoint_plugins
dag-processor | plugin_class = entry_point.load()
dag-processor | File "/Users/pankajkoti/Library/Application Support/hatch/env/virtual/astronomer-cosmos/D9FI7Men/tests.py3.9-3.0-1.9/lib/python3.9/site-packages/importlib_metadata/__init__.py", line 213, in load
dag-processor | return functools.reduce(getattr, attrs, module)
dag-processor | AttributeError: module 'cosmos.plugin' has no attribute 'CosmosPlugin'
```

While this doesn’t block DAG execution or general Airflow usage, I believe it’s still worthwhile to iterate on PR #1692 and explicitly set the plugin to `None` for Airflow 3.x. This avoids the plugin load error altogether.

With that change in place, the error is resolved, and the environment works seamlessly with both Airflow 2 and Airflow 3. I’ve also added a basic sanity check to ensure that CosmosPlugin is either None or properly initialized, depending on the Airflow version in use.

related: #1685 