### PR TITLE
Use `schedule` param in example DAGs instead of 2.10 deprecated and 3.0 removed `schedule_interval`

### DIFF
--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -34,7 +34,7 @@ basic_cosmos_dag = DbtDag(
         "full_refresh": True,  # used only in dbt commands that support this flag
     },
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="basic_cosmos_dag",

--- a/dev/dags/basic_cosmos_task_group_different_owners.py
+++ b/dev/dags/basic_cosmos_task_group_different_owners.py
@@ -28,7 +28,7 @@ profile_config = ProfileConfig(
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
 )

--- a/dev/dags/cosmos_callback_dag.py
+++ b/dev/dags/cosmos_callback_dag.py
@@ -51,7 +51,7 @@ cosmos_callback_dag = DbtDag(
         # --------------------------------------------------------------
     },
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="cosmos_callback_dag",

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -31,7 +31,7 @@ render_config = RenderConfig(load_method=LoadMode.DBT_MANIFEST, select=["path:se
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={"retries": 2},

--- a/dev/dags/cosmos_profile_mapping.py
+++ b/dev/dags/cosmos_profile_mapping.py
@@ -22,7 +22,7 @@ execution_config = ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER)
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
 )

--- a/dev/dags/cosmos_seed_dag.py
+++ b/dev/dags/cosmos_seed_dag.py
@@ -37,7 +37,7 @@ profile_config = ProfileConfig(
 with DAG(
     dag_id="extract_dag",
     start_date=datetime(2022, 11, 27),
-    schedule_interval="@daily",
+    schedule="@daily",
     doc_md=__doc__,
     catchup=False,
     max_active_runs=1,

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -38,7 +38,7 @@ profile_config = ProfileConfig(
 with DAG(
     dag_id="docs_dag",
     start_date=datetime(2023, 1, 1),
-    schedule_interval="@daily",
+    schedule="@daily",
     doc_md=__doc__,
     catchup=False,
     default_args={"retries": 2},

--- a/dev/dags/example_cosmos_cleanup_dag.py
+++ b/dev/dags/example_cosmos_cleanup_dag.py
@@ -12,7 +12,7 @@ from cosmos.cache import delete_unused_dbt_ls_cache, delete_unused_dbt_ls_remote
 
 
 @dag(
-    schedule_interval="0 0 * * 0",  # Runs every Sunday
+    schedule="0 0 * * 0",  # Runs every Sunday
     start_date=datetime(2023, 1, 1),
     catchup=False,
     tags=["example"],

--- a/dev/dags/example_cosmos_dbt_build.py
+++ b/dev/dags/example_cosmos_dbt_build.py
@@ -37,7 +37,7 @@ example_cosmos_dbt_build = DbtDag(
         "full_refresh": True,  # used only in dbt commands that support this flag
     },
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_cosmos_dbt_build",

--- a/dev/dags/example_cosmos_python_models.py
+++ b/dev/dags/example_cosmos_python_models.py
@@ -44,7 +44,7 @@ example_cosmos_python_models = DbtDag(
         "append_env": True,
     },
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_cosmos_python_models",

--- a/dev/dags/example_cosmos_sources.py
+++ b/dev/dags/example_cosmos_sources.py
@@ -80,7 +80,7 @@ example_cosmos_sources = DbtDag(
     profile_config=profile_config,
     render_config=render_config,
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_cosmos_sources",

--- a/dev/dags/example_dbt_deps.py
+++ b/dev/dags/example_dbt_deps.py
@@ -27,7 +27,7 @@ dbt_deps_example_dag = DbtDag(
     project_config=ProjectConfig(DBT_ROOT_PATH / "simple", copy_dbt_packages=True),
     profile_config=profile_config,
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_deps_example",

--- a/dev/dags/example_model_version.py
+++ b/dev/dags/example_model_version.py
@@ -30,7 +30,7 @@ basic_cosmos_dag = DbtDag(
     profile_config=profile_config,
     operator_args={"install_deps": True},
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_model_version",

--- a/dev/dags/example_source_rendering.py
+++ b/dev/dags/example_source_rendering.py
@@ -37,7 +37,7 @@ source_rendering_dag = DbtDag(
     },
     render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2024, 1, 1),
     catchup=False,
     dag_id="source_rendering_dag",

--- a/dev/dags/example_task_mapping.py
+++ b/dev/dags/example_task_mapping.py
@@ -26,7 +26,7 @@ profile_config = ProfileConfig(
 with DAG(
     dag_id="example_task_mapping",
     start_date=datetime(2024, 1, 1),
-    schedule_interval=None,
+    schedule=None,
     catchup=False,
 ) as dag:
 

--- a/dev/dags/example_taskflow.py
+++ b/dev/dags/example_taskflow.py
@@ -28,7 +28,7 @@ def build_partial_dbt_env():
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2024, 1, 1),
     catchup=False,
 )

--- a/dev/dags/example_tasks_map.py
+++ b/dev/dags/example_tasks_map.py
@@ -37,7 +37,7 @@ with DbtDag(
         "full_refresh": True,  # used only in dbt commands that support this flag
     },
     # normal dag parameters
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="customized_cosmos_dag",

--- a/dev/dags/performance_dag.py
+++ b/dev/dags/performance_dag.py
@@ -31,7 +31,7 @@ cosmos_perf_dag = DbtDag(
         dbt_deps=False,
     ),
     # normal dag parameters
-    schedule_interval=None,
+    schedule=None,
     start_date=datetime(2024, 1, 1),
     catchup=False,
     dag_id="performance_dag",

--- a/dev/dags/user_defined_profile.py
+++ b/dev/dags/user_defined_profile.py
@@ -18,7 +18,7 @@ DBT_LS_PATH = Path(DBT_ROOT_PATH, "jaffle_shop", "dbt_ls_models_staging.txt")
 
 
 @dag(
-    schedule_interval="@daily",
+    schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
 )

--- a/tests/operators/test_airflow_async.py
+++ b/tests/operators/test_airflow_async.py
@@ -49,7 +49,7 @@ def test_airflow_async_operator_init(mock_bigquery_conn):
             execution_mode=ExecutionMode.AIRFLOW_ASYNC,
             async_py_requirements=["dbt-bigquery"],
         ),
-        schedule_interval=None,
+        schedule=None,
         start_date=datetime(2023, 1, 1),
         catchup=False,
         dag_id="simple_dag_async",
@@ -75,7 +75,7 @@ def test_airflow_async_operator_init_no_async_py_requirements_raises_error(mock_
             execution_config=ExecutionConfig(
                 execution_mode=ExecutionMode.AIRFLOW_ASYNC,
             ),
-            schedule_interval=None,
+            schedule=None,
             start_date=datetime(2023, 1, 1),
             catchup=False,
             dag_id="simple_dag_async",


### PR DESCRIPTION
Created this isolated PR to alter example DAG changes while working on PR #1646 

related: #1631 
related: #1646 