### PR TITLE
Fix `test_integration_virtualenv_operator`

### DIFF
--- a/dev/dags/example_virtualenv_mini.py
+++ b/dev/dags/example_virtualenv_mini.py
@@ -26,7 +26,7 @@ profile_config = ProfileConfig(
 )
 
 with DAG("example_virtualenv_mini", start_date=datetime(2022, 1, 1)) as dag:
-    pre = BashOperator(task_id="pre", bash_command="mkdir /tmp/persistent-venv2")
+    pre = BashOperator(task_id="pre", bash_command="mkdir -p /tmp/persistent-venv2")
 
     seed_operator = DbtSeedVirtualenvOperator(
         profile_config=profile_config,

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -381,8 +381,6 @@ def test__release_venv_lock_current_process(tmpdir):
     assert not lockfile.exists()
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1707
-@pytest.mark.skipif(AIRFLOW_VERSION.major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.skipif(
     AIRFLOW_VERSION < Version("2.5"),
     reason="This error is only reproducible with dag.test, which was introduced in Airflow 2.5",


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1707

For AF3, it appears that the render_template is attempting to resolve the virtualenv_dir templated field path, which leads to an error during execution.

```
>\nERROR    airflow.sdk.definitions._internal.abstractoperator:abstractoperator.py:382 Exception rendering Jinja template for task \'seed\', field \'virtualenv_dir\'. Template: PosixPath(\'/tmp/persistent-venv2\')\nTraceback (most recent call last):\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/abstractoperator.py", line 379, in _do_render_template_fields\n    rendered_content = self.render_template(value, context, jinja_env, seen_oids)\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/templater.py", line 182, in render_template\n    return resolve(context)\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/pathlib.py", line 1077, in resolve\n    s = self._accessor.realpath(self, strict=strict)\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/posixpath.py", line 396, in realpath\n    path, ok = _joinrealpath(filename[:0], filename, strict, {})\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/posixpath.py", line 431, in _joinrealpath\n    st = os.lstat(newpath)\nFileNotFoundError: [Errno 2] No such file or directory: \'/tmp/persistent-venv2\'\nERROR    airflow.task:taskinstance.py:2457 Task failed with exception\nTraceback (most recent call last):\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 1728, in _run_raw_task\n    TaskInstance._execute_task_with_callbacks(\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 2028, in _execute_task_with_callbacks\n    task_orig = self.render_templates(context=context, jinja_env=jinja_env)\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/models/taskinstance.py", line 2840, in render_templates\n    original_task.render_template_fields(context, jinja_env)\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/sdk/bases/operator.py", line 1558, in render_template_fields\n    self._do_render_template_fields(self, self.template_fields, context, jinja_env, set())\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/abstractoperator.py", line 379, in _do_render_template_fields\n    rendered_content = self.render_template(value, context, jinja_env, seen_oids)\n  File "/home/runner/.local/share/hatch/env/virtual/astronomer-cosmos/Za_bFbg4/tests.py3.10-3.0-1.9/lib/python3.10/site-packages/airflow/sdk/definitions/_internal/templater.py", line 182, in render_template\n    return resolve(context)\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/pathlib.py", line 1077, in resolve\n    s = self._accessor.realpath(self, strict=strict)\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/posixpath.py", line 396, in realpath\n    path, ok = _joinrealpath(filename[:0], filename, strict, {})\n  File "/opt/hostedtoolcache/Python/3.10.17/x64/lib/python3.10/posixpath.py", line 431, in _joinrealpath\n    st = os.lstat(newpath)\nFileNotFoundError: [Errno 2] No such file or
```

This PR introduces a pre-task step to generate the virtualenv_dir value before it's used in the template rendering process, preventing the resolution error.