### PR TITLE
Add files not needed for git tracking to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -113,6 +113,8 @@ celerybeat.pid
 # Environments
 .venv
 env/
+# mock-venv created by Cosmos unit tests
+mock-venv/
 venv/
 ENV/
 env.bak/
@@ -156,6 +158,7 @@ dev/dags/.airflowignore
 airflow.cfg
 airflow.db
 standalone_admin_password.txt
+simple_auth_manager_passwords.json.generated
 webserver_config.py
 
 # VI


### PR DESCRIPTION
The PR adds the following files to `.gitignore`

1. `mock-venv`: generated when running cosmos unit tests locally, e.g. `hatch run tests.py3.11-3.0-1.9:test-cov`
2. `simple_auth_manager_passwords.json.generated`: Airflow 3 standalone generated password file
