### PR TITLE
Ensure virtualenv_dir path exists

### DIFF
--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -83,7 +83,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         self.py_requirements = py_requirements or []
         self.pip_install_options = pip_install_options or []
         self.py_system_site_packages = py_system_site_packages
-        self.virtualenv_dir = virtualenv_dir
+        self.virtualenv_dir = Path(virtualenv_dir) if virtualenv_dir else None
         if self.virtualenv_dir:
             self.virtualenv_dir.mkdir(parents=True, exist_ok=True)
         self.is_virtualenv_dir_temporary = is_virtualenv_dir_temporary

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -84,6 +84,8 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         self.pip_install_options = pip_install_options or []
         self.py_system_site_packages = py_system_site_packages
         self.virtualenv_dir = virtualenv_dir
+        if self.virtualenv_dir:
+            self.virtualenv_dir.mkdir(parents=True, exist_ok=True)
         self.is_virtualenv_dir_temporary = is_virtualenv_dir_temporary
         self.max_retries_lock = settings.virtualenv_max_retries_lock
         self._py_bin: str | None = None

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -381,8 +381,6 @@ def test__release_venv_lock_current_process(tmpdir):
     assert not lockfile.exists()
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1707
-@pytest.mark.skipif(AIRFLOW_VERSION.major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.skipif(
     AIRFLOW_VERSION < Version("2.5"),
     reason="This error is only reproducible with dag.test, which was introduced in Airflow 2.5",


### PR DESCRIPTION
Airflow3 pre-emptively tries to validate rendered fields and also validates that the path exists in case of Path like objects specified in rendered fields. Hence, we ensure that the path specified is created first.


closes: #1707 

Co-authored-by: Pankaj Singh <98807258+pankajastro@users.noreply.github.com>