### PR TITLE
Fix Airflow 3 tests raising `generate_run_id() takes 0 positional arguments`

### DIFF
--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -609,8 +609,6 @@ def test_run_operator_dataset_url_encoded_names(caplog):
     ]
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1705
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 def test_run_operator_caches_partial_parsing(caplog, tmp_path):
     caplog.set_level(logging.DEBUG)
@@ -654,8 +652,6 @@ def test_dbt_base_operator_no_partial_parse() -> None:
     assert "--no-partial-parse" in cmd
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1705
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @pytest.mark.parametrize("invocation_mode", [InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
 def test_run_test_operator_with_callback(invocation_mode, failing_test_dbt_project):
@@ -691,8 +687,6 @@ def test_run_test_operator_with_callback(invocation_mode, failing_test_dbt_proje
     assert on_warning_callback.called
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1705
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @pytest.mark.parametrize("invocation_mode", [InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
 def test_run_test_operator_without_callback(invocation_mode):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -471,7 +471,6 @@ def test_run_operator_dataset_inlets_and_outlets(caplog):
 @pytest.mark.integration
 def test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards(caplog):
     from airflow.models.dataset import DatasetAliasModel
-    from sqlalchemy.orm.exc import FlushError
 
     with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
         seed_operator = DbtSeedLocalOperator(
@@ -507,17 +506,6 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards(caplog):
     assert seed_operator.outlets == []  # because emit_datasets=False,
     assert run_operator.outlets == [DatasetAliasModel(name="test_id_1__run")]
     assert test_operator.outlets == [DatasetAliasModel(name="test_id_1__test")]
-
-    with pytest.raises(FlushError):
-        # This is a known limitation of Airflow 2.10.0 and 2.10.1
-        # https://github.com/apache/airflow/issues/42495
-        run_test_dag(dag)
-        # Once this issue is solved, we should do some type of check on the actual datasets being emitted,
-        # so we guarantee Cosmos is backwards compatible via tests using something along the lines or an alternative,
-        # based on the resolution of the issue logged in Airflow:
-        # dag_run, session = run_test_dag(dag
-        # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
-        # assert dataset_model == 1
 
 
 @patch("cosmos.settings.enable_dataset_alias", 0)

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -511,11 +511,11 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210_onwards(caplog):
     with pytest.raises(FlushError):
         # This is a known limitation of Airflow 2.10.0 and 2.10.1
         # https://github.com/apache/airflow/issues/42495
-        dag_run, session = run_test_dag(dag)
-
+        run_test_dag(dag)
         # Once this issue is solved, we should do some type of check on the actual datasets being emitted,
         # so we guarantee Cosmos is backwards compatible via tests using something along the lines or an alternative,
         # based on the resolution of the issue logged in Airflow:
+        # dag_run, session = run_test_dag(dag
         # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
         # assert dataset_model == 1
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import sys
-import warnings
 from pathlib import Path
 from unittest.mock import patch
 
@@ -13,7 +12,6 @@ except ImportError:
 
 import airflow
 import pytest
-import sqlalchemy
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
@@ -119,31 +117,7 @@ def get_dag_ids() -> list[str]:
 def run_dag(dag_id: str):
     dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
-
-    # This feature is available since Airflow 2.5 and we've backported it in Cosmos:
-    # https://airflow.apache.org/docs/apache-airflow/stable/release_notes.html#airflow-2-5-0-2022-12-02
-    if AIRFLOW_VERSION >= Version("2.5"):
-        if AIRFLOW_VERSION not in (Version("2.10.0"), Version("2.10.1"), Version("2.10.2")):
-            dag.test()
-        else:
-            # This is a work around until we fix the issue in Airflow:
-            # https://github.com/apache/airflow/issues/42495
-            """
-            FAILED tests/test_example_dags.py::test_example_dag[example_model_version] - sqlalchemy.exc.PendingRollbackError:
-            This Session's transaction has been rolled back due to a previous exception during flush. To begin a new transaction with this Session, first issue Session.rollback().
-            Original exception was: Can't flush None value found in collection DatasetModel.aliases (Background on this error at: https://sqlalche.me/e/14/7s2a)
-            FAILED tests/test_example_dags.py::test_example_dag[basic_cosmos_dag]
-            FAILED tests/test_example_dags.py::test_example_dag[cosmos_profile_mapping]
-            FAILED tests/test_example_dags.py::test_example_dag[user_defined_profile]
-            """
-            try:
-                dag.test()
-            except sqlalchemy.exc.PendingRollbackError:
-                warnings.warn(
-                    "Early versions of Airflow 2.10 have issues when running the test command with DatasetAlias / Datasets"
-                )
-    else:
-        test_utils.run_dag(dag)
+    test_utils.run_dag(dag)
 
 
 @pytest.mark.skipif(

--- a/tests/test_example_k8s_dags.py
+++ b/tests/test_example_k8s_dags.py
@@ -2,11 +2,9 @@ import os
 from pathlib import Path
 
 import pytest
-from airflow import __version__ as airflow_version
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
-from packaging import version
 
 from . import utils as test_utils
 
@@ -37,10 +35,6 @@ def get_all_dag_files():
         dag_ignorefile.writelines([f"{file}\n" for file in python_files])
 
 
-# TODO: Add compatibility for Airflow 3.0. Issue: #1705.
-#  Comment: https://github.com/astronomer/astronomer-cosmos/issues/1705#issuecomment-2834926490
-#  Hint: Check if we can dag.test instead for Airflow 3.0 here.
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Add compatibility for 3.0")
 @pytest.mark.integration
 def test_example_dag_kubernetes(session):
     get_all_dag_files()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -31,7 +31,7 @@ def run_dag(dag: DAG, conn_file_path: str | None = None) -> DagRun:
     return test_dag(dag=dag, conn_file_path=conn_file_path)
 
 
-def test_dag(dag) -> DagRun:
+def test_dag(dag, conn_file_path: str | None = None) -> DagRun:
     if AIRFLOW_VERSION >= version.Version("2.5"):
         if AIRFLOW_VERSION not in (Version("2.10.0"), Version("2.10.1"), Version("2.10.2")):
             dag.test()
@@ -53,7 +53,7 @@ def test_dag(dag) -> DagRun:
                     "Early versions of Airflow 2.10 have issues when running the test command with DatasetAlias / Datasets"
                 )
     else:
-        test_old_dag(dag)
+        test_old_dag(dag, conn_file_path)
 
 
 # DAG.test() was added in Airflow version 2.5.0. And to test on older Airflow versions, we need to copy the

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -34,7 +34,7 @@ def run_dag(dag: DAG, conn_file_path: str | None = None) -> DagRun:
 def test_dag(dag, conn_file_path: str | None = None) -> DagRun:
     if AIRFLOW_VERSION >= version.Version("2.5"):
         if AIRFLOW_VERSION not in (Version("2.10.0"), Version("2.10.1"), Version("2.10.2")):
-            dag.test()
+            return dag.test()
         else:
             # This is a work around until we fix the issue in Airflow:
             # https://github.com/apache/airflow/issues/42495
@@ -53,7 +53,7 @@ def test_dag(dag, conn_file_path: str | None = None) -> DagRun:
                     "Early versions of Airflow 2.10 have issues when running the test command with DatasetAlias / Datasets"
                 )
     else:
-        test_old_dag(dag, conn_file_path)
+        return test_old_dag(dag, conn_file_path)
 
 
 # DAG.test() was added in Airflow version 2.5.0. And to test on older Airflow versions, we need to copy the


### PR DESCRIPTION
Action Link: https://github.com/astronomer/astronomer-cosmos/actions/runs/14703034847/job/41256451294?pr=1646#step:7:4023

A few tests in the tests/operators/test_local.py failing with the below error
```
FAILED tests/operators/test_local.py::test_run_operator_dataset_url_encoded_names - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
FAILED tests/operators/test_local.py::test_run_operator_caches_partial_parsing - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
FAILED tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.SUBPROCESS] - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
FAILED tests/operators/test_local.py::test_run_test_operator_with_callback[InvocationMode.DBT_RUNNER] - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
FAILED tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.SUBPROCESS] - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
FAILED tests/operators/test_local.py::test_run_test_operator_without_callback[InvocationMode.DBT_RUNNER] - TypeError: generate_run_id() takes 0 positional arguments but 2 were given
```

The only test this PR is not uncommenting is `test_run_operator_dataset_url_encoded_names` - that is being addressed in PR #1716

Closes: #1705
