### PR TITLE
Enable example DAGs to run in CI that were disabled in PR #1646

### DIFF
--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag
+from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 
 from cosmos import DbtTaskGroup, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
@@ -30,12 +30,12 @@ shared_execution_config = ExecutionConfig(
 )
 
 
-@dag(
+with DAG(
+    dag_id="basic_cosmos_task_group",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-)
-def basic_cosmos_task_group() -> None:
+):
     """
     The simplest example of using Cosmos to render a dbt project as a TaskGroup.
     """
@@ -75,6 +75,3 @@ def basic_cosmos_task_group() -> None:
 
     pre_dbt >> customers >> post_dbt
     pre_dbt >> orders >> post_dbt
-
-
-basic_cosmos_task_group()

--- a/dev/dags/basic_cosmos_task_group_different_owners.py
+++ b/dev/dags/basic_cosmos_task_group_different_owners.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag
+from airflow import DAG
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
@@ -27,12 +27,12 @@ profile_config = ProfileConfig(
 )
 
 
-@dag(
+with DAG(
+    dag_id="basic_cosmos_task_group_different_owners",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-)
-def basic_cosmos_task_group_different_owners() -> None:
+):
     """
     Example of how to override arguments / properties being run per Airflow task
     using dbt YAML.
@@ -72,6 +72,3 @@ def basic_cosmos_task_group_different_owners() -> None:
     )
 
     non_models >> models
-
-
-basic_cosmos_task_group_different_owners()

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag
+from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 
 from cosmos import DbtTaskGroup, ExecutionConfig, LoadMode, ProfileConfig, ProjectConfig, RenderConfig
@@ -30,14 +30,13 @@ profile_config = ProfileConfig(
 render_config = RenderConfig(load_method=LoadMode.DBT_MANIFEST, select=["path:seeds/raw_customers.csv"])
 
 
-@dag(
+with DAG(
+    dag_id="cosmos_manifest_example",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
     default_args={"retries": 2},
-)
-def cosmos_manifest_example() -> None:
-
+):
     pre_dbt = EmptyOperator(task_id="pre_dbt")
 
     # [START local_example]
@@ -105,6 +104,3 @@ def cosmos_manifest_example() -> None:
     post_dbt = EmptyOperator(task_id="post_dbt")
 
     (pre_dbt >> local_example >> aws_s3_example >> gcp_gs_example >> azure_abfs_example >> post_dbt)
-
-
-cosmos_manifest_example()

--- a/dev/dags/cosmos_profile_mapping.py
+++ b/dev/dags/cosmos_profile_mapping.py
@@ -8,7 +8,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag
+from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 
 from cosmos import DbtTaskGroup, ExecutionConfig, ProfileConfig, ProjectConfig
@@ -21,12 +21,12 @@ DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
 execution_config = ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER)
 
 
-@dag(
+with DAG(
+    dag_id="cosmos_profile_mapping",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-)
-def cosmos_profile_mapping() -> None:
+):
     """
     Turns a dbt project into a TaskGroup with a profile mapping.
     """
@@ -52,6 +52,3 @@ def cosmos_profile_mapping() -> None:
     post_dbt = EmptyOperator(task_id="post_dbt")
 
     pre_dbt >> jaffle_shop >> post_dbt
-
-
-cosmos_profile_mapping()

--- a/dev/dags/example_cosmos_cleanup_dag.py
+++ b/dev/dags/example_cosmos_cleanup_dag.py
@@ -6,18 +6,18 @@ parsing the DbtDag or DbtTaskGroup since Cosmos 1.5.
 # [START cache_example]
 from datetime import datetime, timedelta
 
-from airflow.decorators import dag, task
+from airflow import DAG
+from airflow.decorators import task
 
 from cosmos.cache import delete_unused_dbt_ls_cache, delete_unused_dbt_ls_remote_cache_files
 
-
-@dag(
+with DAG(
+    dag_id="example_cosmos_cleanup_dag",
     schedule="0 0 * * 0",  # Runs every Sunday
     start_date=datetime(2023, 1, 1),
     catchup=False,
     tags=["example"],
-)
-def example_cosmos_cleanup_dag():
+):
 
     @task()
     def clear_db_ls_cache(session=None):
@@ -39,5 +39,3 @@ def example_cosmos_cleanup_dag():
 
 
 # [END cache_example]
-
-example_cosmos_cleanup_dag()

--- a/dev/dags/example_taskflow.py
+++ b/dev/dags/example_taskflow.py
@@ -2,7 +2,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag, task
+from airflow import DAG
+from airflow.decorators import task
 
 from cosmos import DbtTaskGroup, ProfileConfig, ProjectConfig
 from cosmos.profiles import PostgresUserPasswordProfileMapping
@@ -27,12 +28,12 @@ def build_partial_dbt_env():
     return {"ENV_VAR_NAME": "value", "ENV_VAR_NAME_2": False}
 
 
-@dag(
+with DAG(
+    dag_id="example_taskflow",
     schedule="@daily",
     start_date=datetime(2024, 1, 1),
     catchup=False,
-)
-def example_taskflow() -> None:
+):
     DbtTaskGroup(
         group_id="transform_task_group",
         project_config=ProjectConfig(
@@ -43,6 +44,3 @@ def example_taskflow() -> None:
         profile_config=profile_config,
         operator_args={"install_deps": True},
     )
-
-
-example_taskflow()

--- a/dev/dags/user_defined_profile.py
+++ b/dev/dags/user_defined_profile.py
@@ -6,7 +6,7 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from airflow.decorators import dag
+from airflow import DAG
 from airflow.operators.empty import EmptyOperator
 
 from cosmos import DbtTaskGroup, LoadMode, ProfileConfig, ProjectConfig, RenderConfig
@@ -17,12 +17,12 @@ PROFILES_FILE_PATH = Path(DBT_ROOT_PATH, "jaffle_shop", "profiles.yml")
 DBT_LS_PATH = Path(DBT_ROOT_PATH, "jaffle_shop", "dbt_ls_models_staging.txt")
 
 
-@dag(
+with DAG(
+    dag_id="user_defined_profile",
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-)
-def user_defined_profile() -> None:
+):
     """
     A DAG that uses Cosmos with a custom profile.
     """
@@ -48,6 +48,3 @@ def user_defined_profile() -> None:
     post_dbt = EmptyOperator(task_id="post_dbt")
 
     pre_dbt >> jaffle_shop >> post_dbt
-
-
-user_defined_profile()

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -41,17 +41,6 @@ MIN_VER_DAG_FILE_VER: dict[Version, list[str]] = {
     Version(version): MIN_VER_DAG_FILE[version] for version in sorted(MIN_VER_DAG_FILE, key=Version, reverse=True)
 }
 
-# TODO: Make following dag tests compatible for AF3. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1706
-AIRFLOW3_IGNORE_DAG_FILES = [
-    "basic_cosmos_task_group_different_owners.py",
-    "cosmos_profile_mapping.py",
-    "user_defined_profile.py",
-    "example_taskflow.py",
-    "cosmos_manifest_example.py",
-    "example_cosmos_cleanup_dag.py",
-    # "basic_cosmos_task_group.py",
-]
-
 
 @provide_session
 def get_session(session=None):
@@ -96,10 +85,6 @@ def get_dag_bag() -> DagBag:
 
         if AIRFLOW_VERSION < Version("2.8.0"):
             file.writelines("example_cosmos_dbt_build.py\n")
-
-        # # TODO: Make following dag tests compatible for AF3. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1706
-        if AIRFLOW_VERSION.major == 3:
-            file.writelines([f"{dag_file}\n" for dag_file in AIRFLOW3_IGNORE_DAG_FILES])
 
     print(".airflowignore contents: ")
     print(AIRFLOW_IGNORE_FILE.read_text())

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -97,9 +97,9 @@ def get_dag_bag() -> DagBag:
         if AIRFLOW_VERSION < Version("2.8.0"):
             file.writelines("example_cosmos_dbt_build.py\n")
 
-        # TODO: Make following dag tests compatible for AF3. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1706
-        if AIRFLOW_VERSION.major == 3:
-            file.writelines([f"{dag_file}\n" for dag_file in AIRFLOW3_IGNORE_DAG_FILES])
+        # # TODO: Make following dag tests compatible for AF3. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1706
+        # if AIRFLOW_VERSION.major == 3:
+        #     file.writelines([f"{dag_file}\n" for dag_file in AIRFLOW3_IGNORE_DAG_FILES])
 
     print(".airflowignore contents: ")
     print(AIRFLOW_IGNORE_FILE.read_text())

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -49,7 +49,7 @@ AIRFLOW3_IGNORE_DAG_FILES = [
     "example_taskflow.py",
     "cosmos_manifest_example.py",
     "example_cosmos_cleanup_dag.py",
-    "basic_cosmos_task_group.py",
+    # "basic_cosmos_task_group.py",
 ]
 
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -98,8 +98,8 @@ def get_dag_bag() -> DagBag:
             file.writelines("example_cosmos_dbt_build.py\n")
 
         # # TODO: Make following dag tests compatible for AF3. Issue: https://github.com/astronomer/astronomer-cosmos/issues/1706
-        # if AIRFLOW_VERSION.major == 3:
-        #     file.writelines([f"{dag_file}\n" for dag_file in AIRFLOW3_IGNORE_DAG_FILES])
+        if AIRFLOW_VERSION.major == 3:
+            file.writelines([f"{dag_file}\n" for dag_file in AIRFLOW3_IGNORE_DAG_FILES])
 
     print(".airflowignore contents: ")
     print(AIRFLOW_IGNORE_FILE.read_text())


### PR DESCRIPTION
Airflow 3.0 does not currently support calling `.test()` on DAGs defined using the `@dag` decorator, as the decorator now returns an object that does not expose the `.test()` method. There is an open issue https://github.com/apache/airflow/issues/45549 around this area. This PR updates the affected example DAGs to explicitly use `airflow.models.DAG` instead of the `@dag` decorator, restoring compatibility with `dag.test()` for local testing and CI.

This also re-enables the example DAGs that were disabled in PR #1646.

closes: #1706 