### PR TITLE
Re-enable integration tests durations to troubleshoot performance degradation

### DIFF
--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -17,6 +17,7 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
+    --durations \
     -m 'integration'  \
     --ignore=tests/perf \
     --ignore=tests/test_async_example_dag.py \

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -17,7 +17,7 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    --durations \
+    --durations=0 \
     -m 'integration'  \
     --ignore=tests/perf \
     --ignore=tests/test_async_example_dag.py \


### PR DESCRIPTION
There is an apparent degradation in the speed when running our integration tests in AF3 compared to AF2.

We're re-enabling these metrics so that we can analyse them.

As an example, during the run https://github.com/astronomer/astronomer-cosmos/actions/runs/14774756080:
- Run-Integration-Tests(3.9,2.10,1.9) took 12m 40s
- Run-Integration-Tests(3.9,3.0,1.9) took 41m 6s
