### PR TITLE
Fix `full_refresh` parameter in `AIRFLOW_ASYNC` execution config mode

### DIFF
--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -81,11 +81,10 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.configuration: dict[str, Any] = {}
         self.dbt_kwargs = dbt_kwargs or {}
         task_id = self.dbt_kwargs.pop("task_id")
-        full_refresh = self.dbt_kwargs.pop("full_refresh", False)
+        self.full_refresh = self.dbt_kwargs.pop("full_refresh", False)
         AbstractDbtLocalBase.__init__(
             self, task_id=task_id, project_dir=project_dir, profile_config=profile_config, **self.dbt_kwargs
         )
-        self.full_refresh = full_refresh
         if kwargs.get("emit_datasets", True) and settings.enable_dataset_alias and AIRFLOW_VERSION >= Version("2.10"):
             from airflow.datasets import DatasetAlias
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -80,11 +80,12 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.extra_context = extra_context or {}
         self.configuration: dict[str, Any] = {}
         self.dbt_kwargs = dbt_kwargs or {}
-        self.full_refresh = kwargs.pop("full_refresh", False)
         task_id = self.dbt_kwargs.pop("task_id")
+        full_refresh = self.dbt_kwargs.pop("full_refresh", False)
         AbstractDbtLocalBase.__init__(
             self, task_id=task_id, project_dir=project_dir, profile_config=profile_config, **self.dbt_kwargs
         )
+        self.full_refresh = full_refresh
         if kwargs.get("emit_datasets", True) and settings.enable_dataset_alias and AIRFLOW_VERSION >= Version("2.10"):
             from airflow.datasets import DatasetAlias
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -61,7 +61,7 @@ def _configure_bigquery_async_op_args(async_op_obj: Any, **kwargs: Any) -> Any:
 
 class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtLocalBase):  # type: ignore[misc]
 
-    template_fields: Sequence[str] = ("gcp_project", "dataset", "location", "compiled_sql")
+    template_fields: Sequence[str] = ("gcp_project", "dataset", "location", "compiled_sql", "full_refresh")
     template_fields_renderers = {
         "compiled_sql": "sql",
     }
@@ -80,6 +80,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.extra_context = extra_context or {}
         self.configuration: dict[str, Any] = {}
         self.dbt_kwargs = dbt_kwargs or {}
+        self.full_refresh = kwargs.pop("full_refresh", False)
         task_id = self.dbt_kwargs.pop("task_id")
         AbstractDbtLocalBase.__init__(
             self, task_id=task_id, project_dir=project_dir, profile_config=profile_config, **self.dbt_kwargs

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -63,6 +63,9 @@ class DbtRunAirflowAsyncOperator(DbtRunAirflowAsyncFactoryOperator):
 
         dbt_kwargs = {}
 
+        # Extract full_refresh from kwargs if present
+        clean_kwargs["full_refresh"] = kwargs.pop("full_refresh", False)
+
         for arg_key, arg_value in kwargs.items():
             if arg_key == "task_id":
                 clean_kwargs[arg_key] = arg_value

--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -64,7 +64,7 @@ class DbtRunAirflowAsyncOperator(DbtRunAirflowAsyncFactoryOperator):
         dbt_kwargs = {}
 
         # Extract full_refresh from kwargs if present
-        clean_kwargs["full_refresh"] = kwargs.pop("full_refresh", False)
+        dbt_kwargs["full_refresh"] = kwargs.pop("full_refresh", False)
 
         for arg_key, arg_value in kwargs.items():
             if arg_key == "task_id":

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -786,7 +786,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         async_context: dict[str, Any] | None = None,
     ) -> FullOutputSubprocessResult | dbtRunnerResult:
         # If this is an async run and we're using the setup task, make sure to include the full_refresh flag if set
-        if run_as_async and settings.enable_setup_async_task and hasattr(self, 'full_refresh') and self.full_refresh:
+        if run_as_async and settings.enable_setup_async_task and hasattr(self, "full_refresh") and self.full_refresh:
             if cmd_flags is None:
                 cmd_flags = []
             if "--full-refresh" not in cmd_flags:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -786,7 +786,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         async_context: dict[str, Any] | None = None,
     ) -> FullOutputSubprocessResult | dbtRunnerResult:
         # If this is an async run and we're using the setup task, make sure to include the full_refresh flag if set
-        if run_as_async and settings.enable_setup_async_task and self.full_refresh:
+        if run_as_async and settings.enable_setup_async_task and getattr(self, "full_refresh", False):
             if cmd_flags is None:
                 cmd_flags = []
             if "--full-refresh" not in cmd_flags:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -785,6 +785,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
     ) -> FullOutputSubprocessResult | dbtRunnerResult:
+        # If this is an async run and we're using the setup task, make sure to include the full_refresh flag if set
+        if run_as_async and settings.enable_setup_async_task and hasattr(self, 'full_refresh') and self.full_refresh:
+            if cmd_flags is None:
+                cmd_flags = []
+            if "--full-refresh" not in cmd_flags:
+                cmd_flags.append("--full-refresh")
+
         dbt_cmd, env = self.build_cmd(context=context, cmd_flags=cmd_flags)
         dbt_cmd = dbt_cmd or []
         result = self.run_command(

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -786,7 +786,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         async_context: dict[str, Any] | None = None,
     ) -> FullOutputSubprocessResult | dbtRunnerResult:
         # If this is an async run and we're using the setup task, make sure to include the full_refresh flag if set
-        if run_as_async and settings.enable_setup_async_task and hasattr(self, "full_refresh") and self.full_refresh:
+        if run_as_async and settings.enable_setup_async_task and self.full_refresh:
             if cmd_flags is None:
                 cmd_flags = []
             if "--full-refresh" not in cmd_flags:

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -38,6 +38,10 @@ simple_dag_async = DbtDag(
     catchup=False,
     dag_id="simple_dag_async",
     tags=["simple"],
-    operator_args={"location": "US", "install_deps": True},
+    operator_args={
+        "location": "US",
+        "install_deps": True,
+        "full_refresh": True,
+    },
 )
 # [END airflow_async_execution_mode_example]

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -38,6 +38,7 @@ def test_dbt_run_airflow_async_bigquery_operator_init(profile_config_mock):
     assert operator.project_dir == "/path/to/project"
     assert operator.profile_config == profile_config_mock
     assert operator.gcp_conn_id == "google_cloud_default"
+    assert operator.full_refresh is False  # Default value should be False
 
 
 def test_dbt_run_airflow_async_bigquery_operator_base_cmd(profile_config_mock):
@@ -156,3 +157,15 @@ def test_execute_complete(mock_store_sql, profile_config_mock):
     assert result == "test_job"
     mock_super_execute.assert_called_once_with(context=mock_context, event=mock_event)
     mock_store_sql.assert_called_once_with(context=mock_context)
+
+
+def test_dbt_run_airflow_async_bigquery_operator_with_full_refresh(profile_config_mock):
+    """Test DbtRunAirflowAsyncBigqueryOperator initializes with full_refresh=True."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task", "full_refresh": True},
+    )
+
+    assert operator.full_refresh is True

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1624,6 +1624,27 @@ def test_async_execution_without_start_task(mock_read_sql, mock_bq_execute):
     mock_bq_execute.assert_called_once()
 
 
+def test_build_and_run_cmd_with_full_refresh_in_async_mode():
+    """Test that build_and_run_cmd adds --full-refresh flag when full_refresh is True in async mode."""
+    AbstractDbtLocalBase.__abstractmethods__ = set()
+
+    with patch("cosmos.operators.local.settings.enable_setup_async_task", True):
+        operator = AbstractDbtLocalBase(
+            task_id="test_task",
+            project_dir="/tmp",
+            profile_config=profile_config,
+        )
+        operator.full_refresh = True
+
+        with patch.object(operator, "build_cmd") as mock_build_cmd:
+            mock_build_cmd.return_value = (["dbt", "run"], {})
+
+            with patch.object(operator, "run_command"):
+                operator.build_and_run_cmd(context={}, run_as_async=True)
+                cmd_flags_arg = mock_build_cmd.call_args[1].get("cmd_flags", [])
+                assert "--full-refresh" in cmd_flags_arg
+
+
 @pytest.mark.integration
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
 @patch("pathlib.Path.rglob")


### PR DESCRIPTION
## Description

This PR fixes an issue where using `operator_args={'full_refresh': True}` with `AIRFLOW_ASYNC` execution mode would cause an error. The fix ensures that:
1. The `full_refresh` parameter is properly passed from `DbtRunAirflowAsyncOperator` to underlying operators.
2. The `--full-refresh` flag is added to the dbt command during the setup async task.

This allows users to properly use the `full_refresh` parameter with async execution mode, ensuring that models are rebuilt from scratch when needed.

## Related Issue(s)

Closes #1736 
Closes #1610
