### PR TITLE
Run listener tests in Airflow 3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, fix_af3_test]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, fix_af3_test]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -58,7 +58,7 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
     if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
         dag_hash = dag_run.dag_hash
     else:
-        dag_hash = dag_run.__hash__()
+        dag_hash = dag_run.dag.__hash__()
 
     additional_telemetry_metrics = {
         "dag_hash": dag_hash,
@@ -86,7 +86,7 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
     if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
         dag_hash = dag_run.dag_hash
     else:
-        dag_hash = dag_run.__hash__()
+        dag_hash = dag_run.dag.__hash__()
 
     additional_telemetry_metrics = {
         "dag_hash": dag_hash,

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -1,16 +1,12 @@
 from __future__ import annotations
 
-from airflow import __version__ as airflow_version
 from airflow.listeners import hookimpl
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
-from packaging import version
+from airflow.utils.hashlib_wrapper import md5
 
 from cosmos import telemetry
-from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
 from cosmos.log import get_logger
-
-AIRFLOW_VERSION_MAJOR = version.parse(airflow_version).major
 
 logger = get_logger(__name__)
 
@@ -55,13 +51,8 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
         logger.debug("The DAG does not use Cosmos")
         return
 
-    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
-        dag_hash = dag_run.dag_hash
-    else:
-        dag_hash = dag_run.dag.__hash__()
-
     additional_telemetry_metrics = {
-        "dag_hash": dag_hash,
+        "dag_hash": md5(dag_run.dag_id.encode("utf-8")).hexdigest(),
         "status": EventStatus.SUCCESS,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),
@@ -83,13 +74,8 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
         logger.debug("The DAG does not use Cosmos")
         return
 
-    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
-        dag_hash = dag_run.dag_hash
-    else:
-        dag_hash = dag_run.dag.__hash__()
-
     additional_telemetry_metrics = {
-        "dag_hash": dag_hash,
+        "dag_hash": md5(dag_run.dag_id.encode("utf-8")).hexdigest(),
         "status": EventStatus.FAILED,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -2,12 +2,17 @@ from __future__ import annotations
 
 import hashlib
 
+from airflow import __version__ as airflow_version
 from airflow.listeners import hookimpl
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
+from packaging import version
 
 from cosmos import telemetry
+from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
 from cosmos.log import get_logger
+
+AIRFLOW_VERSION_MAJOR = version.parse(airflow_version).major
 
 logger = get_logger(__name__)
 
@@ -52,8 +57,13 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
         logger.debug("The DAG does not use Cosmos")
         return
 
+    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
+        dag_hash = dag_run.dag_hash
+    else:
+        dag_hash = hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()
+
     additional_telemetry_metrics = {
-        "dag_hash": hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()[:8],
+        "dag_hash": dag_hash,
         "status": EventStatus.SUCCESS,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),
@@ -75,8 +85,13 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
         logger.debug("The DAG does not use Cosmos")
         return
 
+    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
+        dag_hash = dag_run.dag_hash
+    else:
+        dag_hash = hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()
+
     additional_telemetry_metrics = {
-        "dag_hash": hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()[:8],
+        "dag_hash": dag_hash,
         "status": EventStatus.FAILED,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -1,9 +1,10 @@
 from __future__ import annotations
 
+import hashlib
+
 from airflow.listeners import hookimpl
 from airflow.models.dag import DAG
 from airflow.models.dagrun import DagRun
-from airflow.utils.hashlib_wrapper import md5
 
 from cosmos import telemetry
 from cosmos.log import get_logger
@@ -52,7 +53,7 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
         return
 
     additional_telemetry_metrics = {
-        "dag_hash": md5(dag_run.dag_id.encode("utf-8")).hexdigest(),
+        "dag_hash": hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()[:8],
         "status": EventStatus.SUCCESS,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),
@@ -75,7 +76,7 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
         return
 
     additional_telemetry_metrics = {
-        "dag_hash": md5(dag_run.dag_id.encode("utf-8")).hexdigest(),
+        "dag_hash": hashlib.md5(dag_run.dag_id.encode("utf-8")).hexdigest()[:8],
         "status": EventStatus.FAILED,
         "task_count": len(serialized_dag.task_ids),
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -1,6 +1,6 @@
 import logging
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -8,16 +8,20 @@ import pytest
 from airflow import __version__ as airflow_version
 from airflow.models import DAG
 from airflow.utils.state import State
+from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from packaging import version
 
 from cosmos import DbtRunLocalOperator, ProfileConfig, ProjectConfig
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
+from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
 from cosmos.listeners.dag_run_listener import on_dag_run_failed, on_dag_run_success, total_cosmos_tasks
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DBT_ROOT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt"
 DBT_PROJECT_NAME = "jaffle_shop"
+
+AIRFLOW_VERSION_MAJOR = version.parse(airflow_version).major
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -79,8 +83,8 @@ def test_not_cosmos_dag():
     assert total_cosmos_tasks(dag) == 0
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
+# # TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
+# @pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
@@ -95,10 +99,23 @@ def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
         dag_id="basic_cosmos_dag",
     )
     run_id = str(uuid.uuid1())
-    dag_run = dag.create_dagrun(
-        state=State.NONE,
-        run_id=run_id,
-    )
+
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
+        # Airflow 2
+        dag_run = dag.create_dagrun(
+            state=State.NONE,
+            run_id=run_id,
+        )
+    else:
+        # Airflow 3
+        dag_run = dag.create_dagrun(
+            state=State.NONE,
+            run_id=run_id,
+            run_after=run_after,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.TIMETABLE,
+        )
 
     on_dag_run_success(dag_run, msg="test success")
     assert "Running on_dag_run_success" in caplog.text
@@ -107,7 +124,7 @@ def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
 
 
 # TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
-@pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
+# @pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):
@@ -122,10 +139,22 @@ def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):
         dag_id="basic_cosmos_dag",
     )
     run_id = str(uuid.uuid1())
-    dag_run = dag.create_dagrun(
-        state=State.FAILED,
-        run_id=run_id,
-    )
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    if AIRFLOW_VERSION_MAJOR < _AIRFLOW3_MAJOR_VERSION:
+        # Airflow 2
+        dag_run = dag.create_dagrun(
+            state=State.NONE,
+            run_id=run_id,
+        )
+    else:
+        # Airflow 3
+        dag_run = dag.create_dagrun(
+            state=State.NONE,
+            run_id=run_id,
+            run_after=run_after,
+            run_type=DagRunType.MANUAL,
+            triggered_by=DagRunTriggeredByType.TIMETABLE,
+        )
 
     on_dag_run_failed(dag_run, msg="test failed")
     assert "Running on_dag_run_failed" in caplog.text

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -122,7 +122,6 @@ def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
     assert mock_emit_usage_metrics_if_enabled.call_count == 1
 
 
-# TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -123,7 +123,6 @@ def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
 
 
 # TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
-# @pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -82,8 +82,6 @@ def test_not_cosmos_dag():
     assert total_cosmos_tasks(dag) == 0
 
 
-# # TODO: Make test compatible with Airflow 3.0. Issue:https://github.com/astronomer/astronomer-cosmos/issues/1703
-# @pytest.mark.skipif(version.parse(airflow_version).major == 3, reason="Test need to be updated for Airflow 3.0")
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -8,7 +8,6 @@ import pytest
 from airflow import __version__ as airflow_version
 from airflow.models import DAG
 from airflow.utils.state import State
-from airflow.utils.types import DagRunTriggeredByType, DagRunType
 from packaging import version
 
 from cosmos import DbtRunLocalOperator, ProfileConfig, ProjectConfig
@@ -109,6 +108,8 @@ def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
         )
     else:
         # Airflow 3
+        from airflow.utils.types import DagRunTriggeredByType, DagRunType
+
         dag_run = dag.create_dagrun(
             state=State.NONE,
             run_id=run_id,
@@ -148,6 +149,8 @@ def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):
         )
     else:
         # Airflow 3
+        from airflow.utils.types import DagRunTriggeredByType, DagRunType
+
         dag_run = dag.create_dagrun(
             state=State.NONE,
             run_id=run_id,


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1703

Previously, we sent the dag_hash to Scarf,
but with the removal of DagRun.dag_hash in Airflow 3,
this PR modifies the implementation to send a portion 
of the dag_id hash instead. This change is a reasonable 
compromise, as we only need a unique identifier for the DAG. 
Additionally, the PR updates the relevant test cases to reflect this change.

