### PR TITLE
[Bugfix Docs]: Custom Callback Example Corrected

### DIFF
--- a/docs/configuration/callbacks.rst
+++ b/docs/configuration/callbacks.rst
@@ -89,16 +89,18 @@ Below, find an example of a callback method that raises an exception if the quer
 
         slow_query_threshold = 10
 
-        run_results_path = Path(project_dir, "run_results.json")
+        target_path = f"{project_dir}/target"
+        run_results_path = Path(target_path, "run_results.json")
         if run_results_path.exists():
             with open(run_results_path) as fp:
                 run_results = json.load(fp)
-                node_name = run_results["unique_id"]
-                execution_time = run_results["execution_time"]
-                if execution_time > slow_query_threshold:
-                    raise TimeoutError(
-                        f"The query for the node {node_name} took too long: {execution_time}"
-                    )
+                for result in run_results["results"]:
+                    node_name = result["unique_id"]
+                    execution_time = result["execution_time"]
+                    if execution_time > slow_query_threshold:
+                        raise TimeoutError(
+                            f"The query for the node {node_name} took too long: {execution_time}"
+                        )
 
 Users can use the same approach to call the data observability platform `montecarlo <https://docs.getmontecarlo.com/docs/dbt-core>`_ or other services.
 


### PR DESCRIPTION
A minor change to the custom callback example in the docs here: https://astronomer.github.io/astronomer-cosmos/configuration/callbacks.html#custom-callbacks:

1. The `run_results.json` artifact is in the target directory, not the project directory.
2. The results (at least in version `dbt-core=1.9.4`) is a list in a `results` node, not a value in the root object.