### PR TITLE
Default RenderConfig’s InvocationMode to SUBPROCESS to avoid task hangs observed with dbt Runner on Airflow 2

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.10.0"
+__version__ = "1.10.1a1"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -6,7 +6,7 @@ Astronomer Cosmos is a library for rendering dbt workflows in Airflow.
 Contains dags, task groups, and operators.
 """
 
-__version__ = "1.10.1a1"
+__version__ = "1.10.1a4"
 
 
 from cosmos.airflow.dag import DbtDag

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -51,7 +51,7 @@ class RenderConfig:
     dependencies. Defaults to True
     :param test_behavior: The behavior for running tests. Defaults to after each (model)
     :param load_method: The parsing method for loading the dbt model. Defaults to AUTOMATIC
-    :param invocation_mode: If `LoadMode.DBT_LS` is used, define how dbt ls should be run: using dbtRunner (default) or Python subprocess.
+    :param invocation_mode: If `LoadMode.DBT_LS` is used, define how dbt ls should be run: using dbtRunner or Python subprocess(default).
     :param select: A list of dbt select arguments (e.g. 'config.materialized:incremental')
     :param exclude: A list of dbt exclude arguments (e.g. 'tag:nightly')
     :param selector: Name of a dbt YAML selector to use for parsing. Only supported when using ``load_method=LoadMode.DBT_LS``.
@@ -71,7 +71,8 @@ class RenderConfig:
     emit_datasets: bool = True
     test_behavior: TestBehavior = TestBehavior.AFTER_EACH
     load_method: LoadMode = LoadMode.AUTOMATIC
-    invocation_mode: InvocationMode = InvocationMode.DBT_RUNNER
+    # We're observing that InvocationMode.DBT_RUNNER is causing tasks to be stuck on Airflow 2 task executions. So, until we identify and fix this issue, we're setting the default to InvocationMode.SUBPROCESS.
+    invocation_mode: InvocationMode = InvocationMode.SUBPROCESS
     select: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)
     selector: str | None = None

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -71,7 +71,9 @@ class RenderConfig:
     emit_datasets: bool = True
     test_behavior: TestBehavior = TestBehavior.AFTER_EACH
     load_method: LoadMode = LoadMode.AUTOMATIC
-    # We're observing that InvocationMode.DBT_RUNNER is causing tasks to be stuck on Airflow 2 task executions. So, until we identify and fix this issue, we're setting the default to InvocationMode.SUBPROCESS.
+    # NOTE: InvocationMode.DBT_RUNNER is causing tasks to hang on Airflow 2 task execution.
+    # As a temporary workaround, we are defaulting to InvocationMode.SUBPROCESS until the issue is identified and resolved.
+    # TODO: Revert back to InvocationMode.DBT_RUNNER once https://github.com/astronomer/astronomer-cosmos/issues/1751 is fixed.
     invocation_mode: InvocationMode = InvocationMode.SUBPROCESS
     select: list[str] = field(default_factory=list)
     exclude: list[str] = field(default_factory=list)

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1839,7 +1839,7 @@ def test_run_dbt_deps(run_command_mock):
     graph.local_flags = []
     graph.run_dbt_deps("dbt", "/some/path", {})
     run_command_mock.assert_called_with(
-        ["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {}, InvocationMode.DBT_RUNNER, None
+        ["dbt", "deps", "--vars", '{"var-key": "var-value"}'], "/some/path", {}, InvocationMode.SUBPROCESS, None
     )
 
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -550,8 +550,15 @@ def test_load(
     [
         ("subprocess", True),
         ("subprocess", False),
-        ("dbt_runner", True),
-        ("dbt_runner", False),
+        # NOTE: We are currently defaulting RenderConfig's InvocationMode to SUBPROCESS as part of PR #1750.
+        # As a result, execution does not follow the path expected by these tests, so we are disabling the cases below for now.
+        # They currently fail with the following error:
+        # FAILED tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[dbt_runner-True] - ValueError: not enough values to unpack (expected 2, got 0)
+        # FAILED tests/dbt/test_graph.py::test_load_via_dbt_ls_does_not_create_target_logs_in_original_folder[dbt_runner-False] - ValueError: not enough values to unpack (expected 2, got 0)
+        # TODO: Re-enable these test cases once the default InvocationMode is switched back to DBT_RUNNER when resolving
+        #       https://github.com/astronomer/astronomer-cosmos/issues/1751.
+        # ("dbt_runner", True),
+        # ("dbt_runner", False),
     ],
 )
 @patch("cosmos.config.is_profile_cache_enabled")


### PR DESCRIPTION
We have received user reports of tasks hanging after upgrading to Cosmos 1.9.0. While the issue is not observed on Airflow 3, I was able to reproduce it on Airflow 2. Through investigation, it seems the issue stems from the use of dbt Runner during DAG processing, which was introduced citing optimisations described in [PR #1484](https://github.com/astronomer/astronomer-cosmos/pull/1484). Switching to a subprocess-based invocation resolves the hang and allowed tasks to progress normally.

Changes in this PR:
 - Default `RenderConfig.invocation_mode` to `InvocationMode.SUBPROCESS`.
 - Temporarily disable related test cases that are only relevant when using `DBT_RUNNER`. These tests currently fail due to the adjusted default and will be re-enabled once the issue is resolved.

Reference issues:
- [Cosmos Issue #1751](https://github.com/astronomer/astronomer-cosmos/issues/1751) — Track investigation and resolution of the dbt Runner hang on Airflow 2.

Next steps:
Once we identify and resolve the root cause of the hanging behaviour in Airflow 2 task execution with DBT_RUNNER for dag processing, we can safely revert the default back and re-enable the corresponding tests.

related: #1751