### PR TITLE
Allow to set task display name as a user-defined function

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -193,6 +193,7 @@ def _get_task_id_and_args(
     args: dict[str, Any],
     use_task_group: bool,
     normalize_task_id: Callable[..., Any] | None,
+    normalize_task_display_name: Callable[..., Any] | None,
     resource_suffix: str,
     include_resource_type: bool = False,
 ) -> tuple[str, dict[str, Any]]:
@@ -200,17 +201,30 @@ def _get_task_id_and_args(
     Generate task ID and update args with display name if needed.
     """
     args_update = args
-    task_display_name = f"{node.name}_{resource_suffix}"
+    task_name = f"{node.name}_{resource_suffix}"
+
     if include_resource_type:
-        task_display_name = f"{node.name}_{node.resource_type.value}_{resource_suffix}"
+        task_name = f"{node.name}_{node.resource_type.value}_{resource_suffix}"
+
     if use_task_group:
         task_id = resource_suffix
-    elif normalize_task_id:
+        args_update["task_display_name"] = task_name
+
+    elif normalize_task_id and not normalize_task_display_name:
         task_id = normalize_task_id(node)
-        args_update["task_display_name"] = task_display_name
+        args_update["task_display_name"] = task_name
+    elif not normalize_task_id and normalize_task_display_name:
+        task_id = task_name
+        args_update["task_display_name"] = normalize_task_display_name(node)
+    elif normalize_task_id and normalize_task_display_name:
+        task_id = normalize_task_id(node)
+        args_update["task_display_name"] = normalize_task_display_name(node)
     else:
-        task_id = task_display_name
+        task_id = task_name
+        args_update["task_display_name"] = task_name
+
     return task_id, args_update
+
 
 
 def create_dbt_resource_to_class(test_behavior: TestBehavior) -> dict[str, str]:
@@ -246,6 +260,7 @@ def create_task_metadata(
     use_task_group: bool = False,
     source_rendering_behavior: SourceRenderingBehavior = SourceRenderingBehavior.NONE,
     normalize_task_id: Callable[..., Any] | None = None,
+    normalize_task_display_name: Callable[..., Any] | None = None,
     test_behavior: TestBehavior = TestBehavior.AFTER_ALL,
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER,
     on_warning_callback: Callable[..., Any] | None = None,
@@ -283,10 +298,10 @@ def create_task_metadata(
             args["on_warning_callback"] = on_warning_callback
             exclude_detached_tests_if_needed(node, args, detached_from_parent)
             task_id, args = _get_task_id_and_args(
-                node, args, use_task_group, normalize_task_id, "build", include_resource_type=True
+                node, args, use_task_group, normalize_task_id,normalize_task_display_name, "build", include_resource_type=True
             )
         elif node.resource_type == DbtResourceType.MODEL:
-            task_id, args = _get_task_id_and_args(node, args, use_task_group, normalize_task_id, "run")
+            task_id, args = _get_task_id_and_args(node, args, use_task_group, normalize_task_id,normalize_task_display_name, "run")
         elif node.resource_type == DbtResourceType.SOURCE:
             args["on_warning_callback"] = on_warning_callback
 
@@ -298,7 +313,7 @@ def create_task_metadata(
                 return None
             args["select"] = f"source:{node.resource_name}"
             args.pop("models")
-            task_id, args = _get_task_id_and_args(node, args, use_task_group, normalize_task_id, "source")
+            task_id, args = _get_task_id_and_args(node, args, use_task_group, normalize_task_id,normalize_task_display_name, "source")
             if node.has_freshness is False and source_rendering_behavior == SourceRenderingBehavior.ALL:
                 # render sources without freshness as empty operators
                 # empty operator does not accept custom parameters (e.g., profile_args). recreate the args.
@@ -309,7 +324,7 @@ def create_task_metadata(
                 return TaskMetadata(id=task_id, operator_class="airflow.operators.empty.EmptyOperator", arguments=args)
         else:
             task_id, args = _get_task_id_and_args(
-                node, args, use_task_group, normalize_task_id, node.resource_type.value
+                node, args, use_task_group, normalize_task_id,normalize_task_display_name, node.resource_type.value
             )
 
         _override_profile_if_needed(args, node.profile_config_to_override)
@@ -355,6 +370,7 @@ def generate_task_or_group(
     test_indirect_selection: TestIndirectSelection,
     on_warning_callback: Callable[..., Any] | None,
     normalize_task_id: Callable[..., Any] | None = None,
+    normalize_task_display_name: Callable[..., Any] | None = None,
     detached_from_parent: dict[str, DbtNode] | None = None,
     **kwargs: Any,
 ) -> BaseOperator | TaskGroup | None:
@@ -375,6 +391,7 @@ def generate_task_or_group(
         use_task_group=use_task_group,
         source_rendering_behavior=source_rendering_behavior,
         normalize_task_id=normalize_task_id,
+        normalize_task_display_name=normalize_task_display_name,
         test_behavior=test_behavior,
         test_indirect_selection=test_indirect_selection,
         on_warning_callback=on_warning_callback,
@@ -582,6 +599,7 @@ def build_airflow_graph(
     test_behavior = render_config.test_behavior
     source_rendering_behavior = render_config.source_rendering_behavior
     normalize_task_id = render_config.normalize_task_id
+    normalize_task_display_name = render_config.normalize_task_display_name
     tasks_map: dict[str, Union[TaskGroup, BaseOperator]] = {}
     task_or_group: TaskGroup | BaseOperator
 
@@ -610,6 +628,7 @@ def build_airflow_graph(
             test_indirect_selection=test_indirect_selection,
             on_warning_callback=on_warning_callback,
             normalize_task_id=normalize_task_id,
+            normalize_task_display_name=normalize_task_display_name,
             node=node,
             detached_from_parent=detached_from_parent,
         )

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -65,6 +65,7 @@ class RenderConfig:
     :param source_rendering_behavior: Determines how source nodes are rendered when using cosmos default source node rendering (ALL, NONE, WITH_TESTS_OR_FRESHNESS). Defaults to "NONE" (since Cosmos 1.6).
     :param airflow_vars_to_purge_dbt_ls_cache: Specify Airflow variables that will affect the LoadMode.DBT_LS cache.
     :param normalize_task_id: A callable that takes a dbt node as input and returns the task ID. This allows users to assign a custom node ID separate from the display name.
+    :param normalize_task_display_name: A callable that takes a dbt node as input and returns the task display name. This allows users to assign a custom task display name separate from the node ID.
     :param should_detach_multiple_parents_tests: A boolean that allows users to decide whether to run tests with multiple parent dependencies in separate tasks.
     """
 
@@ -86,6 +87,7 @@ class RenderConfig:
     source_rendering_behavior: SourceRenderingBehavior = SourceRenderingBehavior.NONE
     airflow_vars_to_purge_dbt_ls_cache: list[str] = field(default_factory=list)
     normalize_task_id: Callable[..., Any] | None = None
+    normalize_task_display_name: Callable[..., Any] | None = None
     should_detach_multiple_parents_tests: bool = False
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -23,6 +23,7 @@ The ``RenderConfig`` class takes the following arguments:
 - ``airflow_vars_to_purge_cache``: (new in v1.5) Specify Airflow variables that will affect the ``LoadMode.DBT_LS`` cache. See `Caching <./caching.html>`_ for more information.
 - ``source_rendering_behavior``: Determines how source nodes are rendered when using cosmos default source node rendering (ALL, NONE, WITH_TESTS_OR_FRESHNESS). Defaults to "NONE" (since Cosmos 1.6). See `Source Nodes Rendering <./source-nodes-rendering.html>`_ for more information.
 - ``normalize_task_id``: A callable that takes a dbt node as input and returns the task ID. This function allows users to set a custom task_id independently of the model name, which can be specified as the task’s display_name. This way, task_id can be modified using a user-defined function, while the model name remains as the task’s display name. The display_name parameter is available in Airflow 2.9 and above. See `Task display name <./task-display-name.html>`_ for more information.
+- ``normalize_task_display_name``: This function allows users to set a custom user-defined function to alter the display name independently of the model name. This way, the task_id can be preserved while the model display name is modified.
 - ``should_detach_multiple_parents_tests``: A boolean to control if tests that depend on multiple parents should be run as standalone tasks. See `Parsing Methods <testing-behavior.html>`_ for more information.
 
 

--- a/docs/configuration/task-display-name.rst
+++ b/docs/configuration/task-display-name.rst
@@ -31,3 +31,18 @@ You can provide a function to convert the model name to an ASCII-compatible form
 
 .. note::
     Although the slugify example often works, it may not be suitable for use in actual production. Since slugify performs conversions based on pronunciation, there may be cases where task_id is not unique due to homophones and similar issues.
+
+Similarily, there are cases where the user might want to preserve the ``task_id`` while altering the ``display_name``. This can be accomplished with the ``normalize_task_display_name`` field of ``RenderConfig``.
+
+Example:
+
+You can provide a function to display the dbt models in airflow UI without any suffix (``_source``, ``_run``, etc)
+
+.. code-block:: python
+    def normalize_task_display_name(node):
+        return f"{node.name}"
+    from cosmos import DbtTaskGroup, RenderConfig
+    jaffle_shop = DbtTaskGroup(
+        render_config=RenderConfig(normalize_task_display_name=normalize_task_display_name)
+    )
+..


### PR DESCRIPTION
## Description

re-opened #1756 after resetting the repository by mistake.

> Currently cosmos allows to override the task_id value with the param [normalize_task_id](https://astronomer.github.io/astronomer-cosmos/configuration/task-display-name.html), but there is no process in place to override the display_name . At my current company we have some logic in place using the task_id and corresponding suffixes, but we would like to still change how tasks are displayed in the airflow UI, plus from a user's perspective it is sometimes confusing to have the suffix being displayed in the airflow UI instead of just having the name of the model itself. It would be nice to have a way to keep the task_id as it is while overriding the display_name instead so if a user is already using the task_ids for some custom logic, it is possible to change how the tasks are displayed in the UI without causing issues.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

No
## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
