### PR TITLE
Log contents of `packages.yml` when `AIRFLOW__LOGGING__LOGGING_LEVEL=DEBUG`

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -484,7 +484,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         for filename in DBT_DEPENDENCIES_FILE_NAMES:
             filepath = tmp_dir_path / filename
-            if filepath.exists() and filepath.is_file():
+            if filepath.is_file():
                 self.log.debug(f"Checking for the {filename} dependencies file.")
                 self.log.debug(f"Contents of the <{filepath}> dependencies file:\n{filepath.read_text()}")
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -484,7 +484,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         for filename in DBT_DEPENDENCIES_FILE_NAMES:
             filepath = tmp_dir_path / filename
-            if filepath.is_file():
+            if self.log.isEnabledFor(logging.DEBUG) and filepath.is_file():
                 self.log.debug(f"Checking for the {filename} dependencies file.")
                 self.log.debug(f"Contents of the <{filepath}> dependencies file:\n{filepath.read_text()}")
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import inspect
 import json
+import logging
 import os
 import tempfile
 import time

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -485,9 +485,9 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         for filename in DBT_DEPENDENCIES_FILE_NAMES:
             filepath = tmp_dir_path / filename
-            if self.log.isEnabledFor(logging.DEBUG) and filepath.is_file():
-                self.log.debug(f"Checking for the {filename} dependencies file.")
-                self.log.debug(f"Contents of the <{filepath}> dependencies file:\n{filepath.read_text()}")
+            if filepath.is_file():
+                self.log.debug("Checking for the %s dependencies file.", str(filename))
+                self.log.debug("Contents of the <%s> dependencies file:\n %s", str(filepath), str(filepath.read_text()))
 
         self.invoke_dbt(command=deps_command, env=env, cwd=tmp_dir_path)
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -35,7 +35,12 @@ from cosmos.cache import (
     _get_latest_cached_package_lockfile,
     is_cache_package_lockfile_enabled,
 )
-from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP, InvocationMode
+from cosmos.constants import (
+    _AIRFLOW3_MAJOR_VERSION,
+    DBT_DEPENDENCIES_FILE_NAMES,
+    FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP,
+    InvocationMode,
+)
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.dbt.project import copy_dbt_packages, get_partial_parse_path, has_non_empty_dependencies_file
 from cosmos.exceptions import AirflowCompatibilityError, CosmosDbtRunError, CosmosValueError
@@ -476,6 +481,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     ) -> None:
         self._cache_package_lockfile(tmp_dir_path)
         deps_command = [self.dbt_executable_path, "deps"] + flags
+
+        for filename in DBT_DEPENDENCIES_FILE_NAMES:
+            filepath = tmp_dir_path / filename
+            if filepath.exists() and filepath.is_file():
+                self.log.debug(f"Checking for the {filename} dependencies file.")
+                self.log.debug(f"Contents of the <{filepath}> dependencies file:\n{filepath.read_text()}")
+
         self.invoke_dbt(command=deps_command, env=env, cwd=tmp_dir_path)
 
     @staticmethod


### PR DESCRIPTION
Recently, there have been some concerns that Cosmos may modify the `packages.yml` content, leading to errors.

If users set `AIRFLOW__LOGGING__LOGGING_LEVEL=DEBUG`, they should now be able to confirm the content of the file.

Example of log output:

```
[2025-05-12T10:52:38.183+0100] {local.py:481} DEBUG - Checking for the packages.yml dependencies file.
[2025-05-12T10:52:38.184+0100] {local.py:484} DEBUG - Contents of the </var/folders/td/522y78v91d1f5wgh67mj3p0m0000gn/T/tmp_4q53rv2/packages.yml> dependencies file:
packages:
  - package: dbt-labs/dbt_utils
    version: "1.1.1"

```
