### PR TITLE
Support custom `packages-install-path`

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -8,6 +8,7 @@ from packaging.version import Version
 
 BIGQUERY_PROFILE_TYPE = "bigquery"
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
+DBT_PROJECT_FILENAME = "dbt_project.yml"
 DEFAULT_DBT_PROFILE_NAME = "cosmos_profile"
 DEFAULT_DBT_TARGET_NAME = "cosmos_target"
 DEFAULT_COSMOS_CACHE_DIR_NAME = "cosmos"
@@ -23,7 +24,7 @@ DBT_LOG_FILENAME = "dbt.log"
 DBT_BINARY_NAME = "dbt"
 DEFAULT_PROFILES_FILE_NAME = "profiles.yml"
 PACKAGE_LOCKFILE_YML = "package-lock.yml"
-DBT_PACKAGES_FOLDER = "dbt_packages"
+DBT_DEFAULT_PACKAGES_FOLDER = "dbt_packages"
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -51,7 +51,7 @@ def get_dbt_packages_subpath(source_folder: Path) -> str:
     https://docs.getdbt.com/reference/project-configs/packages-install-path
 
     :param source_folder: The dbt project root directory
-    :returns: A string containing the dbt_packges subpath within the source folder.
+    :returns: A string containing the dbt_packages subpath within the source folder.
     """
     subpath = DBT_DEFAULT_PACKAGES_FOLDER
     dbt_project_yml_path = source_folder / DBT_PROJECT_FILENAME


### PR DESCRIPTION
The feature introduced in #1670 (Support running `dbt deps` incrementally to pre-defined `dbt_packages` during task execution) did not work as expected if users had defined a custom path for `packages-install-path`. It only worked if the default (`dbt_packages` was being used. This PR aims to solve the issue.

