### PR TITLE
Fix task instance try_number attribute for Airflow 3 compatibility

### DIFF
--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -183,7 +183,7 @@ def _construct_dest_file_path(
         f"{context['dag'].dag_id}"
         f"/{context['run_id']}"
         f"/{context['task_instance'].task_id}"
-        f"/{context['task_instance']._try_number}"
+        f"/{context['task_instance'].try_number}"
     )
     rel_path = os.path.relpath(file_path, source_target_dir).lstrip("/")
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1763,7 +1763,7 @@ def test_construct_dest_file_path_with_run_id():
     context = {
         "dag": MagicMock(dag_id="test_dag"),
         "run_id": "test_run_id",
-        "task_instance": MagicMock(task_id="test_task", _try_number=1),
+        "task_instance": MagicMock(task_id="test_task", try_number=1),
     }
     result = _construct_dest_file_path(dest_target_dir, file_path, source_target_dir, source_subpath, context=context)
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -23,7 +23,7 @@ def dummy_kwargs():
         "context": {
             "dag": MagicMock(dag_id="test_dag"),
             "run_id": "test_run_id",
-            "task_instance": MagicMock(task_id="test_task", _try_number=1),
+            "task_instance": MagicMock(task_id="test_task", try_number=1),
         },
         "bucket_name": "test_bucket",
         "container_name": "test_container",


### PR DESCRIPTION
This PR updates the way we access the task instance try number attribute in Cosmos io module's callback utility to ensure compatibility with both Airflow 2 and Airflow 3. The private `_try_number` attribute was removed in Airflow 3, making it necessary to use the public `try_number` property instead. This change ensures that Cosmos works correctly with both Airflow 2 and Airflow 3 versions.

#### Testing
- Updated test cases to reflect the new attribute access
- Verified compatibility with both Airflow 2 and Airflow 3

closes: #1712 
related: #1778 
related: https://github.com/astronomer/oss-integrations-private/issues/124
