### PR TITLE
Set retries to 0 in example DAGs

### DIFF
--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -41,6 +41,6 @@ basic_cosmos_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="basic_cosmos_dag",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END local_example]

--- a/dev/dags/basic_cosmos_dag_full_module_path_imports.py
+++ b/dev/dags/basic_cosmos_dag_full_module_path_imports.py
@@ -42,6 +42,6 @@ basic_cosmos_dag_full_module_path_imports = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="basic_cosmos_dag_full_module_path_imports",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END local_example]

--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -53,7 +53,7 @@ with DAG(
         execution_config=shared_execution_config,
         operator_args={"install_deps": True},
         profile_config=profile_config,
-        default_args={"retries": 2},
+        default_args={"retries": 0},
     )
 
     orders = DbtTaskGroup(
@@ -68,7 +68,7 @@ with DAG(
         execution_config=shared_execution_config,
         operator_args={"install_deps": True},
         profile_config=profile_config,
-        default_args={"retries": 2},
+        default_args={"retries": 0},
     )
 
     post_dbt = EmptyOperator(task_id="post_dbt")

--- a/dev/dags/cosmos_callback_dag.py
+++ b/dev/dags/cosmos_callback_dag.py
@@ -55,6 +55,6 @@ cosmos_callback_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="cosmos_callback_dag",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END cosmos_callback_example]

--- a/dev/dags/cosmos_manifest_example.py
+++ b/dev/dags/cosmos_manifest_example.py
@@ -35,7 +35,7 @@ with DAG(
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 ):
     pre_dbt = EmptyOperator(task_id="pre_dbt")
 

--- a/dev/dags/cosmos_profile_mapping.py
+++ b/dev/dags/cosmos_profile_mapping.py
@@ -46,7 +46,7 @@ with DAG(
             ),
         ),
         operator_args={"install_deps": True},
-        default_args={"retries": 2},
+        default_args={"retries": 0},
     )
 
     post_dbt = EmptyOperator(task_id="post_dbt")

--- a/dev/dags/cosmos_seed_dag.py
+++ b/dev/dags/cosmos_seed_dag.py
@@ -41,7 +41,7 @@ with DAG(
     doc_md=__doc__,
     catchup=False,
     max_active_runs=1,
-    default_args={"owner": "01-EXTRACT", "retries": 2},
+    default_args={"owner": "01-EXTRACT", "retries": 0},
 ) as dag:
     with TaskGroup(group_id="drop_seeds_if_exist") as drop_seeds:
         for seed in ["raw_customers", "raw_payments", "raw_orders"]:

--- a/dev/dags/dbt_docs.py
+++ b/dev/dags/dbt_docs.py
@@ -41,7 +41,7 @@ with DAG(
     schedule="@daily",
     doc_md=__doc__,
     catchup=False,
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 ) as dag:
     generate_dbt_docs_aws = DbtDocsS3Operator(
         task_id="generate_dbt_docs_aws",

--- a/dev/dags/example_cosmos_dbt_build.py
+++ b/dev/dags/example_cosmos_dbt_build.py
@@ -41,6 +41,6 @@ example_cosmos_dbt_build = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_cosmos_dbt_build",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END build_example]

--- a/dev/dags/example_cosmos_python_models.py
+++ b/dev/dags/example_cosmos_python_models.py
@@ -48,6 +48,6 @@ example_cosmos_python_models = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_cosmos_python_models",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END example_cosmos_python_models]

--- a/dev/dags/example_dbt_deps.py
+++ b/dev/dags/example_dbt_deps.py
@@ -31,5 +31,5 @@ dbt_deps_example_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="dbt_deps_example",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )

--- a/dev/dags/example_model_version.py
+++ b/dev/dags/example_model_version.py
@@ -34,6 +34,6 @@ basic_cosmos_dag = DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="example_model_version",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 )
 # [END local_example]

--- a/dev/dags/example_source_rendering.py
+++ b/dev/dags/example_source_rendering.py
@@ -41,7 +41,7 @@ source_rendering_dag = DbtDag(
     start_date=datetime(2024, 1, 1),
     catchup=False,
     dag_id="source_rendering_dag",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
     on_warning_callback=lambda context: print(context),
 )
 # [END cosmos_source_node_example]

--- a/dev/dags/example_tasks_map.py
+++ b/dev/dags/example_tasks_map.py
@@ -41,7 +41,7 @@ with DbtDag(
     start_date=datetime(2023, 1, 1),
     catchup=False,
     dag_id="customized_cosmos_dag",
-    default_args={"retries": 2},
+    default_args={"retries": 0},
 ) as dag:
     # Walk the dbt graph
     for unique_id, dbt_node in dag.dbt_graph.filtered_nodes.items():

--- a/dev/dags/user_defined_profile.py
+++ b/dev/dags/user_defined_profile.py
@@ -42,7 +42,7 @@ with DAG(
             dbt_ls_path=DBT_LS_PATH,
         ),
         operator_args={"append_env": True, "install_deps": True},
-        default_args={"retries": 2},
+        default_args={"retries": 0},
     )
 
     post_dbt = EmptyOperator(task_id="post_dbt")


### PR DESCRIPTION
This PR removes default retries from example DAGs to speed up CI and surface failures faster. While we can add retries to specific DAGs if needed, having them enabled by default adds unnecessary delays to our test suite.

related: https://github.com/astronomer/oss-integrations-private/issues/124