### PR TITLE
Fix test hash value for Darwin when using Py 3.12.10

### DIFF
--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1881,6 +1881,7 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     hash_dir, hash_args = version.split(",")
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
+        # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
         assert hash_dir in ("391db5c7e1fb90214d829dd0476059a1", "0148da6f5f7fd260c9fa55c3b3c45168")
     else:
         assert hash_dir == "0148da6f5f7fd260c9fa55c3b3c45168"


### PR DESCRIPTION
This is a test-only change that affects running tests locally in MacOS and does not affect the actual implementation of Cosmos.

In the past, we observed inconsistencies in how hashing worked across different platforms (Darwin vs. Linux).

When setting up Cosmos in a brand new laptop that runs MacOS 15.4.1 (Arm 64), I noticed the hash was the same as the CI, and I faced the following issue when running `hatch run tests.py3.9-2.10-1.9:test-cov`:
```
FAILED tests/dbt/test_graph.py::test_save_dbt_ls_cache - AssertionError: assert '0148da6f5f7fd260c9fa55c3b3c45168' == '391db5c7e1fb90214d829dd0476059a1'
  
  - 391db5c7e1fb90214d829dd0476059a1
  + 0148da6f5f7fd260c9fa55c3b3c45168
```

In order not to break for others, I'm still supporting the other value for MacOS.

