### PR TITLE
doc: update testing behavior file with k8s exec mode

### DIFF
--- a/docs/configuration/testing-behavior.rst
+++ b/docs/configuration/testing-behavior.rst
@@ -54,7 +54,7 @@ Warning Behavior
 
 .. note::
 
-    As of now, this feature is only available for the default execution mode ``local`` and for ``virtualenv``
+    As of now, this feature is only available for the default execution mode ``local``, ``virtualenv`` and ``kubernetes``
 
 Cosmos enables you to receive warning notifications from tests and process them using a callback function.
 The ``on_warning_callback`` parameter adds two extra context variables to the callback function: ``test_names`` and ``test_results``.


### PR DESCRIPTION
## Description

Very small doc update for supported execution modes for `on_warning_callback` feature.

## Related Issue(s)

closes #1811 

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
