### PR TITLE
Fix dbt Fusion documentation

### DIFF
--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -65,6 +65,4 @@ Limitations
 - Currently (23 June 2025) dbt Fusion is still in beta
 - dbt Fusion only supports Snowflake
 - Cosmos does not support dbt Fusion when using ``ExecutionMode.AIRFLOW_ASYNC``
-- To support dbt Fusion, Cosmos changed how it interacts with dbt. This works with the latest versions of dbt-core, but may not
-work with older versions. If you want to continue using dbt-core and was affected, set the environment variable
-``AIRFLOW__COSMOS__PRE_DBT_FUSION=1`` and Cosmos interaction with dbt-core will work as previous versions.
+- To support dbt Fusion, Cosmos changed how it interacts with dbt. This works with the latest versions of dbt-core, but may not work with older versions. If you want to continue using dbt-core and was affected, set the environment variable ``AIRFLOW__COSMOS__PRE_DBT_FUSION=1`` and Cosmos interaction with dbt-core will work as previous versions.

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -40,24 +40,24 @@ How to use
 
 End-users should install the dbt Fusion package themselves. An example of how to do this in Astro would be to add the following lines in your ``Dockerfile``:
 
-```
-USER root
-RUN apt install -y curl
-RUN curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
-```
+.. code-block:: 
+
+    USER root
+    RUN apt install -y curl
+    RUN curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 
 2. Update your ``DbtDag`` or ``DbtTaskGroup`` to use the dbt Fusion binary
 
 Example:
 
-```
-DbtDag(
-    ...,
-    execution_config=ExecutionConfig(
-        dbt_executable_path="/home/astro/.local/bin/dbt"
+.. code-block:: 
+    DbtDag(
+        ...,
+        execution_config=ExecutionConfig(
+            dbt_executable_path="/home/astro/.local/bin/dbt"
+        )
     )
-)
-```
+
 
 Limitations
 -----------

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -40,7 +40,7 @@ How to use
 
 End-users should install the dbt Fusion package themselves. An example of how to do this in Astro would be to add the following lines in your ``Dockerfile``:
 
-.. code-block:: 
+.. code-block::
 
     USER root
     RUN apt install -y curl
@@ -50,7 +50,7 @@ End-users should install the dbt Fusion package themselves. An example of how to
 
 Example:
 
-.. code-block:: 
+.. code-block::
     DbtDag(
         ...,
         execution_config=ExecutionConfig(


### PR DESCRIPTION
Fix dbt Fusion docs rendering issue due to Markdown syntax in RestructuredText file:

<img width="689" alt="Screenshot 2025-06-25 at 13 18 26" src="https://github.com/user-attachments/assets/b6a03692-55c5-470e-a798-222ba550f9ed" />
https://astronomer.github.io/astronomer-cosmos/configuration/dbt-fusion.html