### PR TITLE
Update dbt-fusion.rst to explicitly highlight it is in alpha

### DIFF
--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -4,7 +4,7 @@ dbt Fusion support
 ==================
 
 .. note::
-    Available since Cosmos 1.11 when using ``ExecutionMode.LOCAL``.
+    Available since Cosmos 1.11.0a1 when using ``ExecutionMode.LOCAL``.
 
 Context
 -------
@@ -30,14 +30,21 @@ Some reported dbt Fusion features include:
 Support
 -------
 
-Cosmos 1.11 adds initial support to running dbt Fusion with Cosmos when using ``ExecutionMode.LOCAL``.
+Cosmos 1.11.0a adds initial support for running dbt Fusion with Cosmos when using ``ExecutionMode.LOCAL``.
 
 We do not have a solution for using `ExecutionMode.AIRFLOW_ASYNC <https://astronomer.github.io/astronomer-cosmos/getting_started/execution-modes.html#airflow-async>`_.
 
 How to use
 ----------
 
-1. Install dbt Fusion in your Airflow deployment
+1. Install Cosmos 1.11 alpha
+
+```
+pip install astronomer-cosmos --pre
+```
+
+
+2. Install dbt Fusion in your Airflow deployment
 
 End-users should install the dbt Fusion package themselves. An example of how to do this in Astro would be to add the following lines in your ``Dockerfile``:
 
@@ -47,7 +54,7 @@ End-users should install the dbt Fusion package themselves. An example of how to
     RUN apt install -y curl
     RUN curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
 
-2. Update your ``DbtDag`` or ``DbtTaskGroup`` to use the dbt Fusion binary
+3. Update your ``DbtDag`` or ``DbtTaskGroup`` to use the dbt Fusion binary
 
 Example:
 
@@ -64,7 +71,8 @@ Example:
 Limitations
 -----------
 
+- This feature is in Cosmos 1.11 pre-release versions
 - Currently (23 June 2025) dbt Fusion is still in beta
 - dbt Fusion only supports Snowflake
 - Cosmos does not support dbt Fusion when using ``ExecutionMode.AIRFLOW_ASYNC``
-- To support dbt Fusion, Cosmos changed how it interacts with dbt. This works with the latest versions of dbt-core, but may not work with older versions. If you want to continue using dbt-core and was affected, set the environment variable ``AIRFLOW__COSMOS__PRE_DBT_FUSION=1`` and Cosmos interaction with dbt-core will work as previous versions.
+To support dbt Fusion, Cosmos modified its interaction with dbt. This works with the latest versions of dbt-core, but may not work with older versions. If you want to continue using dbt-core and was affected, set the environment variable ``AIRFLOW__COSMOS__PRE_DBT_FUSION=1`` and Cosmos interaction with dbt-core will work as previous versions.

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -43,8 +43,6 @@ How to use
 
     pip install astronomer-cosmos --pre
 
-
-
 2. Install dbt Fusion in your Airflow deployment
 
 End-users should install the dbt Fusion package themselves. An example of how to do this in Astro would be to add the following lines in your ``Dockerfile``:

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -30,7 +30,7 @@ Some reported dbt Fusion features include:
 Support
 -------
 
-Cosmos 1.11.0a adds initial support for running dbt Fusion with Cosmos when using ``ExecutionMode.LOCAL``.
+Cosmos 1.11.0a1 adds initial support for running dbt Fusion with Cosmos when using ``ExecutionMode.LOCAL``.
 
 We do not have a solution for using `ExecutionMode.AIRFLOW_ASYNC <https://astronomer.github.io/astronomer-cosmos/getting_started/execution-modes.html#airflow-async>`_.
 

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -37,7 +37,7 @@ We do not have a solution for using `ExecutionMode.AIRFLOW_ASYNC <https://astron
 How to use
 ----------
 
-1. Install Cosmos 1.11 alpha
+1. Install Cosmos 1.11.0a1 alpha
 
 .. code-block::
 

--- a/docs/configuration/dbt-fusion.rst
+++ b/docs/configuration/dbt-fusion.rst
@@ -39,9 +39,10 @@ How to use
 
 1. Install Cosmos 1.11 alpha
 
-```
-pip install astronomer-cosmos --pre
-```
+.. code-block::
+
+    pip install astronomer-cosmos --pre
+
 
 
 2. Install dbt Fusion in your Airflow deployment


### PR DESCRIPTION
Since Astronomer is publishing a blog post on the official dbt Fusion support, we should make it explicit in our docs that this is alpha and inform users how to install the alpha.