### PR TITLE
Leverage Trusted Publisher Management when publishing PyPI package

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,20 +24,23 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
-  publish:
-    name: Publish release
+  pypi-publish:
+    name: Upload release to PyPI
+    runs-on: ubuntu-latest
     needs:
       - build
-    runs-on: ubuntu-latest
-
+    environment:
+      name: pypi
+      url: https://pypi.org/p/astronomer-cosmos
+    permissions:
+      id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
     steps:
+      # retrieve your distributions here
       - uses: actions/download-artifact@v4
         with:
           name: artifacts
           path: dist
 
-      - name: Push build artifacts to PyPi
-        uses: pypa/gh-action-pypi-publish@v1.12.4
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_TOKEN }}
+      # More information in https://github.com/pypa/gh-action-pypi-publish
+      - name: Publish package distributions to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
Change Cosmos PyPI package publishing from using a PyPI token to use Trusted Publisher Management.

We'll need to merge this in order to test the change, and cut an alpha.
