### PR TITLE
CI: Add back accidentally deleted python-version matrix for running unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main,add-python-version-matrix-unit-tests]
+    branches: [main]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main,add-python-version-matrix-unit-tests]
   pull_request_target: # Also run on pull requests originated from forks
     branches: [main]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,6 +41,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         airflow-version: ["2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"]
         dbt-version: ["1.9"]
         exclude:


### PR DESCRIPTION
Looks like the CI is failing to run tests after having accidentally dropped the matrix entries for python-version in https://github.com/astronomer/astronomer-cosmos/pull/1807

This came to my attention while I'm working on another PR whose action run complained about this in https://github.com/astronomer/astronomer-cosmos/actions/runs/16320855168

We are getting a yml validation error for the missing matrix key. The PR fixes this issue by adding back the deleted matrix entry.