### PR TITLE
Remove commented code and fix mypy failures

### DIFF
--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -241,19 +241,15 @@ class DbtTestWarningHandler(KubernetesPodOperatorCallback):  # type: ignore[misc
 
         # Check for warnings
         warning_detected = False
-        test_names, test_results = [], []
         if isinstance(task, DbtTestKubernetesOperator):
             warn_count = self._detect_standard_warnings(logs_text)
             if warn_count:
                 self.operator.log.info(f"Detected {warn_count} warnings using standard pattern")
-                # test_names, test_results = self._extract_standard_log_issues(logs_text)
                 warning_detected = True
         elif isinstance(task, DbtSourceKubernetesOperator):
             source_freshness_warnings = self._detect_source_freshness_warnings(logs_text)
             if source_freshness_warnings:
                 self.operator.log.info(f"Detected {len(source_freshness_warnings)} source freshness warnings")
-                # test_names = [w["name"] for w in source_freshness_warnings]
-                # test_results = [w["status"] for w in source_freshness_warnings]
                 warning_detected = True
 
         if not warning_detected:


### PR DESCRIPTION
Some commented code was pushed as part of https://github.com/astronomer/astronomer-cosmos/pull/1859/ and also responsible for mypy failures. Removing that unused commented code fixes the [type-check failures](https://github.com/astronomer/astronomer-cosmos/actions/runs/16322249943/job/46169121034#step:5:595) observed in main branch CI.

Successful type check job run from this PR: https://github.com/astronomer/astronomer-cosmos/actions/runs/16343955179/job/46172890065?pr=1876#step:5:591

related: https://github.com/astronomer/astronomer-cosmos/pull/1859/
related: #1873 