### PR TITLE
Fix dbt Fusion tests: Harden DbtNode against null config/meta 

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -307,7 +307,7 @@ def parse_dbt_ls_output(project_path: Path | None, ls_stdout: str) -> dict[str, 
                     # dbt-core defined the node path via "original_file_path", dbt fusion identifies it via "path"
                     file_path=base_path / (node_dict["original_file_path"] or node_dict.get("path")),
                     tags=node_dict.get("tags", []),
-                    config=node_dict.get("config", {}),
+                    config=node_dict.get("config") or {},
                     has_freshness=(
                         is_freshness_effective(node_dict.get("freshness"))
                         if DbtResourceType(node_dict["resource_type"]) == DbtResourceType.SOURCE
@@ -923,7 +923,7 @@ class DbtGraph:
                     depends_on=node_dict.get("depends_on", {}).get("nodes", []),
                     file_path=self.execution_config.project_path / _normalize_path(node_dict["original_file_path"]),
                     tags=node_dict["tags"],
-                    config=node_dict["config"],
+                    config=node_dict.get("config") or {},
                     has_freshness=(
                         is_freshness_effective(node_dict.get("freshness"))
                         if DbtResourceType(node_dict["resource_type"]) == DbtResourceType.SOURCE

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -89,7 +89,8 @@ class DbtNode:
         Extract node-specific configuration declared in the model dbt YAML configuration.
         These will be used while instantiating Airflow tasks.
         """
-        value = self.config.get("meta", {}).get("cosmos", {})
+        meta_cfg = self.config.get("meta") or {}
+        value = meta_cfg.get("cosmos", {})
         if not isinstance(value, dict):
             raise CosmosLoadDbtException(
                 f"Error parsing dbt node <{self.unique_id}>. Invalid type: 'cosmos' in meta must be a dict."
@@ -148,7 +149,9 @@ class DbtNode:
 
     @property
     def owner(self) -> str:
-        return str(self.config.get("meta", {}).get("owner", ""))
+        cfg = self.config or {}
+        meta_cfg = cfg.get("meta") or {}
+        return str(meta_cfg.get("owner", ""))
 
     @property
     def context_dict(self) -> dict[str, Any]:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -149,8 +149,8 @@ class DbtNode:
 
     @property
     def owner(self) -> str:
-        cfg = self.config or {}
-        meta_cfg = cfg.get("meta") or {}
+        config_dict = self.config or {}
+        meta_cfg = config_dict.get("meta") or {}
         return str(meta_cfg.get("owner", ""))
 
     @property

--- a/dev/dags/basic_cosmos_task_group_different_owners.py
+++ b/dev/dags/basic_cosmos_task_group_different_owners.py
@@ -13,7 +13,7 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
-PROJECT_DIR = DBT_ROOT_PATH / "jaffle_shop"
+PROJECT_DIR = DBT_ROOT_PATH / "altered_jaffle_shop"
 
 
 profile_config = ProfileConfig(
@@ -40,7 +40,7 @@ with DAG(
 
     # Considering the `dbt_project.yml` file contains the following:
     # seeds:
-    #   jaffle_shop:
+    #   altered_jaffle_shop:
     #     +meta:
     #       cosmos:
     #         profile_config:

--- a/dev/dags/dbt/altered_jaffle_shop/.gitignore
+++ b/dev/dags/dbt/altered_jaffle_shop/.gitignore
@@ -3,3 +3,4 @@ target/
 dbt_packages/
 logs/
 !target/manifest.json
+dbt_internal_packages/

--- a/dev/dags/dbt/altered_jaffle_shop/dbt_project.yml
+++ b/dev/dags/dbt/altered_jaffle_shop/dbt_project.yml
@@ -24,3 +24,12 @@ models:
       materialized: table
       staging:
         materialized: view
+
+seeds:
+  altered_jaffle_shop:
+      +meta:
+        cosmos:
+          profile_config:
+            profile_name: postgres_profile
+            profile_mapping:
+              threads: 2

--- a/dev/dags/dbt/jaffle_shop/dbt_project.yml
+++ b/dev/dags/dbt/jaffle_shop/dbt_project.yml
@@ -24,13 +24,3 @@ models:
       materialized: table
       staging:
         materialized: view
-
-
-seeds:
-  jaffle_shop:
-      +meta:
-        cosmos:
-          profile_config:
-            profile_name: postgres_profile
-            profile_mapping:
-              threads: 2

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1883,9 +1883,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
         # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
-        assert hash_dir in ("c2c47529eaec412281bdb243a479b734", "efabb6a9130840317ded8d2c05caaea4")
+        assert hash_dir in ("c2c47529eaec412281bdb243a479b734", "fa93914ecb491cc40a17ab956397359a")
     else:
-        assert hash_dir == "efabb6a9130840317ded8d2c05caaea4"
+        assert hash_dir == "fa93914ecb491cc40a17ab956397359a"
 
 
 @pytest.mark.integration

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -82,11 +82,12 @@ def get_dag_bag() -> DagBag:  # noqa: C901
         if AIRFLOW_VERSION < Version("2.8.0"):
             file.writelines("example_cosmos_dbt_build.py\n")
 
-        # Disabling this DAG temporarily due to an Airflow 3 bug on processing DatasetAlias that contain non-ASCII characters:
+        # Disabling these DAGs temporarily due to an Airflow 3 bug on processing DatasetAlias that contain non-ASCII characters:
         # https://github.com/apache/airflow/issues/51566
         # https://github.com/astronomer/astronomer-cosmos/issues/1802
         if AIRFLOW_VERSION >= Version("3.0.0"):
             file.writelines("example_source_rendering.py\n")
+            file.writelines("basic_cosmos_task_group_different_owners.py\n")
 
     print(".airflowignore contents: ")
     print(AIRFLOW_IGNORE_FILE.read_text())


### PR DESCRIPTION
This PR fixes a crash in `DbtNode` when dbt emits `null` for `config` or `meta` and a bit of housekeeping around the demo projects and tests. The fixes are:
1.  Handle `null` `config`/`meta` in `DbtNode` (observed in case of using dbt Fusion)
dbt may output `"config": null` or `"meta": null` for nodes with no explicit config block.
to fix this, updated property accessors:
`meta` — safely coalesces to {}
`owner` — safely coalesces to ""
Parsers (`parse_dbt_ls_output`, `load_from_dbt_manifest`) now create every node with
```
  config=node_dict.get("config") or {}
```
ensuring the field is always a dict.
2. `basic_cosmos_task_group_different_owners` example DAG now targets the `altered_jaffle_shop` project
   - Point `basic_cosmos_task_group_different_owners.py` at the altered_jaffle_shop project (`dev/dags/dbt/altered_jaffle_shop`) instead of the `jaffle_shop` project.
   - In `altered_jaffle_shop/dbt_project.yml`, add a seed-level `meta` block to showcase per-resource profile overrides.
   - Remove the conflicting seed meta from the `jaffle_shop` project (it was using `postgres_profile`, which clashed with the Fusion tests’ `snowflake_profile`)
3. At the same time the PR disables running the `basic_cosmos_task_group_different_owners` example DAG on Airflow 3 due to a known issue #1802 on Airflow 3 wrt DatasetAlias with non-ascii characters (present in the `altered_jaffle_shop` project)


related: #1873 
related: #1802 