### PR TITLE
Resolve 'overly broad permissions' warnings from Zizmor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     name: Build wheels and source distribution
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
 
     steps:
       - uses: actions/checkout@v4
@@ -34,6 +36,7 @@ jobs:
       url: https://pypi.org/p/astronomer-cosmos
     permissions:
       id-token: write  # IMPORTANT: this permission is mandatory for trusted publishing
+      contents: read
     steps:
       # retrieve your distributions here
       - uses: actions/download-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,16 @@ jobs:
       github.event.pull_request.head.repo.full_name != github.repository &&
       'external' || 'internal' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - run: true
 
   Type-Check:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,6 +42,8 @@ jobs:
   Run-Unit-Tests:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -104,6 +110,8 @@ jobs:
   Run-Integration-Tests:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -196,6 +204,8 @@ jobs:
   Run-Integration-Tests-Expensive:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         python-version: ["3.11"]
@@ -278,6 +288,8 @@ jobs:
   Run-Integration-Tests-DBT-1-5-4:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -348,6 +360,8 @@ jobs:
   Run-Integration-Tests-DBT-Async:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -418,6 +432,8 @@ jobs:
   Run-Integration-dbt-fusion-Tests:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -474,6 +490,8 @@ jobs:
   Run-Performance-Tests:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -545,6 +563,8 @@ jobs:
   Run-Kubernetes-Tests:
     needs: Authorize
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       fail-fast: false
       matrix:
@@ -618,6 +638,8 @@ jobs:
       - Run-Integration-Tests-Expensive
       - Run-Kubernetes-Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
scan results from this PR: https://github.com/astronomer/astronomer-cosmos/security/code-scanning?query=is%3Aopen+pr%3A1889

vs

on main: https://github.com/astronomer/astronomer-cosmos/security/code-scanning (this will change after merging this PR, but can be compared while the PR is still open)

related: https://github.com/astronomer/oss-integrations-private/issues/156