### PR TITLE
Resolve 'credential persistence through GitHub Actions artifacts' warnings from Zizmor

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -44,6 +44,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v4
+      with:
+        persist-credentials: false
 
     # Add any setup steps before running the `github/codeql-action/init` action.
     # This includes steps like installing compilers or runtimes (`actions/setup-node`

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,6 +11,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Install build dependencies
         run: python -m pip install --upgrade build

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/setup-python@v5
         with:
@@ -71,6 +72,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/cache@v4
         with:
@@ -139,6 +141,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/cache@v4
         with:
@@ -219,6 +222,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -301,6 +306,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -371,6 +378,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -429,6 +438,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
 
       - uses: actions/cache@v4
         with:
@@ -497,6 +507,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -555,6 +567,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - uses: actions/cache@v4
         with:
           path: |
@@ -622,6 +636,8 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
       - name: Set up Python 3.11
         uses: actions/setup-python@v5
         with:


### PR DESCRIPTION
The persist-credentials option in the actions/checkout action determines whether the Git credentials used to fetch the repository are left in the Git configuration after the checkout step. Setting persist-credentials to true (the default) means the credentials will remain, allowing subsequent steps in the workflow to perform authenticated Git operations without re-authentication. Setting it to false removes the credentials, which is useful for security when you don't want later steps to have access to the credentials.

scan results from this PR: https://github.com/astronomer/astronomer-cosmos/security/code-scanning?query=is%3Aopen+pr%3A1890

vs

on main: https://github.com/astronomer/astronomer-cosmos/security/code-scanning (this will change after merging this PR, but can be compared while the PR is still open)

related: https://github.com/astronomer/oss-integrations-private/issues/156