### PR TITLE
Fix failing dbt-fusion tests when run in parallel in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -478,11 +478,13 @@ jobs:
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Set RESOURCE_PREFIX without periods
+        id: set-resource-prefix
         run: |
           PYTHON_VER=$(echo "${{ matrix.python-version }}" | tr -d '.')
           AIRFLOW_VER=$(echo "${{ matrix.airflow-version }}" | tr -d '.')
           DBT_VER=$(echo "${{ matrix.dbt-version }}" | tr -d '.')
-          echo "RESOURCE_PREFIX=COSMOS_${{ github.run_id }}_PY${PYTHON_VER}_AF${AIRFLOW_VER}_DBT${DBT_VER}" >> $GITHUB_ENV
+          PREFIX="COSMOS_${{ github.run_id }}_PY${PYTHON_VER}_AF${AIRFLOW_VER}_DBT${DBT_VER}"
+          echo "prefix=${PREFIX}" >> $GITHUB_OUTPUT
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
         run: |
@@ -499,7 +501,7 @@ jobs:
           SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
-          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
+          RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -521,7 +523,7 @@ jobs:
           SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
-          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
+          RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
 
 
   Run-Performance-Tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -482,7 +482,7 @@ jobs:
           PYTHON_VER=$(echo "${{ matrix.python-version }}" | tr -d '.')
           AIRFLOW_VER=$(echo "${{ matrix.airflow-version }}" | tr -d '.')
           DBT_VER=$(echo "${{ matrix.dbt-version }}" | tr -d '.')
-          echo "RESOURCE_PREFIX=COSMOS_${{ github.run_id }}_Py${PYTHON_VER}_AF${AIRFLOW_VER}_DBT${DBT_VER}" >> $GITHUB_ENV
+          echo "RESOURCE_PREFIX=COSMOS_${{ github.run_id }}_PY${PYTHON_VER}_AF${AIRFLOW_VER}_DBT${DBT_VER}" >> $GITHUB_ENV
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -477,6 +477,13 @@ jobs:
           uv pip install --system hatch
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
+      - name: Set RESOURCE_PREFIX without periods
+        run: |
+          PYTHON_VER=$(echo "${{ matrix.python-version }}" | tr -d '.')
+          AIRFLOW_VER=$(echo "${{ matrix.airflow-version }}" | tr -d '.')
+          DBT_VER=$(echo "${{ matrix.dbt-version }}" | tr -d '.')
+          echo "RESOURCE_PREFIX=COSMOS_${{ github.run_id }}_Py${PYTHON_VER}_AF${AIRFLOW_VER}_DBT${DBT_VER}" >> $GITHUB_ENV
+
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbtf-setup
@@ -489,7 +496,8 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-          SNOWFLAKE_SCHEMA: COSMOS_${{ github.event.pull_request.number || github.run_id }}_Py${{ matrix.python-version }}_AF${{ matrix.airflow-version }}_DBT${{ matrix.dbt-version }}
+          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
+          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main,fix-dbt-fusion]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.
@@ -489,7 +489,7 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
-          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
+          SNOWFLAKE_SCHEMA: COSMOS_${{ github.event.pull_request.number || github.run_id }}_Py${{ matrix.python-version }}_AF${{ matrix.airflow-version }}_DBT${{ matrix.dbt-version }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main,fix-dbt-fusion]
+    branches: [main]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -497,9 +497,9 @@ jobs:
           SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
-          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -507,6 +507,22 @@ jobs:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
           path: .coverage
           include-hidden-files: true
+
+      - name: Clean up Snowflake resources
+        if: always()
+        run: |
+         pip install snowflake-connector-python
+         # Trigger a python script to delete the resources
+         python scripts/ci_dbtf_delete_snowflake_resources.py
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+          RESOURCE_PREFIX: ${{ env.RESOURCE_PREFIX }}
+
 
   Run-Performance-Tests:
     needs: Authorize

--- a/dev/dags/dbt/jaffle_shop/macros/generate_alias_name.sql
+++ b/dev/dags/dbt/jaffle_shop/macros/generate_alias_name.sql
@@ -1,0 +1,8 @@
+{% macro generate_alias_name(custom_alias_name=None, node=None) -%}
+  {%- set base = custom_alias_name if custom_alias_name else node.name -%}
+  {%- if env_var('RESOURCE_PREFIX', '') -%}
+    {{ return(env_var('RESOURCE_PREFIX') ~ '_' ~ base) }}
+  {%- else -%}
+    {{ base }}
+  {%- endif -%}
+{%- endmacro %}

--- a/scripts/ci_dbtf_delete_snowflake_resources.py
+++ b/scripts/ci_dbtf_delete_snowflake_resources.py
@@ -1,0 +1,45 @@
+import os
+
+import snowflake.connector
+
+
+def delete_snowflake_resource():
+    """
+    Delete Snowflake resources with a given prefix(set as an environment variable).
+    """
+    conn = snowflake.connector.connect(
+        user=os.environ["SNOWFLAKE_USER"],
+        password=os.environ["SNOWFLAKE_PASSWORD"],
+        account=os.environ["SNOWFLAKE_ACCOUNT"],
+        warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
+        database=os.environ["SNOWFLAKE_DATABASE"],
+        schema=os.environ["SNOWFLAKE_SCHEMA"],
+    )
+    prefix = os.getenv("RESOURCE_PREFIX", "")
+    if prefix:
+        cursor = conn.cursor()
+        cursor.execute(
+            f"""
+            SELECT table_name, table_type
+            FROM information_schema.tables
+            WHERE table_schema = '{os.environ['SNOWFLAKE_SCHEMA']}'
+            AND table_name LIKE '{prefix}_%'
+            """
+        )
+
+        resources = cursor.fetchall()
+
+        for resource_name, resource_type in resources:
+            if resource_type == "BASE TABLE":
+                cursor.execute(f"DROP TABLE IF EXISTS {resource_name}")
+            elif resource_type == "VIEW":
+                cursor.execute(f"DROP VIEW IF EXISTS {resource_name}")
+        cursor.close()
+        print(f"Deleted {len(resources)} resources")
+    else:
+        print("No resources to delete")
+    conn.close()
+
+
+if __name__ == "__main__":
+    delete_snowflake_resource()

--- a/scripts/ci_dbtf_delete_snowflake_resources.py
+++ b/scripts/ci_dbtf_delete_snowflake_resources.py
@@ -18,15 +18,14 @@ def delete_snowflake_resource():
     prefix = os.getenv("RESOURCE_PREFIX", "")
     if prefix:
         cursor = conn.cursor()
-        cursor.execute(
-            f"""
-            SELECT table_name, table_type
-            FROM information_schema.tables
-            WHERE table_schema = '{os.environ['SNOWFLAKE_SCHEMA']}'
-            AND table_name LIKE '{prefix}_%'
-            """
-        )
-
+        query = f"""
+        SELECT table_name, table_type
+        FROM information_schema.tables
+        WHERE table_schema = '{os.environ['SNOWFLAKE_SCHEMA']}'
+        AND table_name LIKE '{prefix}_%'
+        """
+        print(query)
+        cursor.execute(query)
         resources = cursor.fetchall()
 
         for resource_name, resource_type in resources:

--- a/scripts/ci_dbtf_delete_snowflake_resources.py
+++ b/scripts/ci_dbtf_delete_snowflake_resources.py
@@ -18,21 +18,20 @@ def delete_snowflake_resource():
     prefix = os.getenv("RESOURCE_PREFIX", "")
     if prefix:
         cursor = conn.cursor()
-        query = f"""
+        query = """
         SELECT table_name, table_type
         FROM information_schema.tables
-        WHERE table_schema = '{os.environ['SNOWFLAKE_SCHEMA']}'
-        AND table_name LIKE '{prefix}_%'
+        WHERE table_schema = %s
+        AND table_name LIKE %s
         """
-        print(query)
-        cursor.execute(query)
+        cursor.execute(query, (os.environ['SNOWFLAKE_SCHEMA'], f"{prefix}_%"))
         resources = cursor.fetchall()
 
         for resource_name, resource_type in resources:
             if resource_type == "BASE TABLE":
-                cursor.execute(f"DROP TABLE IF EXISTS {resource_name}")
+                cursor.execute("DROP TABLE IF EXISTS %s", (resource_name,))
             elif resource_type == "VIEW":
-                cursor.execute(f"DROP VIEW IF EXISTS {resource_name}")
+                cursor.execute("DROP VIEW IF EXISTS %s", (resource_name,))
         cursor.close()
         print(f"Deleted {len(resources)} resources")
     else:

--- a/scripts/ci_dbtf_delete_snowflake_resources.py
+++ b/scripts/ci_dbtf_delete_snowflake_resources.py
@@ -24,7 +24,7 @@ def delete_snowflake_resource():
         WHERE table_schema = %s
         AND table_name LIKE %s
         """
-        cursor.execute(query, (os.environ['SNOWFLAKE_SCHEMA'], f"{prefix}_%"))
+        cursor.execute(query, (os.environ["SNOWFLAKE_SCHEMA"], f"{prefix}_%"))
         resources = cursor.fetchall()
 
         for resource_name, resource_type in resources:

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1908,9 +1908,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
         # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
-        assert hash_dir in ("c2c47529eaec412281bdb243a479b734", "fa93914ecb491cc40a17ab956397359a")
+        assert hash_dir in ("c2c47529eaec412281bdb243a479b734", "71bbf303ad4e06a7b1e2be20e0b73c0d")
     else:
-        assert hash_dir == "fa93914ecb491cc40a17ab956397359a"
+        assert hash_dir == "71bbf303ad4e06a7b1e2be20e0b73c0d"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
### Problem
The dbt Fusion integration tests were experiencing resource conflicts when multiple matrix jobs ran in parallel against the same Snowflake schema. All jobs were attempting to create and operate on tables/views with identical names (e.g., customers, orders, stg_payments), leading to:
- Race conditions between parallel jobs
- dbt test failures due to duplicate records

### Initial attempt to resolve:
As described in issue #1887, I attempted to specify a separate schema in the environment variable to uniquely identify the PR, and matrix entry. However, since such schemas don't pre-exist in our database, when dbt tries to create them, we encounter failures because the Snowflake CI account does not have the necessary permissions to create schemas.

### Working solution proposed in the PR:
Instead of creating separate schemas, this PR implements resource-level isolation within a shared schema:
1. Unique Resource Prefixes: Each matrix job gets a unique prefix like `COSMOS_<PR_IDENTIFIER>_PY311_AF210_DBT20_`
2. Custom dbt Macro: Added `generate_alias_name` macro that prefixes all table/view names when `RESOURCE_PREFIX` is set (this is set for CI jobs)
3. Safe Environment Handling: Uses GitHub Actions step outputs instead of `$GITHUB_ENV` (one of the initial attempts to export `RESOURCE_PREFIX` and make it available for subsequent steps in the CI jobs) to avoid security issues flagged by Zizmor
4. Automatic Cleanup: Added a cleanup step (calling a Python script) that removes all objects created by each job after completion, as otherwise it would just keep on populating a huge number of tables and views for each PR * matrix entry in the database.


Successful job run: https://github.com/astronomer/astronomer-cosmos/actions/runs/16622909325

And a specific dbt fusion tests job example: https://github.com/astronomer/astronomer-cosmos/actions/runs/16622909325/job/47031551362?pr=1896

closes: #1887
