### PR TITLE
feat: Add Jinja templating support for dbt_cmd_flags

### DIFF
--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -76,7 +76,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
     :param extra_context: A dictionary of values to add to the TaskInstance's Context
     """
 
-    template_fields: Sequence[str] = ("env", "select", "exclude", "selector", "vars", "models")
+    template_fields: Sequence[str] = ("env", "select", "exclude", "selector", "vars", "models", "dbt_cmd_flags")
     global_flags = (
         "project_dir",
         "select",
@@ -148,7 +148,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
         self.partial_parse = partial_parse
         self.cancel_query_on_kill = cancel_query_on_kill
         self.dbt_executable_path = dbt_executable_path
-        self.dbt_cmd_flags = dbt_cmd_flags
+        self.dbt_cmd_flags = dbt_cmd_flags or []
         self.dbt_cmd_global_flags = dbt_cmd_global_flags or []
         self.cache_dir = cache_dir
         self.extra_context = extra_context or {}
@@ -287,7 +287,9 @@ class AbstractDbtBase(metaclass=ABCMeta):
 
         # add user-supplied args
         if self.dbt_cmd_flags:
-            dbt_cmd.extend(self.dbt_cmd_flags)
+            # Filter out empty strings that might result from template rendering
+            filtered_flags = [flag for flag in self.dbt_cmd_flags if flag and str(flag).strip()]
+            dbt_cmd.extend(filtered_flags)
 
         env = self.get_env(context)
 

--- a/docs/configuration/operator-args.rst
+++ b/docs/configuration/operator-args.rst
@@ -147,9 +147,33 @@ The following operator args support templating, and are accessible both through 
 - ``env``
 - ``vars``
 - ``full_refresh`` (for the ``build``, ``seed``, and ``run`` operators since Cosmos 1.4.)
+- ``dbt_cmd_flags``
 
 .. note::
     Using Jinja templating for ``env`` and ``vars`` may cause problems when using ``LoadMode.DBT_LS`` to render your DAG.
+
+Example usage of templated ``dbt_cmd_flags`` for microbatch models with event-time ranges:
+
+.. code-block:: python
+
+    DbtDag(
+        # ... other parameters
+        operator_args={
+            "dbt_cmd_flags": [
+                "{% if params.EVENT_TIME_START %}--event-time-start{% endif %}",
+                "{% if params.EVENT_TIME_START %}{{ params.EVENT_TIME_START }}{% endif %}",
+                "{% if params.EVENT_TIME_END %}--event-time-end{% endif %}",
+                "{% if params.EVENT_TIME_END %}{{ params.EVENT_TIME_END }}{% endif %}",
+                "--select",
+                "{{ params.MODEL_NAME if params.MODEL_NAME else 'default_model' }}",
+            ]
+        },
+        params={
+            "EVENT_TIME_START": Param(default=None, type=["null", "string"]),
+            "EVENT_TIME_END": Param(default=None, type=["null", "string"]),
+            "MODEL_NAME": Param(default="stg_funnel_events", type="string"),
+        },
+    )
 
 The following template fields are only selectable when using the operators in a standalone context (starting in Cosmos 1.4):
 


### PR DESCRIPTION
## Description

Add dbt_cmd_flags to template_fields in AbstractDbtbase class

## Related Issue(s)

"closes #1894"

## Breaking Change?

No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
