### PR TITLE
Fix broken CI test

### DIFF
--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -10,9 +10,13 @@ NEXT_MINOR_VERSION=$(echo "$DBT_VERSION" | awk -F. '{print $1"."$2+1}')
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
 pip uninstall -y 'dbt-bigquery' 'dbt-databricks' 'dbt-duckdb' 'dbt-postgres' 'dbt-vertica' 'dbt-core'
-rm -rf airflow.*
+
+rm $AIRFLOW_HOME/airflow.cfg
+rm $AIRFLOW_HOME/airflow.db
+
 pip freeze | grep airflow
 airflow db reset -y
+
 
 AIRFLOW_VERSION=$(airflow version)
 AIRFLOW_MAJOR_VERSION=$(echo "$AIRFLOW_VERSION" | cut -d. -f1)
@@ -26,8 +30,6 @@ else
 fi
 
 uv pip install -U "dbt-core==$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica 'dbt-databricks' pyspark
-
-pip install  -U openlineage-airflow
 
 if python3 -c "import sys; print(sys.version_info >= (3, 9))" | grep -q 'True'; then
   pip install  'dbt-duckdb' 'airflow-provider-duckdb>=0.2.0'

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -14,6 +14,7 @@ airflow db check
 
 rm -rf dbt/jaffle_shop/dbt_packages;
 pytest -vv \
+    tests/test_example_dags_no_connections.py \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -43,12 +43,14 @@ if [ "$AIRFLOW_VERSION" = "2.4" ] || [ "$AIRFLOW_VERSION" = "2.5" ] || [ "$AIRFL
   uv pip install  "apache-airflow-providers-google<10.11" "apache-airflow==$AIRFLOW_VERSION"
   uv pip install "apache-airflow-providers-microsoft-azure" "apache-airflow==$AIRFLOW_VERSION"
   uv pip install pyopenssl --upgrade
+  pip install  -U openlineage-airflow "apache-airflow==$AIRFLOW_VERSION"
 elif [ "$AIRFLOW_VERSION" = "2.6" ] ; then
   uv pip install "apache-airflow-providers-amazon" --constraint /tmp/constraint.txt
   uv pip install "apache-airflow-providers-cncf-kubernetes" --constraint /tmp/constraint.txt
   uv pip install  "apache-airflow-providers-google" --constraint /tmp/constraint.txt
   uv pip install apache-airflow-providers-microsoft-azure --constraint /tmp/constraint.txt
   uv pip install "pydantic<2.0"
+  pip install  -U openlineage-airflow "apache-airflow==$AIRFLOW_VERSION"
 elif [ "$AIRFLOW_VERSION" = "2.7" ] ; then
   uv pip install "apache-airflow-providers-amazon" --constraint /tmp/constraint.txt
   uv pip install "apache-airflow-providers-cncf-kubernetes" --constraint /tmp/constraint.txt
@@ -84,8 +86,10 @@ else
   uv pip install "apache-airflow-providers-microsoft-azure" --constraint /tmp/constraint.txt
 fi
 
+
 rm /tmp/constraint.txt
 
+uv pip freeze
 actual_version=$(airflow version | cut -d. -f1,2)
 
 if [ "$actual_version" = $AIRFLOW_VERSION ]; then


### PR DESCRIPTION
Installing openlineage-airflow was leading to AF3 to be installed instead of AF2.8 when running

```bash
hatch run tests.py3.11-2.8-1.9:test-integration-setup
```
