### PR TITLE
Add dbt project's hash to dag docs to support dag versioning in Airflow 3

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -359,7 +359,7 @@ class DbtToAirflowConverter:
             if dag.doc_md:
                 dag.doc_md += hash_suffix
             else:
-                dag.doc_md = f"dbt project hash: `{dbt_project_hash}`"
+                dag.doc_md = f"**dbt project hash:** `{dbt_project_hash}`"
 
             logger.debug(f"Appended dbt project hash {dbt_project_hash} to DAG {dag.dag_id} documentation")
         except Exception as e:

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+from cosmos.log import get_logger
+
+logger = get_logger(__name__)
+
+
+def _create_folder_version_hash(dir_path: Path) -> str:
+    """
+    Given a directory, iterate through its content and create a hash that will change in case the
+    contents of the directory change. The value should not change if the values of the directory do not change, even if
+    the command is run from different Airflow instances.
+
+    This method output must be concise and it currently changes based on operating system.
+    """
+    # This approach is less efficient than using modified time
+    # sum([path.stat().st_mtime for path in dir_path.glob("**/*")])
+    # unfortunately, the modified time approach does not work well for dag-only deployments
+    # where DAGs are constantly synced to the deployed Airflow
+    # for 5k files, this seems to take 0.14
+    hasher = hashlib.md5()
+    filepaths = []
+
+    for root_dir, dirs, files in os.walk(dir_path):
+        paths = [os.path.join(root_dir, filepath) for filepath in files]
+        filepaths.extend(paths)
+
+    for filepath in sorted(filepaths):
+        try:
+            with open(str(filepath), "rb") as fp:
+                buf = fp.read()
+                hasher.update(buf)
+        except FileNotFoundError:
+            logger.warning(f"The dbt project folder contains a symbolic link to a non-existent file: {filepath}")
+
+    return hasher.hexdigest()

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -28,7 +28,6 @@ from cosmos.cache import (
     _configure_remote_cache_dir,
     _copy_partial_parse_to_project,
     _create_cache_identifier,
-    _create_folder_version_hash,
     _get_latest_cached_package_lockfile,
     _get_latest_partial_parse,
     _get_or_create_profile_cache_dir,
@@ -121,38 +120,6 @@ def test__copy_partial_parse_to_project_msg_fails_msgpack(mock_unpack, tmp_path,
         _copy_partial_parse_to_project(partial_parse_filepath, Path(tmp_dir))
 
     assert "Unable to patch the partial_parse.msgpack file due to ValueError()" in caplog.text
-
-
-def test__create_folder_version_hash(tmp_path, caplog):
-    """
-    Test that Cosmos is still able to create the hash of a dbt project folder even when
-    there is a symbolic link referencing a no longer existing file.
-
-    This test addresses the issue:
-    https://github.com/astronomer/astronomer-cosmos/issues/1096
-    """
-    caplog.set_level(logging.INFO)
-
-    # Create a source folder with two files
-    source_dir = tmp_path / "original_dbt_folder"
-    source_dir.mkdir()
-    file_1 = Path(source_dir / "file_1.sql")
-    file_1.touch()
-    file_2 = Path(source_dir / "file_2.sql")
-    file_2.touch()
-
-    # Create a target folder with symbolic links to the two files in the source folder
-    target_dir = tmp_path / "cosmos_dbt_folder"
-    target_dir.mkdir()
-    file_1_symlink = Path(target_dir / "file_1.sql")
-    file_1_symlink.symlink_to(file_1)
-    file_2_symlink = Path(target_dir / "file_2.sql")
-    file_2_symlink.symlink_to(file_2)
-
-    # Delete one of the original files from the source folder
-    file_1.unlink()
-
-    _create_folder_version_hash(target_dir)
 
 
 @patch("cosmos.cache.shutil.copyfile")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -993,7 +993,7 @@ def test_dag_versioning_hash_appended_to_empty_doc_md(mock_load_dbt_graph, mock_
         execution_config=execution_config,
     )
 
-    assert dag.doc_md == "dbt project hash: `abc123def456`"
+    assert dag.doc_md == "**dbt project hash:** `abc123def456`"
     mock_hash_func.assert_called_once()
 
 

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,0 +1,36 @@
+import logging
+from pathlib import Path
+
+from cosmos.versioning import _create_folder_version_hash
+
+
+def test__create_folder_version_hash(tmp_path, caplog):
+    """
+    Test that Cosmos is still able to create the hash of a dbt project folder even when
+    there is a symbolic link referencing a no longer existing file.
+
+    This test addresses the issue:
+    https://github.com/astronomer/astronomer-cosmos/issues/1096
+    """
+    caplog.set_level(logging.INFO)
+
+    # Create a source folder with two files
+    source_dir = tmp_path / "original_dbt_folder"
+    source_dir.mkdir()
+    file_1 = Path(source_dir / "file_1.sql")
+    file_1.touch()
+    file_2 = Path(source_dir / "file_2.sql")
+    file_2.touch()
+
+    # Create a target folder with symbolic links to the two files in the source folder
+    target_dir = tmp_path / "cosmos_dbt_folder"
+    target_dir.mkdir()
+    file_1_symlink = Path(target_dir / "file_1.sql")
+    file_1_symlink.symlink_to(file_1)
+    file_2_symlink = Path(target_dir / "file_2.sql")
+    file_2_symlink.symlink_to(file_2)
+
+    # Delete one of the original files from the source folder
+    file_1.unlink()
+
+    _create_folder_version_hash(target_dir)


### PR DESCRIPTION
This PR leverages the existing method for generating a hash of the dbt project contents and appends that hash to the DAG documentation. This enables Airflow 3’s automatic DAG versioning feature to track changes in dbt project content.

Airflow 3 introduces automatic DAG versioning by detecting changes in a DAG’s structure or metadata. By embedding the dbt content hash into the doc_md field (a part of the serialized DAG), this change allows Airflow to:
	•	Detect when dbt project files are added, modified, or deleted
	•	Automatically generate a new DAG version in response to those changes

This ensures accurate and automatic versioning of DAGs tied to evolving dbt projects, without requiring manual intervention.

closes: #1868 