### PR TITLE
 Fix cache behaviour when DAG name contains "."

### DIFF
--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -123,7 +123,7 @@ def _create_cache_identifier(dag: DAG, task_group: TaskGroup | None) -> str:
     task_group_id = metadata.get("task_group_id")
 
     if dag_id:
-        cache_identifiers_list.append(dag_id)
+        cache_identifiers_list.append(dag_id.replace(".", "___"))
     if task_group_id:
         cache_identifiers_list.append(task_group_id.replace(".", "__"))
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1908,7 +1908,7 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
         # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
-        assert hash_dir in ("c2c47529eaec412281bdb243a479b734", "71bbf303ad4e06a7b1e2be20e0b73c0d")
+        assert hash_dir in ("e16e6aef5f03f4e12d744b9412d90272", "71bbf303ad4e06a7b1e2be20e0b73c0d")
     else:
         assert hash_dir == "71bbf303ad4e06a7b1e2be20e0b73c0d"
 

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -50,6 +50,8 @@ from cosmos.settings import AIRFLOW_IO_AVAILABLE, dbt_profile_cache_dir_name
 
 START_DATE = datetime(2024, 4, 16)
 example_dag = DAG("dag", start_date=START_DATE)
+example_dag_with_dots = DAG("dag.with.dots", start_date=START_DATE)
+
 SAMPLE_PARTIAL_PARSE_FILEPATH = Path(__file__).parent / "sample/partial_parse.msgpack"
 
 
@@ -57,6 +59,7 @@ SAMPLE_PARTIAL_PARSE_FILEPATH = Path(__file__).parent / "sample/partial_parse.ms
     "dag, task_group, result_identifier",
     [
         (example_dag, None, "dag"),
+        (example_dag_with_dots, None, "dag___with___dots"),
         (None, TaskGroup(dag=example_dag, group_id="inner_tg"), "dag__inner_tg"),
         (
             None,


### PR DESCRIPTION
Cosmos stores the result of dbt ls as a Variable based on the DAG name, but if the name has a . in it, that Variable name will be invalid when working with certain secret managers, including Google Cloud's.
    
This is an example of an error that is raised:
  ```
  Invalid secret ID myhost-cosmos_cache__dag.moredag.yetmoredag
  Only ASCII alphabets (a-Z), numbers (0-9), dashes (-), and underscores (_) are allowed in the secret ID.
  ```
  
  In this PR, we replace those names to use underscores instead of ".".
  
  Closes: #1875

