### PR TITLE
Pin package dbt-databricks

### DIFF
--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -31,7 +31,8 @@ else
 fi
 
 if [ "$DBT_VERSION" = "1.10" ]; then
-    uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica "dbt-databricks>=1.10.8" pyspark
+    # The package dbt-databricks version 1.10.8 has been yanked from PyPI: https://pypi.org/project/dbt-databricks/1.10.8/
+    uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica "dbt-databricks!=1.10.8" pyspark
 else
     uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
 fi

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -30,9 +30,7 @@ else
     airflow db init
 fi
 
-if [ "$DBT_VERSION" = "1.10" ]; then
-    uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
-fi
+uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
 
 if python3 -c "import sys; print(sys.version_info >= (3, 9))" | grep -q 'True'; then
   pip install  'dbt-duckdb' "airflow-provider-duckdb>=0.2.0" "apache-airflow==$AIRFLOW_VERSION"

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -31,9 +31,6 @@ else
 fi
 
 if [ "$DBT_VERSION" = "1.10" ]; then
-    # The package dbt-databricks version 1.10.8 has been yanked from PyPI: https://pypi.org/project/dbt-databricks/1.10.8/
-    uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica "dbt-databricks!=1.10.8" pyspark
-else
     uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
 fi
 


### PR DESCRIPTION
This PR remove the min version limitation of the package `dbt-databricks`.  The `dbt-databricks` version `1.10.8` has been yanked.