### PR TITLE
Release 1.10.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -11,6 +11,65 @@ Feature
 (many other features, pending details)
 
 
+1.10.2 (2025-08-08)
+---------------------
+
+Bug Fixes
+
+* Fix task instance ``try_number`` attribute for Airflow 3 compatibility by @pankajkoti in #1781
+* Fix rendered template override logic when ``should_store_compiled_sql=False`` to restore pre-refactor behaviour by @pankajkoti in #1777
+* Fix ``ProfileConfig`` in GCP Cloud Run job execution mode by @ramonvermeulen in #1783
+* Fix dbt Docs page height by @1cadumagalhaes in #1793
+* Add support to base64 encoded pem in Snowflake profiles by @brunocmartins in #1801
+* Allow to disable owner inheritance from dbt into airflow DAG owners by @CorsettiS in #1787
+* Fix Kubernetes Pod Operator conversion of ``container_resources`` to ``resources`` by @johnhoran in #1821
+* Fix ``dbt deps`` with project level variables by @AlexandrKhabarov in #1822
+* Fix source freshness warnings in kubernetes execution mode by @Pawel-Drabczyk in #1859
+* Fix: Harden DbtNode against null config/meta by @pankajkoti in #1877
+* Fix cache behaviour when DAG name contains "." by @tatiana in #1908
+
+Documentation
+
+* Fix ``contributing.rst`` docs by @tatiana in #1785
+* Fix docs rendering in Airflow 3 Compatibility by @pankajastro in #1790
+* Fix typo in ``selecting-excluding.rst`` by @msshroff in #1814
+* Update testing behavior file with ``ExecutionMode.KUBERNETES`` by @LuigiCerone in #1813
+* Add step to fork repo in contributing guide by @pankajastro in #1808
+* Fix ``depends_on`` attribute by @benedikt-buchert in #1837
+* Fix character name by @ThePsyjo in #1860
+* Update suggested MWAA startup script by @jaklan in #1884
+* Make implementation & docs consistent regarding ``use_dataset_airflow3_uri_standard`` by @Anti0ff in #1878
+
+Others
+
+* Set retries to 0 in example DAGs by @pankajkoti in #1782
+* Fix ``test_async_example_dag_without_setup_task`` tests by @pankajastro in #1788
+* Fix test hash value for Darwin when using Py 3.12.10 by @tatiana in #1786
+* Upgrade Python and Airflow used to run MyPy checks by @tatiana in #1796
+* Assert example DAGs' ``DagRunState`` and fix issues by @pankajkoti and @tatiana in #1778
+* Update the conflict matrix to include AF 2.10, 2.11 & 3.0 and dbt 1.9 & 1.10 by @tatiana in #1820
+* Fix broken CI due to Pydantic conflicts by @tatiana in #1809
+* Drop Python 3.8 Support by @pankajastro in #1852
+* Add Airflow 2.11 to the test matrix by @tatiana in #1807
+* Require Authorize for all jobs on pull requests from external contributors in CI by @pankajkoti in #1861
+* Leverage Trusted Publisher Management when publishing PyPI package by @tatiana in #1862
+* CI: Add back accidentally deleted python-version matrix for running unit tests by @pankajkoti in #1872
+* Remove commented code and fix mypy failures by @pankajkoti in #1876
+* Add Zizmor analysis GitHub action by @pankajkoti in #1870
+* Catch FlushError on Datasets for Airflow 2.11 dags test by @pankajkoti in #1880
+* Add deprecation warning for ``LoadMode.CUSTOM`` parser by @duongphannamhung in #1885
+* CI: Add GitHub CodeQL analysis workflow (codeql.yml) by @pankajkoti in #1871
+* Resolve 'credential persistence through GitHub Actions artifacts' warnings from Zizmor by @pankajkoti in #1890
+* Resolve 'overly broad permissions' warnings from Zizmor by @pankajkoti in #1889
+* Resolve Zizmor error alerts for unpinned image references; mark alert for pull_request_target ignored by @pankajkoti in #1888
+* Fix broken CI ``tests.py3.11-2.8-1.9:test-integration-setup`` by @tatiana in #1902
+* Add dbt-core 1.10 to test matrix by @tatiana in #1767
+* Pin package dbt-databricks by @pankajastro in #1909
+* Enable matrix test entry for dbt-1.9, python-3.9 and airflow-3.0 tests in CI by @pankajastro in #1900
+* Pre-commit updates: #1779, #1795, #1800, #1857, #1863, #1869, #1892, #1901
+* Dependabot updates: #1904
+
+
 1.10.1 (2025-05-21)
 -------------------
 

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -25,7 +25,7 @@ The ``RenderConfig`` class takes the following arguments:
 - ``normalize_task_id``: A callable that takes a dbt node as input and returns the task ID. This function allows users to set a custom task_id independently of the model name, which can be specified as the task’s display_name. This way, task_id can be modified using a user-defined function, while the model name remains as the task’s display name. The display_name parameter is available in Airflow 2.9 and above. See `Task display name <./task-display-name.html>`_ for more information.
 - ``normalize_task_display_name``: This function allows users to set a custom user-defined function to alter the display name independently of the model name. This way, the task_id can be preserved while the model display name is modified.
 - ``should_detach_multiple_parents_tests``: A boolean to control if tests that depend on multiple parents should be run as standalone tasks. See `Parsing Methods <testing-behavior.html>`_ for more information.
-- ``enable_owner_inheritance``: A boolean to control if dbt owners should be imported as part of the airflow DAG owners. Defaults to True.
+- ``enable_owner_inheritance``: (introduced in 1.10.2) A boolean to control if dbt owners should be imported as part of the airflow DAG owners. Defaults to True.
 
 
 How to run dbt ls (invocation mode)


### PR DESCRIPTION
**Bug Fixes**

* Fix task instance ``try_number`` attribute for Airflow 3 compatibility by @pankajkoti in #1781
* Fix rendered template override logic when ``should_store_compiled_sql=False`` to restore pre-refactor behaviour by @pankajkoti in #1777
* Fix ``ProfileConfig`` in GCP Cloud Run job execution mode by @ramonvermeulen in #1783
* Fix dbt Docs page height by @1cadumagalhaes in #1793
* Add support to base64 encoded pem in Snowflake profiles by @brunocmartins in #1801
* Allow to disable owner inheritance from dbt into airflow DAG owners by @CorsettiS in #1787
* Fix Kubernetes Pod Operator conversion of ``container_resources`` to ``resources`` by @johnhoran in #1821
* Fix ``dbt deps`` with project level variables by @AlexandrKhabarov in #1822
* Fix source freshness warnings in kubernetes execution mode by @Pawel-Drabczyk in #1859
* Fix: Harden DbtNode against null config/meta by @pankajkoti in #1877
* Fix cache behaviour when DAG name contains "." by @tatiana in #1908

**Documentation**

* Fix ``contributing.rst`` docs by @tatiana in #1785
* Fix docs rendering in Airflow 3 Compatibility by @pankajastro in #1790
* Fix typo in ``selecting-excluding.rst`` by @msshroff in #1814
* Update testing behavior file with ``ExecutionMode.KUBERNETES`` by @LuigiCerone in #1813
* Add step to fork repo in contributing guide by @pankajastro in #1808
* Fix ``depends_on`` attribute by @benedikt-buchert in #1837
* Fix character name by @ThePsyjo in #1860
* Update suggested MWAA startup script by @jaklan in #1884
* Make implementation & docs consistent regarding ``use_dataset_airflow3_uri_standard`` by @Anti0ff in #1878

**Others**

* Set retries to 0 in example DAGs by @pankajkoti in #1782
* Fix ``test_async_example_dag_without_setup_task`` tests by @pankajastro in #1788
* Fix test hash value for Darwin when using Py 3.12.10 by @tatiana in #1786
* Upgrade Python and Airflow used to run MyPy checks by @tatiana in #1796
* Assert example DAGs' ``DagRunState`` and fix issues by @pankajkoti and @tatiana in #1778
* Update the conflict matrix to include AF 2.10, 2.11 & 3.0 and dbt 1.9 & 1.10 by @tatiana in #1820
* Fix broken CI due to Pydantic conflicts by @tatiana in #1809
* Drop Python 3.8 Support by @pankajastro in #1852
* Add Airflow 2.11 to the test matrix by @tatiana in #1807
* Require Authorize for all jobs on pull requests from external contributors in CI by @pankajkoti in #1861
* Leverage Trusted Publisher Management when publishing PyPI package by @tatiana in #1862
* CI: Add back accidentally deleted python-version matrix for running unit tests by @pankajkoti in #1872
* Remove commented code and fix mypy failures by @pankajkoti in #1876
* Add Zizmor analysis GitHub action by @pankajkoti in #1870
* Catch FlushError on Datasets for Airflow 2.11 dags test by @pankajkoti in #1880
* Add deprecation warning for ``LoadMode.CUSTOM`` parser by @duongphannamhung in #1885
* CI: Add GitHub CodeQL analysis workflow (codeql.yml) by @pankajkoti in #1871
* Resolve 'credential persistence through GitHub Actions artifacts' warnings from Zizmor by @pankajkoti in #1890
* Resolve 'overly broad permissions' warnings from Zizmor by @pankajkoti in #1889
* Resolve Zizmor error alerts for unpinned image references; mark alert for pull_request_target ignored by @pankajkoti in #1888
* Fix broken CI ``tests.py3.11-2.8-1.9:test-integration-setup`` by @tatiana in #1902
* Add dbt-core 1.10 to test matrix by @tatiana in #1767
* Pin package dbt-databricks by @pankajastro in #1909
* Enable matrix test entry for dbt-1.9, python-3.9 and airflow-3.0 tests in CI by @pankajastro in #1900
* Pre-commit updates: #1779, #1795, #1800, #1857, #1863, #1869, #1892, #1901
* Dependabot updates: #1904

Co-authored-by: Tatiana Al-Chueyr <tatiana.alchueyr@gmail.com>