### PR TITLE
Use pepy.tech downloads badge in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@
 .. |ossrank| image:: https://img.shields.io/endpoint?url=https://ossrank.com/shield/2121
     :target: https://ossrank.com/p/2121-astronomer-cosmos
 
-.. |downloads| image:: https://img.shields.io/pypi/dm/astronomer-cosmos.svg
-    :target: https://img.shields.io/pypi/dm/astronomer-cosmos
+.. |downloads| image:: https://pepy.tech/badge/astronomer-cosmos/month
+    :target: https://pepy.tech/badge/astronomer-cosmos/month
 
 .. |pre-commit| image:: https://results.pre-commit.ci/badge/github/astronomer/astronomer-cosmos/main.svg
    :target: https://results.pre-commit.ci/latest/github/astronomer/astronomer-cosmos/main

--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
     :target: https://ossrank.com/p/2121-astronomer-cosmos
 
 .. |downloads| image:: https://pepy.tech/badge/astronomer-cosmos/month
-    :target: https://pepy.tech/badge/astronomer-cosmos/month
+    :target: https://pepy.tech/project/astronomer-cosmos
 
 .. |pre-commit| image:: https://results.pre-commit.ci/badge/github/astronomer/astronomer-cosmos/main.svg
    :target: https://results.pre-commit.ci/latest/github/astronomer/astronomer-cosmos/main


### PR DESCRIPTION
Since https://img.shields.io badges are no longer working due to [pypistats.org being down](https://github.com/crflynn/pypistats.org/issues/82), use the alternative badge 
provider pepy.tech to display download counts in the README.