### PR TITLE
Use XCom to store sql when using ExecutionMode.AIRFLOW_ASYNC

### DIFF
--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -132,7 +132,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     def base_cmd(self) -> list[str]:
         return ["run"]
 
-    def get_sql_from_xocm(self, context: Context) -> str:
+    def get_sql_from_xcom(self, context: Context) -> str:
         start_time = time.time()
         file_path = self.async_context["dbt_node_config"]["file_path"]
         project_dir_parent = str(Path(self.project_dir).parent)
@@ -181,7 +181,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         if settings.enable_setup_async_task:
 
             if settings.upload_sql_to_xocm:
-                sql_query = self.get_sql_from_xocm(context)
+                sql_query = self.get_sql_from_xcom(context)
             else:
                 sql_query = self.get_remote_sql()
 
@@ -201,7 +201,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             self.log.info("SQL cannot be made available, skipping registration of compiled_sql template field")
             return
         if settings.upload_sql_to_xocm:
-            sql = self.get_sql_from_xocm(context)
+            sql = self.get_sql_from_xcom(context)
         else:
             sql = self.get_remote_sql().strip()
         self.log.debug("Executed SQL is: %s", sql)

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -180,7 +180,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
 
         if settings.enable_setup_async_task:
 
-            if settings.upload_sql_to_xocm:
+            if settings.upload_sql_to_xcom:
                 sql_query = self.get_sql_from_xcom(context)
             else:
                 sql_query = self.get_remote_sql()
@@ -200,7 +200,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         if not settings.enable_setup_async_task:
             self.log.info("SQL cannot be made available, skipping registration of compiled_sql template field")
             return
-        if settings.upload_sql_to_xocm:
+        if settings.upload_sql_to_xcom:
             sql = self.get_sql_from_xcom(context)
         else:
             sql = self.get_remote_sql().strip()

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -175,12 +175,13 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         if self.async_context.get("run_id") is None:
             self.async_context["run_id"] = context["run_id"]
 
-        if settings.upload_sql_to_xocm:
-            sql_query = self.get_sql_from_xocm(context)
-        else:
-            sql_query = self.get_remote_sql()
-
         if settings.enable_setup_async_task:
+
+            if settings.upload_sql_to_xocm:
+                sql_query = self.get_sql_from_xocm(context)
+            else:
+                sql_query = self.get_remote_sql()
+
             self.configuration = {
                 "query": {
                     "query": sql_query,

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -27,6 +27,10 @@ from cosmos.dbt.executable import get_system_dbt
 from cosmos.log import get_logger
 
 
+def _sanitize_xcom_key(file_path: str) -> str:
+    return file_path.replace("/", "_").replace("\\", "_")
+
+
 class AbstractDbtBase(metaclass=ABCMeta):
     """
     Executes a dbt core cli command.

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -365,12 +365,11 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             dest_file_path = self._construct_dest_file_path(Path(""), file_path, source_run_dir, resource_type)
             with open(file_path, encoding="utf-8") as f:
                 file_data = f.read()
-                self.log.info("DAta %s", file_data)
                 context["ti"].xcom_push(key=dest_file_path, value=file_data)
-            self.log.info("Copied %s", file_path)
+            self.log.debug("SQL files %s uploaded to xcom.", file_path)
 
         elapsed_time = time.time() - start_time
-        self.log.info("SQL files upload completed in %.2f seconds.", elapsed_time)
+        self.log.info("SQL files upload to xcom completed in %.2f seconds.", elapsed_time)
 
     def _delete_sql_files(self) -> None:
         """Deletes the entire run-specific directory from the remote target."""

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -360,7 +360,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         elapsed_time = time.time() - start_time
         self.log.info("SQL files upload completed in %.2f seconds.", elapsed_time)
 
-    def _upload_sql_files_xocm(self, context: Context, tmp_project_dir: str, resource_type: str) -> None:
+    def _upload_sql_files_xcom(self, context: Context, tmp_project_dir: str, resource_type: str) -> None:
         start_time = time.time()
         source_run_dir = Path(tmp_project_dir) / f"target/{resource_type}"
         files = [str(file) for file in source_run_dir.rglob("*") if file.is_file()]
@@ -595,7 +595,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if settings.enable_setup_async_task:
             if settings.upload_sql_to_xocm:
-                self._upload_sql_files_xocm(context, tmp_project_dir, "run")
+                self._upload_sql_files_xcom(context, tmp_project_dir, "run")
             else:
                 self._upload_sql_files(tmp_project_dir, "run")
         else:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -333,7 +333,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         rel_path = os.path.relpath(file_path, source_compiled_dir).lstrip("/")
         run_id = self.extra_context["run_id"]
 
-        if settings.upload_sql_to_xocm:
+        if settings.upload_sql_to_xcom:
             return f"{dag_task_group_identifier}/{run_id}/{resource_type}/{rel_path}"
 
         return f"{dest_target_dir_str}/{dag_task_group_identifier}/{run_id}/{resource_type}/{rel_path}"
@@ -594,7 +594,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if settings.enable_setup_async_task:
-            if settings.upload_sql_to_xocm:
+            if settings.upload_sql_to_xcom:
                 self._upload_sql_files_xcom(context, tmp_project_dir, "run")
             else:
                 self._upload_sql_files(tmp_project_dir, "run")

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import inspect
 import json
 import os
@@ -7,6 +8,7 @@ import tempfile
 import time
 import urllib.parse
 import warnings
+import zlib
 from abc import ABC, abstractmethod
 from functools import cached_property
 from pathlib import Path
@@ -114,6 +116,7 @@ from cosmos.operators.base import (
     DbtSnapshotMixin,
     DbtSourceMixin,
     DbtTestMixin,
+    _sanitize_xcom_key,
 )
 
 AIRFLOW_VERSION = Version(airflow.__version__)
@@ -362,11 +365,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         source_run_dir = Path(tmp_project_dir) / f"target/{resource_type}"
         files = [str(file) for file in source_run_dir.rglob("*") if file.is_file()]
         for file_path in files:
-            dest_file_path = self._construct_dest_file_path(Path(""), file_path, source_run_dir, resource_type)
+            sql_model_path = os.path.relpath(file_path, source_run_dir).lstrip("/")
             with open(file_path, encoding="utf-8") as f:
-                file_data = f.read()
-                context["ti"].xcom_push(key=dest_file_path, value=file_data)
-            self.log.debug("SQL files %s uploaded to xcom.", file_path)
+                sql_query = f.read()
+            compressed_sql = zlib.compress(sql_query.encode("utf-8"))
+            compressed_b64_sql = base64.b64encode(compressed_sql).decode("utf-8")
+            context["ti"].xcom_push(key=_sanitize_xcom_key(sql_model_path), value=compressed_b64_sql)
+            self.log.debug("SQL files %s uploaded to xcom.", sql_model_path)
 
         elapsed_time = time.time() - start_time
         self.log.info("SQL files upload to xcom completed in %.2f seconds.", elapsed_time)

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -43,6 +43,7 @@ remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
+upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xocm", fallback=True)
 
 # Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
 # which can significantly increase memory usage—even when Cosmos is installed but not actively used.

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -43,7 +43,7 @@ remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
-upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xcom", fallback=False)
+upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xcom", fallback=True)
 
 # Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
 # which can significantly increase memory usage—even when Cosmos is installed but not actively used.

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -43,7 +43,7 @@ remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
-upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xocm", fallback=False)
+upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xcom", fallback=False)
 
 # Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
 # which can significantly increase memory usage—even when Cosmos is installed but not actively used.

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -43,7 +43,7 @@ remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
-upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xcom", fallback=True)
+upload_sql_to_xcom = conf.getboolean("cosmos", "upload_sql_to_xcom", fallback=True)
 
 # Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
 # which can significantly increase memory usage—even when Cosmos is installed but not actively used.

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -43,7 +43,7 @@ remote_cache_dir = conf.get("cosmos", "remote_cache_dir", fallback=None)
 remote_cache_dir_conn_id = conf.get("cosmos", "remote_cache_dir_conn_id", fallback=None)
 remote_target_path = conf.get("cosmos", "remote_target_path", fallback=None)
 remote_target_path_conn_id = conf.get("cosmos", "remote_target_path_conn_id", fallback=None)
-upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xocm", fallback=True)
+upload_sql_to_xocm = conf.getboolean("cosmos", "upload_sql_to_xocm", fallback=False)
 
 # Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
 # which can significantly increase memory usage—even when Cosmos is installed but not actively used.

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -190,7 +190,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 `upload_sql_to_xcom`_:
     (Introduced in Cosmos 1.11.0): Enable this if the setup async task is enabled for ``ExecutionMode.AIRFLOW_ASYNC`` and you want to upload the compiled SQL to Airflow XCom instead of a remote location (e.g., S3 or GCS).
 
-    - Default: ``False``
+    - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__UPLOAD_SQL_TO_XCOM``
 
 .. _use_dataset_airflow3_uri_standard:

--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -185,6 +185,14 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_TEARDOWN_ASYNC_TASK``
 
+.. _upload_sql_to_xcom:
+
+`upload_sql_to_xcom`_:
+    (Introduced in Cosmos 1.11.0): Enable this if the setup async task is enabled for ``ExecutionMode.AIRFLOW_ASYNC`` and you want to upload the compiled SQL to Airflow XCom instead of a remote location (e.g., S3 or GCS).
+
+    - Default: ``False``
+    - Environment Variable: ``AIRFLOW__COSMOS__UPLOAD_SQL_TO_XCOM``
+
 .. _use_dataset_airflow3_uri_standard:
 
 `use_dataset_airflow3_uri_standard`_:

--- a/docs/getting_started/async-execution-mode.rst
+++ b/docs/getting_started/async-execution-mode.rst
@@ -14,7 +14,7 @@ Advantages of Airflow Async Mode
 ++++++++++++++++++++++++++++++++
 
 - **Improved Task Throughput:** Async tasks free up Airflow workers by leveraging the Airflow Trigger framework. While long-running SQL transformations are executing in the data warehouse, the worker is released and can handle other tasks, increasing overall task throughput.
-- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to a remote location or xcom. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution.
+- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to a remote location or xcom. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution. We have observed a dbt project with 129 models takes ~500 seconds with remote SQL file upload/download, but only ~2 seconds using xcom.
 - **Better Resource Utilization:** By minimizing idle time on Airflow workers, async tasks allow more efficient use of compute resources. Workers aren't blocked waiting for external systems and can be reused for other work while waiting on async operations.
 
 Getting Started with Airflow Async Mode

--- a/docs/getting_started/async-execution-mode.rst
+++ b/docs/getting_started/async-execution-mode.rst
@@ -7,14 +7,14 @@ Airflow Async Execution Mode
 
 The Airflow async execution mode in Cosmos is designed to improve pipeline performance. This execution mode could be preferred when you’ve long running resources and you want to run them asynchronously by leveraging Airflow’s `deferrable operators <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__. In this mode, additional operators—``SetupAsyncOperator`` and ``TeardownAsyncOperator``—are added to your workflow.
 
-- **SetupAsyncOperator:** This task runs a mocked ``dbt run`` command on your dbt project, which outputs compiled SQL files to the project’s target directory. These compiled SQLs are then uploaded to a remote location specified by the ``remote_target_path`` configuration.
+- **SetupAsyncOperator:** This task runs a mocked ``dbt run`` command on your dbt project, which outputs compiled SQL files to the project’s target director. If ``upload_sql_xcom`` is enabled, the compiled SQL files will be uploaded to Airflow XCom. Otherwise, they will be uploaded to the remote location specified by the ``remote_target_path`` configuration.
 - **TeardownAsyncOperator:** This task deletes the resources created by ``SetupAsyncOperator`` from the remote location defined by the ``remote_target_path`` configuration.
 
 Advantages of Airflow Async Mode
 ++++++++++++++++++++++++++++++++
 
 - **Improved Task Throughput:** Async tasks free up Airflow workers by leveraging the Airflow Trigger framework. While long-running SQL transformations are executing in the data warehouse, the worker is released and can handle other tasks, increasing overall task throughput.
-- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to a remote location. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution.
+- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to a remote location or xcom. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution.
 - **Better Resource Utilization:** By minimizing idle time on Airflow workers, async tasks allow more efficient use of compute resources. Workers aren't blocked waiting for external systems and can be reused for other work while waiting on async operations.
 
 Getting Started with Airflow Async Mode

--- a/docs/getting_started/async-execution-mode.rst
+++ b/docs/getting_started/async-execution-mode.rst
@@ -14,7 +14,7 @@ Advantages of Airflow Async Mode
 ++++++++++++++++++++++++++++++++
 
 - **Improved Task Throughput:** Async tasks free up Airflow workers by leveraging the Airflow Trigger framework. While long-running SQL transformations are executing in the data warehouse, the worker is released and can handle other tasks, increasing overall task throughput.
-- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to a remote location or xcom. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution. We have observed a dbt project with 129 models takes ~500 seconds with remote SQL file upload/download, but only ~2 seconds using xcom.
+- **Faster Task Execution:** With Cosmos ``SetupAsyncOperator``, the SQL transformations are precompiled and uploaded to xcom (default behaviour) or a remote location. Instead of invoking a full dbt run during each dbt model task, the SQL files are downloaded from this remote path and executed directly. This eliminates unnecessary overhead from running the full dbt command, resulting in faster and more efficient task execution. We have observed a dbt project with 129 models takes ~500 seconds with remote SQL file upload/download, but only ~2 seconds using xcom.
 - **Better Resource Utilization:** By minimizing idle time on Airflow workers, async tasks allow more efficient use of compute resources. Workers aren't blocked waiting for external systems and can be reused for other work while waiting on async operations.
 
 Getting Started with Airflow Async Mode

--- a/docs/getting_started/async-execution-mode.rst
+++ b/docs/getting_started/async-execution-mode.rst
@@ -7,7 +7,7 @@ Airflow Async Execution Mode
 
 The Airflow async execution mode in Cosmos is designed to improve pipeline performance. This execution mode could be preferred when you’ve long running resources and you want to run them asynchronously by leveraging Airflow’s `deferrable operators <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`__. In this mode, additional operators—``SetupAsyncOperator`` and ``TeardownAsyncOperator``—are added to your workflow.
 
-- **SetupAsyncOperator:** This task runs a mocked ``dbt run`` command on your dbt project, which outputs compiled SQL files to the project’s target director. If ``upload_sql_xcom`` is enabled, the compiled SQL files will be uploaded to Airflow XCom. Otherwise, they will be uploaded to the remote location specified by the ``remote_target_path`` configuration.
+- **SetupAsyncOperator:** This task runs a mocked ``dbt run`` command on your dbt project, which outputs compiled SQL files to the project’s target director. If ``upload_sql_xcom`` is enabled (default behaviour), the compiled SQL files will be uploaded to Airflow XCom. Otherwise, they will be uploaded to the remote location specified by the ``remote_target_path`` configuration.
 - **TeardownAsyncOperator:** This task deletes the resources created by ``SetupAsyncOperator`` from the remote location defined by the ``remote_target_path`` configuration.
 
 Advantages of Airflow Async Mode

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -54,7 +54,7 @@ def test_dbt_run_airflow_async_bigquery_operator_base_cmd(profile_config_mock):
     assert operator.base_cmd == ["run"]
 
 
-def test_get_sql_from_xocm(profile_config_mock):
+def test_get_sql_from_xcom(profile_config_mock):
     fake_sql = "SELECT 42;"
     compressed_sql = zlib.compress(fake_sql.encode("utf-8"))
     compressed_b64_sql = base64.b64encode(compressed_sql).decode("utf-8")
@@ -79,7 +79,7 @@ def test_get_sql_from_xocm(profile_config_mock):
 
     expected_key = "models_test.sql"
 
-    result = obj.get_sql_from_xocm(mock_context)
+    result = obj.get_sql_from_xcom(mock_context)
 
     mock_context["ti"].xcom_pull.assert_called_once_with(
         task_ids="dbt_setup_async",

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -152,6 +152,7 @@ def test_configure_bigquery_async_op_args_missing_sql(async_operator_mock):
         _configure_bigquery_async_op_args(async_operator_mock)
 
 
+@patch("cosmos.settings.upload_sql_to_xcom", False)
 @patch("cosmos.operators._asynchronous.bigquery.DbtRunAirflowAsyncBigqueryOperator.get_remote_sql")
 @patch("cosmos.operators._asynchronous.bigquery.DbtRunAirflowAsyncBigqueryOperator._override_rtif")
 def test_store_compiled_sql(mock_override_rtif, mock_get_remote_sql, profile_config_mock):

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -82,38 +82,6 @@ def test_get_sql_from_xocm(profile_config_mock):
     assert result == fake_sql
 
 
-# def test_get_sql_from_xocm(mock_context):
-#     operator = DbtRunAirflowAsyncBigqueryOperator(
-#         task_id="test_task",
-#         project_dir="/path/to/project",
-#         profile_config=profile_config_mock,
-#         dbt_kwargs={"task_id": "test_task"},
-#     )
-#     # Setup required async_context attributes
-#     operator.async_context = {
-#         "dbt_node_config": {
-#             "file_path": "/opt/airflow/dags/dbt_project/target/models/my_model.sql"
-#         },
-#         "dbt_dag_task_group_identifier": "my_dag_group",
-#         "run_id": "abc123"
-#     }
-#
-#     operator.project_dir = "/opt/airflow/dags/dbt_project"
-#
-#     # Simulate context['ti'].xcom_pull returning SQL
-#     mock_context.__getitem__.return_value.xcom_pull.return_value = "SELECT * FROM users;"
-#
-#     with mock.patch.object(DbtRunAirflowAsyncBigqueryOperator, "log", autospec=True):
-#         result = operator.get_sql_from_xocm(mock_context)
-#
-#     expected_key = "my_dag_group/abc123/run/models/my_model.sql"
-#     mock_context.__getitem__.return_value.xcom_pull.assert_called_once_with(
-#         task_ids="dbt_setup_async",
-#         key=expected_key
-#     )
-#     assert result == "SELECT * FROM users;"
-
-
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "build_and_run_cmd")
 @patch("cosmos.operators._asynchronous.bigquery.settings.enable_setup_async_task", False)
 def test_dbt_run_airflow_async_bigquery_operator_execute(mock_build_and_run_cmd, profile_config_mock):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1585,6 +1585,7 @@ def test_upload_sql_files_xcom(tmp_path):
 
 
 @pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
+@patch("cosmos.settings.upload_sql_to_xcom", False)
 @patch("airflow.io.path.ObjectStoragePath.copy")
 @patch("airflow.io.path.ObjectStoragePath")
 @patch("cosmos.operators.local.DbtCompileLocalOperator._configure_remote_target_path")
@@ -1804,6 +1805,7 @@ def test_construct_dest_file_path_with_run_id():
     assert "test_run_id" in result
 
 
+@patch("cosmos.settings.upload_sql_to_xcom", False)
 def test_operator_construct_dest_file_path_with_run_id():
     """Test that the operator's _construct_dest_file_path method uses run_id correctly."""
     operator = ConcreteDbtLocalBaseOperator(
@@ -1824,6 +1826,7 @@ def test_operator_construct_dest_file_path_with_run_id():
     assert "test_run_id" in result
 
 
+@patch("cosmos.settings.upload_sql_to_xcom", False)
 def test_construct_dest_file_path_in_operator():
     """Test that the operator's _construct_dest_file_path method uses run_id correctly."""
     operator = ConcreteDbtLocalBaseOperator(

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1562,7 +1562,7 @@ def test_upload_compiled_sql_no_remote_path_raises_error(mock_configure_remote):
         operator._upload_sql_files(tmp_project_dir, "compiled")
 
 
-def test_upload_sql_files_xocm(tmp_path):
+def test_upload_sql_files_xcom(tmp_path):
     sql_query = "SELECT 1;"
     sql_file = tmp_path / "target" / "models" / "dest.sql"
     sql_file.parent.mkdir(parents=True, exist_ok=True)
@@ -1577,7 +1577,7 @@ def test_upload_sql_files_xocm(tmp_path):
     )
     obj._construct_dest_file_path = lambda a, b, c, d: "dest.sql"
 
-    obj._upload_sql_files_xocm(mock_context, str(tmp_path), "models")
+    obj._upload_sql_files_xcom(mock_context, str(tmp_path), "models")
 
     compressed_sql = zlib.compress(sql_query.encode("utf-8"))
     compressed_b64_sql = base64.b64encode(compressed_sql).decode("utf-8")

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -161,16 +161,3 @@ def test_example_dag(session, dag_id: str):
 def test_async_example_dag_without_setup_task(session, monkeypatch):
     async_dag_id = "simple_dag_async"
     run_dag(async_dag_id)
-
-
-@pytest.mark.skipif(
-    AIRFLOW_VERSION in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS,
-    reason="Airflow 2.9.0 and 2.9.1 have a breaking change in Dataset URIs, and Cosmos errors if `emit_datasets` is not False",
-)
-@patch.dict(
-    {"AIRFLOW__COSMOS__UPLOAD_SQL_TO_XCOM": "true"},
-)
-@pytest.mark.integration
-def test_async_example_dag_upload_sql_to_xcom(session, monkeypatch):
-    async_dag_id = "simple_dag_async"
-    run_dag(async_dag_id)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -161,3 +161,16 @@ def test_example_dag(session, dag_id: str):
 def test_async_example_dag_without_setup_task(session, monkeypatch):
     async_dag_id = "simple_dag_async"
     run_dag(async_dag_id)
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS,
+    reason="Airflow 2.9.0 and 2.9.1 have a breaking change in Dataset URIs, and Cosmos errors if `emit_datasets` is not False",
+)
+@patch.dict(
+    {"AIRFLOW__COSMOS__UPLOAD_SQL_TO_XCOM": "true"},
+)
+@pytest.mark.integration
+def test_async_example_dag_upload_sql_to_xcom(session, monkeypatch):
+    async_dag_id = "simple_dag_async"
+    run_dag(async_dag_id)


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1891

Feature: Use XCom to store SQL queries when ExecutionMode.AIRFLOW_ASYNC is enabled.

This change introduces an option to store the SQL query in Airflow’s XCom instead of uploading to and downloading from remote storage (GCS/SC) during AIRFLOW_ASYNC execution mode. This approach significantly reduces the network overhead associated with file transfers in the setup task.

Implementation:

- Added a new flag upload_sql_to_xcom to enable or disable this behaviour.
- The flag is disabled by default to maintain backwards compatibility.

Benefit:

- Reduced API call network latency.
- Improved overall task execution time when running in async mode.

Observation: A dbt project containing 129 models takes approximately 500 seconds to complete when uploading and downloading SQL files to/from a bucket via network calls. In contrast, using XCom, the same takes approximately 2 seconds. Tested on PR: https://github.com/astronomer/cosmos-benchmark/pull/9

Alpha: https://pypi.org/project/astronomer-cosmos/1.11.0a3/