### PR TITLE
Refactor AIRFLOW_ASYNC teardown so it doesn't install the virtualenv

### DIFF
--- a/cosmos/operators/_asynchronous/__init__.py
+++ b/cosmos/operators/_asynchronous/__init__.py
@@ -5,6 +5,8 @@ import textwrap
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from cosmos.operators.local import DbtRunLocalOperator
+
 if TYPE_CHECKING:  # pragma: no cover
     try:
         from airflow.sdk.definitions.context import Context
@@ -48,37 +50,22 @@ class SetupAsyncOperator(DbtRunVirtualenvOperator):
         )
 
 
-class TeardownAsyncOperator(DbtRunVirtualenvOperator):
+class TeardownAsyncOperator(DbtRunLocalOperator):
     def __init__(self, *args: Any, **kwargs: Any):
         kwargs["emit_datasets"] = False
         super().__init__(*args, **kwargs)
 
-    def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str) -> FullOutputSubprocessResult:
-        profile_type = self.profile_config.get_profile_type()
-        if not self._py_bin:
-            raise AttributeError("_py_bin attribute not set for VirtualEnv operator")
-        dbt_executable_path = str(Path(self._py_bin).parent / "dbt")
-        asynchronous_operator_module = f"cosmos.operators._asynchronous.{profile_type}"
-        mock_function_name = f"_mock_{profile_type}_adapter"
-        mock_function = load_method_from_module(asynchronous_operator_module, mock_function_name)
-        mock_function_full_source = inspect.getsource(mock_function)
-        mock_function_body = textwrap.dedent("\n".join(mock_function_full_source.split("\n")[1:]))
-
-        with open(dbt_executable_path) as f:
-            dbt_entrypoint_script = f.readlines()
-        if dbt_entrypoint_script[0].startswith("#!"):
-            dbt_entrypoint_script.insert(1, mock_function_body)
-        with open(dbt_executable_path, "w") as f:
-            f.writelines(dbt_entrypoint_script)
-
-        return super().run_subprocess(command, env, cwd)
-
     def execute(self, context: Context, **kwargs: Any) -> Any:
-        async_context = {
-            "profile_type": self.profile_config.get_profile_type(),
-            "teardown_task": True,
-            "run_id": context["run_id"],
-        }
-        self.build_and_run_cmd(
-            context=context, cmd_flags=self.dbt_cmd_flags, run_as_async=True, async_context=async_context
-        )
+
+        dest_target_dir, dest_conn_id = self._configure_remote_target_path()
+
+        from airflow.io.path import ObjectStoragePath
+
+        dag_task_group_identifier = self.extra_context["dbt_dag_task_group_identifier"]
+        run_id = context["run_id"]
+        run_dir_path_str = f"{str(dest_target_dir).rstrip('/')}/{dag_task_group_identifier}/{run_id}"
+
+        run_dir_path = ObjectStoragePath(run_dir_path_str, conn_id=dest_conn_id)
+
+        if run_dir_path.exists():
+            run_dir_path.rmdir(recursive=True)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -571,10 +571,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.callback(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
-        if async_context.get("teardown_task") and settings.enable_teardown_async_task:
-            self._delete_sql_files()
-            return
-
         if settings.enable_setup_async_task:
             self._upload_sql_files(tmp_project_dir, "run")
         else:

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import pytest
 
@@ -151,7 +151,11 @@ def test_execute_removes_existing_path(mock_object_storage_path):
     mock_path_instance.exists.return_value = True
     mock_object_storage_path.return_value = mock_path_instance
 
-    operator = TeardownAsyncOperator(task_id="dbt_teardown_async")
+    operator = TeardownAsyncOperator(
+        task_id="dbt_teardown_async",
+        profile_config=Mock(),
+        project_dir="fake-dir",
+    )
     operator._configure_remote_target_path = MagicMock(return_value=("s3://my-bucket/path", "my_conn_id"))
     operator.extra_context = {"dbt_dag_task_group_identifier": "jaffle_shop"}
 

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -145,7 +145,7 @@ def test_setup_run_subprocess_py_bin_unset(
         op.run_subprocess(command, env, cwd)
 
 
-@patch("cosmos.operators._asynchronous.__init__.ObjectStoragePath")
+@patch("airflow.io.path.ObjectStoragePath")
 def test_execute_removes_existing_path(mock_object_storage_path):
     mock_path_instance = MagicMock()
     mock_path_instance.exists.return_value = True

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
+import airflow
 import pytest
+from packaging.version import Version
 
 from cosmos.config import ProfileConfig
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
@@ -11,6 +13,8 @@ from cosmos.operators._asynchronous.base import DbtRunAirflowAsyncFactoryOperato
 from cosmos.operators._asynchronous.bigquery import DbtRunAirflowAsyncBigqueryOperator
 from cosmos.operators._asynchronous.databricks import DbtRunAirflowAsyncDatabricksOperator
 from cosmos.operators.local import DbtRunLocalOperator
+
+AIRFLOW_VERSION = Version(airflow.__version__)
 
 
 @pytest.mark.parametrize(
@@ -145,6 +149,7 @@ def test_setup_run_subprocess_py_bin_unset(
         op.run_subprocess(command, env, cwd)
 
 
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.8"), reason="ObjectStoragePath requires Apache Airflow >= 2.8")
 @patch("airflow.io.path.ObjectStoragePath")
 def test_execute_removes_existing_path(mock_object_storage_path):
     mock_path_instance = MagicMock()

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -145,7 +145,7 @@ def test_setup_run_subprocess_py_bin_unset(
         op.run_subprocess(command, env, cwd)
 
 
-@patch("cosmos.operators._asynchronous.ObjectStoragePath")  # Patch where it's imported
+@patch("cosmos.operators._asynchronous.__init__.ObjectStoragePath")
 def test_execute_removes_existing_path(mock_object_storage_path):
     mock_path_instance = MagicMock()
     mock_path_instance.exists.return_value = True

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1701,31 +1701,6 @@ def test_build_and_run_cmd_with_full_refresh_in_async_mode():
                 assert "--full-refresh" in cmd_flags_arg
 
 
-@pytest.mark.integration
-@pytest.mark.skipif(not AIRFLOW_IO_AVAILABLE, reason="Airflow did not have Object Storage until the 2.8 release")
-@patch("pathlib.Path.rglob")
-@patch("cosmos.operators.local.AbstractDbtLocalBase._construct_dest_file_path")
-@patch("cosmos.operators.local.AbstractDbtLocalBase._configure_remote_target_path")
-@patch("airflow.io.path.ObjectStoragePath")
-def test_async_execution_teardown_delete_files(
-    mock_object_storage_path, mock_configure_remote, mock_construct_dest_file_path, mock_rglob
-):
-    mock_path = MagicMock()
-    mock_path.exists.return_value = True
-    mock_object_storage_path.return_value = mock_path
-    mock_configure_remote.return_value = (Path("/mock/path"), "mock_conn_id")
-
-    project_dir = Path(__file__).parent.parent.parent / "dev/dags/dbt/altered_jaffle_shop"
-    operator = DbtRunLocalOperator(
-        task_id="test",
-        project_dir=project_dir,
-        profile_config=profile_config,
-        extra_context={"dbt_dag_task_group_identifier": "test_dag_task_group", "run_id": "test_run_id"},
-    )
-    operator._handle_async_execution(project_dir, {}, {"profile_type": "bigquery", "teardown_task": True})
-    mock_path.rmdir.assert_called_once_with(recursive=True)
-
-
 def test_read_run_sql_from_target_dir():
     tmp_project_dir = "/tmp/project"
     sql_context = {"dbt_node_config": {"file_path": "/path/to/file.sql"}, "package_name": "package_name"}


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1611

This PR remove the need for a virtual environment in the teardown task and directly deletes the run_id folder from the remote location


<img width="1706" height="697" alt="Screenshot 2025-08-26 at 4 42 55 PM" src="https://github.com/user-attachments/assets/d5e0f853-f41d-40c2-8378-e3c3ce617518" />
