### PR TITLE
Reuse the virtual env for AIRFLOW_ASYNC setup task

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 from cosmos import settings
 
-__version__ = "1.11.0a1"
+__version__ = "1.11.0a4"
 
 if not settings.enable_memory_optimised_imports:
     from cosmos.airflow.dag import DbtDag

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -477,7 +477,6 @@ def _add_dbt_setup_async_task(
     task_group: TaskGroup | None,
     render_config: RenderConfig | None = None,
     async_py_requirements: list[str] | None = None,
-    virtualenv_dir: str | None = None,
 ) -> None:
     if execution_mode != ExecutionMode.AIRFLOW_ASYNC:
         return
@@ -490,8 +489,6 @@ def _add_dbt_setup_async_task(
         task_args["selector"] = render_config.selector
         task_args["exclude"] = render_config.exclude
         task_args["py_requirements"] = async_py_requirements
-
-    task_args["virtualenv_dir"] = virtualenv_dir
 
     setup_task_metadata = TaskMetadata(
         id=DBT_SETUP_ASYNC_TASK_ID,
@@ -714,12 +711,11 @@ def build_airflow_graph(
         _add_dbt_setup_async_task(
             dag,
             execution_mode,
-            task_args,
+            {**task_args, "virtualenv_dir": virtualenv_dir},
             tasks_map,
             task_group,
             render_config=render_config,
             async_py_requirements=async_py_requirements,
-            virtualenv_dir=virtualenv_dir,
         )
     if settings.enable_teardown_async_task:
         _add_teardown_task(

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -592,7 +592,7 @@ def _add_teardown_task(
     tasks_map[DBT_TEARDOWN_ASYNC_TASK_ID] = teardown_airflow_task
 
 
-def build_airflow_graph(  # noqa: C901
+def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astronomer-cosmos/issues/1943
     nodes: dict[str, DbtNode],
     dag: DAG,  # Airflow-specific - parent DAG where to associate tasks and (optional) task groups
     execution_mode: ExecutionMode,  # Cosmos-specific - decide what which class to use

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -592,7 +592,7 @@ def _add_teardown_task(
     tasks_map[DBT_TEARDOWN_ASYNC_TASK_ID] = teardown_airflow_task
 
 
-def build_airflow_graph(
+def build_airflow_graph(  # noqa: C901
     nodes: dict[str, DbtNode],
     dag: DAG,  # Airflow-specific - parent DAG where to associate tasks and (optional) task groups
     execution_mode: ExecutionMode,  # Cosmos-specific - decide what which class to use
@@ -643,7 +643,9 @@ def build_airflow_graph(
     detached_from_parent: dict[str, list[DbtNode]] = defaultdict(list)
     identify_detached_nodes(nodes, render_config, detached_nodes, detached_from_parent)
 
-    virtualenv_dir = task_args.pop("virtualenv_dir", None)
+    virtualenv_dir = None
+    if execution_mode == ExecutionMode.AIRFLOW_ASYNC:
+        virtualenv_dir = task_args.pop("virtualenv_dir", None)
 
     for node_id, node in nodes.items():
         conversion_function = node_converters.get(node.resource_type, generate_task_or_group)

--- a/tests/operators/_asynchronous/test_base.py
+++ b/tests/operators/_asynchronous/test_base.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import MagicMock, Mock, mock_open, patch
 
 import airflow
@@ -172,3 +173,21 @@ def test_execute_removes_existing_path(mock_object_storage_path):
     mock_object_storage_path.assert_called_once_with(expected_path, conn_id="my_conn_id")
     mock_path_instance.exists.assert_called_once()
     mock_path_instance.rmdir.assert_called_once_with(recursive=True)
+
+
+def test_run_with_existing_venv(profile_config_mock):
+
+    virtualenv_path = Path("/temp/myenv")
+
+    with patch.object(Path, "mkdir") as mock_mkdir:
+        # Simulate that the directory already exists
+        mock_mkdir.return_value = None
+
+        SetupAsyncOperator(
+            task_id="test_task",
+            project_dir="some/path",
+            profile_config=profile_config_mock,
+            virtualenv_dir=virtualenv_path,
+        )
+        # Assert that mkdir was called with expected arguments
+        mock_mkdir.assert_called_once_with(parents=True, exist_ok=True)


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1936


<img width="1720" height="937" alt="Screenshot 2025-08-26 at 6 39 09 PM" src="https://github.com/user-attachments/assets/532744c6-d30c-4707-9329-1baa426d43de" />


DAG
```python

# [START airflow_async_execution_mode_example]
simple_dag_async = DbtDag(
    # dbt/cosmos-specific parameters
    project_config=ProjectConfig("/usr/local/airflow/dbt/jaffle_shop"),
    profile_config=profile_config,
    execution_config=ExecutionConfig(
        execution_mode=ExecutionMode.AIRFLOW_ASYNC,
        async_py_requirements=[f"dbt-bigquery=={DBT_ADAPTER_VERSION}"],
    ),

    render_config=RenderConfig(test_behavior=TestBehavior.NONE),
    # normal dag parameters
    schedule=None,
    start_date=datetime(2023, 1, 1),
    catchup=False,
    dag_id="simple_dag_async",
    tags=["simple"],
    operator_args={
        "location": "US",
        "install_deps": True,
        "full_refresh": True,
        "virtualenv_dir": "/usr/local/airflow/include/dbt_venv2",
    },
)
```
Alpha: https://pypi.org/project/astronomer-cosmos/1.11.0a4/