### PR TITLE
Fix running tests with dbt Fusion 2.0.0 preview versions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, fix-1929]
+    branches: [main]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -381,7 +381,7 @@ jobs:
       matrix:
         python-version: [ "3.11" ]
         airflow-version: [ "2.11", "3.0" ]
-        dbt-version: ["1.5", "1.6", "1.7", "1.8", "1.9", "1.10"]
+        dbt-version: ["1.6", "1.7", "1.8", "1.9", "1.10"]
     services:
       postgres:
         image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -434,6 +434,7 @@ jobs:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
+      AIRFLOW__COSMOS__ENABLE_DATASET_ALIAS: 0
       AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
       AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
       AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -421,16 +421,6 @@ jobs:
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-async
-        env:
-          AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
-          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
-          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
-          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
-          PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
-          AIRFLOW__COSMOS__ENABLE_CACHE: 0
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
-          DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -441,10 +431,18 @@ jobs:
 
     env:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
-      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
+      AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+      AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+      AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+      AIRFLOW__COSMOS__ENABLE_CACHE: 0
+      AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+      AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+      DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+
       # The following are only required because the profiles.yml file references them. They are not used by the tests selected by this job.
+      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
       POSTGRES_HOST: localhost
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -370,6 +370,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
           DBT_PROJECT_NAME: "altered_jaffle_shop"  # The syntax of jaffle_shop is not supported in dbt 1.5.4, only in dbt >= 1.10
+          TEST_SINGLE_DAG: "basic_cosmos_task_group.py"
 
   Run-Integration-Tests-DBT-Async:
     needs: Authorize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -431,13 +431,6 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
           DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
-          # The following are only required because the profiles.yml file references them. They are not used by the tests selected by this job.
-          POSTGRES_HOST: localhost
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_SCHEMA: public
-          POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4
@@ -450,6 +443,14 @@ jobs:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+
+      # The following are only required because the profiles.yml file references them. They are not used by the tests selected by this job.
+      POSTGRES_HOST: localhost
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_SCHEMA: public
+      POSTGRES_PORT: 5432
 
   Run-Integration-dbt-fusion-Tests:
     needs: Authorize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -369,6 +369,7 @@ jobs:
           POSTGRES_PORT: 5432
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+          DBT_PROJECT_NAME: "altered_jaffle_shop"  # The syntax of jaffle_shop is not supported in dbt 1.5.4, only in dbt >= 1.10
 
   Run-Integration-Tests-DBT-Async:
     needs: Authorize

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -431,6 +431,13 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
           DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+          # The following are only required because the profiles.yml file references them. They are not used by the tests selected by this job.
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@v4

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, fix-1929]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.
@@ -614,7 +614,7 @@ jobs:
       matrix:
         python-version: [ "3.12" ]
         airflow-version: [ "2.10", "3.0" ]
-        dbt-version: [ "1.9" ]
+        dbt-version: [ "1.10" ]
     steps:
       - uses: actions/checkout@v5
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -434,6 +434,7 @@ jobs:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
+      DBT_PROJECT_NAME: "altered_jaffle_shop" # The syntax of jaffle_shop is not supported in dbt 1.5.4, only in dbt >= 1.10
       AIRFLOW__COSMOS__ENABLE_DATASET_ALIAS: 0
       AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
       AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}

--- a/dev/dags/basic_cosmos_dag.py
+++ b/dev/dags/basic_cosmos_dag.py
@@ -14,6 +14,9 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
+
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -28,9 +31,7 @@ profile_config = ProfileConfig(
 # [START local_example]
 basic_cosmos_dag = DbtDag(
     # dbt/cosmos-specific parameters
-    project_config=ProjectConfig(
-        DBT_ROOT_PATH / "jaffle_shop",
-    ),
+    project_config=ProjectConfig(DBT_PROJECT_PATH),
     profile_config=profile_config,
     operator_args={
         "install_deps": True,  # install any necessary dependencies before running any dbt command

--- a/dev/dags/basic_cosmos_dag_full_module_path_imports.py
+++ b/dev/dags/basic_cosmos_dag_full_module_path_imports.py
@@ -15,6 +15,8 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -30,7 +32,7 @@ profile_config = ProfileConfig(
 basic_cosmos_dag_full_module_path_imports = DbtDag(
     # dbt/cosmos-specific parameters
     project_config=ProjectConfig(
-        DBT_ROOT_PATH / "jaffle_shop",
+        DBT_PROJECT_PATH,
     ),
     profile_config=profile_config,
     operator_args={

--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -61,7 +61,7 @@ with DAG(
     orders = DbtTaskGroup(
         group_id="orders",
         project_config=ProjectConfig(
-            (DBT_ROOT_PATH / "jaffle_shop").as_posix(),
+            (DBT_PROJECT_PATH).as_posix(),
         ),
         render_config=RenderConfig(
             select=["path:seeds/raw_orders.csv"],

--- a/dev/dags/basic_cosmos_task_group.py
+++ b/dev/dags/basic_cosmos_task_group.py
@@ -15,6 +15,8 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).resolve().parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -43,7 +45,7 @@ with DAG(
 
     customers = DbtTaskGroup(
         group_id="customers",
-        project_config=ProjectConfig((DBT_ROOT_PATH / "jaffle_shop").as_posix(), dbt_vars={"var": "2"}),
+        project_config=ProjectConfig((DBT_PROJECT_PATH).as_posix(), dbt_vars={"var": "2"}),
         render_config=RenderConfig(
             select=["path:seeds/raw_customers.csv"],
             enable_mock_profile=False,

--- a/dev/dags/dbt/jaffle_shop/dbt_project.yml
+++ b/dev/dags/dbt/jaffle_shop/dbt_project.yml
@@ -21,6 +21,6 @@ require-dbt-version: [">=1.0.0", "<2.0.0"]
 
 models:
   jaffle_shop:
-      materialized: table
+      +materialized: table
       staging:
-        materialized: view
+        +materialized: view

--- a/dev/dags/dbt/jaffle_shop/models/schema.yml
+++ b/dev/dags/dbt/jaffle_shop/models/schema.yml
@@ -55,7 +55,8 @@ models:
         description: '{{ doc("orders_status") }}'
         tests:
           - accepted_values:
-              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+              arguments:
+                values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
       - name: amount
         description: Total amount (AUD) of the order

--- a/dev/dags/dbt/jaffle_shop/models/staging/schema.yml
+++ b/dev/dags/dbt/jaffle_shop/models/staging/schema.yml
@@ -17,7 +17,8 @@ models:
       - name: status
         tests:
           - accepted_values:
-              values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
+              arguments:
+                values: ['placed', 'shipped', 'completed', 'return_pending', 'returned']
 
   - name: stg_payments
     columns:
@@ -28,4 +29,5 @@ models:
       - name: payment_method
         tests:
           - accepted_values:
-              values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']
+              arguments:
+                values: ['credit_card', 'coupon', 'bank_transfer', 'gift_card']

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -8,6 +8,8 @@ from cosmos.profiles import GoogleCloudServiceAccountDictProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).resolve().parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
 
 DBT_ADAPTER_VERSION = os.getenv("DBT_ADAPTER_VERSION", "1.9")
 
@@ -24,7 +26,7 @@ profile_config = ProfileConfig(
 simple_dag_async = DbtDag(
     # dbt/cosmos-specific parameters
     project_config=ProjectConfig(
-        DBT_ROOT_PATH / "altered_jaffle_shop",
+        DBT_PROJECT_PATH,
     ),
     profile_config=profile_config,
     execution_config=ExecutionConfig(

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -24,7 +24,7 @@ profile_config = ProfileConfig(
 simple_dag_async = DbtDag(
     # dbt/cosmos-specific parameters
     project_config=ProjectConfig(
-        DBT_ROOT_PATH / "jaffle_shop",
+        DBT_ROOT_PATH / "altered_jaffle_shop",
     ),
     profile_config=profile_config,
     execution_config=ExecutionConfig(

--- a/scripts/test/integration-dbt-1-5-4.sh
+++ b/scripts/test/integration-dbt-1-5-4.sh
@@ -27,4 +27,4 @@ pytest -vv \
     -m 'integration and not dbtFusion' \
     --ignore=tests/perf \
     --ignore=tests/test_example_k8s_dags.py \
-    -k 'basic_cosmos_task_group'
+    "tests/test_example_dags.py::test_example_dag[basic_cosmos_task_group]"

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -22,4 +22,4 @@ pytest -vv \
     --ignore=tests/perf \
     --ignore=tests/test_async_example_dag.py \
     --ignore=tests/test_example_k8s_dags.py \
-    -k 'not ( example_cosmos_python_models or example_virtualenv or jaffle_shop_kubernetes)'
+    -k 'not (simple_dag_async or example_cosmos_python_models or example_virtualenv or jaffle_shop_kubernetes)'

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1908,9 +1908,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
         # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
-        assert hash_dir in ("e16e6aef5f03f4e12d744b9412d90272", "71bbf303ad4e06a7b1e2be20e0b73c0d")
+        assert hash_dir in ("481324dabe926f5cf6352b05e5ebe5d7", "60c08a4730a39d03d89f0f87a8ff3931")
     else:
-        assert hash_dir == "71bbf303ad4e06a7b1e2be20e0b73c0d"
+        assert hash_dir == "60c08a4730a39d03d89f0f87a8ff3931"
 
 
 @pytest.mark.integration

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -117,8 +117,9 @@ def get_dag_bag_single_dag(single_dag: str) -> DagBag:
 
 
 def get_dag_ids() -> list[str]:
-    if os.getenv("TEST_SINGLE_DAG"):
-        dag_bag = get_dag_bag_single_dag(os.getenv("TEST_SINGLE_DAG"))
+    single_dag = os.getenv("TEST_SINGLE_DAG")
+    if single_dag:
+        dag_bag = get_dag_bag_single_dag(single_dag)
         return dag_bag.dag_ids
     else:
         dag_bag = get_dag_bag()
@@ -126,7 +127,11 @@ def get_dag_ids() -> list[str]:
 
 
 def run_dag(dag_id: str):
-    dag_bag = get_dag_bag()
+    single_dag = os.getenv("TEST_SINGLE_DAG")
+    if single_dag:
+        dag_bag = get_dag_bag_single_dag(single_dag)
+    else:
+        dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
     assert dag
     test_utils.run_dag(dag)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -131,8 +131,11 @@ def get_dag_ids() -> list[str]:
     return dag_bag.dag_ids
 
 
-def run_dag(dag_id: str):
-    dag_bag = get_dagbag_depending_on_single_dag()
+def run_dag(dag_id: str, consider_singLe_dag: bool = True):
+    if consider_singLe_dag:
+        dag_bag = get_dagbag_depending_on_single_dag()
+    else:
+        dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
     assert dag
     test_utils.run_dag(dag)
@@ -163,4 +166,4 @@ def test_example_dag(session, dag_id: str):
 @pytest.mark.integration
 def test_async_example_dag_without_setup_task(session, monkeypatch):
     async_dag_id = "simple_dag_async"
-    run_dag(async_dag_id)
+    run_dag(async_dag_id, consider_singLe_dag=False)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -71,9 +71,6 @@ def get_dag_bag() -> DagBag:  # noqa: C901
             print(f"Adding {dagfile} to .airflowignore")
             file.writelines([f"{dagfile}\n"])
 
-        # We are testing this DAG in a dedicated CI job
-        file.writelines(["simple_dag_async.py\n"])
-
         if DBT_VERSION < Version("1.6.0"):
             file.writelines(["example_model_version.py\n"])
             file.writelines(["example_operators.py\n"])
@@ -131,11 +128,8 @@ def get_dag_ids() -> list[str]:
     return dag_bag.dag_ids
 
 
-def run_dag(dag_id: str, consider_singLe_dag: bool = True):
-    if consider_singLe_dag:
-        dag_bag = get_dagbag_depending_on_single_dag()
-    else:
-        dag_bag = get_dag_bag()
+def run_dag(dag_id: str):
+    dag_bag = get_dagbag_depending_on_single_dag()
     dag = dag_bag.get_dag(dag_id)
     assert dag
     test_utils.run_dag(dag)
@@ -166,4 +160,4 @@ def test_example_dag(session, dag_id: str):
 @pytest.mark.integration
 def test_async_example_dag_without_setup_task(session, monkeypatch):
     async_dag_id = "simple_dag_async"
-    run_dag(async_dag_id, consider_singLe_dag=False)
+    run_dag(async_dag_id)

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -71,8 +71,10 @@ def get_dag_bag() -> DagBag:  # noqa: C901
             print(f"Adding {dagfile} to .airflowignore")
             file.writelines([f"{dagfile}\n"])
 
+        # We are testing this DAG in a dedicated CI job
+        file.writelines(["simple_dag_async.py\n"])
+
         if DBT_VERSION < Version("1.6.0"):
-            file.writelines(["simple_dag_async.py\n"])
             file.writelines(["example_model_version.py\n"])
             file.writelines(["example_operators.py\n"])
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -99,9 +99,30 @@ def get_dag_bag() -> DagBag:  # noqa: C901
     return db
 
 
+def get_dag_bag_single_dag(single_dag: str) -> DagBag:
+    """Create a DagBag by adding the files that are not supported to .airflowignore"""
+    # add everything to airflow ignore that isn't performance_dag.py
+    with open(AIRFLOW_IGNORE_FILE, "w+") as f:
+        for file in EXAMPLE_DAGS_DIR.iterdir():
+            if file.is_file() and file.suffix == ".py":
+                if file.name != single_dag:
+                    print(f"Adding {file.name} to .airflowignore")
+                    f.write(f"{file.name}\n")
+    print(".airflowignore contents: ")
+    print(AIRFLOW_IGNORE_FILE.read_text())
+    db = DagBag(EXAMPLE_DAGS_DIR, include_examples=False)
+    assert db.dags
+    assert not db.import_errors
+    return db
+
+
 def get_dag_ids() -> list[str]:
-    dag_bag = get_dag_bag()
-    return dag_bag.dag_ids
+    if os.getenv("TEST_SINGLE_DAG"):
+        dag_bag = get_dag_bag_single_dag(os.getenv("TEST_SINGLE_DAG"))
+        return dag_bag.dag_ids
+    else:
+        dag_bag = get_dag_bag()
+        return dag_bag.dag_ids
 
 
 def run_dag(dag_id: str):

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -116,22 +116,23 @@ def get_dag_bag_single_dag(single_dag: str) -> DagBag:
     return db
 
 
-def get_dag_ids() -> list[str]:
+def get_dagbag_depending_on_single_dag() -> DagBag:
+    """Return DagBag for a single DAG or for all DAGs, depending on environment variable TEST_SINGLE_DAG"""
     single_dag = os.getenv("TEST_SINGLE_DAG")
     if single_dag:
         dag_bag = get_dag_bag_single_dag(single_dag)
-        return dag_bag.dag_ids
     else:
         dag_bag = get_dag_bag()
-        return dag_bag.dag_ids
+    return dag_bag
+
+
+def get_dag_ids() -> list[str]:
+    dag_bag = get_dagbag_depending_on_single_dag()
+    return dag_bag.dag_ids
 
 
 def run_dag(dag_id: str):
-    single_dag = os.getenv("TEST_SINGLE_DAG")
-    if single_dag:
-        dag_bag = get_dag_bag_single_dag(single_dag)
-    else:
-        dag_bag = get_dag_bag()
+    dag_bag = get_dagbag_depending_on_single_dag()
     dag = dag_bag.get_dag(dag_id)
     assert dag
     test_utils.run_dag(dag)


### PR DESCRIPTION
The dbt Fusion tests in Cosmos' main branch were failing with errors like:
```
>           raise CosmosLoadDbtException(f"Unable to run {command} due to the error:\n{details}")
E           cosmos.dbt.graph.CosmosLoadDbtException: Unable to run ['/home/runner/.local/bin/dbt', 'ls', '--output', 'json', '--output-keys', 'name', 'unique_id', 'resource_type', 'depends_on', 'original_file_path', 'tags', 'config', 'freshness', '--project-dir', '/tmp/tmp5viijrkb', '--profiles-dir', '/home/runner/work/astronomer-cosmos/astronomer-cosmos/dev/dags/dbt/jaffle_shop', '--profile', 'snowflake_profile', '--target', 'dev'] due to the error:
E           stderr: error: dbt1060: Ignored unexpected key 'materialized'. Try '+materialized' instead. YAML path: 'jaffle_shop.materialized'.
E             --> dbt_project.yml:24:21
E           error: dbt1060: Ignored unexpected key 'materialized'. Try '+materialized' instead. YAML path: 'jaffle_shop.staging.materialized'.
E             --> dbt_project.yml:26:23
E           error: dbt0102: Deprecated test arguments: ["values"] at top-level detected. Please migrate to the new format under the 'arguments' field: https://docs.getdbt.com/reference/deprecations#missingargumentspropertyingenerictestdeprecation.
E             --> models/schema.yml:58:23
E           error: dbt0102: Deprecated test arguments: ["values"] at top-level detected. Please migrate to the new format under the 'arguments' field: https://docs.getdbt.com/reference/deprecations#missingargumentspropertyingenerictestdeprecation.
E             --> models/staging/schema.yml:20:23
E           error: dbt0102: Deprecated test arguments: ["values"] at top-level detected. Please migrate to the new format under the 'arguments' field: https://docs.getdbt.com/reference/deprecations#missingargumentspropertyingenerictestdeprecation.
E             --> models/staging/schema.yml:31:23
E           
E           stdout: dbt-fusion 2.0.0-preview.3
E              Loading ../../home/runner/work/astronomer-cosmos/astronomer-cosmos/dev/dags/dbt/jaffle_shop/profiles.yml
E              Loading packages.yml
E           suggestion: Run 'dbt deps' to see the latest fusion compatible packages. For compatibility errors, try the autofix script: https://github.com/dbt-labs/dbt-autofix
E             Finished 'ls' target 'dev' with 5 errors in 91ms
```

Example:
https://github.com/astronomer/astronomer-cosmos/actions/runs/17485309398/job/49663095838?pr=1947

This issue is due to breaking changes introduced in the dbt schema and dbt project syntax as part of the dbt Fusion promotion (and only back-ported to dbt Core 1.10). The latest versions of dbt Fusion no longer accept the previous syntax, which was supported by dbt versions 1.9 and earlier.

This PR:
- Changes the `jaffle_shop` so that it is compatible with the new syntax. This has fixed the dbt Fusion tests.
- For tests that need to run with dbt Core versions before 1.10, modify the DAGs to use `altered_jaffle_shop`, allowing us to maintain both project syntaxes and validate against both versions. We must support dbt Core 1.9, as it has not yet reached the end of life (https://docs.getdbt.com/docs/dbt-versions/core).

There were a few changes to the CI, and a successful test run against these new configurations can be seen at:
https://github.com/astronomer/astronomer-cosmos/actions/runs/17733688014/job/50390249064

Tests worked with dbt Fusion 2.0.0 preview 13.

Closes: #1929
