### PR TITLE
Add Scarf metric to collect the execution mode uses

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -167,8 +167,8 @@ TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtReso
 DBT_SETUP_ASYNC_TASK_ID = "dbt_setup_async"
 DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 
-TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}"
-TELEMETRY_VERSION = "v1"
+TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}/{execution_modes}"
+TELEMETRY_VERSION = "v2"
 TELEMETRY_TIMEOUT = 1.0
 
 _AIRFLOW3_MAJOR_VERSION = 3

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -56,6 +56,9 @@ def get_execution_modes(dag: DAG) -> str:
         if (getattr(task, "_task_module", None) or task.__class__.__module__).startswith("cosmos.")
     }
 
+    if not modes:
+        return "none"
+
     # Sorted to ensure consistent and predictable output
     return "__".join(sorted(modes))
 

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -56,9 +56,6 @@ def get_execution_modes(dag: DAG) -> str:
         if (getattr(task, "_task_module", None) or task.__class__.__module__).startswith("cosmos.")
     }
 
-    if not modes:
-        return "none"
-
     # Sorted to ensure consistent and predictable output
     return "__".join(sorted(modes))
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -67,7 +67,7 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. Status code: 404. Message: Non existent URL"""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local. Status code: 404. Message: Non existent URL"""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -94,7 +94,7 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. An HTTPX connection error occurred: Something is not right."""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local. An HTTPX connection error occurred: Something is not right."""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -84,10 +84,11 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
         "dag_hash": "d151d1fa2f03270ea116cc7494f2c591",
         "task_count": 3,
         "cosmos_task_count": 3,
+        "execution_modes": "local",
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
         timeout=1.0,
         follow_redirects=True,
     )
@@ -111,6 +112,7 @@ def test_emit_usage_metrics_succeeds(caplog):
         "dag_hash": "dag-hash-ci",
         "task_count": 33,
         "cosmos_task_count": 33,
+        "execution_modes": "local",
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     assert is_success

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -62,12 +62,12 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
         timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. Status code: 404. Message: Non existent URL"""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. Status code: 404. Message: Non existent URL"""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 
@@ -94,7 +94,7 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. An HTTPX connection error occurred: Something is not right."""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3. An HTTPX connection error occurred: Something is not right."""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -58,10 +58,11 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
         "dag_hash": "d151d1fa2f03270ea116cc7494f2c591",
         "task_count": 3,
         "cosmos_task_count": 3,
+        "execution_modes": "local",
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v1/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
         timeout=1.0,
         follow_redirects=True,
     )


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/1975

This PR introduces tracking of the execution mode in `DbtDag` and `DbtTaskGroup` to help understand usage patterns and support better decision-making during development.

- Collecting execution modes used by `DbtDag` and `DbtTaskGroup`.
- Collect multiple execution modes per DbtTaskGroup (e.g., when using multiple DbtTaskGroups with different execution settings). Concatenating modes using `__ ` as a delimiter (e.g., kubernetes__local).
- Introducing a new versioned metrics endpoint to collect execution mode data while preserving support for the legacy format.
<img width="1318" height="126" alt="variable-downloads-execution_modes-astronomer-2025-09-18T21_35_51 537Z" src="https://github.com/user-attachments/assets/d69ab8d1-2b6c-452c-bce0-86fa8e49c7f5" />

