### PR TITLE
Add @pankajkoti and @pankajastro to `contributors.rst`

### DIFF
--- a/docs/contributors.rst
+++ b/docs/contributors.rst
@@ -14,6 +14,8 @@ Committers
 * Daniel Reeves (`@dwreeves <https://github.com/dwreeves>`_)
 * Julian LaNeve (`@jlaneve <https://github.com/jlaneve>`_)
 * Justin Bandoro (`@jbandoro <https://github.com/jbandoro>`_)
+* Pankaj Koti (`@pankajkoti <https://github.com/pankajkoti>`_)
+* Pankaj Singh (`@pankajastro <https://github.com/pankajastro>`_)
 * Tatiana Al-Chueyr (`@tatiana <https://github.com/tatiana>`_)
 
 


### PR DESCRIPTION
In practice, @pankajastro and @pankajkoti have been committers of Cosmos for over a year. They initially asked not to be added to the list until they had made enough contributions, and I believe they both earned this a while ago:

<img width="1011" height="263" alt="Screenshot 2025-09-18 at 13 20 22" src="https://github.com/user-attachments/assets/43def992-112b-4758-adcf-580b24e148dd" />
