### PR TITLE
Use click<8.3.0 for hatch as click 8.3 breaks hatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main,fix-click-hatch]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.
@@ -40,7 +40,7 @@ jobs:
           python-version: "3.10"
           architecture: "x64"
 
-      - run: pip3 install hatch
+      - run: pip3 install hatch "click<8.3.0"
       - run: hatch run tests.py3.10-2.10-1.9:type-check
 
   Run-Unit-Tests:
@@ -98,7 +98,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
@@ -172,7 +172,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
@@ -255,7 +255,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
@@ -341,7 +341,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt 1.5.4
@@ -417,7 +417,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
@@ -487,7 +487,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Set RESOURCE_PREFIX without periods
@@ -584,7 +584,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Run performance tests against against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
@@ -649,7 +649,7 @@ jobs:
       - name: Install packages and dependencies
         run: |
           python -m pip install uv
-          uv pip install --system hatch
+          uv pip install --system hatch "click<8.3.0"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
       - name: Run kubernetes tests


### PR DESCRIPTION
`click 8.3.0` release broke hatch run.

We're seeing the following error in CI:
```
 + zstandard==0.25.0
╭───────────────────── Traceback (most recent call last) ──────────────────────╮
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/hatch/c │
│ li/__init__.py:221 in main                                                   │
│                                                                              │
│   218                                                                        │
│   219 def main():  # no cov                                                  │
│   220 │   try:                                                               │
│ ❱ 221 │   │   hatch(prog_name='hatch', windows_expand_args=False)            │
│   222 │   except Exception:  # noqa: BLE001                                  │
│   223 │   │   import sys                                                     │
│   224                                                                        │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:1462 in __call__                                                      │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:1383 in main                                                          │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:1850 in invoke                                                        │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:1246 in invoke                                                        │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:814 in invoke                                                         │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/d │
│ ecorators.py:34 in new_func                                                  │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/hatch/c │
│ li/run/__init__.py:147 in run                                                │
│                                                                              │
│   144 │   elif not env_name:                                                 │
│   145 │   │   env_name = 'system'                                            │
│   146 │                                                                      │
│ ❱ 147 │   ctx.invoke(                                                        │
│   148 │   │   run_command,                                                   │
│   149 │   │   args=[command, *final_args],                                   │
│   150 │   │   env_names=[env_name],                                          │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/c │
│ ore.py:814 in invoke                                                         │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/click/d │
│ ecorators.py:46 in new_func                                                  │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/site-packages/hatch/c │
│ li/env/run.py:123 in run                                                     │
│                                                                              │
│   120 │   if filter_json:                                                    │
│   121 │   │   import json                                                    │
│   122 │   │                                                                  │
│ ❱ 123 │   │   filter_data = json.loads(filter_json)                          │
│   124 │   │   if not isinstance(filter_data, dict):                          │
│   125 │   │   │   app.abort('The --filter/-f option must be a JSON mapping') │
│   126                                                                        │
│                                                                              │
│ /opt/hostedtoolcache/Python/3.11.13/x64/lib/python3.11/json/__init__.py:339  │
│ in loads                                                                     │
│                                                                              │
│   336 │   │   │   │   │   │   │   │     s, 0)                                │
│   337 │   else:                                                              │
│   338 │   │   if not isinstance(s, (bytes, bytearray)):                      │
│ ❱ 339 │   │   │   raise TypeError(f'the JSON object must be str, bytes or by │
│   340 │   │   │   │   │   │   │   f'not {s.__class__.__name__}')             │
│   341 │   │   s = s.decode(detect_encoding(s), 'surrogatepass')              │
│   342                                                                        │
╰──────────────────────────────────────────────────────────────────────────────╯
TypeError: the JSON object must be str, bytes or bytearray, not Sentinel
Error: Process completed with exit code 1.
```

related: https://github.com/pypa/hatch/issues/2050