### PR TITLE
Add default priority_weight for DbtProducerWatcherOperator

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -23,6 +23,8 @@ except ImportError:  # pragma: no cover
 logger = logging.getLogger(__name__)
 
 
+PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT = 9999
+
 # Example dbt event JSON dictionaries (kept for reference)
 nodefinished_model__fhir_dbt_utils__fhir_table_list = {
     "info": {
@@ -147,7 +149,7 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
-        kwargs["priority_weight"] = kwargs.get("priority_weight", 9999)
+        kwargs["priority_weight"] = kwargs.get("priority_weight", PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT)
         super().__init__(task_id=task_id, *args, **kwargs)
 
     @staticmethod

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -147,6 +147,7 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
+        kwargs["priority_weight"] = kwargs.get("priority_weight", 9999)
         super().__init__(task_id=task_id, *args, **kwargs)
 
     @staticmethod

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -51,6 +51,18 @@ def test_serialize_event(mock_mtd):
     mock_mtd.assert_called()
 
 
+def test_dbt_producer_watcher_operator_priority_weight_default():
+    """Test that DbtProducerWatcherOperator uses default priority_weight of 9999."""
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    assert op.priority_weight == 9999
+
+
+def test_dbt_producer_watcher_operator_priority_weight_override():
+    """Test that DbtProducerWatcherOperator allows overriding priority_weight."""
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None, priority_weight=100)
+    assert op.priority_weight == 100
+
+
 def test_handle_startup_event():
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
     lst: list[dict] = []

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -5,7 +5,7 @@ from types import SimpleNamespace
 from unittest.mock import patch
 
 from cosmos.config import InvocationMode
-from cosmos.operators.watcher import DbtProducerWatcherOperator
+from cosmos.operators.watcher import PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT, DbtProducerWatcherOperator
 
 
 class _MockTI:
@@ -54,7 +54,7 @@ def test_serialize_event(mock_mtd):
 def test_dbt_producer_watcher_operator_priority_weight_default():
     """Test that DbtProducerWatcherOperator uses default priority_weight of 9999."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
-    assert op.priority_weight == 9999
+    assert op.priority_weight == PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT
 
 
 def test_dbt_producer_watcher_operator_priority_weight_override():


### PR DESCRIPTION
Add a high-value `priority_weight` (9999) to the `DbtProducerWatcherOperator`
so that we guarantee this task runs before any sensor tasks in the DAG that
would have the default `priority_weight=1` 

Refer: https://airflow.apache.org/docs/apache-airflow/stable/administration-and-deployment/priority-weight.html

closes: #1959 
closes: https://github.com/astronomer/oss-integrations-private/issues/237