### PR TITLE
Add `DbtConsumerWatcherSensor` for the proposed `ExecutionMode.WATCHER`

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -132,7 +132,6 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
     def __init__(
         self,
         *,
-        model_unique_id: str,
         profile_config: ProfileConfig | None = None,
         project_dir: str | None = None,
         profiles_dir: str | None = None,
@@ -141,6 +140,7 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
         timeout: int = 60 * 60,  # 1 h safety valve
         **kwargs: Any,
     ) -> None:
+        extra_context = kwargs.pop("extra_context") if "extra_context" in kwargs else {}
         super().__init__(
             poke_interval=poke_interval,
             timeout=timeout,
@@ -149,7 +149,7 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
             profiles_dir=profiles_dir,
             **kwargs,
         )
-        self.model_unique_id = model_unique_id
+        self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
         self.master_task_id = master_task_id
 
     @staticmethod

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import ast
 import base64
 import json
 import logging
@@ -211,7 +210,7 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
 
         compressed_bytes = base64.b64decode(compressed_b64_event_msg)
         event_json_str = zlib.decompress(compressed_bytes).decode("utf-8")
-        event_json = ast.literal_eval(event_json_str)
+        event_json = json.loads(event_json_str)
 
         self.log.info("Node Info: %s", event_json_str)
 
@@ -225,7 +224,7 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
 
         compressed_bytes = base64.b64decode(compressed_b64_run_results)
         run_results_str = zlib.decompress(compressed_bytes).decode("utf-8")
-        run_results_json = ast.literal_eval(run_results_str)
+        run_results_json = json.loads(run_results_str)
 
         self.log.debug("Run results: %s", run_results_json)
 

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import ast
 import base64
 import json
 import logging
@@ -12,8 +13,15 @@ if TYPE_CHECKING:  # pragma: no cover
     except ImportError:
         from airflow.utils.context import Context  # type: ignore[attr-defined]
 
+try:
+    from airflow.sdk.bases.sensor import BaseSensorOperator
+except ImportError:
+    from airflow.sensors.base import BaseSensorOperator
+from airflow.exceptions import AirflowException
+
+from cosmos.config import ProfileConfig
 from cosmos.constants import InvocationMode
-from cosmos.operators.local import DbtLocalBaseOperator
+from cosmos.operators.local import DbtLocalBaseOperator, DbtRunLocalOperator
 
 try:
     from dbt_common.events.base_types import EventMsg
@@ -116,3 +124,121 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
         # Fallback – push run_results.json via base class helper
         kwargs["push_run_results_to_xcom"] = True
         return super().execute(context=context, **kwargs)
+
+
+class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ignore[misc]
+    template_fields = ("model_unique_id",)
+
+    def __init__(
+        self,
+        *,
+        model_unique_id: str,
+        profile_config: ProfileConfig | None = None,
+        project_dir: str | None = None,
+        profiles_dir: str | None = None,
+        master_task_id: str = "dbt_build_coordinator",
+        poke_interval: int = 20,
+        timeout: int = 60 * 60,  # 1 h safety valve
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(
+            poke_interval=poke_interval,
+            timeout=timeout,
+            profile_config=profile_config,
+            project_dir=project_dir,
+            profiles_dir=profiles_dir,
+            **kwargs,
+        )
+        self.model_unique_id = model_unique_id
+        self.master_task_id = master_task_id
+
+    @staticmethod
+    def _filter_flags(flags: list[str]) -> list[str]:
+        """Filters out dbt flags that are incompatible with retry (e.g., --select, --exclude)."""
+        filtered = []
+        skip_next = False
+        for token in flags:
+            if skip_next:
+                if token.startswith("--"):
+                    skip_next = False
+                else:
+                    continue  # skip value of previous flag
+            if token in ("--select", "--exclude"):
+                skip_next = True
+                continue
+            filtered.append(token)
+        return filtered
+
+    def _handle_task_retry(self, try_number: int, context: Context) -> bool:
+        """
+        Handles logic for retrying a failed dbt model execution.
+        Reconstructs the dbt command by cloning the project and re-running the model
+        with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
+        """
+        self.log.info(
+            "Retry attempt #%s – Re-running model '%s' from project '%s'",
+            try_number - 1,
+            self.model_unique_id,
+            self.project_dir,
+        )
+
+        upstream_task = context["ti"].task.dag.get_task(self.master_task_id)
+
+        extra_flags: list[str] = []
+        if upstream_task and hasattr(upstream_task, "add_cmd_flags"):
+            raw_flags = upstream_task.add_cmd_flags()
+            extra_flags = self._filter_flags(raw_flags)
+
+        model_selector = self.model_unique_id.split(".")[-1]
+        cmd_flags = extra_flags + ["--select", model_selector]
+
+        self.build_and_run_cmd(context, cmd_flags=cmd_flags)
+
+        self.log.info("dbt run completed successfully on retry for model '%s'", self.model_unique_id)
+        return True
+
+    def poke(self, context: Context) -> bool:
+        """
+        Checks the status of a dbt model run by pulling relevant XComs from the master task.
+        Handles retries and checks for successful completion of the model execution.
+        """
+        try_number = context["ti"].try_number
+        ti = context["ti"]
+
+        if try_number > 1:
+            return self._handle_task_retry(try_number, context)
+
+        logger.info(
+            "Pulling status from task_id %s for model %s",
+            self.master_task_id,
+            self.model_unique_id,
+        )
+
+        dbt_startup_events = ti.xcom_pull(task_ids=self.master_task_id, key="dbt_startup_events")
+        if dbt_startup_events:
+            self.log.info("dbt_startup_events: %s", dbt_startup_events)  # TODO: FixMe
+
+        pipeline_outlets = ti.xcom_pull(task_ids=self.master_task_id, key="pipeline_outlets")
+        if pipeline_outlets:
+            self.log.info("pipeline_outlets: %s", pipeline_outlets)  # TODO: FixMe
+
+        node_finished_key = f"nodefinished_{self.model_unique_id.replace('.', '__')}"
+        compressed_b64_event_data = ti.xcom_pull(task_ids=self.master_task_id, key=node_finished_key)
+
+        if not compressed_b64_event_data:
+            return False
+
+        compressed_event_msg = base64.b64decode(compressed_b64_event_data)
+        event_msg = zlib.decompress(compressed_event_msg).decode("utf-8")
+        if event_msg:
+            self.log.info("event_data: %s", event_msg)  # TODO: FixMe
+
+        event_json = ast.literal_eval(event_msg)
+        status = event_json.get("data", {}).get("run_result", {}).get("status")
+
+        self.log.info("Model %s finished with status %s", self.model_unique_id, status)
+
+        if status == "success":
+            return True
+        else:
+            raise AirflowException(f"Model {self.model_unique_id} finished with status '{status}'")

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -200,7 +200,7 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
     def _get_status_from_events(self, ti: Any) -> Any:
 
         dbt_startup_events = ti.xcom_pull(task_ids=self.master_task_id, key="dbt_startup_events")
-        if dbt_startup_events:
+        if dbt_startup_events:  # pragma: no cover
             self.log.info("Dbt Startup Event: %s", dbt_startup_events)
 
         node_finished_key = f"nodefinished_{self.model_unique_id.replace('.', '__')}"
@@ -230,14 +230,14 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
         self.log.debug("Run results: %s", run_results_json)
 
         results = run_results_json.get("results", [])
-        model_result = next((r for r in results if r.get("unique_id") == self.model_unique_id), None)
+        node_result = next((r for r in results if r.get("unique_id") == self.model_unique_id), None)
 
-        if not model_result:
+        if not node_result:  # pragma: no cover
             self.log.warning("No matching result found for unique_id '%s'", self.model_unique_id)
             return None
 
         self.log.info("Node Info: %s", run_results_str)
-        return model_result.get("status")
+        return node_result.get("status")
 
     def poke(self, context: Context) -> bool:
         """
@@ -258,6 +258,7 @@ class DbtNodeStatusSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ign
 
         if not self.invocation_mode:
             self._discover_invocation_mode()
+
         use_events = self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None
 
         if use_events:

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -10,7 +10,7 @@ from airflow.exceptions import AirflowException
 from cosmos.config import InvocationMode
 from cosmos.operators.watcher import (
     PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT,
-    DbtNodeStatusSensor,
+    DbtConsumerWatcherSensor,
     DbtProducerWatcherOperator,
 )
 
@@ -199,12 +199,12 @@ ENCODED_RUN_RESULTS_FAILED = base64.b64encode(
 ENCODED_EVENT = base64.b64encode(zlib.compress(b"{'data': {'run_result': {'status': 'success'}}}")).decode("utf-8")
 
 
-class TestDbtNodeStatusSensor:
+class TestDbtConsumerWatcherSensor:
 
     def make_sensor(self, **kwargs):
         extra_context = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
         kwargs["extra_context"] = extra_context
-        sensor = DbtNodeStatusSensor(
+        sensor = DbtConsumerWatcherSensor(
             task_id="model.my_model",
             project_dir="/tmp/project",
             profile_config=None,
@@ -311,7 +311,7 @@ class TestDbtNodeStatusSensor:
         flags = ["--select", "model", "--exclude", "other", "--threads", "2"]
         expected = ["--threads", "2"]
 
-        result = DbtNodeStatusSensor._filter_flags(flags)
+        result = DbtConsumerWatcherSensor._filter_flags(flags)
 
         assert result == expected
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -202,9 +202,10 @@ ENCODED_EVENT = base64.b64encode(zlib.compress(b"{'data': {'run_result': {'statu
 class TestDbtNodeStatusSensor:
 
     def make_sensor(self, **kwargs):
+        extra_context = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
+        kwargs["extra_context"] = extra_context
         sensor = DbtNodeStatusSensor(
             task_id="model.my_model",
-            model_unique_id=MODEL_UNIQUE_ID,
             project_dir="/tmp/project",
             profile_config=None,
             **kwargs,

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -196,7 +196,7 @@ ENCODED_RUN_RESULTS_FAILED = base64.b64encode(
     zlib.compress(b'{"results":[{"unique_id":"model.jaffle_shop.stg_orders","status":"fail"}]}')
 ).decode("utf-8")
 
-ENCODED_EVENT = base64.b64encode(zlib.compress(b"{'data': {'run_result': {'status': 'success'}}}")).decode("utf-8")
+ENCODED_EVENT = base64.b64encode(zlib.compress(b'{"data": {"run_result": {"status": "success"}}}')).decode("utf-8")
 
 
 class TestDbtConsumerWatcherSensor:


### PR DESCRIPTION
This PR add `DbtConsumerWatcherSensor` for the proposed ExecutionMode.WATCHER.


Introduced a new `DbtConsumerWatcherSensor` class that extends BaseSensorOperator and reuses `DbtRunLocalOperator` functionality to monitor and handle the status of a dbt model execution triggered by a coordinating task.

- Added DbtConsumerWatcherSensor:
- Pulls XComs from the upstream master_task_id to check dbt model status.
- Handles task retries by reconstructing and re-running dbt commands with sanitized flags.
- Implemented _filter_flags helper to exclude incompatible flags like --select or --exclude.
- Decodes and decompresses dbt event messages from XComs to inspect model status.
- Logs detailed information for debugging and visibility during execution and retries.
- Raises AirflowException if the model finishes with a non-success status.

Airflow task to test with jaffle-shop
```python
sensor = DbtConsumerWatcherSensor(
        task_id="jaffle_shop__customers",
        producer_task_id="dbt_build",
        poke_interval=1,
        profile_config=bigquery_db,
        project_dir=DBT_PROFILES_DIR,
        extra_context={"dbt_node_config": {"unique_id": "model.jaffle_shop.customers"}}
    )
```

closes: https://github.com/astronomer/astronomer-cosmos/issues/1971