### PR TITLE
Push producer's task completion status to XCOM

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -121,6 +121,6 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
             context["ti"].xcom_push(key="task_status", value="completed")
             return return_value
 
-        except Exception as e:
+        except Exception:
             context["ti"].xcom_push(key="task_status", value="completed")
             raise

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -90,29 +90,37 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
             ti.xcom_push(key="dbt_startup_events", value=startup_events)
 
     def execute(self, context: Context, **kwargs: Any) -> Any:
-        if not self.invocation_mode:
-            self._discover_invocation_mode()
+        try:
+            if not self.invocation_mode:
+                self._discover_invocation_mode()
 
-        use_events = self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None
-        self.log.debug("DbtProducerWatcherOperator: use_events=%s", use_events)
+            use_events = self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None
+            self.log.debug("DbtProducerWatcherOperator: use_events=%s", use_events)
 
-        startup_events: list[dict[str, Any]] = []
+            startup_events: list[dict[str, Any]] = []
 
-        if use_events:
+            if use_events:
 
-            def _callback(ev: EventMsg) -> None:
-                name = ev.info.name
-                if name in {"MainReportVersion", "AdapterRegistered"}:
-                    self._handle_startup_event(ev, startup_events)
-                elif name == "NodeFinished":
-                    self._handle_node_finished(ev, context)
+                def _callback(ev: EventMsg) -> None:
+                    name = ev.info.name
+                    if name in {"MainReportVersion", "AdapterRegistered"}:
+                        self._handle_startup_event(ev, startup_events)
+                    elif name == "NodeFinished":
+                        self._handle_node_finished(ev, context)
 
-            self._dbt_runner_callbacks = [_callback]
-            result = super().execute(context=context, **kwargs)
+                self._dbt_runner_callbacks = [_callback]
+                result = super().execute(context=context, **kwargs)
 
-            self._finalize(context, startup_events)
-            return result
+                self._finalize(context, startup_events)
+                return_value = result
+            else:
+                # Fallback – push run_results.json via base class helper
+                kwargs["push_run_results_to_xcom"] = True
+                return_value = super().execute(context=context, **kwargs)
 
-        # Fallback – push run_results.json via base class helper
-        kwargs["push_run_results_to_xcom"] = True
-        return super().execute(context=context, **kwargs)
+            context["ti"].xcom_push(key="task_status", value="completed")
+            return return_value
+
+        except Exception as e:
+            context["ti"].xcom_push(key="task_status", value="completed")
+            raise e

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -123,4 +123,4 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
 
         except Exception as e:
             context["ti"].xcom_push(key="task_status", value="completed")
-            raise e
+            raise

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -7,8 +7,6 @@ from unittest.mock import MagicMock, patch
 import pytest
 from airflow.exceptions import AirflowException
 
-import pytest
-
 from cosmos.config import InvocationMode
 from cosmos.operators.watcher import (
     PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT,


### PR DESCRIPTION
This PR pushes a `task_status` XCOM for the `DbtProducerWatcherOperator` task after its completion -- be it failed or succeeded.

The idea is that sensors will pull this XCOM while checking for the result of the model. If a sensor sees that the `DbtProducerWatcherOperator` task has completed (either succeeded or failed), but the `DbtProducerWatcherOperator` has not pushed the model status to XCOM—whether via the `node_finished...` XCOM or the `run_results` XCOM—it means the operator has already finished processing and will not push any further status updates.

In that case, the sensor should immediately mark the model as failed, since there is no chance of receiving a run status for it in the future, and the sensor task itself should also fail.

related: https://github.com/astronomer/oss-integrations-private/issues/239
related: https://github.com/astronomer/astronomer-cosmos/issues/1960
