### PR TITLE
Update setup script for airflow3 script

### DIFF
--- a/scripts/airflow3/env.sh
+++ b/scripts/airflow3/env.sh
@@ -26,3 +26,5 @@ export AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID=gcp_gs_conn
 export AIRFLOW__COSMOS__REMOTE_TARGET_PATH=gs://cosmos_remote_target
 #export AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID=s3_conn
 #export AIRFLOW__COSMOS__REMOTE_TARGET_PATH="s3://cosmos-remote-target"
+
+set +e

--- a/scripts/airflow3/requirements.txt
+++ b/scripts/airflow3/requirements.txt
@@ -8,7 +8,6 @@ apache-airflow-providers-cncf-kubernetes
 # if you want to keep remote storage as S3.
 apache-airflow-providers-amazon[s3fs]
 apache-airflow-providers-google
-psycopg2
-asyncpg
+psycopg2-binary
 dbt-postgres
 dbt-bigquery


### PR DESCRIPTION
## Description

Hello again!

I'm setting up Airflow 3 for the first time on my laptop and ran into some issues with the setup as-written. I implemented some relatively conservative changes to the development environment setup that is within `scripts/airflow3`.

- `env.sh` script does not have execute permission (644); changed to 755.
- "set +e" is required at the end of the env.sh script to prevent it from closing out.
- - In requirements.txt: psycopg2 -> psycopg2-binary. Via psycopg2 readme: "The binary package is a practical choice for development and testing but in production it is advised to use the package built from sources." Since these is a development environment, it should be preferred and reduces issues.
- I don't believe asyncpg is necessary; the psycopg2 driver is completely independent of asyncpg.

## Related Issue(s)

None

## Breaking Change?

Not applicable

## Checklist

- [x] **(Not applicable)** I have made corresponding changes to the documentation (if required)
- [x] **(Not applicable)** I have added tests that prove my fix is effective or that my feature works
