### PR TITLE
docs: correct the default value of `cache_dir`

### DIFF
--- a/docs/configuration/cosmos-conf.rst
+++ b/docs/configuration/cosmos-conf.rst
@@ -19,7 +19,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 `cache_dir`_:
     The directory used for caching Cosmos data.
 
-    - Default: ``{TMPDIR}/cosmos_cache`` (where ``{TMPDIR}`` is the system temporary directory)
+    - Default: ``{TMPDIR}/cosmos`` (where ``{TMPDIR}`` is the system temporary directory)
     - Environment Variable: ``AIRFLOW__COSMOS__CACHE_DIR``
 
 .. _enable_cache:


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

The documentation should update the stated default value from cosmos_cache to cosmos.

It seems to be a small typo in the document.

https://github.com/astronomer/astronomer-cosmos/blob/f3488c41313da75629a50febbff5b55de2727a77/cosmos/constants.py#L14

There exist `DEFAULT_COSMOS_CACHE_DIR_NAME` which has the value `"cosmos"`.

https://github.com/astronomer/astronomer-cosmos/blob/f3488c41313da75629a50febbff5b55de2727a77/cosmos/settings.py#L12-L19

And it used the constant with temp directory concatenating.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
https://github.com/astronomer/astronomer-cosmos/issues/2026
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

Nope.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
