### PR TITLE
Prevent pytest from trying to test classes that aren't actually tests

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -79,6 +79,8 @@ class TestBehavior(Enum):
     Behavior of the tests.
     """
 
+    __test__ = False
+
     BUILD = "build"
     NONE = "none"
     AFTER_EACH = "after_each"
@@ -115,6 +117,8 @@ class TestIndirectSelection(Enum):
     """
     Modes to configure the test behavior when performing indirect selection.
     """
+
+    __test__ = False
 
     EAGER = "eager"
     CAUTIOUS = "cautious"


### PR DESCRIPTION
## Description

Tells pytest to ignore TestBehavior and TestIndirectSelection classes even though they start with "Test" since they're not expected to be tests.  This fixes the pytest warnings.  

To check if it's fixed, see the logs from running cosmos tests.  

Before change:
```
(env) aconti ~/Coding/astronomer-cosmos [main] $ pytest tests/airflow/test_graph.py
============================================ test session starts =============================================
platform darwin -- Python 3.10.4, pytest-7.4.2, pluggy-1.5.0
rootdir: /Users/aconti/Coding/astronomer-cosmos
configfile: pyproject.toml
plugins: time-machine-2.16.0, anyio-4.8.0
collected 79 items                                                                                           

tests/airflow/test_graph.py .......................................................................... [ 93%]
.....                                                                                                  [100%]

============================================== warnings summary ==============================================
cosmos/constants.py:77
  /Users/aconti/Coding/astronomer-cosmos/cosmos/constants.py:77: PytestCollectionWarning: cannot collect test class 'TestBehavior' because it has a __new__ constructor (from: tests/airflow/test_graph.py)
    class TestBehavior(Enum):

cosmos/constants.py:114
  /Users/aconti/Coding/astronomer-cosmos/cosmos/constants.py:114: PytestCollectionWarning: cannot collect test class 'TestIndirectSelection' because it has a __new__ constructor (from: tests/airflow/test_graph.py)
    class TestIndirectSelection(Enum):

-- Docs: https://docs.pytest.org/en/stable/how-to/capture-warnings.html
======================================= 79 passed, 2 warnings in 1.61s =======================================
```

After change:
```
(env) aconti ~/Coding/astronomer-cosmos [main] $ pytest tests/airflow/test_graph.py
============================================ test session starts =============================================
platform darwin -- Python 3.10.4, pytest-7.4.2, pluggy-1.5.0
rootdir: /Users/aconti/Coding/astronomer-cosmos
configfile: pyproject.toml
plugins: time-machine-2.16.0, anyio-4.8.0
collected 79 items                                                                                           

tests/airflow/test_graph.py .......................................................................... [ 93%]
.....                                                                                                  [100%]

============================================= 79 passed in 2.15s =============================================
```

## Related Issue(s)

Closes #2031 

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required) - not needed
- [ ] I have added tests that prove my fix is effective or that my feature works - no functionality change so not needed
