### PR TITLE
Fail sensor tasks immediately if the `ExecutionMode.WATCHER` producer task fails

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -5,7 +5,7 @@ import json
 import logging
 import zlib
 from datetime import timedelta
-from typing import TYPE_CHECKING, Any, List, Sequence, Union
+from typing import TYPE_CHECKING, Any, Callable, List, Sequence, Union
 
 import airflow
 from packaging.version import Version
@@ -324,7 +324,7 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
 
         if producer_task_state == "failed":
             raise AirflowException(
-                f"""The build command failed in producer task. Please check the log of task{self.producer_task_id} for details."""
+                f"""The dbt build command failed in producer task. Please check the log of task {self.producer_task_id} for details."""
             )
 
         # We have assumption here that both the build producer and the sensor task will have same invocation mode

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -291,7 +291,7 @@ class TestDbtConsumerWatcherSensor:
         sensor.invocation_mode = InvocationMode.DBT_RUNNER
         ti = MagicMock()
         ti.try_number = 1
-        ti.xcom_pull.side_effect = [None, None]  # no event msg found
+        ti.xcom_pull.side_effect = [None, None, None]  # no event msg found
         context = self.make_context(ti)
 
         result = sensor.poke(context)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -282,6 +282,16 @@ def test_execute_discovers_invocation_mode(_mock_execute, _mock_is_available):
     assert op.invocation_mode == InvocationMode.SUBPROCESS
 
 
+def test_store_producer_task_state_pushes_failed_state():
+    mock_ti = MagicMock()
+    mock_context = {"ti": mock_ti}
+    instance = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+
+    instance._store_producer_task_state(mock_context)
+
+    mock_ti.xcom_push.assert_called_once_with(key="state", value="failed")
+
+
 MODEL_UNIQUE_ID = "model.jaffle_shop.stg_orders"
 ENCODED_RUN_RESULTS = base64.b64encode(
     zlib.compress(b'{"results":[{"unique_id":"model.jaffle_shop.stg_orders","status":"success"}]}')


### PR DESCRIPTION
relates to: https://github.com/astronomer/astronomer-cosmos/issues/1960

This PR adds a default `on_failure_callback` to the producer task. The callback records the producer task’s state and ensures that the sensor fails immediately if the producer task has failed, improving error visibility and reducing unnecessary wait time.