### PR TITLE
Fix Cosmos behaviour when using watcher with `InvocationMode.DBT_RUNNER`

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -434,7 +434,11 @@ class ExecutionConfig:
     async_py_requirements: list[str] | None = None
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
-        if self.invocation_mode and self.execution_mode not in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
+        if self.invocation_mode and self.execution_mode not in (
+            ExecutionMode.WATCHER,
+            ExecutionMode.LOCAL,
+            ExecutionMode.VIRTUALENV,
+        ):
             raise CosmosValueError(
                 "ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL and ExecutionMode.VIRTUALENV."
             )

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -440,7 +440,7 @@ class ExecutionConfig:
             ExecutionMode.VIRTUALENV,
         ):
             raise CosmosValueError(
-                "ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL and ExecutionMode.VIRTUALENV."
+                "ExecutionConfig.invocation_mode is only configurable for ExecutionMode.WATCHER, ExecutionMode.LOCAL, and ExecutionMode.VIRTUALENV."
             )
         if self.execution_mode == ExecutionMode.VIRTUALENV:
             if self.invocation_mode == InvocationMode.DBT_RUNNER:

--- a/dev/dags/example_watcher.py
+++ b/dev/dags/example_watcher.py
@@ -40,12 +40,12 @@ if os.getenv("CI"):
     operator_args["trigger_rule"] = "all_success"
 
 
+from cosmos.constants import InvocationMode
+
 # [START example_watcher]
 example_watcher = DbtDag(
     # dbt/cosmos-specific parameters
-    execution_config=ExecutionConfig(
-        execution_mode=ExecutionMode.WATCHER,
-    ),
+    execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER, invocation_mode=InvocationMode.DBT_RUNNER),
     project_config=ProjectConfig(DBT_PROJECT_PATH),
     profile_config=profile_config,
     operator_args=operator_args,


### PR DESCRIPTION
Fix Cosmos behaviour when users set `invocation_mode=InvocationMode.DBT_RUNNER`  with `ExecutionMode.WATCHER` in  1.11.0a8.

If users attempted to run the DbtDag or TaskGroup setting the invocation_mode=InvocationMode.DBT_RUNNER:
    
```
    from cosmos.constants import InvocationMode
    
    example_watcher = DbtDag(
        # dbt/cosmos-specific parameters
        execution_config=ExecutionConfig(
            execution_mode=ExecutionMode.WATCHER,
            invocation_mode=InvocationMode.DBT_RUNNER
        ),
        project_config=ProjectConfig(DBT_PROJECT_PATH),
        profile_config=profile_config,
        operator_args=operator_args,
        # normal dag parameters
        schedule="@daily",
        start_date=datetime(2023, 1, 1),
        catchup=False,
        dag_id="example_watcher",
        default_args={"retries": 0},
    )
```

Previously, Cosmos would fail with:
    
```
      File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/dags/example_watcher.py", line 46, in <module>
        execution_config=ExecutionConfig(
                         ^^^^^^^^^^^^^^^^
      File "<string>", line 9, in __init__
      File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/cosmos/config.py", line 438, in __post_init__
        raise CosmosValueError(
    cosmos.exceptions.CosmosValueError: ExecutionConfig.invocation_mode is only configurable for ExecutionMode.LOCAL and ExecutionMode.VIRTUALENV.
```

This PR solves this.