### PR TITLE
feat(operators): support dbt docs on Kubernetes via DbtDocsS3KubernetesOperator

### DIFF
--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -57,6 +57,11 @@ try:
 except ImportError:
     from airflow.models import BaseOperator  # Airflow 2
 
+try:
+    from airflow.sdk.bases.hook import BaseHook
+except ImportError:  # Since Airflow 3.1, BaseHook is in the airflow.sdk.bases.hook module
+    from airflow.hooks.base import BaseHook
+
 
 class DbtKubernetesBaseOperator(AbstractDbtBase, KubernetesPodOperator):  # type: ignore
     """
@@ -470,6 +475,10 @@ class DbtDocsCloudKubernetesOperator(DbtDocsKubernetesOperator, ABC):
         `docs_target` to cloud storage. Implemented by subclasses.
         """
 
+    @abstractmethod
+    def get_upload_env_vars(self) -> dict[str, str]:
+        """Return env vars required by the upload command."""
+
     def build_and_run_cmd(
         self,
         context: Context,
@@ -478,6 +487,8 @@ class DbtDocsCloudKubernetesOperator(DbtDocsKubernetesOperator, ABC):
         async_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> Any:
+        self.inject_upload_env_vars(self.get_upload_env_vars())
+
         # Build base Kubernetes pod args (incl. dbt CLI command)
         self.build_kube_args(context, cmd_flags)
 
@@ -502,24 +513,42 @@ class DbtDocsCloudKubernetesOperator(DbtDocsKubernetesOperator, ABC):
         self.log.info(result)
         return result
 
+    def inject_upload_env_vars(self, env_vars: dict[str, str]) -> None:
+        declared_env_var_names = {env_var.name for env_var in self.env_vars or [] if getattr(env_var, "name", None)} | {
+            secret.deploy_target
+            for secret in self.secrets or []
+            if getattr(secret, "deploy_type", None) == "env" and getattr(secret, "deploy_target", None)
+        }
+
+        missing_env_vars = {
+            key: value for key, value in env_vars.items() if value and key not in declared_env_var_names
+        }
+
+        if not missing_env_vars:
+            return
+
+        self.env_vars = list(self.env_vars or []) + convert_env_vars(missing_env_vars)
+
 
 class DbtDocsS3KubernetesOperator(DbtDocsCloudKubernetesOperator):
     """
     Executes `dbt docs generate` inside a Kubernetes Pod and uploads the generated
     documentation to S3 *also inside that Pod* using `aws s3 sync`.
-        - Airflow S3Hook and `connection_id` are NOT used in Kubernetes mode.
-        - The Kubernetes Pod must have AWS credentials (IRSA, kube2iam, Secret env).
+        - The Kubernetes Pod receives AWS credentials resolved from the supplied
+          Airflow `connection_id`.
     """
 
     ui_color = "#FF9900"
 
     def __init__(
         self,
+        connection_id: str,
         bucket_name: str,
         folder_dir: str | None = None,
         **kwargs: Any,
     ) -> None:
         super().__init__(**kwargs)
+        self.connection_id = connection_id
         self.bucket_name = bucket_name
         self.folder_dir = folder_dir
 
@@ -530,3 +559,39 @@ class DbtDocsS3KubernetesOperator(DbtDocsCloudKubernetesOperator):
             s3_prefix = f"s3://{self.bucket_name}"
 
         return f"aws s3 sync {docs_target} {s3_prefix}"
+
+    def get_upload_env_vars(self) -> dict[str, str]:
+        return self.aws_env_vars_from_connection(self.connection_id)
+
+    def aws_env_vars_from_connection(self, connection_id: str) -> dict[str, str]:
+        conn = BaseHook.get_connection(connection_id)
+        conn_extra = conn.extra_dejson
+
+        access_key = conn.login or conn_extra.get("aws_access_key_id")
+        secret_key = conn.password or conn_extra.get("aws_secret_access_key")
+        session_token = conn_extra.get("aws_session_token") or conn_extra.get("session_token")
+
+        session_kwargs = conn_extra.get("session_kwargs", {})
+        config_kwargs = conn_extra.get("config_kwargs", {})
+        if not isinstance(session_kwargs, dict):
+            session_kwargs = {}
+        if not isinstance(config_kwargs, dict):
+            config_kwargs = {}
+        region_name = (
+            conn_extra.get("region_name")
+            or conn_extra.get("region")
+            or session_kwargs.get("region_name")
+            or config_kwargs.get("region_name")
+        )
+
+        env_vars = {}
+        if access_key:
+            env_vars["AWS_ACCESS_KEY_ID"] = access_key
+        if secret_key:
+            env_vars["AWS_SECRET_ACCESS_KEY"] = secret_key
+        if session_token:
+            env_vars["AWS_SESSION_TOKEN"] = session_token
+        if region_name:
+            env_vars["AWS_DEFAULT_REGION"] = region_name
+
+        return env_vars

--- a/dev/dags/jaffle_shop_kubernetes.py
+++ b/dev/dags/jaffle_shop_kubernetes.py
@@ -55,27 +55,6 @@ postgres_host_secret = Secret(
     key="host",
 )
 
-aws_access_key_secret = Secret(
-    deploy_type="env",
-    deploy_target="AWS_ACCESS_KEY_ID",
-    secret="aws-s3-secrets",
-    key="aws_access_key_id",
-)
-
-aws_secret_key_secret = Secret(
-    deploy_type="env",
-    deploy_target="AWS_SECRET_ACCESS_KEY",
-    secret="aws-s3-secrets",
-    key="aws_secret_access_key",
-)
-
-aws_region_secret = Secret(
-    deploy_type="env",
-    deploy_target="AWS_DEFAULT_REGION",
-    secret="aws-s3-secrets",
-    key="aws_default_region",
-)
-
 
 with DAG(
     dag_id="jaffle_shop_kubernetes",
@@ -107,13 +86,8 @@ with DAG(
     upload_docs_to_s3 = DbtDocsS3KubernetesOperator(
         task_id="generate_dbt_docs_aws",
         project_dir=K8S_PROJECT_DIR,
-        secrets=[
-            postgres_host_secret,
-            postgres_password_secret,
-            aws_access_key_secret,
-            aws_secret_key_secret,
-            aws_region_secret,
-        ],
+        connection_id="aws_s3_conn",
+        secrets=[postgres_host_secret, postgres_password_secret],
         profile_config=ProfileConfig(
             profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="postgres_profile", target_name="dev"
         ),

--- a/scripts/test/kubernetes-setup.sh
+++ b/scripts/test/kubernetes-setup.sh
@@ -13,41 +13,10 @@ NEXT_MINOR_VERSION=$(echo "$DBT_VERSION" | awk -F. '{print $1"."$2+1}')
 pip uninstall dbt-adapters dbt-common dbt-core dbt-extractor dbt-postgres dbt-semantic-interfaces -y
 pip install -U "dbt-core>=$DBT_VERSION,<$NEXT_MINOR_VERSION" dbt-postgres
 
-if [ -z "${AIRFLOW_CONN_AWS_S3_CONN:-}" ]; then
-  echo "AIRFLOW_CONN_AWS_S3_CONN must be set for kubernetes docs upload tests."
-  exit 1
-fi
-
-read -r AWS_ACCESS_KEY_ID AWS_SECRET_ACCESS_KEY AWS_DEFAULT_REGION <<EOF
-$(python - <<'PY'
-import os
-from urllib.parse import parse_qs, unquote, urlparse
-
-uri = os.environ["AIRFLOW_CONN_AWS_S3_CONN"]
-parsed = urlparse(uri)
-query = parse_qs(parsed.query)
-
-access_key = unquote(parsed.username or "")
-secret_key = unquote(parsed.password or "")
-region = query.get("region_name", [None])[0] or query.get("region", [None])[0] or "us-east-1"
-
-if not access_key or not secret_key:
-    raise SystemExit("AIRFLOW_CONN_AWS_S3_CONN must include AWS access key and secret key.")
-PY
-)
-EOF
-
 # Create a Kubernetes secret named 'postgres-secrets' with the specified literals for host and password
-set +x
 kubectl create secret generic postgres-secrets \
   --from-literal=host=postgres-postgresql.default.svc.cluster.local \
   --from-literal=password=postgres
-
-kubectl create secret generic aws-s3-secrets \
-  --from-literal=aws_access_key_id="$AWS_ACCESS_KEY_ID" \
-  --from-literal=aws_secret_access_key="$AWS_SECRET_ACCESS_KEY" \
-  --from-literal=aws_default_region="$AWS_DEFAULT_REGION"
-set -x
 
 # Apply the PostgreSQL deployment configuration from the specified YAML file
 kubectl apply -f scripts/test/postgres-deployment.yaml

--- a/tests/operators/test_kubernetes.py
+++ b/tests/operators/test_kubernetes.py
@@ -4,6 +4,7 @@ from unittest.mock import MagicMock, Mock, patch
 import kubernetes.client as k8s
 import pytest
 from airflow.models import DAG
+from airflow.models.connection import Connection
 
 try:
     from airflow.sdk.definitions.context import Context
@@ -30,7 +31,7 @@ from cosmos.operators.kubernetes import (
     DbtTestWarningHandler,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
-from tests.conftest import make_task_instance
+from tests.conftest import base_operator_get_connection_path, make_task_instance
 
 profile_config = ProfileConfig(
     profile_name="default",
@@ -661,7 +662,7 @@ def test_operator_execute_with_flags(operator_class, kwargs, expected_cmd):
 )
 def test_operator_execute_without_flags(operator_class):
     operator_class_kwargs = {
-        DbtDocsS3KubernetesOperator: {"bucket_name": "fake-bucket"},
+        DbtDocsS3KubernetesOperator: {"connection_id": "aws_s3_conn", "bucket_name": "fake-bucket"},
     }
     task = operator_class(
         profile_config=profile_config,
@@ -817,3 +818,33 @@ def test_dbt_docs_kubernetes_operator_ignores_graph_gpickle():
         dbt_cmd_global_flags=["--no-write-json"],
     )
     assert operator.required_files == ["index.html", "manifest.json", "catalog.json"]
+
+
+@patch(
+    "cosmos.operators.kubernetes.DbtKubernetesBaseOperator.build_cmd", return_value=(["dbt", "docs", "generate"], {})
+)
+def test_dbt_docs_s3_kubernetes_operator_uses_connection_id(mock_build_cmd, mock_kubernetes_execute):
+    conn = Connection(
+        conn_id="aws_s3_conn",
+        conn_type="aws",
+        login="l",
+        password="p",
+        extra='{"region_name": "us-east-1", "aws_session_token": "t"}',
+    )
+    operator = DbtDocsS3KubernetesOperator(
+        task_id="fake-task",
+        project_dir="fake-dir",
+        image="fake-image",
+        profile_config=profile_config,
+        connection_id="aws_s3_conn",
+        bucket_name="fake-bucket",
+    )
+
+    with patch(base_operator_get_connection_path, return_value=conn):
+        operator.build_and_run_cmd(context={})
+
+    env_vars = {env_var.name: env_var.value for env_var in operator.env_vars}
+    assert env_vars["AWS_ACCESS_KEY_ID"] == "l"
+    assert env_vars["AWS_SECRET_ACCESS_KEY"] == "p"
+    assert env_vars["AWS_SESSION_TOKEN"] == "t"
+    assert env_vars["AWS_DEFAULT_REGION"] == "us-east-1"


### PR DESCRIPTION
## Description

Add a new operator `DbtDocsS3KubernetesOperator` that runs `dbt docs generate` on Kubernetes and uploads the generated documentation to AWS S3.

### Key changes
- A new base class `DbtDocsKubernetesOperator`, extending `DbtKubernetesBaseOperator`, to handle `dbt docs generate` execution.
- Added `DbtDocsCloudKubernetesOperator` as an abstract class for cloud-specific doc upload implementations.
- Implemented `DbtDocsS3KubernetesOperator`, which:
  - Accepts `connection_id`, `bucket_name`, and optional `folder_dir` parameters.
  - Uses `S3Hook` to upload output files (`index.html`, `manifest.json`, `catalog.json`, `static_index.html`) to the specified S3 bucket.
- Updated operator registry to expose the new operator.
- Added comprehensive unit tests verifying:
  - Correct file selection and upload behavior.
  - Expected `dbt docs` command execution.
  - Validation of required fields and failure cases.

### Example usage

```python
generate_dbt_docs_aws = DbtDocsS3KubernetesOperator(
    task_id="generate_dbt_docs_aws",
    project_dir=DBT_ROOT_PATH / "jaffle_shop",
    profile_config=profile_config,
    connection_id="aws_s3_conn",
    bucket_name="cosmos-ci-docs",
    install_deps=True,
    image="dbt-jaffle-shop:1.0.0",
    get_logs=True,
    is_delete_operator_pod=False,
)
```

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes #1906

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
