### PR TITLE
Set `push_run_results_to_xcom` kwargs correctly for invocation mode subprocess and Watcher mode

### DIFF
--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -120,6 +120,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -110,6 +110,7 @@ class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInsta
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -306,6 +306,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
         cmd_flags: list[str],
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         """Override this method for the operator to execute the dbt command"""
 
@@ -313,7 +314,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
         if self.extra_context:
             context_merge(context, self.extra_context)
 
-        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
+        self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags(), **kwargs)
 
 
 class DbtBuildMixin:

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -101,6 +101,7 @@ class DbtDockerBaseOperator(AbstractDbtBase, DockerOperator):  # type: ignore
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")

--- a/cosmos/operators/gcp_cloud_run_job.py
+++ b/cosmos/operators/gcp_cloud_run_job.py
@@ -122,6 +122,7 @@ class DbtGcpCloudRunJobBaseOperator(AbstractDbtBase, CloudRunExecuteJobOperator)
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -120,6 +120,7 @@ class DbtKubernetesBaseOperator(AbstractDbtBase, KubernetesPodOperator):  # type
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         self.build_kube_args(context, cmd_flags)
         self.log.info(f"Running command: {self.arguments}")
@@ -360,6 +361,7 @@ class DbtWarningKubernetesOperator(DbtKubernetesBaseOperator, ABC):
         cmd_flags: list[str] | None = None,
         run_as_async: bool = False,
         async_context: dict[str, Any] | None = None,
+        **kwargs: Any,
     ) -> Any:
         if self.warning_handler:
             self.warning_handler.context = context

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -912,7 +912,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             context=context,
             run_as_async=run_as_async,
             async_context=async_context,
-            push_run_results_to_xcom=kwargs.get("push_run_results_to_xcom") or False,
+            push_run_results_to_xcom=kwargs.get("push_run_results_to_xcom", False),
         )
         return result
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -907,7 +907,12 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         dbt_cmd, env = self.build_cmd(context=context, cmd_flags=cmd_flags)
         dbt_cmd = dbt_cmd or []
         result = self.run_command(
-            cmd=dbt_cmd, env=env, context=context, run_as_async=run_as_async, async_context=async_context, **kwargs
+            cmd=dbt_cmd,
+            env=env,
+            context=context,
+            run_as_async=run_as_async,
+            async_context=async_context,
+            push_run_results_to_xcom=kwargs.get("push_run_results_to_xcom") or False,
         )
         return result
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -989,6 +989,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["seed", "--full-refresh"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
@@ -1000,6 +1001,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["build", "--full-refresh"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
@@ -1011,6 +1013,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["run", "--full-refresh"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
@@ -1022,17 +1025,32 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["clone", "--full-refresh"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
             DbtTestLocalOperator,
             {},
-            {"context": {}, "env": {}, "cmd_flags": ["test"], "run_as_async": False, "async_context": None},
+            {
+                "context": {},
+                "env": {},
+                "cmd_flags": ["test"],
+                "run_as_async": False,
+                "async_context": None,
+                "push_run_results_to_xcom": False,
+            },
         ),
         (
             DbtTestLocalOperator,
             {"select": []},
-            {"context": {}, "env": {}, "cmd_flags": ["test"], "run_as_async": False, "async_context": None},
+            {
+                "context": {},
+                "env": {},
+                "cmd_flags": ["test"],
+                "run_as_async": False,
+                "async_context": None,
+                "push_run_results_to_xcom": False,
+            },
         ),
         (
             DbtTestLocalOperator,
@@ -1043,6 +1061,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["test", "--select", "tag:daily", "--exclude", "tag:disabled"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
@@ -1054,6 +1073,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["test", "--selector", "nightly_snowplow"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
         (
@@ -1065,6 +1085,7 @@ def test_store_compiled_sql_airflow3() -> None:
                 "cmd_flags": ["run-operation", "bla", "--args", "days: 7\ndry_run: true\n"],
                 "run_as_async": False,
                 "async_context": None,
+                "push_run_results_to_xcom": False,
             },
         ),
     ],


### PR DESCRIPTION
This PR fixes incorrect handling of the `push_run_results_to_xcom` keyword argument in subprocess invocation, Watcher execution modes. The issue likely stems from a method signature mismatch between the build_and_run method in the base class and its override in the [local](https://github.com/astronomer/astronomer-cosmos/blob/main/cosmos/operators/local.py#L898)


Summary of changes:
- Align method signatures between base and local classes
- Ensure push_run_results_to_xcom is passed correctly in all invocation modes

related: https://github.com/astronomer/astronomer-cosmos/issues/1968
related: https://github.com/astronomer/oss-integrations-private/issues/243
