### PR TITLE
Fix broken CI due to fastapi incompatibility with cadwyn for Airflow 3

### DIFF
--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -23,7 +23,7 @@ AIRFLOW_VERSION=$(airflow version)
 AIRFLOW_MAJOR_VERSION=$(echo "$AIRFLOW_VERSION" | cut -d. -f1)
 if [ "$AIRFLOW_MAJOR_VERSION" -ge 3 ]; then
   # https://github.com/zmievsa/cadwyn/issues/283, hence kept cadwyn>=5.4.1
-  # https://github.com/zmievsa/cadwyn/issues/305
+  # https://github.com/zmievsa/cadwyn/issues/305, hence kept fastapi<0.121.0
     uv pip install "cadwyn>=5.4.1" "fastapi<0.121.0"
     echo "Detected Airflow $AIRFLOW_VERSION. Running 'airflow db migrate'..."
     airflow db migrate


### PR DESCRIPTION
Our CI started failing after fastapi [0.121.0 ](https://pypi.org/project/fastapi/0.121.0/) was released yesterday. It's observed that cadwyn(that airflow uses for its migrations) is [incompatible](https://github.com/zmievsa/cadwyn/issues/305) with the latest the release of fastapi. Hence, putting an upper bound for fastapi version which can be removed once cadwyn becomes compatible.

Succesful run: https://github.com/astronomer/astronomer-cosmos/actions/runs/19061976838

closes: #2079 