### PR TITLE
Fix `ExecutionMode.AIRFLOW_ASYNC` `TaskGroup` XCom issue

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -657,9 +657,16 @@ def _add_dbt_setup_async_task(
     )
     setup_airflow_task = create_airflow_task(setup_task_metadata, dag, task_group=task_group)
 
-    for task_id, task in tasks_map.items():
-        if not task.upstream_list:
-            setup_airflow_task >> task
+    for node_id, task_or_taskgroup in tasks_map.items():
+        node_tasks = (
+            list(task_or_taskgroup.children.values())
+            if isinstance(task_or_taskgroup, TaskGroup)
+            else [task_or_taskgroup]
+        )
+        for task in node_tasks:
+            task.producer_task_id = setup_airflow_task.task_id  # type: ignore[attr-defined]
+            if not task.upstream_list:
+                setup_airflow_task >> task
 
     tasks_map[DBT_SETUP_ASYNC_TASK_ID] = setup_airflow_task
 
@@ -979,7 +986,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             execution_mode,
             {**task_args, "virtualenv_dir": virtualenv_dir},
             tasks_map,
-            task_group,
+            task_group=task_group,
             render_config=render_config,
             async_py_requirements=async_py_requirements,
         )

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -69,6 +69,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     template_fields_renderers = {
         "compiled_sql": "sql",
     }
+    producer_task_id: str = "dbt_setup_async"
 
     def __init__(
         self,
@@ -86,6 +87,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.dbt_kwargs = dbt_kwargs or {}
         task_id = self.dbt_kwargs.pop("task_id")
         self.full_refresh = self.dbt_kwargs.pop("full_refresh", False)
+
         AbstractDbtLocalBase.__init__(
             self, task_id=task_id, project_dir=project_dir, profile_config=profile_config, **self.dbt_kwargs
         )
@@ -137,7 +139,9 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         file_path = self.async_context["dbt_node_config"]["file_path"]
         project_dir_parent = str(Path(self.project_dir).parent)
         sql_model_path = str(file_path).replace(project_dir_parent, "").lstrip("/")
-        compressed_b64_sql = context["ti"].xcom_pull(task_ids="dbt_setup_async", key=_sanitize_xcom_key(sql_model_path))
+        compressed_b64_sql = context["ti"].xcom_pull(
+            task_ids=self.producer_task_id, key=_sanitize_xcom_key(sql_model_path)
+        )
         compressed_b64_sql = base64.b64decode(compressed_b64_sql)
         sql_query = zlib.decompress(compressed_b64_sql).decode("utf-8")
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -29,6 +29,7 @@ from cosmos.operators.local import AbstractDbtLocalBase
 from cosmos.settings import remote_target_path, remote_target_path_conn_id
 
 AIRFLOW_VERSION = Version(airflow.__version__)
+DEFAULT_PRODUCER_ASYNC_TASK_ID = "dbt_setup_async"
 
 
 def _mock_bigquery_adapter() -> None:
@@ -69,7 +70,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     template_fields_renderers = {
         "compiled_sql": "sql",
     }
-    producer_task_id: str = "dbt_setup_async"
+    producer_task_id: str = DEFAULT_PRODUCER_ASYNC_TASK_ID
 
     def __init__(
         self,

--- a/dev/dags/simple_dag_async.py
+++ b/dev/dags/simple_dag_async.py
@@ -2,7 +2,8 @@ import os
 from datetime import datetime
 from pathlib import Path
 
-from cosmos import ExecutionConfig, ExecutionMode, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos import DbtDag, ExecutionConfig, ExecutionMode, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import TestBehavior
 from cosmos.profiles import GoogleCloudServiceAccountDictProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).resolve().parent / "dbt"
@@ -22,29 +23,29 @@ profile_config = ProfileConfig(
 
 
 # [START airflow_async_execution_mode_example]
-# simple_dag_async = DbtDag(
-#     # dbt/cosmos-specific parameters
-#     project_config=ProjectConfig(
-#         DBT_PROJECT_PATH,
-#     ),
-#     profile_config=profile_config,
-#     execution_config=ExecutionConfig(
-#         execution_mode=ExecutionMode.AIRFLOW_ASYNC,
-#         async_py_requirements=[f"dbt-bigquery=={DBT_ADAPTER_VERSION}"],
-#     ),
-#     render_config=RenderConfig(select=["path:models"], test_behavior=TestBehavior.NONE),
-#     # normal dag parameters
-#     schedule=None,
-#     start_date=datetime(2023, 1, 1),
-#     catchup=False,
-#     dag_id="simple_dag_async",
-#     tags=["simple"],
-#     operator_args={
-#         "location": "US",
-#         "install_deps": True,
-#         "full_refresh": True,
-#     },
-# )
+simple_dag_async = DbtDag(
+    # dbt/cosmos-specific parameters
+    project_config=ProjectConfig(
+        DBT_PROJECT_PATH,
+    ),
+    profile_config=profile_config,
+    execution_config=ExecutionConfig(
+        execution_mode=ExecutionMode.AIRFLOW_ASYNC,
+        async_py_requirements=[f"dbt-bigquery=={DBT_ADAPTER_VERSION}"],
+    ),
+    render_config=RenderConfig(select=["path:models"], test_behavior=TestBehavior.NONE),
+    # normal dag parameters
+    schedule=None,
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="simple_dag_async",
+    tags=["simple"],
+    operator_args={
+        "location": "US",
+        "install_deps": True,
+        "full_refresh": True,
+    },
+)
 # [END airflow_async_execution_mode_example]
 
 

--- a/scripts/test/integration-dbt-async.sh
+++ b/scripts/test/integration-dbt-async.sh
@@ -68,3 +68,9 @@ pytest -vv \
     --cov-report=term-missing \
     --cov-report=xml \
     "tests/test_async_example_dag.py::test_example_dag[simple_dag_async]"
+
+pytest -vv \
+    --cov=cosmos \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    "tests/test_async_example_dag.py::test_example_dag[simple_dag_async_taskgroup]"


### PR DESCRIPTION
When attempting to use `ExecutionMode.AIRFLOW_ASYNC` with `TaskGroup` in Cosmos 1.11.0, it started failing due to our handling of XCom. The main issue was that we were not setting the relative setup task ID in the consumer tasks, and they were trying to consume the XCom from a task that did not exist.

Example of DAG:
```
from airflow.models import DAG

try:
    from airflow.providers.standard.operators.empty import EmptyOperator
except ImportError:
    from airflow.operators.empty import EmptyOperator

from cosmos import DbtTaskGroup

profile_config = ProfileConfig(
    profile_name="default",
    target_name="dev",
    profile_mapping=GoogleCloudServiceAccountDictProfileMapping(
        conn_id="gcp_gs_conn", profile_args={"dataset": "release_17", "project": "astronomer-dag-authoring"}
    ),
)

with DAG(
    dag_id="simple_dag_async_taskgroup",
    schedule="@daily",
    start_date=datetime(2023, 1, 1),
    catchup=False,
):
    pre_dbt = EmptyOperator(task_id="pre_dbt")

    first_dbt_task_group = DbtTaskGroup(
        group_id="first_dbt_task_group",
        execution_config=ExecutionConfig(
            execution_mode=ExecutionMode.AIRFLOW_ASYNC,
            async_py_requirements=[f"dbt-bigquery=={DBT_ADAPTER_VERSION}"],
        ),
        render_config=RenderConfig(select=["*customers*"], exclude=["path:seeds"]),
        project_config=ProjectConfig(DBT_PROJECT_PATH),
        profile_config=profile_config,
        operator_args={
            "location": "US",
            "install_deps": True,
            "full_refresh": True,
        },
    )

    pre_dbt >> first_dbt_task_group
```

<img width="1624" height="1056" alt="Image" src="https://github.com/user-attachments/assets/6e38464f-8fe6-4f6a-8ebc-762e8f3d65f4" />

Error:
```
Traceback (most recent call last):
  File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/venv-af31/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 920, in run
    result = _execute_task(context=context, ti=ti, log=log)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/venv-af31/lib/python3.12/site-packages/airflow/sdk/execution_time/task_runner.py", line 1307, in _execute_task
    result = ctx.run(execute, context=context)
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/venv-af31/lib/python3.12/site-packages/airflow/sdk/bases/operator.py", line 416, in wrapper
    return func(self, *args, **kwargs)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/cosmos/operators/_asynchronous/bigquery.py", line 187, in execute
    sql_query = self.get_sql_from_xcom(context)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/tatiana.alchueyr/Code/astronomer-cosmos/cosmos/operators/_asynchronous/bigquery.py", line 141, in get_sql_from_xcom
    compressed_b64_sql = base64.b64decode(compressed_b64_sql)
                         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/base64.py", line 83, in b64decode
    s = _bytes_from_decode_data(s)
        ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.12/lib/python3.12/base64.py", line 45, in _bytes_from_decode_data
    raise TypeError("argument should be a bytes-like object or ASCII "
TypeError: argument should be a bytes-like object or ASCII string, not 'NoneType'
```

Example of successful run after applying this PR:
<img width="1624" height="1056" alt="Screenshot 2025-11-07 at 14 17 44" src="https://github.com/user-attachments/assets/9ae39c4d-0cbb-45c2-a895-4381bbcac815" />

Closes: #2054