### PR TITLE
docs: correct example YAML key from operator_args to operator_kwargs

### DIFF
--- a/docs/getting_started/custom-airflow-properties.rst
+++ b/docs/getting_started/custom-airflow-properties.rst
@@ -16,7 +16,7 @@ Sample dbt Model YAML
         description: description
         meta:
           cosmos:
-            operator_args:
+            operator_kwargs:
                 pool: abcd
 
 


### PR DESCRIPTION
## Description

Update docs/getting_started/custom-airflow-properties.rst to rename operator_args → operator_kwargs in the sample dbt model YAML.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes #1655

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
