### PR TITLE
Fix pip install options link

### DIFF
--- a/docs/getting_started/gcc.rst
+++ b/docs/getting_started/gcc.rst
@@ -49,7 +49,7 @@ In your ``my_cosmos_dag.py`` file, import the ``DbtDag`` class from Cosmos and c
 
 Make sure to rename the ``<your-adapter>`` value below to your adapter's Python package (i.e. ``dbt-snowflake`` or ``dbt-bigquery``)
 
-If you need to modify the pip install options, you can do so by adding ``pip_install_options`` to the ``operator_args`` dictionary. For example, if you wanted to install packages from local wheels you could set it too: ``["--no-index", "--find-links=/path/to/wheels"]``. All options can be found here: <https://pip.pypa.io/en/stable/cli/pip_install/>
+If you need to modify the pip install options, you can do so by adding ``pip_install_options`` to the ``operator_args`` dictionary. For example, if you wanted to install packages from local wheels you could set it too: ``["--no-index", "--find-links=/path/to/wheels"]``. See documentation for available `pip install options <https://pip.pypa.io/en/stable/cli/pip_install/>`_.
 
 .. code-block:: python
 


### PR DESCRIPTION
## Description

The PR fixes link for pip install options on `Getting Started on Google Cloud Composer (GCC)` page.

Before changes
<img width="1121" height="451" alt="image" src="https://github.com/user-attachments/assets/35242750-f04c-47a5-a73d-0b09e5063ba1" />

After changes
<img width="1133" height="415" alt="image" src="https://github.com/user-attachments/assets/b94be2e8-0c8e-47a2-a805-42c45849c6a9" />

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
