### PR TITLE
Fix ExecutionMode.WATCHER to use install_dbt_deps from ProjectConfig

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -218,7 +218,7 @@ def override_configuration(
     if execution_config.invocation_mode:
         operator_args["invocation_mode"] = execution_config.invocation_mode
 
-    if execution_config.execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV):
+    if execution_config.execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV, ExecutionMode.WATCHER):
         if "install_deps" not in operator_args:
             operator_args["install_deps"] = project_config.install_dbt_deps
         if "copy_dbt_packages" not in operator_args:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -722,11 +722,14 @@ def test_validate_converter_fetches_project_name_from_render_config(
         (ExecutionMode.KUBERNETES, {}, False, None),
         (ExecutionMode.LOCAL, {}, False, False),
         (ExecutionMode.VIRTUALENV, {}, False, False),
+        (ExecutionMode.WATCHER, {}, False, False),
         (ExecutionMode.LOCAL, {}, True, True),
         (ExecutionMode.VIRTUALENV, {}, True, True),
+        (ExecutionMode.WATCHER, {}, True, True),
         (ExecutionMode.KUBERNETES, {"install_deps": True}, False, True),
         (ExecutionMode.LOCAL, {"install_deps": True}, False, True),
         (ExecutionMode.VIRTUALENV, {"install_deps": True}, False, True),
+        (ExecutionMode.WATCHER, {"install_deps": True}, False, True),
     ],
 )
 @patch("cosmos.config.ProjectConfig.validate_project")
@@ -744,7 +747,7 @@ def test_project_config_install_dbt_deps_overrides_operator_args(
     expected,
 ):
     """Tests that the value project_config.install_dbt_deps is used to define operator_args["install_deps"] if
-    execution mode is ExecutionMode.LOCAL or ExecutionMode.VIRTUALENV and operator_args["install_deps"] is not
+    execution mode is ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV, or ExecutionMode.WATCHER and operator_args["install_deps"] is not
     already defined.
     """
     project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")


### PR DESCRIPTION
## Description

With the new ExecutionMode.WATCHER, the decision if we install dbt deps should be done in the same manner as LOCAL  or VIRTUALENV execution modes.  

So I am changing the code to use the ProjectConfig settings for dbt deps to also work with the Watcher and now it will be in sync with the documentation.

## Related Issue(s)

https://github.com/astronomer/astronomer-cosmos/issues/2099

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
