### PR TITLE
Force watcher producer retries to zero

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -103,7 +103,7 @@ class DbtProducerWatcherOperator(DbtLocalBaseOperator):
         kwargs.setdefault("priority_weight", PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT)
         kwargs.setdefault("weight_rule", WEIGHT_RULE)
         # Consumer watcher retry logic handles model-level reruns using the LOCAL execution mode; rerunning the producer
-        # would repeat the full dbt build and duplicate watcher callbacks which may not be processed by the consumers if 
+        # would repeat the full dbt build and duplicate watcher callbacks which may not be processed by the consumers if
         # they have already processed output XCOMs from the first run of the producer, so we disable retries.
         default_args = dict(kwargs.get("default_args", {}) or {})
         default_args["retries"] = 0

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -216,8 +216,11 @@ How retries work
 ~~~~~~~~~~~~~~~~
 
 When the ``dbt build`` command run by ``DbtProducerWatcherOperator`` fails, it will notify all the ``DbtConsumerWatcherSensor``.
+Cosmos always sets the producer's Airflow task retries to ``0``; this ensures the failure surfaces immediately and avoids kicking off a second full ``dbt build`` run.
 
 The individual watcher tasks, that subclass ``DbtConsumerWatcherSensor``, can retry the dbt command by themselves using the same behaviour as ``ExecutionMode.LOCAL``.
+This is also the reason why we set ``retries`` to ``0`` in the ``DbtProducerWatcherOperator`` task because rerunning the producer would repeat the full dbt build and duplicate 
+watcher callbacks which may not be processed by the consumers if they have already processed output XCOMs from the first run of the producer.
 
 If a branch of the DAG failed, users can clear the status of a failed consumer task, including its downstream tasks, via the Airflow UI - and each of them will run using the ``ExecutionMode.LOCAL``.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -219,7 +219,7 @@ When the ``dbt build`` command run by ``DbtProducerWatcherOperator`` fails, it w
 Cosmos always sets the producer's Airflow task retries to ``0``; this ensures the failure surfaces immediately and avoids kicking off a second full ``dbt build`` run.
 
 The individual watcher tasks, that subclass ``DbtConsumerWatcherSensor``, can retry the dbt command by themselves using the same behaviour as ``ExecutionMode.LOCAL``.
-This is also the reason why we set ``retries`` to ``0`` in the ``DbtProducerWatcherOperator`` task because rerunning the producer would repeat the full dbt build and duplicate 
+This is also the reason why we set ``retries`` to ``0`` in the ``DbtProducerWatcherOperator`` task because rerunning the producer would repeat the full dbt build and duplicate
 watcher callbacks which may not be processed by the consumers if they have already processed output XCOMs from the first run of the producer.
 
 If a branch of the DAG failed, users can clear the status of a failed consumer task, including its downstream tasks, via the Airflow UI - and each of them will run using the ``ExecutionMode.LOCAL``.

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -110,6 +110,23 @@ def test_dbt_producer_watcher_operator_priority_weight_override():
     assert op.priority_weight == 100
 
 
+def test_dbt_producer_watcher_operator_retries_forced_to_zero():
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    assert op.retries == 0
+
+
+def test_dbt_producer_watcher_operator_retries_ignores_user_input():
+    user_default_args = {"retries": 5}
+    op = DbtProducerWatcherOperator(
+        project_dir=".",
+        profile_config=None,
+        default_args=user_default_args,
+        retries=3,
+    )
+
+    assert op.retries == 0
+    assert user_default_args["retries"] == 5
+
 def test_dbt_producer_watcher_operator_pushes_completion_status():
     """Test that operator pushes 'completed' status to XCom in both success and failure cases."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -127,6 +127,7 @@ def test_dbt_producer_watcher_operator_retries_ignores_user_input():
     assert op.retries == 0
     assert user_default_args["retries"] == 5
 
+
 def test_dbt_producer_watcher_operator_pushes_completion_status():
     """Test that operator pushes 'completed' status to XCom in both success and failure cases."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -164,6 +164,18 @@ def test_dbt_producer_watcher_operator_pushes_completion_status():
         mock_execute.assert_called_once()
 
 
+def test_dbt_producer_watcher_operator_requires_task_instance():
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    context: dict[str, object] = {}
+
+    with patch("cosmos.operators.local.DbtLocalBaseOperator.execute") as mock_execute:
+        with pytest.raises(AirflowException) as excinfo:
+            op.execute(context=context)
+
+    mock_execute.assert_not_called()
+    assert "expects a task instance" in str(excinfo.value)
+
+
 def test_handle_startup_event():
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
     lst: list[dict] = []

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -4,6 +4,7 @@ import base64
 import json
 import zlib
 from contextlib import nullcontext
+import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace
@@ -52,6 +53,7 @@ profile_config = ProfileConfig(
 class _MockTI:
     def __init__(self) -> None:
         self.store: dict[str, str] = {}
+        self.try_number = 1
 
     def xcom_push(self, key: str, value: str, **_):
         self.store[key] = value
@@ -168,6 +170,36 @@ def test_handle_startup_event():
     ev = _fake_event("MainReportVersion")
     op._handle_startup_event(ev, lst)
     assert lst and lst[0]["name"] == "MainReportVersion"
+
+
+def test_dbt_producer_watcher_operator_logs_retry_message(caplog):
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    ti = _MockTI()
+    ti.try_number = 1
+    context = {"ti": ti}
+
+    with patch("cosmos.operators.local.DbtLocalBaseOperator.execute", return_value="ok") as mock_execute:
+        with caplog.at_level(logging.INFO):
+            op.execute(context=context)
+
+    mock_execute.assert_called_once()
+    assert any("forces Airflow retries to 0" in message for message in caplog.messages)
+
+
+def test_dbt_producer_watcher_operator_blocks_retry_attempt(caplog):
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    ti = _MockTI()
+    ti.try_number = 2
+    context = {"ti": ti}
+
+    with patch("cosmos.operators.local.DbtLocalBaseOperator.execute") as mock_execute:
+        with caplog.at_level(logging.ERROR):
+            with pytest.raises(AirflowException) as excinfo:
+                op.execute(context=context)
+
+    mock_execute.assert_not_called()
+    assert "does not support Airflow retries" in str(excinfo.value)
+    assert any("does not support Airflow retries" in message for message in caplog.messages)
 
 
 def test_handle_node_finished_pushes_xcom():

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2,9 +2,9 @@ from __future__ import annotations
 
 import base64
 import json
+import logging
 import zlib
 from contextlib import nullcontext
-import logging
 from datetime import datetime, timedelta
 from pathlib import Path
 from types import SimpleNamespace


### PR DESCRIPTION
The PR makes the following changes:
- hard-set `DbtProducerWatcherOperator` `retries` (and `default_args["retries"]`) to zero so WATCHER never auto-retries the full dbt build
-  Log at INFO that producer retries are disabled, and fail fast if Airflow attempts a retry (try number > 1), improving user visibility into the behavior.
- explain the rationale inline (sensor retry path handles per-model reruns)
- document behavior in the WATCHER guide and add tests covering the forced retry value

closes: #2105 