### PR TITLE
Remove Python3.8 uses from GH action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -131,8 +131,6 @@ jobs:
             airflow-version: "2.4"
           - python-version: "3.11"
             airflow-version: "2.5"
-          # It's observed that the dependencies resolution for Apache Airflow versions 2.7 are error-ring out with deep
-          # resolutions. This is a temporary exclusion until the issue is resolved.
     services:
       postgres:
         image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18


### PR DESCRIPTION
Remove Python 3.8 uses from GitHub action since we don't support Python 3.8