### PR TITLE
Release 1.11.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,7 @@
 Changelog
 =========
 
-1.12.0a2 (2025-11-04)
+1.12.0a2 (2025-11-12)
 -------------------
 
 Breaking changes
@@ -17,13 +17,37 @@ Features
 
 Enhancements
 
-* Remove usage of contextmanager in plugins for accessing connections in Airflow >= 3.1.2 by @pankajkoti in #2073
+* By default, use deferrable sensors when using ``ExecutionMode.WATCHER`` by @pankajastro in #2084
+* Unify airflow version handling into ``constants.py`` by @tatiana in #2089
 * Refactor ``airflow/graph.py`` to simplify code-base by @tatiana in #2080
+
+
+1.11.1 (2025-11-12)
+--------------------
+
+Bug fixes
+
+* Fix ``ExecutionMode.WATCHER`` deadlock in Airflow 3.0 & 3.1 by @tatiana in #2087
+* Fix ``ExecutionMode.AIRFLOW_ASYNC`` ``TaskGroup`` XCom issue by @tatiana in #2088
+* Guard watcher callback exceptions to avoid hanging producer tasks by @pankajkoti in #2101
+* Fix SQL templated field rendering for dynamically mapped tasks in Airflow 2 by @tatiana in #2119
+
+Enhancements
+
+* Remove usage of contextmanager in plugins for accessing connections in Airflow >= 3.1.2 by @pankajkoti in #2073
+
+Docs
+
+* Improve ``ExecutionMode.AIRFLOW_ASYNC`` docs by @tatiana in #2103
+* Add note about experimenting threads count for the Watcher Execution mode by @pankajkoti in #2083
+* Fix minor documentation formatting issue by @dnskrv in #2098
+* Correct example YAML key from ``operator_args`` to ``operator_kwargs`` by @jx2lee in #2091
 
 Others
 
 * Fix broken CI due to fastapi incompatibility with cadwyn for Airflow 3 by @pankajkoti in #2076
-* Pre-commit updates: #2078
+* pre-commit autoupdate in #2078, #2104
+
 
 1.11.0 (2025-10-29)
 ---------------------


### PR DESCRIPTION
Bug fixes

* Fix ``ExecutionMode.WATCHER`` deadlock in Airflow 3.0 & 3.1 by @tatiana in #2087
* Fix ``ExecutionMode.AIRFLOW_ASYNC`` ``TaskGroup`` XCom issue by @tatiana in #2088
* Guard watcher callback exceptions to avoid hanging producer tasks by @pankajkoti in #2101
* Fix SQL templated field rendering for dynamically mapped tasks in Airflow 2 by @tatiana in #2119
* Fix `ExecutionMode.WATCHER` to use `install_dbt_deps` from `ProjectConfig` by @michal-mrazek in #2112 

Enhancements

* Remove usage of contextmanager in plugins for accessing connections in Airflow >= 3.1.2 by @pankajkoti in #2073

Docs

* Improve ``ExecutionMode.AIRFLOW_ASYNC`` docs by @tatiana in #2103
* Add note about experimenting threads count for the Watcher Execution mode by @pankajkoti in #2083
* Fix minor documentation formatting issue by @dnskrv in #2098
* Correct example YAML key from ``operator_args`` to ``operator_kwargs`` by @jx2lee in #2091

Others

* Fix broken CI due to fastapi incompatibility with cadwyn for Airflow 3 by @pankajkoti in #2076
* pre-commit autoupdate in #2078, #2104

Closes: https://github.com/astronomer/oss-integrations-private/issues/272