### PR TITLE
Update 1.11.1 change log

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -41,7 +41,7 @@ Docs
 
 * Improve ``ExecutionMode.AIRFLOW_ASYNC`` docs by @tatiana in #2103
 * Add note about experimenting threads count for the Watcher Execution mode by @pankajkoti in #2083
-* Fix minor documentation formatting issue by @dnskrv in #2098
+* Fix minor documentation formatting issue by @dnskr in #2098
 * Correct example YAML key from ``operator_args`` to ``operator_kwargs`` by @jx2lee in #2091
 
 Others


### PR DESCRIPTION
Fixes two issues:
- Add commit that was part of the release but was not documented in the changelog by mistake
- Fix mispelled contributor name