### PR TITLE
Fail consumer sensors when producer task failure observed using Airflow context

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -418,9 +418,7 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
                 )
                 return str(task_states.get(run_id, {}).get(self.producer_task_id, ""))
             except (ImportError, NameError) as exc:
-                logger.warning(
-                    "Could not retrieve producer task status via RuntimeTaskInstance: %s", exc
-                )
+                logger.warning("Could not retrieve producer task status via RuntimeTaskInstance: %s", exc)
             return None
 
     def execute(self, context: Context, **kwargs: Any) -> None:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -386,8 +386,12 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
 
         if AIRFLOW_VERSION < Version("3.0.0"):
             # Airflow 2: Query TaskInstance from database
-            from airflow.models import TaskInstance
-            from airflow.utils.session import create_session
+            try:
+                from airflow.models import TaskInstance
+                from airflow.utils.session import create_session
+            except Exception as exc:  # pragma: no cover - defensive fallback for tests without DB
+                logger.warning("Could not import create_session to read producer state: %s", exc)
+                return None
 
             with create_session() as session:
                 producer_ti = (

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -417,9 +417,11 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
                     run_ids=[run_id],
                 )
                 return str(task_states.get(run_id, {}).get(self.producer_task_id, ""))
-            except ImportError:
-                logger.warning("Could not get producer task status, falling back to XCom state check")
-                return None
+            except (ImportError, NameError) as exc:
+                logger.warning(
+                    "Could not retrieve producer task status via RuntimeTaskInstance: %s", exc
+                )
+            return None
 
     def execute(self, context: Context, **kwargs: Any) -> None:
         if not self.deferrable:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -389,7 +389,7 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
             try:
                 from airflow.models import TaskInstance
                 from airflow.utils.session import create_session
-            except Exception as exc:  # pragma: no cover - defensive fallback for tests without DB
+            except ImportError as exc:  # pragma: no cover - defensive fallback for tests without DB
                 logger.warning("Could not import create_session to read producer state: %s", exc)
                 return None
 
@@ -416,7 +416,10 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
                     task_ids=[self.producer_task_id],
                     run_ids=[run_id],
                 )
-                return str(task_states.get(run_id, {}).get(self.producer_task_id, ""))
+                state = task_states.get(run_id, {}).get(self.producer_task_id)
+                if state is not None:
+                    return str(state)
+                return None
             except (ImportError, NameError) as exc:
                 logger.warning("Could not retrieve producer task status via RuntimeTaskInstance: %s", exc)
             return None

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -585,7 +585,10 @@ class TestDbtConsumerWatcherSensor:
 
     @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
     @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("3.0.0"))
-    @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states", side_effect=ImportError("missing runtime"))
+    @patch(
+        "airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states",
+        side_effect=ImportError("missing runtime"),
+    )
     def test_get_producer_task_status_airflow3_import_error(self, _mock_get_task_states):
         sensor = self.make_sensor()
         sensor._get_producer_task_status = DbtConsumerWatcherSensor._get_producer_task_status.__get__(


### PR DESCRIPTION
Ensure `DbtConsumerWatcherSensor` uses the Airflow context to fail fast when the watcher producer ends in a failure state.

related: #2086 