### PR TITLE
Retry flaky telemetry success test

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ dependencies = [
     "pytest>=6.0",
     "pytest-split",
     "pytest-dotenv",
+    "pytest-rerunfailures",
     "requests-mock",
     "pytest-cov",
     "pytest-describe",

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -130,7 +130,6 @@ def test_emit_usage_metrics_if_enabled_fails(mock_should_emit, caplog):
     assert "Telemetry is disabled. To enable it, export AIRFLOW__COSMOS__ENABLE_TELEMETRY=True." in caplog.text
 
 
-@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @patch("cosmos.telemetry.should_emit", return_value=True)
 @patch("cosmos.telemetry.collect_standard_usage_metrics", return_value={"k1": "v1", "k2": "v2", "variables": {}})
 @patch("cosmos.telemetry.emit_usage_metrics")

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -100,6 +100,7 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
 
 
 @pytest.mark.integration
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 def test_emit_usage_metrics_succeeds(caplog):
     caplog.set_level(logging.DEBUG)
     sample_metrics = {
@@ -129,6 +130,7 @@ def test_emit_usage_metrics_if_enabled_fails(mock_should_emit, caplog):
     assert "Telemetry is disabled. To enable it, export AIRFLOW__COSMOS__ENABLE_TELEMETRY=True." in caplog.text
 
 
+@pytest.mark.flaky(reruns=2, reruns_delay=1)
 @patch("cosmos.telemetry.should_emit", return_value=True)
 @patch("cosmos.telemetry.collect_standard_usage_metrics", return_value={"k1": "v1", "k2": "v2", "variables": {}})
 @patch("cosmos.telemetry.emit_usage_metrics")


### PR DESCRIPTION
Uses https://pypi.org/project/pytest-rerunfailures/ for rerunning flaky telemetry test `test_emit_usage_metrics_succeeds`  for observed timeout errors as reported in #2137 


closes: #2137 