### PR TITLE
Improve example DAG `jaffle_shop_kubernetes.py`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,5 +1,8 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
+default_language_version:
+  python: python3.10
+
 repos:
   - repo: local
     hooks:

--- a/dev/dags/jaffle_shop_kubernetes.py
+++ b/dev/dags/jaffle_shop_kubernetes.py
@@ -54,6 +54,7 @@ postgres_host_secret = Secret(
     key="host",
 )
 
+
 with DAG(
     dag_id="jaffle_shop_kubernetes",
     start_date=datetime(2022, 11, 27),
@@ -69,6 +70,14 @@ with DAG(
         image=DBT_IMAGE,
         is_delete_operator_pod=False,
         secrets=[postgres_password_secret, postgres_host_secret],
+        profile_config=ProfileConfig(
+            profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="postgres_profile", target_name="dev"
+        ),
+        env_vars={
+            "POSTGRES_DB": "postgres",
+            "POSTGRES_SCHEMA": "public",
+            "POSTGRES_USER": "postgres",
+        },
     )
     # [END kubernetes_seed_example]
 
@@ -78,6 +87,8 @@ with DAG(
         profile_config=ProfileConfig(
             profile_name="postgres_profile",
             target_name="dev",
+            # The following profile mapping works for the DAG parsing
+            # However, it is not exposed during the K8s pod operators execution
             profile_mapping=PostgresUserPasswordProfileMapping(
                 conn_id="postgres_default",
                 profile_args={
@@ -92,6 +103,11 @@ with DAG(
             "get_logs": True,
             "is_delete_operator_pod": False,
             "secrets": [postgres_password_secret, postgres_host_secret],
+            "env_vars": {
+                "POSTGRES_DB": "postgres",
+                "POSTGRES_SCHEMA": "public",
+                "POSTGRES_USER": "postgres",
+            },
         },
     )
     # [END kubernetes_tg_example]

--- a/tests/test_example_k8s_dags.py
+++ b/tests/test_example_k8s_dags.py
@@ -41,4 +41,5 @@ def test_example_dag_kubernetes(session):
     db = DagBag(EXAMPLE_DAGS_DIR, include_examples=False)
     # for dag_id in KUBERNETES_DAG_FILES:
     dag = db.get_dag("jaffle_shop_kubernetes")
+    assert not db.import_errors
     test_utils.run_dag(dag)


### PR DESCRIPTION
Previously, the `DbtSeedKubernetesOperator` had a misleading `profile_config` argument that used a `ProfileMapping` class, which was not being used. 

Cosmos 1.11 does not support `ProfileMapping` during the execution of tasks created with `ExecutionMode.KUBERNETES`.