### PR TITLE
Watcher: fetch async producer status from Airflow runtime

### DIFF
--- a/cosmos/_triggers/watcher.py
+++ b/cosmos/_triggers/watcher.py
@@ -72,8 +72,10 @@ class WatcherTrigger(BaseTrigger):
                         task_id=self.producer_task_id,
                         run_id=self.run_id,
                     )
-                    .one()
+                    .first()
                 )
+                if ti is None:
+                    return None
                 return ti.xcom_pull(task_ids=self.producer_task_id, key=key)
 
         return await sync_to_async(_get_xcom_val)()

--- a/cosmos/_utils/watcher_state.py
+++ b/cosmos/_utils/watcher_state.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable
+
+from packaging.version import Version
+
+ProducerStateFetcher = Callable[[], str | None]
+
+
+def _load_airflow2_dependencies() -> tuple[Any, Callable[[], Any]]:
+    from airflow.models import TaskInstance
+    from airflow.utils.session import create_session
+
+    return TaskInstance, create_session
+
+
+def _load_airflow3_dependencies() -> Any:
+    from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
+
+    return RuntimeTaskInstance
+
+
+def build_producer_state_fetcher(
+    *,
+    airflow_version: Version,
+    dag_id: str,
+    run_id: str,
+    producer_task_id: str,
+    logger: logging.Logger,
+) -> ProducerStateFetcher | None:
+    """Return a callable that fetches the producer task state for the given Airflow version."""
+
+    if airflow_version < Version("3.0.0"):
+        try:
+            TaskInstance, create_session = _load_airflow2_dependencies()
+        except ImportError as exc:  # pragma: no cover - defensive guard for stripped test envs
+            logger.warning("Could not import Airflow 2 state dependencies: %s", exc)
+            return None
+
+        def fetch_state() -> str | None:
+            with create_session() as session:
+                ti = (
+                    session.query(TaskInstance)
+                    .filter_by(
+                        dag_id=dag_id,
+                        task_id=producer_task_id,
+                        run_id=run_id,
+                    )
+                    .one_or_none()
+                )
+                if ti is not None:
+                    return str(ti.state)
+                return None
+
+        return fetch_state
+
+    try:
+        RuntimeTaskInstance = _load_airflow3_dependencies()
+    except (ImportError, NameError) as exc:  # pragma: no cover - Airflow 3 libs missing
+        logger.warning("Could not load Airflow 3 RuntimeTaskInstance: %s", exc)
+        return None
+
+    def fetch_state() -> str | None:
+        task_states = RuntimeTaskInstance.get_task_states(
+            dag_id=dag_id,
+            task_ids=[producer_task_id],
+            run_ids=[run_id],
+        )
+        state = task_states.get(run_id, {}).get(producer_task_id)
+        if state is not None:
+            return str(state)
+        return None
+
+    return fetch_state

--- a/cosmos/_utils/watcher_state.py
+++ b/cosmos/_utils/watcher_state.py
@@ -38,7 +38,7 @@ def build_producer_state_fetcher(
             logger.warning("Could not import Airflow 2 state dependencies: %s", exc)
             return None
 
-        def fetch_state() -> str | None:
+        def fetch_state_airflow2() -> str | None:
             with create_session() as session:
                 ti = (
                     session.query(TaskInstance)
@@ -53,7 +53,7 @@ def build_producer_state_fetcher(
                     return str(ti.state)
                 return None
 
-        return fetch_state
+        return fetch_state_airflow2
 
     try:
         RuntimeTaskInstance = _load_airflow3_dependencies()
@@ -61,7 +61,7 @@ def build_producer_state_fetcher(
         logger.warning("Could not load Airflow 3 RuntimeTaskInstance: %s", exc)
         return None
 
-    def fetch_state() -> str | None:
+    def fetch_state_airflow3() -> str | None:
         task_states = RuntimeTaskInstance.get_task_states(
             dag_id=dag_id,
             task_ids=[producer_task_id],
@@ -72,4 +72,4 @@ def build_producer_state_fetcher(
             return str(state)
         return None
 
-    return fetch_state
+    return fetch_state_airflow3

--- a/cosmos/_utils/watcher_state.py
+++ b/cosmos/_utils/watcher_state.py
@@ -69,9 +69,7 @@ def build_producer_state_fetcher(
                 run_ids=[run_id],
             )
         except NameError as exc:  # pragma: no cover - Airflow 3.0 missing supervisor comms
-            logger.warning(
-                "RuntimeTaskInstance.get_task_states unavailable due to NameError: %s", exc
-            )
+            logger.warning("RuntimeTaskInstance.get_task_states unavailable due to NameError: %s", exc)
             return None
         state = task_states.get(run_id, {}).get(producer_task_id)
         if state is not None:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -32,9 +32,9 @@ except ImportError:  # pragma: no cover
 
 from packaging.version import Version
 
+from cosmos._utils.watcher_state import build_producer_state_fetcher
 from cosmos.config import ProfileConfig
 from cosmos.constants import AIRFLOW_VERSION, PRODUCER_WATCHER_TASK_ID, InvocationMode
-from cosmos._utils.watcher_state import build_producer_state_fetcher
 from cosmos.operators.base import (
     DbtBuildMixin,
     DbtRunMixin,

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -34,6 +34,7 @@ from packaging.version import Version
 
 from cosmos.config import ProfileConfig
 from cosmos.constants import AIRFLOW_VERSION, PRODUCER_WATCHER_TASK_ID, InvocationMode
+from cosmos._utils.watcher_state import build_producer_state_fetcher
 from cosmos.operators.base import (
     DbtBuildMixin,
     DbtRunMixin,
@@ -384,45 +385,17 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
         run_id = context["run_id"]
         dag_id = ti.dag_id
 
-        if AIRFLOW_VERSION < Version("3.0.0"):
-            # Airflow 2: Query TaskInstance from database
-            try:
-                from airflow.models import TaskInstance
-                from airflow.utils.session import create_session
-            except ImportError as exc:  # pragma: no cover - defensive fallback for tests without DB
-                logger.warning("Could not import create_session to read producer state: %s", exc)
-                return None
-
-            with create_session() as session:
-                producer_ti = (
-                    session.query(TaskInstance)
-                    .filter_by(
-                        dag_id=dag_id,
-                        task_id=self.producer_task_id,
-                        run_id=run_id,
-                    )
-                    .first()
-                )
-                if producer_ti:
-                    return str(producer_ti.state)
-                return None
-        else:
-            # Airflow 3: Use RuntimeTaskInstance.get_task_states
-            try:
-                from airflow.sdk.execution_time.task_runner import RuntimeTaskInstance
-
-                task_states = RuntimeTaskInstance.get_task_states(
-                    dag_id=dag_id,
-                    task_ids=[self.producer_task_id],
-                    run_ids=[run_id],
-                )
-                state = task_states.get(run_id, {}).get(self.producer_task_id)
-                if state is not None:
-                    return str(state)
-                return None
-            except (ImportError, NameError) as exc:
-                logger.warning("Could not retrieve producer task status via RuntimeTaskInstance: %s", exc)
+        fetch_state = build_producer_state_fetcher(
+            airflow_version=AIRFLOW_VERSION,
+            dag_id=dag_id,
+            run_id=run_id,
+            producer_task_id=self.producer_task_id,
+            logger=logger,
+        )
+        if fetch_state is None:
             return None
+
+        return fetch_state()
 
     def execute(self, context: Context, **kwargs: Any) -> None:
         if not self.deferrable:

--- a/tests/_triggers/test_watcher.py
+++ b/tests/_triggers/test_watcher.py
@@ -1,12 +1,9 @@
-import sys
-import types
 from unittest.mock import ANY, AsyncMock, MagicMock, patch
 
 import pytest
 from packaging.version import Version
 
 from cosmos._triggers.watcher import AIRFLOW_VERSION, WatcherTrigger
-
 
 _real_import = __import__
 
@@ -191,7 +188,9 @@ class TestWatcherTrigger:
         fetcher.assert_called_once_with()
         assert state is None
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="RuntimeTaskInstance import exists on Airflow >= 3.0")
+    @pytest.mark.skipif(
+        AIRFLOW_VERSION < Version("3.0.0"), reason="RuntimeTaskInstance import exists on Airflow >= 3.0"
+    )
     @pytest.mark.asyncio
     async def test_get_producer_task_status_airflow3_import_error(self):
         def _import_side_effect(name: str, *args, **kwargs):

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -538,9 +538,9 @@ class TestDbtConsumerWatcherSensor:
             status = sensor._get_producer_task_status(context)
 
         mock_builder.assert_called_once_with(
-            airflow_version=Version('2.7.0'),
-            dag_id='example_dag',
-            run_id='run_1',
+            airflow_version=Version("2.7.0"),
+            dag_id="example_dag",
+            run_id="run_1",
             producer_task_id=sensor.producer_task_id,
             logger=ANY,
         )


### PR DESCRIPTION
With this PR, the Watcher deferrable trigger now mirrors the synchronous sensor (as implemented in PR #2126) by querying the producer task state through Airflow instead of the state XCom. The PR adds `_get_producer_task_status` to `WatcherTrigger` (database lookup in Airflow 2, `RuntimeTaskInstance` in Airflow 3) and wires the `run()` method to utilise it, so async sensors raise `producer_failed` events when the producer dies.
  
related: #2126 
related: #2086 