### PR TITLE
Run pre-commit on watcher modules

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -30,7 +30,6 @@ try:
 except ImportError:  # pragma: no cover
     from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
 
-from packaging.version import Version
 
 from cosmos._utils.watcher_state import build_producer_state_fetcher
 from cosmos.config import ProfileConfig


### PR DESCRIPTION
This PR removes an unused import from the watcher module as part of running pre-commit hooks. The change addresses automatic formatting issues that were being flagged by pre-commit in the release PR #2149 