### PR TITLE
Refactor: Use shared airflow version constant

### DIFF
--- a/cosmos/_triggers/watcher.py
+++ b/cosmos/_triggers/watcher.py
@@ -6,14 +6,12 @@ import json
 import zlib
 from typing import Any, AsyncIterator
 
-import airflow
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from asgiref.sync import sync_to_async
 from packaging.version import Version
 
 from cosmos._utils.watcher_state import build_producer_state_fetcher
-
-AIRFLOW_VERSION = Version(airflow.__version__)
+from cosmos.constants import AIRFLOW_VERSION
 
 
 class WatcherTrigger(BaseTrigger):


### PR DESCRIPTION
Following PR #2089, do similarly for the Airflow version constant in the cosmos/_triggers/watcher.py module that was added in PR #2084 (probably it was worked upon in parallel with PR 2089 and hence was not identified then). 

