### PR TITLE
Release 1.11.2

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Bug fixes
 
 * Force ``DbtProducerWatcherOperator`` retries to zero by @pankajkoti in #2114
 * Fail ``DbtConsumerWatcherSensor`` tasks immediately when the ``DbtProducerWatcherOperator`` fails using Airflow context by @pankajkoti in #2126
-* Fix forwarding ``DbtProducerWatcherOperator`` ``dbt build`` flags by by @michal-mrazek in #2127
+* Fix forwarding ``DbtProducerWatcherOperator`` ``dbt build`` flags by @michal-mrazek in #2127
 
 Documentation
 


### PR DESCRIPTION
Bug fixes

* Force ``DbtProducerWatcherOperator`` retries to zero by @pankajkoti in #2114
* Fail ``DbtConsumerWatcherSensor`` tasks immediately when the ``DbtProducerWatcherOperator`` fails using Airflow context by @pankajkoti in #2126
* Fix forwarding ``DbtProducerWatcherOperator`` ``dbt build`` flags by @michal-mrazek in #2127

Documentation

* Expand ``ExecutionMode.KUBERNETES`` guidance by @tatiana in #2139
* Document dataset-event limitation when using ``ExecutionMode.AIRFLOW_ASYNC`` by @varaprasadregani in #2143

related: https://github.com/astronomer/oss-integrations-private/issues/274