### PR TITLE
Docs: clarify AIRFLOW_ASYNC dataset limits.

### DIFF
--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. This feature is only available for `ExecutionMode.LOCAL`, `ExecutionMode.VIRTUALENV` and `ExecutionMode.WATCHER`.
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. This feature is only available for ``ExecutionMode.LOCAL``, ``ExecutionMode.VIRTUALENV`` and ``ExecutionMode.WATCHER``.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``invocation_mode``: (new in v1.9) how to run ``dbt ls``, when using ``LoadMode.DBT_LS``. Learn more about this below.

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_. ``ExecutionMode.AIRFLOW_ASYNC`` does not emit datasets today, even if this flag is ``True``.
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_. ``ExecutionMode.AIRFLOW_ASYNC`` currently does not emit datasets, even if this flag is ``True``.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``invocation_mode``: (new in v1.9) how to run ``dbt ls``, when using ``LoadMode.DBT_LS``. Learn more about this below.

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_. ``ExecutionMode.AIRFLOW_ASYNC`` currently does not emit datasets, even if this flag is ``True``.
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. This feature is only available for `ExecutionMode.LOCAL`, `ExecutionMode.VIRTUALENV` and `ExecutionMode.WATCHER`.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``invocation_mode``: (new in v1.9) how to run ``dbt ls``, when using ``LoadMode.DBT_LS``. Learn more about this below.

--- a/docs/configuration/render-config.rst
+++ b/docs/configuration/render-config.rst
@@ -7,7 +7,7 @@ It does this by exposing a ``cosmos.config.RenderConfig`` class that you can use
 
 The ``RenderConfig`` class takes the following arguments:
 
-- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_. If a model in the project has a name containing multibyte characters, the dataset name will be URL-encoded.
+- ``emit_datasets``: whether or not to emit Airflow datasets to be used for data-aware scheduling. Defaults to True. Depends on `additional dependencies <lineage.html>`_. ``ExecutionMode.AIRFLOW_ASYNC`` does not emit datasets today, even if this flag is ``True``.
 - ``test_behavior``: how to run tests. Defaults to running a model's tests immediately after the model is run. For more information, see the `Testing Behavior <testing-behavior.html>`_ section.
 - ``load_method``: how to load your dbt project. See `Parsing Methods <parsing-methods.html>`_ for more information.
 - ``invocation_mode``: (new in v1.9) how to run ``dbt ls``, when using ``LoadMode.DBT_LS``. Learn more about this below.

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -29,6 +29,10 @@ Data-Aware Scheduling
 
 By default, if using a version between Airflow 2.4 or higher is used, Cosmos emits `Airflow Datasets <https://airflow.apache.org/docs/apache-airflow/stable/concepts/datasets.html>`_ when running dbt projects. This allows you to use Airflow's data-aware scheduling capabilities to schedule your dbt projects. Cosmos emits datasets using the OpenLineage URI format, as detailed in the `OpenLineage Naming Convention <https://github.com/OpenLineage/OpenLineage/blob/main/spec/Naming.md>`_.
 
+.. important::
+
+   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream DAGs depending on Airflow's data-aware scheduling will not trigger automatically. This limitation is tracked in `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
+
 Cosmos calculates these URIs during the task execution, by using the library `OpenLineage Integration Common <https://pypi.org/project/openlineage-integration-common/>`_.
 
 This block illustrates a Cosmos-generated dataset for Postgres:

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -31,7 +31,7 @@ By default, if using a version between Airflow 2.4 or higher is used, Cosmos emi
 
 .. important::
 
-   This feature is only available for `ExecutionMode.LOCAL`, `ExecutionMode.VIRTUALENV` and `ExecutionMode.WATCHER`.
+   This feature is only available for ``ExecutionMode.LOCAL``, ``ExecutionMode.VIRTUALENV`` and ``ExecutionMode.WATCHER``.
 
 Cosmos calculates these URIs during the task execution, by using the library `OpenLineage Integration Common <https://pypi.org/project/openlineage-integration-common/>`_.
 

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -31,7 +31,7 @@ By default, if using a version between Airflow 2.4 or higher is used, Cosmos emi
 
 .. important::
 
-   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream DAGs depending on Airflow's data-aware scheduling will not trigger automatically. This limitation is tracked in `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
+   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream DAGs that rely on Airflow's data-aware scheduling will not trigger automatically. This behaviour is tracked in `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
 
 Cosmos calculates these URIs during the task execution, by using the library `OpenLineage Integration Common <https://pypi.org/project/openlineage-integration-common/>`_.
 

--- a/docs/configuration/scheduling.rst
+++ b/docs/configuration/scheduling.rst
@@ -31,7 +31,7 @@ By default, if using a version between Airflow 2.4 or higher is used, Cosmos emi
 
 .. important::
 
-   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream DAGs that rely on Airflow's data-aware scheduling will not trigger automatically. This behaviour is tracked in `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
+   This feature is only available for `ExecutionMode.LOCAL`, `ExecutionMode.VIRTUALENV` and `ExecutionMode.WATCHER`.
 
 Cosmos calculates these URIs during the task execution, by using the library `OpenLineage Integration Common <https://pypi.org/project/openlineage-integration-common/>`_.
 

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -307,12 +307,6 @@ This execution mode could be preferred when you've long running resources and yo
 leveraging Airflow's deferrable operators. With that, you would be able to potentially observe higher throughput of tasks
 as more dbt nodes will be run in parallel since they won't be blocking Airflow's worker slots.
 
-.. important::
-
-   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream
-   DAGs that rely on data-aware scheduling will not trigger automatically. This behaviour is tracked in
-   `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
-
 Example DAG:
 
 .. literalinclude:: ../../dev/dags/simple_dag_async.py

--- a/docs/getting_started/execution-modes.rst
+++ b/docs/getting_started/execution-modes.rst
@@ -307,6 +307,12 @@ This execution mode could be preferred when you've long running resources and yo
 leveraging Airflow's deferrable operators. With that, you would be able to potentially observe higher throughput of tasks
 as more dbt nodes will be run in parallel since they won't be blocking Airflow's worker slots.
 
+.. important::
+
+   ``ExecutionMode.AIRFLOW_ASYNC`` currently **does not emit Dataset or DatasetAlias events** after models complete. Downstream
+   DAGs that rely on data-aware scheduling will not trigger automatically. This behaviour is tracked in
+   `#2141 <https://github.com/astronomer/astronomer-cosmos/issues/2141>`_.
+
 Example DAG:
 
 .. literalinclude:: ../../dev/dags/simple_dag_async.py


### PR DESCRIPTION
Following up on PR #2143, add a note on the dataset event emission limitation for `ExecutionMode.AIRFLOW_ASYNC` in other relevant places of the documentation.

closes: #2142 
related: #2143 
related: #2141 