### PR TITLE
Remove duplicate `dbt-duckdb` dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,7 +50,6 @@ dbt-all = [
     "dbt-databricks!=1.9.0",
     "dbt-duckdb",
     "dbt-exasol",
-    "dbt-duckdb",
     "dbt-mysql",
     "dbt-oracle",
     "dbt-postgres",


### PR DESCRIPTION
The dbt-duckdb package was accidentally included twice in our dependency list. This PR cleans up the duplication.
