### PR TITLE
Unpin Airflow to satisfy GitHub Security tab requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,7 +1,7 @@
 aenum
 deprecation
 msgpack
-apache-airflow
+apache-airflow>=2.6.0
 pydantic
 pydata-sphinx-theme
 sphinx


### PR DESCRIPTION
Unpin Airflow to satisfy GitHub Security tab requirements

local working dependency
```bash
The HTML pages are in docs/_build.
[sphinx-autobuild] Serving on http://127.0.0.1:8000
[sphinx-autobuild] Waiting to detect changes...
^C%                                                                                                                                                                                                        (docsenv)  ~/Documents/astro_code/astronomer-cosmos ➜ pip list
Package                                  Version
---------------------------------------- -----------
a2wsgi                                   1.10.10
accessible-pygments                      0.0.5
aenum                                    3.1.16
aiosmtplib                               5.0.0
aiosqlite                                0.21.0
alabaster                                1.0.0
alembic                                  1.17.2
annotated-types                          0.7.0
anyio                                    4.12.0
apache-airflow                           3.1.3
apache-airflow-core                      3.1.3
apache-airflow-providers-common-compat   1.10.0
apache-airflow-providers-common-io       1.7.0
apache-airflow-providers-common-sql      1.29.0
apache-airflow-providers-smtp            2.4.0
apache-airflow-providers-standard        1.9.2
apache-airflow-task-sdk                  1.1.3
argcomplete                              3.6.3
asgiref                                  3.11.0
astroid                                  4.0.2
attrs                                    25.4.0
babel                                    2.17.0
beautifulsoup4                           4.14.3
cadwyn                                   5.4.5
certifi                                  2025.11.12
cffi                                     2.0.0
charset-normalizer                       3.4.4
click                                    8.3.1
colorama                                 0.4.6
colorlog                                 6.10.1
cron_descriptor                          2.0.6
croniter                                 6.0.0
cryptography                             46.0.3
Deprecated                               1.3.1
deprecation                              2.1.0
dill                                     0.4.0
dnspython                                2.8.0
docutils                                 0.22.3
email-validator                          2.3.0
fastapi                                  0.117.1
fastapi-cli                              0.0.16
fsspec                                   2025.10.0
googleapis-common-protos                 1.72.0
greenback                                1.2.1
greenlet                                 3.2.4
grpcio                                   1.76.0
h11                                      0.16.0
httpcore                                 1.0.9
httptools                                0.7.1
httpx                                    0.28.1
idna                                     3.11
imagesize                                1.4.1
importlib_metadata                       8.7.0
itsdangerous                             2.2.0
Jinja2                                   3.1.6
jsonschema                               4.25.1
jsonschema-specifications                2025.9.1
lazy-object-proxy                        1.12.0
libcst                                   1.8.6
linkify-it-py                            2.0.3
lockfile                                 0.12.2
Mako                                     1.3.10
markdown-it-py                           4.0.0
MarkupSafe                               3.0.3
mdurl                                    0.1.2
methodtools                              0.4.7
more-itertools                           10.8.0
msgpack                                  1.1.2
msgspec                                  0.20.0
natsort                                  8.4.0
opentelemetry-api                        1.38.0
opentelemetry-exporter-otlp              1.38.0
opentelemetry-exporter-otlp-proto-common 1.38.0
opentelemetry-exporter-otlp-proto-grpc   1.38.0
opentelemetry-exporter-otlp-proto-http   1.38.0
opentelemetry-proto                      1.38.0
opentelemetry-sdk                        1.38.0
opentelemetry-semantic-conventions       0.59b0
outcome                                  1.3.0.post0
packaging                                25.0
pathspec                                 0.12.1
pendulum                                 3.1.0
pip                                      25.1.1
pluggy                                   1.6.0
protobuf                                 6.33.1
psutil                                   7.1.3
pycparser                                2.23
pydantic                                 2.12.5
pydantic_core                            2.41.5
pydata-sphinx-theme                      0.16.1
Pygments                                 2.19.2
pygtrie                                  2.5.0
PyJWT                                    2.10.1
python-daemon                            3.1.2
python-dateutil                          2.9.0.post0
python-dotenv                            1.2.1
python-multipart                         0.0.20
python-slugify                           8.0.4
pytz                                     2025.2
PyYAML                                   6.0.3
PyYAML-ft                                8.0.0
referencing                              0.37.0
requests                                 2.32.5
rich                                     14.2.0
rich-argparse                            1.7.2
rich-toolkit                             0.17.0
roman-numerals                           3.1.0
rpds-py                                  0.30.0
setproctitle                             1.3.7
shellingham                              1.5.4
six                                      1.17.0
sniffio                                  1.3.1
snowballstemmer                          3.0.1
soupsieve                                2.8
Sphinx                                   9.0.0
sphinx-autoapi                           3.6.1
sphinx-autobuild                         2025.8.25
sphinxcontrib-applehelp                  2.0.0
sphinxcontrib-devhelp                    2.0.0
sphinxcontrib-htmlhelp                   2.1.0
sphinxcontrib-jsmath                     1.0.1
sphinxcontrib-qthelp                     2.0.0
sphinxcontrib-serializinghtml            2.0.0
SQLAlchemy                               2.0.44
SQLAlchemy-JSONField                     1.0.2
SQLAlchemy-Utils                         0.42.0
sqlparse                                 0.5.4
starlette                                0.48.0
structlog                                25.5.0
svcs                                     25.1.0
tabulate                                 0.9.0
tenacity                                 9.1.2
termcolor                                3.2.0
text-unidecode                           1.3
typer                                    0.20.0
typing_extensions                        4.15.0
typing-inspection                        0.4.2
tzdata                                   2025.2
uc-micro-py                              1.0.3
universal_pathlib                        0.2.6
urllib3                                  2.5.0
uuid6                                    2025.0.1
uvicorn                                  0.38.0
uvloop                                   0.22.1
watchfiles                               1.1.1
websockets                               15.0.1
wirerope                                 1.0.0
wrapt                                    2.0.1
zipp                                     3.23.0

```