### PR TITLE
Pin the pydantic<2.0 for Airflow 2.6

### DIFF
--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -46,7 +46,6 @@ if [ "$AIRFLOW_VERSION" = "2.6" ]  ; then
   uv pip install "apache-airflow-providers-cncf-kubernetes" "apache-airflow==$AIRFLOW_VERSION"
   uv pip install  "apache-airflow-providers-google<10.11" "apache-airflow==$AIRFLOW_VERSION"
   uv pip install "apache-airflow-providers-microsoft-azure" "apache-airflow==$AIRFLOW_VERSION"
-  # uv pip install pyopenssl --upgrade
   uv pip install "pydantic<2.0"
 elif [ "$AIRFLOW_VERSION" = "2.7" ] ; then
   uv pip install "apache-airflow-providers-amazon" --constraint /tmp/constraint.txt


### PR DESCRIPTION
I accidentally removed the pinned pydantic<2.0 in PR https://github.com/astronomer/astronomer-cosmos/pull/2161 while cleaning some redundant code, and CI also did not complain. This PR bring it back. 
This PR also remove manual installation of `pyopenssl`