### PR TITLE
Add targeted type: ignore for untyped decorators to fix mypy errors

### DIFF
--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -49,8 +49,8 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     removed_in="2.0",
     current_version=cosmos_version,
     details="Use the `cosmos.dbt.runner.parse_number_of_warnings` instead.",
-)  # type: ignore[misc]
-def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:  # type: ignore[misc]
+)  # type: ignore[untyped-decorator]
+def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     """Parses a dbt runner result and returns the number of warnings found. This only works for dbtRunnerResult
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
@@ -121,7 +121,7 @@ def extract_log_issues(log_list: List[str]) -> Tuple[List[str], List[str]]:
     removed_in="2.0",
     current_version=cosmos_version,
     details="Use the `cosmos.dbt.runner.extract_message_by_status` instead.",
-)  # type: ignore[misc]
+)  # type: ignore[untyped-decorator]
 def extract_dbt_runner_issues(
     result: dbtRunnerResult, status_levels: list[str] = ["warn"]
 ) -> Tuple[List[str], List[str]]:  # type: ignore[misc]

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -133,15 +133,15 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
         # Make sure the static folder is not overwritten, as we want to use it.
         return super().create_blueprint(appbuilder, endpoint=endpoint, static_folder=self.static_folder)  # type: ignore[no-any-return]
 
-    @expose("/dbt_docs")  # type: ignore[misc]
-    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[misc]
+    @expose("/dbt_docs")  # type: ignore[untyped-decorator]
+    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
     def dbt_docs(self) -> str:
         if dbt_docs_dir is None:
             return self.render_template("dbt_docs_not_set_up.html")  # type: ignore[no-any-return,no-untyped-call]
         return self.render_template("dbt_docs.html")  # type: ignore[no-any-return,no-untyped-call]
 
-    @expose("/dbt_docs_index.html")  # type: ignore[misc]
-    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[misc]
+    @expose("/dbt_docs_index.html")  # type: ignore[untyped-decorator]
+    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
     def dbt_docs_index(self) -> Tuple[str, int, Dict[str, Any]]:
         if dbt_docs_dir is None:
             abort(404)
@@ -153,8 +153,8 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
             html = html.replace("</head>", f"{IFRAME_SCRIPT}</head>")
             return html, 200, {"Content-Security-Policy": "frame-ancestors 'self'"}
 
-    @expose("/catalog.json")  # type: ignore[misc]
-    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[misc]
+    @expose("/catalog.json")  # type: ignore[untyped-decorator]
+    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
     def catalog(self) -> Tuple[str, int, Dict[str, Any]]:
         if dbt_docs_dir is None:
             abort(404)
@@ -165,8 +165,8 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
         else:
             return data, 200, {"Content-Type": "application/json"}
 
-    @expose("/manifest.json")  # type: ignore[misc]
-    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[misc]
+    @expose("/manifest.json")  # type: ignore[untyped-decorator]
+    @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
     def manifest(self) -> Tuple[str, int, Dict[str, Any]]:
         if dbt_docs_dir is None:
             abort(404)


### PR DESCRIPTION
This PR updates mypy type ignore comments from the generic misc error code to the more specific untyped-decorator error code for decorator-related type checking issues. This provides better clarity about what specific mypy errors are being suppressed.

- Changes type: ignore[misc] to type: ignore[untyped-decorator] for decorator annotations
- Removes redundant type: ignore[misc] from one function signature where the decorator annotation is sufficient
- Improves type checking precision by using targeted error codes instead of generic ones