### PR TITLE
Update CODEOWNERS to have active code reviewers

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astronomer/astro-cosmos-admins @astronomer/oss-integrations @jbandoro @dwreeves @corsettigyg
+* @astronomer/astro-cosmos-admins @astronomer/oss-integrations @corsettigyg


### PR DESCRIPTION
I observed that we have to manually assign reviewers on opening PRs. The current CODEOWNERS file reports an invalid syntax. I am updating the list to be for active PR reviewers. We can update the file as and when needed.