### PR TITLE
Emit asset events in async execution mode

### DIFF
--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -30,11 +30,8 @@ from cosmos.config import ProfileConfig
 from cosmos.constants import AIRFLOW_VERSION
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.exceptions import CosmosValueError
-from cosmos.log import get_logger
 from cosmos.operators.local import AbstractDbtLocalBase
 from cosmos.settings import remote_target_path, remote_target_path_conn_id
-
-logger = get_logger(__name__)
 
 DEFAULT_PRODUCER_ASYNC_TASK_ID = "dbt_setup_async"
 
@@ -253,7 +250,6 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     def _register_event(self, context: Context) -> None:
         dbt_node_config = self.async_context.get("dbt_node_config", {})
         unique_id = dbt_node_config.get("unique_id", f"unknown_model_{self.task_id}")
-
         table_name = unique_id.split(".")[-1]
 
         if AIRFLOW_VERSION.major >= 3:

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -236,7 +236,8 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         else:
             self.build_and_run_cmd(context=context, run_as_async=True, async_context=self.async_context)
         self._store_template_fields(context=context)
-        self._register_event(context)
+        if self.emit_datasets:
+            self._register_event(context)
 
     def _store_template_fields(self, context: Context) -> None:
         if not settings.enable_setup_async_task:
@@ -273,7 +274,8 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         job_id = super().execute_complete(context=context, event=event)
         self.log.info("Configuration is %s", str(self.configuration))
         self._store_template_fields(context=context)
-        self._register_event(context)
+        if self.emit_datasets:
+            self._register_event(context)
         return job_id
 
     def _get_asset_uri(self) -> str:

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -13,7 +13,6 @@ from cosmos.log import get_logger
 
 logger = get_logger(__name__)
 from airflow.models.taskinstance import TaskInstance
-from airflow.providers.common.compat.openlineage.facet import Dataset
 
 from cosmos.operators.base import _sanitize_xcom_key
 
@@ -292,6 +291,11 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         self.register_dataset([], output, context)
 
     def get_openlineage_facets_on_complete(self, task_instance: TaskInstance) -> OperatorLineage:
+        try:
+            from openlineage.facet import Dataset
+        except ImportError:
+            from airflow.providers.common.compat.openlineage.facet import Dataset
+
         inputs: list[Dataset] = []
         outputs: list[Dataset] = []
         run_facets: dict[str, Any] = {}

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -7,10 +7,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from cosmos.log import get_logger
-
-logger = get_logger(__name__)
-
 from cosmos.operators.base import _sanitize_xcom_key
 
 try:

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -283,10 +283,6 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         return asset_uri
 
     def _register_event(self, context: Context) -> None:
-        """
-        Register a BigQuery-style dummy asset event in Airflow 3.x,
-        ensuring outlets exists.
-        """
         dataset_alias_name = get_dataset_alias_name(self.dag, self.task_group, self.task_id)
 
         output = [Asset(name=dataset_alias_name, uri=self._get_asset_uri())]

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -7,12 +7,9 @@ from collections.abc import Sequence
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from attrs import define
-
 from cosmos.log import get_logger
 
 logger = get_logger(__name__)
-from airflow.models.taskinstance import TaskInstance
 
 from cosmos.operators.base import _sanitize_xcom_key
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -309,8 +309,6 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             )
         )
 
-        self.log.info("Set OpenLineage output: %s", asset_uri)
-
         return OperatorLineage(
             inputs=inputs,
             outputs=outputs,

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -30,9 +30,9 @@ from cosmos.config import ProfileConfig
 from cosmos.constants import AIRFLOW_VERSION
 from cosmos.dataset import get_dataset_alias_name
 from cosmos.exceptions import CosmosValueError
+from cosmos.log import get_logger
 from cosmos.operators.local import AbstractDbtLocalBase
 from cosmos.settings import remote_target_path, remote_target_path_conn_id
-from cosmos.log import get_logger
 
 logger = get_logger(__name__)
 
@@ -257,7 +257,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             unique_id = f"unknown_model_{self.task_id}"
             logger.warning(f"dbt_node_config or unique_id not found in async_context, using fallback {unique_id}")
         else:
-            unique_id = unique_id.split('.')[-1]
+            unique_id = unique_id.split(".")[-1]
 
         if AIRFLOW_VERSION.major >= 3:
             asset_uri = f"bigquery://{self.gcp_project}/{self.dataset}/{unique_id}"

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -254,7 +254,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         dbt_node_config = self.async_context.get("dbt_node_config", {})
         unique_id = dbt_node_config.get("unique_id", f"unknown_model_{self.task_id}")
 
-        table_name = unique_id.split('.')[-1]
+        table_name = unique_id.split(".")[-1]
 
         if AIRFLOW_VERSION.major >= 3:
             asset_uri = f"bigquery://{self.gcp_project}/{self.dataset}/{table_name}"

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -252,17 +252,14 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
 
     def _register_event(self, context: Context) -> None:
         dbt_node_config = self.async_context.get("dbt_node_config", {})
-        unique_id = dbt_node_config.get("unique_id")
-        if unique_id is None:
-            unique_id = f"unknown_model_{self.task_id}"
-            logger.warning(f"dbt_node_config or unique_id not found in async_context, using fallback {unique_id}")
-        else:
-            unique_id = unique_id.split(".")[-1]
+        unique_id = dbt_node_config.get("unique_id", f"unknown_model_{self.task_id}")
+
+        table_name = unique_id.split('.')[-1]
 
         if AIRFLOW_VERSION.major >= 3:
-            asset_uri = f"bigquery://{self.gcp_project}/{self.dataset}/{unique_id}"
+            asset_uri = f"bigquery://{self.gcp_project}/{self.dataset}/{table_name}"
         else:
-            asset_uri = f"bigquery://{self.gcp_project}.{self.dataset}.{unique_id}"
+            asset_uri = f"bigquery://{self.gcp_project}.{self.dataset}.{table_name}"
 
         output = [Asset(uri=asset_uri)]
         self.register_dataset([], output, context)

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -5,15 +5,15 @@ import zlib
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
-from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
-from packaging import version
+
 import pytest
 from airflow import DAG
-from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
-from tests.utils import test_dag as run_test_dag
 from airflow import __version__ as airflow_version
+from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from packaging import version
 
 from cosmos.config import ProfileConfig
+from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators._asynchronous.bigquery import (
     DbtRunAirflowAsyncBigqueryOperator,
@@ -21,6 +21,7 @@ from cosmos.operators._asynchronous.bigquery import (
     _mock_bigquery_adapter,
 )
 from cosmos.profiles import PostgresUserPasswordProfileMapping
+from tests.utils import test_dag as run_test_dag
 
 real_profile_config = ProfileConfig(
     profile_name="default",
@@ -232,7 +233,6 @@ def test_dbt_run_airflow_async_bigquery_operator_with_full_refresh(profile_confi
     )
 
     assert operator.full_refresh is True
-
 
 
 @pytest.mark.skipif(

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -99,6 +99,8 @@ def test_dbt_run_airflow_async_bigquery_operator_execute(mock_build_and_run_cmd,
         dbt_kwargs={"task_id": "test_task"},
     )
 
+    operator.emit_datasets = False
+
     # Mock context with run_id
     mock_context = MagicMock()
     mock_context.__getitem__.return_value = "test_run_id"  # For context["run_id"]

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -6,6 +6,7 @@ from unittest.mock import MagicMock, Mock, patch
 
 import pytest
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
+from packaging.version import Version
 
 from cosmos.config import ProfileConfig
 from cosmos.constants import AIRFLOW_VERSION
@@ -271,6 +272,7 @@ def test_execute_does_not_call_register_event_when_emit_datasets_false(
     mock_register_event.assert_not_called()
 
 
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), "Require Airflow >= 2.10")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
 def test_execute_complete_calls_register_event_when_emit_datasets_true(
@@ -298,6 +300,7 @@ def test_execute_complete_calls_register_event_when_emit_datasets_true(
     mock_register_event.assert_called_once_with(mock_context)
 
 
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), "Require Airflow >= 2.10")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "register_dataset")
 def test_register_event_with_uri(mock_register_dataset, profile_config_mock):
     """Test that _register_event correctly extracts table name from complex unique_id."""
@@ -321,7 +324,7 @@ def test_register_event_with_uri(mock_register_dataset, profile_config_mock):
     args, kwargs = mock_register_dataset.call_args
     assert args[0] == []  # inlets
     assert len(args[1]) == 1  # outlets
-    if AIRFLOW_VERSION.major >= 3:
+    if AIRFLOW_VERSION >= Version("3.0.0"):
         assert args[1][0].uri == "bigquery://my_project/my_dataset/my_complex_table_name"
     else:
         assert args[1][0].uri == "bigquery://my_project.my_dataset.my_complex_table_name/"

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -298,33 +298,8 @@ def test_execute_complete_calls_register_event_when_emit_datasets_true(
     mock_register_event.assert_called_once_with(mock_context)
 
 
-@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
-@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
-def test_execute_complete_does_not_call_register_event_when_emit_datasets_false(
-    mock_register_event, mock_store_template_fields, profile_config_mock
-):
-    """Test that _register_event is NOT called when emit_datasets=False in execute_complete method."""
-    operator = DbtRunAirflowAsyncBigqueryOperator(
-        task_id="test_task",
-        project_dir="/path/to/project",
-        profile_config=profile_config_mock,
-        dbt_kwargs={"task_id": "test_task"},
-    )
-
-    operator.emit_datasets = False
-
-    mock_context = MagicMock()
-    mock_context.__getitem__.return_value = "test_run_id"
-    mock_event = {"job_id": "test_job"}
-
-    with patch.object(BigQueryInsertJobOperator, "execute_complete", return_value="test_job"):
-        operator.execute_complete(mock_context, mock_event)
-
-    mock_register_event.assert_not_called()
-
-
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "register_dataset")
-def test_register_event_handles_complex_unique_id(mock_register_dataset, profile_config_mock):
+def test_register_event_with_uri(mock_register_dataset, profile_config_mock):
     """Test that _register_event correctly extracts table name from complex unique_id."""
     operator = DbtRunAirflowAsyncBigqueryOperator(
         task_id="test_task",
@@ -349,4 +324,4 @@ def test_register_event_handles_complex_unique_id(mock_register_dataset, profile
     if AIRFLOW_VERSION.major >= 3:
         assert args[1][0].uri == "bigquery://my_project/my_dataset/my_complex_table_name"
     else:
-        assert args[1][0].uri == "bigquery://my_project.my_dataset.my_complex_table_name"
+        assert args[1][0].uri == "bigquery://my_project.my_dataset.my_complex_table_name/"

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -272,7 +272,7 @@ def test_execute_does_not_call_register_event_when_emit_datasets_false(
     mock_register_event.assert_not_called()
 
 
-@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), "Require Airflow >= 2.10")
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), reason="Require Airflow >= 2.10")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
 def test_execute_complete_calls_register_event_when_emit_datasets_true(
@@ -300,7 +300,7 @@ def test_execute_complete_calls_register_event_when_emit_datasets_true(
     mock_register_event.assert_called_once_with(mock_context)
 
 
-@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), "Require Airflow >= 2.10")
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), reason="Require Airflow >= 2.10")
 @patch.object(DbtRunAirflowAsyncBigqueryOperator, "register_dataset")
 def test_register_event_with_uri(mock_register_dataset, profile_config_mock):
     """Test that _register_event correctly extracts table name from complex unique_id."""

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -2,34 +2,17 @@ from __future__ import annotations
 
 import base64
 import zlib
-from datetime import datetime
-from pathlib import Path
 from unittest.mock import MagicMock, Mock, patch
 
 import pytest
-from airflow import DAG
-from airflow import __version__ as airflow_version
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
-from packaging import version
 
 from cosmos.config import ProfileConfig
-from cosmos.constants import PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators._asynchronous.bigquery import (
     DbtRunAirflowAsyncBigqueryOperator,
     _configure_bigquery_async_op_args,
     _mock_bigquery_adapter,
-)
-from cosmos.profiles import PostgresUserPasswordProfileMapping
-from tests.utils import test_dag as run_test_dag
-
-real_profile_config = ProfileConfig(
-    profile_name="default",
-    target_name="dev",
-    profile_mapping=PostgresUserPasswordProfileMapping(
-        conn_id="example_conn",
-        profile_args={"schema": "public"},
-    ),
 )
 
 
@@ -233,40 +216,3 @@ def test_dbt_run_airflow_async_bigquery_operator_with_full_refresh(profile_confi
     )
 
     assert operator.full_refresh is True
-
-
-@pytest.mark.skipif(
-    version.parse(airflow_version) in PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS,
-    reason="Airflow inlets and outlets do not work by default in Airflow 2.9.0 and 2.9.1",
-)
-@pytest.mark.skipif(
-    version.parse(airflow_version) >= version.parse("3"),
-    reason="We do not support emitting assets with Airflow 3.0 without dataset alias.",
-)
-@pytest.mark.integration
-@patch("cosmos.settings.enable_dataset_alias", 0)
-def test_run_operator_dataset_url_encoded_names_in_airflow2(caplog):
-    try:
-        from airflow.sdk.definitions.asset import Dataset
-    except ImportError:
-        from airflow.datasets import Dataset
-
-    with DAG("test-id-1", start_date=datetime(2022, 1, 1)) as dag:
-        run_operator = DbtRunAirflowAsyncBigqueryOperator(
-            profile_config=real_profile_config,
-            project_dir=Path(__file__).parent.parent.parent / "dev/dags/dbt/altered_jaffle_shop",
-            task_id="run",
-            dbt_cmd_flags=["--models", "ｍｕｌｔｉｂｙｔｅ"],
-            install_deps=True,
-            append_env=True,
-        )
-        run_operator
-
-    run_test_dag(dag)
-
-    assert run_operator.outlets == [
-        Dataset(
-            uri="postgres://0.0.0.0:5432/postgres.public.%EF%BD%8D%EF%BD%95%EF%BD%8C%EF%BD%94%EF%BD%89%EF%BD%82%EF%BD%99%EF%BD%94%EF%BD%85",
-            extra=None,
-        )
-    ]

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -196,6 +196,8 @@ def test_execute_complete(mock_store_sql, profile_config_mock):
         dbt_kwargs={"task_id": "test_task"},
     )
 
+    operator.emit_datasets = False
+
     with patch.object(BigQueryInsertJobOperator, "execute_complete", return_value="test_job") as mock_super_execute:
         result = operator.execute_complete(mock_context, mock_event)
 

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -8,6 +8,7 @@ import pytest
 from airflow.providers.google.cloud.operators.bigquery import BigQueryInsertJobOperator
 
 from cosmos.config import ProfileConfig
+from cosmos.constants import AIRFLOW_VERSION
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators._asynchronous.bigquery import (
     DbtRunAirflowAsyncBigqueryOperator,
@@ -216,3 +217,136 @@ def test_dbt_run_airflow_async_bigquery_operator_with_full_refresh(profile_confi
     )
 
     assert operator.full_refresh is True
+
+
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "build_and_run_cmd")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
+@patch("cosmos.operators._asynchronous.bigquery.settings.enable_setup_async_task", False)
+def test_execute_calls_register_event_when_emit_datasets_true(
+    mock_register_event, mock_store_template_fields, mock_build_and_run_cmd, profile_config_mock
+):
+    """Test that _register_event is called when emit_datasets=True in execute method."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+
+    operator.emit_datasets = True
+    operator.gcp_project = "test_project"
+    operator.dataset = "test_dataset"
+
+    mock_context = MagicMock()
+    mock_context.__getitem__.return_value = "test_run_id"
+
+    operator.execute(mock_context)
+
+    mock_register_event.assert_called_once_with(mock_context)
+
+
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "build_and_run_cmd")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
+@patch("cosmos.operators._asynchronous.bigquery.settings.enable_setup_async_task", False)
+def test_execute_does_not_call_register_event_when_emit_datasets_false(
+    mock_register_event, mock_store_template_fields, mock_build_and_run_cmd, profile_config_mock
+):
+    """Test that _register_event is NOT called when emit_datasets=False in execute method."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+
+    operator.emit_datasets = False
+
+    mock_context = MagicMock()
+    mock_context.__getitem__.return_value = "test_run_id"
+
+    operator.execute(mock_context)
+
+    mock_register_event.assert_not_called()
+
+
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
+def test_execute_complete_calls_register_event_when_emit_datasets_true(
+    mock_register_event, mock_store_template_fields, profile_config_mock
+):
+    """Test that _register_event is called when emit_datasets=True in execute_complete method."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+
+    operator.emit_datasets = True
+    operator.gcp_project = "test_project"
+    operator.dataset = "test_dataset"
+
+    mock_context = MagicMock()
+    mock_context.__getitem__.return_value = "test_run_id"
+    mock_event = {"job_id": "test_job"}
+
+    with patch.object(BigQueryInsertJobOperator, "execute_complete", return_value="test_job"):
+        operator.execute_complete(mock_context, mock_event)
+
+    mock_register_event.assert_called_once_with(mock_context)
+
+
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_store_template_fields")
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "_register_event")
+def test_execute_complete_does_not_call_register_event_when_emit_datasets_false(
+    mock_register_event, mock_store_template_fields, profile_config_mock
+):
+    """Test that _register_event is NOT called when emit_datasets=False in execute_complete method."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+
+    operator.emit_datasets = False
+
+    mock_context = MagicMock()
+    mock_context.__getitem__.return_value = "test_run_id"
+    mock_event = {"job_id": "test_job"}
+
+    with patch.object(BigQueryInsertJobOperator, "execute_complete", return_value="test_job"):
+        operator.execute_complete(mock_context, mock_event)
+
+    mock_register_event.assert_not_called()
+
+
+@patch.object(DbtRunAirflowAsyncBigqueryOperator, "register_dataset")
+def test_register_event_handles_complex_unique_id(mock_register_dataset, profile_config_mock):
+    """Test that _register_event correctly extracts table name from complex unique_id."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+
+    operator.gcp_project = "my_project"
+    operator.dataset = "my_dataset"
+    operator.async_context = {"dbt_node_config": {"unique_id": "model.my_project.my_schema.my_complex_table_name"}}
+
+    mock_context = MagicMock()
+
+    operator._register_event(mock_context)
+
+    # Verify register_dataset was called with correct table name (last part of unique_id)
+    mock_register_dataset.assert_called_once()
+    args, kwargs = mock_register_dataset.call_args
+    assert args[0] == []  # inlets
+    assert len(args[1]) == 1  # outlets
+    if AIRFLOW_VERSION.major >= 3:
+        assert args[1][0].uri == "bigquery://my_project/my_dataset/my_complex_table_name"
+    else:
+        assert args[1][0].uri == "bigquery://my_project.my_dataset.my_complex_table_name"


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/2141

This PR implements asset event emission for BigQuery async execution mode, addressing issue #2141. The changes enable Airflow to track dataset lineage when using async operators by registering output datasets after task execution.

**Key changes:**
- Added asset/dataset event registration in `execute()` and `execute_complete()` methods
- Implemented helper methods  `_register_event()` to generate BigQuery asset URIs and register them

<img width="1716" height="855" alt="Screenshot 2025-12-09 at 2 00 59 PM" src="https://github.com/user-attachments/assets/c3c646bb-c31c-4809-a67b-b56cd47cca3e" />

