### PR TITLE
Update pre-commit default language version

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.10
+  python: python3
 
 repos:
   - repo: local


### PR DESCRIPTION
I'm using Python 3.11 virtual environment  and getting below error
```
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
An unexpected error has occurred: CalledProcessError: command: ('/Users/pankaj/Documents/astro_code/astronomer-cosmos/devenv/bin/python3.11', '-mvirtualenv', '/Users/pankaj/.cache/pre-commit/repou5hulpgs/py_env-python3.10', '-p', 'python3.10')
return code: 1
stdout:
    RuntimeError: failed to find interpreter for Builtin discover of python_spec='python3.10'
stderr: (none)
Check the log at /Users/pankaj/.cache/pre-commit/pre-commit.log
```

Changed default_language_version.python from python3.10 to python3 to allow pre-commit to use any available Python 3 interpreter