### PR TITLE
Register the listener in Airflow 3 plugin impl

### DIFF
--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -17,8 +17,9 @@ from airflow.sdk import ObjectStoragePath
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from packaging.version import Version
-from cosmos.listeners import dag_run_listener
+
 from cosmos.constants import AIRFLOW_OBJECT_STORAGE_PATH_URL_SCHEMES
+from cosmos.listeners import dag_run_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 
 # Airflow version gating: External views feature for the plugins used here (CosmosAF3Plugin) exist only in >= 3.1

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -17,7 +17,7 @@ from airflow.sdk import ObjectStoragePath
 from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from packaging.version import Version
-
+from cosmos.listeners import dag_run_listener
 from cosmos.constants import AIRFLOW_OBJECT_STORAGE_PATH_URL_SCHEMES
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 
@@ -262,6 +262,8 @@ class CosmosAF3Plugin(AirflowPlugin):
 
     # Register external views for navigation
     external_views: list[dict[str, Any]] = []
+
+    listeners = [dag_run_listener]
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -4,6 +4,8 @@ from airflow import __version__ as airflow_version
 from packaging import version
 
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
+from cosmos.plugin.airflow3 import CosmosAF3Plugin
+from cosmos.listeners import dag_run_listener
 
 # The Cosmos AF3 plugin is only loaded if the Airflow version is greater than 3.0.
 if version.parse(airflow_version).major < _AIRFLOW3_MAJOR_VERSION:
@@ -409,3 +411,14 @@ def test_dbt_docs_projects_malformed_json_raises(caplog):
         with pytest.raises(json.JSONDecodeError):
             af3._load_projects_from_conf()
         assert "Invalid JSON in [cosmos] dbt_docs_projects:" in caplog.text
+
+
+def test_plugin_registers_listeners():
+    """Ensure CosmosAF3Plugin registers the listeners."""
+    plugin = CosmosAF3Plugin()
+
+    assert hasattr(plugin, "listeners"), "Plugin must define a `listeners` attribute"
+
+    assert dag_run_listener in plugin.listeners, (
+        "CosmosAF3Plugin.listeners must include airflow3_listeners module"
+    )

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -413,6 +413,7 @@ def test_dbt_docs_projects_malformed_json_raises(caplog):
         assert "Invalid JSON in [cosmos] dbt_docs_projects:" in caplog.text
 
 
+@skip_pre_airflow_31
 def test_plugin_registers_listeners():
     """Ensure CosmosAF3Plugin registers the listeners."""
     plugin = CosmosAF3Plugin()

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -4,8 +4,6 @@ from airflow import __version__ as airflow_version
 from packaging import version
 
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
-from cosmos.listeners import dag_run_listener
-from cosmos.plugin.airflow3 import CosmosAF3Plugin
 
 # The Cosmos AF3 plugin is only loaded if the Airflow version is greater than 3.0.
 if version.parse(airflow_version).major < _AIRFLOW3_MAJOR_VERSION:
@@ -416,6 +414,9 @@ def test_dbt_docs_projects_malformed_json_raises(caplog):
 @skip_pre_airflow_31
 def test_plugin_registers_listeners():
     """Ensure CosmosAF3Plugin registers the listeners."""
+    from cosmos.listeners import dag_run_listener
+    from cosmos.plugin.airflow3 import CosmosAF3Plugin
+
     plugin = CosmosAF3Plugin()
 
     assert hasattr(plugin, "listeners"), "Plugin must define a `listeners` attribute"

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -419,4 +419,4 @@ def test_plugin_registers_listeners():
 
     assert hasattr(plugin, "listeners"), "Plugin must define a `listeners` attribute"
 
-    assert dag_run_listener in plugin.listeners, "CosmosAF3Plugin.listeners must include airflow3_listeners module"
+    assert dag_run_listener in plugin.listeners, "CosmosAF3Plugin.listeners must include dag_run_listener module"

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -4,8 +4,8 @@ from airflow import __version__ as airflow_version
 from packaging import version
 
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION
-from cosmos.plugin.airflow3 import CosmosAF3Plugin
 from cosmos.listeners import dag_run_listener
+from cosmos.plugin.airflow3 import CosmosAF3Plugin
 
 # The Cosmos AF3 plugin is only loaded if the Airflow version is greater than 3.0.
 if version.parse(airflow_version).major < _AIRFLOW3_MAJOR_VERSION:
@@ -419,6 +419,4 @@ def test_plugin_registers_listeners():
 
     assert hasattr(plugin, "listeners"), "Plugin must define a `listeners` attribute"
 
-    assert dag_run_listener in plugin.listeners, (
-        "CosmosAF3Plugin.listeners must include airflow3_listeners module"
-    )
+    assert dag_run_listener in plugin.listeners, "CosmosAF3Plugin.listeners must include airflow3_listeners module"


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/2182

This PR registers the `dag_run_listener` module in the Airflow 3 plugin implementation to enable DAG run event tracking and telemetry for Cosmos tasks, addressing issue #2182.

- Adds listener registration to `CosmosAF3Plugin` class
- Adds test coverage to verify listener registration
