### PR TITLE
Update telemetry to v3 format with query parameters

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -180,8 +180,13 @@ DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 
 PRODUCER_WATCHER_TASK_ID = "dbt_producer_watcher"
 
-TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}/{execution_modes}"
-TELEMETRY_VERSION = "v2"
+# Telemetry URL for v1 (for record purposes)
+# URL format: astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}
+# Telemetry URL for v2 (commented for record purposes)
+# TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}/{execution_modes}"
+# Telemetry URL for v3 - uses query params instead of path params
+TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/event-collection/{event_type}?{query_string}"
+TELEMETRY_VERSION = "v3"
 TELEMETRY_TIMEOUT = 1.0
 
 _AIRFLOW3_MAJOR_VERSION = 3

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -180,12 +180,12 @@ DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 
 PRODUCER_WATCHER_TASK_ID = "dbt_producer_watcher"
 
-# Telemetry URL for v1 (for record purposes)
+# Telemetry URL for v1 (for record purposes) — shipped with Cosmos 1.8.0 through 1.10.x.
 # URL format: astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}
-# Telemetry URL for v2 (commented for record purposes)
+# Telemetry URL for v2 (commented for record purposes) — Cosmos 1.11.0 added execution mode tracking via the extra path segment.
 # TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{cosmos_version}/{airflow_version}/{python_version}/{platform_system}/{platform_machine}/{event_type}/{status}/{dag_hash}/{task_count}/{cosmos_task_count}/{execution_modes}"
-# Telemetry URL for v3 - uses query params instead of path params
-TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/event-collection/{event_type}?{query_string}"
+# Telemetry URL for v3 - uses query params instead of path params and is the format from Cosmos 1.12.0 onward.
+TELEMETRY_URL = "https://astronomer.gateway.scarf.sh/astronomer-cosmos/{telemetry_version}/{event_type}?{query_string}"
 TELEMETRY_VERSION = "v3"
 TELEMETRY_TIMEOUT = 1.0
 

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -47,7 +47,7 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
     telemetry_url = constants.TELEMETRY_URL.format(
         telemetry_version=constants.TELEMETRY_VERSION, event_type=event_type, query_string=query_string
     )
-    logger.debug("Telemetry is enabled. Emitting the following usage metrics to %s: %s", telemetry_url, metrics)
+    logger.debug("Telemetry is enabled. Emitting the following usage metrics for event type %s to %s: %s", event_type, telemetry_url, metrics)
     try:
         response = httpx.get(telemetry_url, timeout=constants.TELEMETRY_TIMEOUT, follow_redirects=True)
     except httpx.HTTPError as e:

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -42,9 +42,10 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
 
     The metrics must contain the necessary fields to build the TELEMETRY_URL.
     """
+    event_type = metrics.pop("event_type")
     query_string = urlencode(metrics)
     telemetry_url = constants.TELEMETRY_URL.format(
-        **metrics, telemetry_version=constants.TELEMETRY_VERSION, query_string=query_string
+        telemetry_version=constants.TELEMETRY_VERSION, event_type=event_type, query_string=query_string
     )
     logger.debug("Telemetry is enabled. Emitting the following usage metrics to %s: %s", telemetry_url, metrics)
     try:
@@ -76,7 +77,6 @@ def emit_usage_metrics_if_enabled(event_type: str, additional_metrics: dict[str,
     if should_emit():
         metrics = collect_standard_usage_metrics()
         metrics["event_type"] = event_type
-        metrics["variables"].update(additional_metrics)  # type: ignore[attr-defined]
         metrics.update(additional_metrics)
         is_success = emit_usage_metrics(metrics)
         return is_success

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -42,8 +42,9 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
 
     The metrics must contain the necessary fields to build the TELEMETRY_URL.
     """
-    event_type = metrics.pop("event_type")
-    query_string = urlencode(metrics)
+    event_type = metrics.get("event_type")
+    metrics_for_query = {k: v for k, v in metrics.items() if k != "event_type"}
+    query_string = urlencode(metrics_for_query)
     telemetry_url = constants.TELEMETRY_URL.format(
         telemetry_version=constants.TELEMETRY_VERSION, event_type=event_type, query_string=query_string
     )

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -47,7 +47,12 @@ def emit_usage_metrics(metrics: dict[str, object]) -> bool:
     telemetry_url = constants.TELEMETRY_URL.format(
         telemetry_version=constants.TELEMETRY_VERSION, event_type=event_type, query_string=query_string
     )
-    logger.debug("Telemetry is enabled. Emitting the following usage metrics for event type %s to %s: %s", event_type, telemetry_url, metrics)
+    logger.debug(
+        "Telemetry is enabled. Emitting the following usage metrics for event type %s to %s: %s",
+        event_type,
+        telemetry_url,
+        metrics,
+    )
     try:
         response = httpx.get(telemetry_url, timeout=constants.TELEMETRY_TIMEOUT, follow_redirects=True)
     except httpx.HTTPError as e:

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -62,12 +62,12 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
         timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local. Status code: 404. Message: Non existent URL"""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. Status code: 404. Message: Non existent URL"""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 
@@ -89,12 +89,12 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
         timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v2/1.8.0a4/2.10.1/3.11/darwin/amd64/dag_run/success/d151d1fa2f03270ea116cc7494f2c591/3/3/local. An HTTPX connection error occurred: Something is not right."""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. An HTTPX connection error occurred: Something is not right."""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 
@@ -142,5 +142,5 @@ def test_emit_usage_metrics_if_enabled_succeeds(
         "k1": "v1",
         "k2": "v2",
         "event_type": "any",
-        "variables": {"k2": "v2"},
+        "variables": {},
     }

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -119,7 +119,7 @@ def test_emit_usage_metrics_succeeds(caplog):
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     assert is_success
     assert caplog.text.startswith("DEBUG")
-    assert "Telemetry is enabled. Emitting the following usage metrics to" in caplog.text
+    assert "Telemetry is enabled. Emitting the following usage metrics for event type" in caplog.text
 
 
 @patch("cosmos.telemetry.should_emit", return_value=False)

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -62,12 +62,12 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
         timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. Status code: 404. Message: Non existent URL"""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. Status code: 404. Message: Non existent URL"""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 
@@ -89,12 +89,12 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
     }
     is_success = telemetry.emit_usage_metrics(sample_metrics)
     mock_httpx_get.assert_called_once_with(
-        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
+        f"""https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local""",
         timeout=1.0,
         follow_redirects=True,
     )
     assert not is_success
-    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/event-collection/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. An HTTPX connection error occurred: Something is not right."""
+    log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. An HTTPX connection error occurred: Something is not right."""
     assert caplog.text.startswith("WARNING")
     assert log_msg in caplog.text
 


### PR DESCRIPTION
- Migrate from v2 path-based URL to v3 query parameter format
- Change endpoint to event-collection/{event_type} with query params
- Add comments documenting v1 and v2 URL formats for record purposes
- Update tests to match the new v3 URL format

closes: https://github.com/astronomer/oss-integrations-private/issues/277