### PR TITLE
Add telemetry task listener metrics for Cosmos operators

### DIFF
--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -151,7 +151,7 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
 
 @hookimpl
 def on_task_instance_success(
-    previous_state: Any, task_instance: TaskInstance, session: "Session"
+    previous_state: Any, task_instance: TaskInstance, session: Session
 ) -> None:  # type: ignore[override]
     if not _is_cosmos_task(task_instance):
         return
@@ -163,7 +163,7 @@ def on_task_instance_success(
 
 @hookimpl
 def on_task_instance_failed(
-    previous_state: Any, task_instance: TaskInstance, session: "Session"
+    previous_state: Any, task_instance: TaskInstance, session: Session
 ) -> None:  # type: ignore[override]
     if not _is_cosmos_task(task_instance):
         return

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -1,11 +1,12 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.listeners import hookimpl
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
+    from sqlalchemy.orm import Session
 
 from cosmos import telemetry
 from cosmos.constants import InvocationMode
@@ -149,7 +150,9 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
 
 
 @hookimpl
-def on_task_instance_success(previous_state, task_instance, session):  # type: ignore[override]
+def on_task_instance_success(
+    previous_state: Any, task_instance: TaskInstance, session: "Session"
+) -> None:  # type: ignore[override]
     if not _is_cosmos_task(task_instance):
         return
 
@@ -159,7 +162,9 @@ def on_task_instance_success(previous_state, task_instance, session):  # type: i
 
 
 @hookimpl
-def on_task_instance_failed(previous_state, task_instance, session):  # type: ignore[override]
+def on_task_instance_failed(
+    previous_state: Any, task_instance: TaskInstance, session: "Session"
+) -> None:  # type: ignore[override]
     if not _is_cosmos_task(task_instance):
         return
 

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -9,8 +9,8 @@ if TYPE_CHECKING:
 
 from cosmos import telemetry
 from cosmos.constants import InvocationMode
-from cosmos.operators.base import AbstractDbtBase
 from cosmos.log import get_logger
+from cosmos.operators.base import AbstractDbtBase
 
 logger = get_logger(__name__)
 

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -159,7 +159,7 @@ def on_task_instance_success(previous_state, task_instance, session):  # type: i
 
 
 @hookimpl
-def on_task_instance_failed(previous_state, task_instance, error, session):  # type: ignore[override]
+def on_task_instance_failed(previous_state, task_instance, session):  # type: ignore[override]
     if not _is_cosmos_task(task_instance):
         return
 

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -119,8 +119,6 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
         "is_cosmos_operator_subclass": _is_cosmos_subclass(task_instance),
         "invocation_mode": _invocation_mode(task_instance),
         "execution_mode": _execution_mode_from_task(task_instance),
-        "queue": task_instance.queue,
-        "priority_weight": task_instance.priority_weight,
         "map_index": task_instance.map_index,
     }
 
@@ -137,9 +135,6 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
     dag_run = getattr(task_instance, "dag_run", None)
     if dag_run is not None:
         metrics["dag_run_id"] = dag_run.run_id
-        dag_hash = getattr(dag_run, "dag_hash", None)
-        if dag_hash is not None:
-            metrics["dag_hash"] = dag_hash
 
     duration = getattr(task_instance, "duration", None)
     if duration is not None:
@@ -149,7 +144,7 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
 
 
 @hookimpl
-def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, **kwargs: Any) -> None:  # type: ignore[override]
+def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
     """Handle task instance success for both Airflow 2 (with session) and Airflow 3 (without session)."""
     if not _is_cosmos_task(task_instance):
         return
@@ -160,7 +155,7 @@ def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, *
 
 
 @hookimpl
-def on_task_instance_failed(previous_state: Any, task_instance: TaskInstance, **kwargs: Any) -> None:  # type: ignore[override]
+def on_task_instance_failed(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
     """Handle task instance failure for both Airflow 2 (with session) and Airflow 3 (with error and without session)."""
     if not _is_cosmos_task(task_instance):
         return

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -6,10 +6,9 @@ from airflow.listeners import hookimpl
 
 if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
-    from sqlalchemy.orm import Session
 
 from cosmos import telemetry
-from cosmos.constants import InvocationMode
+from cosmos.constants import InvocationMode, _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 from cosmos.log import get_logger
 from cosmos.operators.base import AbstractDbtBase
 
@@ -150,9 +149,8 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
 
 
 @hookimpl
-def on_task_instance_success(
-    previous_state: Any, task_instance: TaskInstance, session: Session
-) -> None:  # type: ignore[override]
+def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, **kwargs: Any) -> None:  # type: ignore[override]
+    """Handle task instance success for both Airflow 2 (with session) and Airflow 3 (without session)."""
     if not _is_cosmos_task(task_instance):
         return
 
@@ -162,9 +160,8 @@ def on_task_instance_success(
 
 
 @hookimpl
-def on_task_instance_failed(
-    previous_state: Any, task_instance: TaskInstance, session: Session
-) -> None:  # type: ignore[override]
+def on_task_instance_failed(previous_state: Any, task_instance: TaskInstance, **kwargs: Any) -> None:  # type: ignore[override]
+    """Handle task instance failure for both Airflow 2 (with session) and Airflow 3 (with error and without session)."""
     if not _is_cosmos_task(task_instance):
         return
 

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
     from airflow.models.taskinstance import TaskInstance
 
 from cosmos import telemetry
-from cosmos.constants import InvocationMode, _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
+from cosmos.constants import InvocationMode
 from cosmos.log import get_logger
 from cosmos.operators.base import AbstractDbtBase
 

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -77,6 +77,20 @@ def _dbt_command(task_instance: TaskInstance) -> str | None:
     return str(command)
 
 
+def _install_deps(task_instance: TaskInstance) -> bool | None:
+    """Return the effective install_deps flag when available."""
+
+    task = task_instance.task
+    if not isinstance(task, AbstractDbtBase):
+        return None
+
+    install_deps = getattr(task, "install_deps", None)
+    if install_deps is None:
+        return None
+
+    return bool(install_deps)
+
+
 def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, object]:
     """Build telemetry payload for task completion events."""
 
@@ -96,6 +110,10 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
     dbt_command = _dbt_command(task_instance)
     if dbt_command:
         metrics["dbt_command"] = dbt_command
+
+    install_deps = _install_deps(task_instance)
+    if install_deps is not None:
+        metrics["install_deps"] = install_deps
 
     dag_run = getattr(task_instance, "dag_run", None)
     if dag_run is not None:

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from airflow.listeners import hookimpl
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
+
+from cosmos import telemetry
+from cosmos.constants import InvocationMode
+from cosmos.operators.base import AbstractDbtBase
+from cosmos.log import get_logger
+
+logger = get_logger(__name__)
+
+TASK_INSTANCE_EVENT = "task_instance"
+
+
+def _is_cosmos_task(task_instance: TaskInstance) -> bool:
+    """Return True if the task instance is powered by Cosmos operators."""
+
+    task = task_instance.task
+    module = getattr(task, "_task_module", None) or task.__class__.__module__
+    return module.startswith("cosmos.") or isinstance(task, AbstractDbtBase)
+
+
+def _execution_mode_from_task(task_instance: TaskInstance) -> str | None:
+    """Extract Cosmos execution mode from the task's module path."""
+
+    module = getattr(task_instance.task, "_task_module", None) or task_instance.task.__class__.__module__
+    parts = module.split(".")
+    if len(parts) >= 3 and parts[0] == "cosmos" and parts[1] == "operators":
+        return parts[2]
+    # TODO: When users subclass Cosmos operators in external modules, encode execution mode directly on the task
+    # so telemetry does not rely on module inspection.
+    return None
+
+
+def _invocation_mode(task_instance: TaskInstance) -> str | None:
+    """Return the invocation mode recorded in Cosmos operators."""
+
+    mode = getattr(task_instance.task, "invocation_mode", None)
+    if mode is None:
+        return None
+    if isinstance(mode, InvocationMode):
+        return mode.value
+    return str(mode)
+
+
+def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, object]:
+    """Build telemetry payload for task completion events."""
+
+    metrics: dict[str, object] = {
+        "dag_id": task_instance.dag_id,
+        "task_id": task_instance.task_id,
+        "status": status,
+        "operator_name": task_instance.task.__class__.__name__,
+        "is_cosmos_operator_subclass": isinstance(task_instance.task, AbstractDbtBase),
+        "invocation_mode": _invocation_mode(task_instance),
+        "execution_mode": _execution_mode_from_task(task_instance),
+        "queue": task_instance.queue,
+        "priority_weight": task_instance.priority_weight,
+        "map_index": task_instance.map_index,
+    }
+
+    dag_run = getattr(task_instance, "dag_run", None)
+    if dag_run is not None:
+        metrics["dag_run_id"] = dag_run.run_id
+        dag_hash = getattr(dag_run, "dag_hash", None)
+        if dag_hash is not None:
+            metrics["dag_hash"] = dag_hash
+
+    duration = getattr(task_instance, "duration", None)
+    if duration is not None:
+        metrics["duration"] = duration
+
+    return metrics
+
+
+@hookimpl
+def on_task_instance_success(previous_state, task_instance, session):  # type: ignore[override]
+    if not _is_cosmos_task(task_instance):
+        return
+
+    logger.debug("Telemetry task listener success for %s.%s", task_instance.dag_id, task_instance.task_id)
+    metrics = _build_task_metrics(task_instance, "success")
+    telemetry.emit_usage_metrics_if_enabled(TASK_INSTANCE_EVENT, metrics)
+
+
+@hookimpl
+def on_task_instance_failed(previous_state, task_instance, error, session):  # type: ignore[override]
+    if not _is_cosmos_task(task_instance):
+        return
+
+    logger.debug("Telemetry task listener failure for %s.%s", task_instance.dag_id, task_instance.task_id)
+    metrics = _build_task_metrics(task_instance, "failed")
+    telemetry.emit_usage_metrics_if_enabled(TASK_INSTANCE_EVENT, metrics)

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -10,7 +10,7 @@ from airflow.www.views import AirflowBaseView
 from flask import abort
 from flask_appbuilder import AppBuilder, expose
 
-from cosmos.listeners import dag_run_listener
+from cosmos.listeners import dag_run_listener, task_instance_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 from cosmos.settings import dbt_docs_conn_id, dbt_docs_dir, dbt_docs_index_file_name, in_astro_cloud
 
@@ -190,4 +190,4 @@ class CosmosPlugin(AirflowPlugin):
         "href": conf.get("webserver", "base_url") + "/cosmos/dbt_docs",
     }
     appbuilder_views = [item]
-    listeners = [dag_run_listener]
+    listeners = [dag_run_listener, task_instance_listener]

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -20,7 +20,7 @@ from fastapi.responses import HTMLResponse, JSONResponse, Response
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_OBJECT_STORAGE_PATH_URL_SCHEMES
-from cosmos.listeners import dag_run_listener
+from cosmos.listeners import dag_run_listener, task_instance_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 
 # Airflow version gating: External views feature for the plugins used here (CosmosAF3Plugin) exist only in >= 3.1
@@ -265,7 +265,7 @@ class CosmosAF3Plugin(AirflowPlugin):
     # Register external views for navigation
     external_views: list[dict[str, Any]] = []
 
-    listeners = [dag_run_listener]
+    listeners = [dag_run_listener, task_instance_listener]
 
     def __init__(self) -> None:
         super().__init__()

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -210,7 +210,7 @@ def test_on_task_instance_success_emits_for_cosmos_task(mock_emit):
     operator = DummyDbtOperator()
     ti = _make_task_instance(operator)
 
-    task_instance_listener.on_task_instance_success(None, ti, None)
+    task_instance_listener.on_task_instance_success(None, ti, session=None)
 
     mock_emit.assert_called_once()
     args, _ = mock_emit.call_args
@@ -224,7 +224,7 @@ def test_on_task_instance_failed_emits_failed_status(mock_emit):
     operator = DummyDbtOperator()
     ti = _make_task_instance(operator)
 
-    task_instance_listener.on_task_instance_failed(None, ti, None)
+    task_instance_listener.on_task_instance_failed(None, ti, error=None, session=None)
 
     mock_emit.assert_called_once()
     args, _ = mock_emit.call_args
@@ -236,7 +236,7 @@ def test_on_task_instance_failed_emits_failed_status(mock_emit):
 def test_on_task_instance_success_skips_non_cosmos_task(mock_emit):
     ti = _make_task_instance(NonCosmosOperator())
 
-    task_instance_listener.on_task_instance_success(None, ti, None)
+    task_instance_listener.on_task_instance_success(None, ti, session=None)
 
     mock_emit.assert_not_called()
 
@@ -245,6 +245,6 @@ def test_on_task_instance_success_skips_non_cosmos_task(mock_emit):
 def test_on_task_instance_failed_skips_non_cosmos_task(mock_emit):
     ti = _make_task_instance(NonCosmosOperator())
 
-    task_instance_listener.on_task_instance_failed(None, ti, None)
+    task_instance_listener.on_task_instance_failed(None, ti, error=None, session=None)
 
     mock_emit.assert_not_called()

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -138,7 +138,7 @@ def test_on_task_instance_failed_emits_failed_status(mock_emit):
     operator = DummyDbtOperator()
     ti = _make_task_instance(operator)
 
-    task_instance_listener.on_task_instance_failed(None, ti, RuntimeError("boom"), None)
+    task_instance_listener.on_task_instance_failed(None, ti, None)
 
     mock_emit.assert_called_once()
     args, _ = mock_emit.call_args

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -119,8 +119,6 @@ def test_build_task_metrics_sets_has_callback_for_callable():
     assert metrics["has_callback"] is True
 
 
-
-
 @patch("cosmos.listeners.task_instance_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_task_instance_success_emits_for_cosmos_task(mock_emit):
     operator = DummyDbtOperator()

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -18,7 +18,9 @@ class DummyDbtOperator(AbstractDbtBase):
         if install_deps is not None:
             self.install_deps = install_deps
 
-    def build_and_run_cmd(self, context, cmd_flags, run_as_async=False, async_context=None, **kwargs):  # pragma: no cover
+    def build_and_run_cmd(
+        self, context, cmd_flags, run_as_async=False, async_context=None, **kwargs
+    ):  # pragma: no cover
         return None
 
 

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -1,0 +1,132 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from cosmos.constants import InvocationMode
+from cosmos.listeners import task_instance_listener
+from cosmos.operators.base import AbstractDbtBase
+
+
+class DummyDbtOperator(AbstractDbtBase):
+    base_cmd = ["run"]
+
+    def __init__(self, *, module: str = "cosmos.operators.local.fake", install_deps: bool | None = True) -> None:
+        super().__init__(project_dir="/tmp")
+        self.invocation_mode = InvocationMode.DBT_RUNNER
+        self._task_module = module
+        if install_deps is not None:
+            self.install_deps = install_deps
+
+    def build_and_run_cmd(self, context, cmd_flags, run_as_async=False, async_context=None, **kwargs):  # pragma: no cover
+        return None
+
+
+class DummyDbtOperatorNoDeps(DummyDbtOperator):
+    base_cmd = ["seed"]
+
+    def __init__(self) -> None:
+        super().__init__(module="cosmos.operators.kubernetes.fake", install_deps=None)
+        self.invocation_mode = InvocationMode.SUBPROCESS
+        if hasattr(self, "install_deps"):
+            delattr(self, "install_deps")
+
+
+class CustomDbtSubclass(DummyDbtOperator):
+    def __init__(self) -> None:
+        super().__init__(module="custom.pipeline.dummy")
+
+
+class NonCosmosOperator:
+    __module__ = "airflow.operators.bash"
+
+    def __init__(self) -> None:
+        self._task_module = "airflow.operators.bash"
+
+
+def _make_task_instance(task, **overrides) -> SimpleNamespace:
+    defaults = dict(
+        dag_id="example_dag",
+        task_id="example_task",
+        task=task,
+        queue="default",
+        priority_weight=5,
+        map_index=-1,
+        dag_run=SimpleNamespace(run_id="run-1", dag_hash="hash-123"),
+        duration=7.0,
+    )
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_build_task_metrics_records_core_fields():
+    operator = DummyDbtOperator()
+    ti = _make_task_instance(operator)
+
+    metrics = task_instance_listener._build_task_metrics(ti, status="success")
+
+    assert metrics["operator_name"] == "DummyDbtOperator"
+    assert metrics["dbt_command"] == "run"
+    assert metrics["install_deps"] is True
+    assert metrics["invocation_mode"] == InvocationMode.DBT_RUNNER.value
+    assert metrics["execution_mode"] == "local"
+    assert metrics["is_cosmos_operator_subclass"] is False
+    assert metrics["dag_run_id"] == "run-1"
+    assert metrics["dag_hash"] == "hash-123"
+
+
+def test_build_task_metrics_ignores_missing_install_deps():
+    operator = DummyDbtOperatorNoDeps()
+    ti = _make_task_instance(operator)
+
+    metrics = task_instance_listener._build_task_metrics(ti, status="failed")
+
+    assert metrics["dbt_command"] == "seed"
+    assert "install_deps" not in metrics
+    assert metrics["execution_mode"] == "kubernetes"
+
+
+def test_build_task_metrics_marks_custom_subclasses():
+    operator = CustomDbtSubclass()
+    ti = _make_task_instance(operator)
+
+    metrics = task_instance_listener._build_task_metrics(ti, status="success")
+
+    assert metrics["is_cosmos_operator_subclass"] is True
+    assert metrics["execution_mode"] is None
+
+
+@patch("cosmos.listeners.task_instance_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_task_instance_success_emits_for_cosmos_task(mock_emit):
+    operator = DummyDbtOperator()
+    ti = _make_task_instance(operator)
+
+    task_instance_listener.on_task_instance_success(None, ti, None)
+
+    mock_emit.assert_called_once()
+    args, _ = mock_emit.call_args
+    assert args[0] == task_instance_listener.TASK_INSTANCE_EVENT
+    assert args[1]["status"] == "success"
+    assert args[1]["dbt_command"] == "run"
+
+
+@patch("cosmos.listeners.task_instance_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_task_instance_failed_emits_failed_status(mock_emit):
+    operator = DummyDbtOperator()
+    ti = _make_task_instance(operator)
+
+    task_instance_listener.on_task_instance_failed(None, ti, RuntimeError("boom"), None)
+
+    mock_emit.assert_called_once()
+    args, _ = mock_emit.call_args
+    assert args[0] == task_instance_listener.TASK_INSTANCE_EVENT
+    assert args[1]["status"] == "failed"
+
+
+@patch("cosmos.listeners.task_instance_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_task_instance_success_skips_non_cosmos_task(mock_emit):
+    ti = _make_task_instance(NonCosmosOperator())
+
+    task_instance_listener.on_task_instance_success(None, ti, None)
+
+    mock_emit.assert_not_called()

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -74,10 +74,8 @@ def _make_task_instance(task, **overrides) -> SimpleNamespace:
         dag_id="example_dag",
         task_id="example_task",
         task=task,
-        queue="default",
-        priority_weight=5,
         map_index=-1,
-        dag_run=SimpleNamespace(run_id="run-1", dag_hash="hash-123"),
+        dag_run=SimpleNamespace(run_id="run-1"),
         duration=7.0,
     )
     defaults.update(overrides)
@@ -97,7 +95,6 @@ def test_build_task_metrics_records_core_fields():
     assert metrics["execution_mode"] == "local"
     assert metrics["is_cosmos_operator_subclass"] is False
     assert metrics["dag_run_id"] == "run-1"
-    assert metrics["dag_hash"] == "hash-123"
 
 
 def test_build_task_metrics_ignores_missing_install_deps():


### PR DESCRIPTION
The PR introduces the Airflow task-instance listener and emits task-level telemetry for Cosmos operators (operator name, invocation mode, execution mode, dbt command, install_deps flag, has_callback, subclass detection)

related: https://github.com/astronomer/astronomer-cosmos/issues/2110
related: #2192 