### PR TITLE
Adjust `pre-commit` so Python 3.10 or higher can be used

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 # See https://pre-commit.com for more information
 # See https://pre-commit.com/hooks.html for more hooks
 default_language_version:
-  python: python3.10
+  python: python3
 
 repos:
   - repo: local


### PR DESCRIPTION
I incorrectly closed #2185, thinking that the `- --py310-plus` syntax used in #2190 was `pre-commit`, not pyupgrade specific.

This PR aims to allow anyone using `Python versions => 3.10` to be able to run `pre-commit`, while failing if a previous version is used. 