### PR TITLE
Release 1.10.3 and 1.11.3 with backported change

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -29,7 +29,7 @@ Enhancements
 
 Bug Fixes
 
-* (back-ported) Fix resolution of packages-install-path when it uses env_var by @tatiana in Fix resolution of packages-install-path when it uses env_var #2194
+* (back-ported) Fix resolution of ``packages-install-path`` when it uses ``env_var`` by @tatiana in #2194
 
 1.11.2 (2025-11-24)
 --------------------


### PR DESCRIPTION
We decided to backport a minor change (#2194) that will be released in Cosmos 1.12.0, both in:
- 1.10.3
- 1.11.3

This PR updates the `main` branch release notes accordingly.