### PR TITLE
Replace `map_index` with `is_mapped_task` boolean in task telemetry

### DIFF
--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -119,7 +119,7 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
         "is_cosmos_operator_subclass": _is_cosmos_subclass(task_instance),
         "invocation_mode": _invocation_mode(task_instance),
         "execution_mode": _execution_mode_from_task(task_instance),
-        "map_index": task_instance.map_index,
+        "is_mapped_task": task_instance.map_index >= 0,
     }
 
     dbt_command = _dbt_command(task_instance)

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -119,6 +119,7 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
         "is_cosmos_operator_subclass": _is_cosmos_subclass(task_instance),
         "invocation_mode": _invocation_mode(task_instance),
         "execution_mode": _execution_mode_from_task(task_instance),
+        # map_index is -1 for non-mapped tasks, >= 0 for mapped tasks
         "is_mapped_task": task_instance.map_index >= 0,
     }
 

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -94,7 +94,17 @@ def test_build_task_metrics_records_core_fields():
     assert metrics["invocation_mode"] == InvocationMode.DBT_RUNNER.value
     assert metrics["execution_mode"] == "local"
     assert metrics["is_cosmos_operator_subclass"] is False
+    assert metrics["is_mapped_task"] is False
     assert metrics["dag_run_id"] == "run-1"
+
+
+def test_build_task_metrics_detects_mapped_task():
+    operator = DummyDbtOperator()
+    ti = _make_task_instance(operator, map_index=2)
+
+    metrics = task_instance_listener._build_task_metrics(ti, status="success")
+
+    assert metrics["is_mapped_task"] is True
 
 
 def test_build_task_metrics_ignores_missing_install_deps():


### PR DESCRIPTION
Change task telemetry to emit `is_mapped_task` boolean instead of raw `map_index` integer value for clearer intent

related: #2195 
related: #2110 