### PR TITLE
Remove unnecessary information from telemetry

### DIFF
--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -112,8 +112,6 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
     """Build telemetry payload for task completion events."""
 
     metrics: dict[str, object] = {
-        "dag_id": task_instance.dag_id,
-        "task_id": task_instance.task_id,
         "status": status,
         "operator_name": task_instance.task.__class__.__name__,
         "is_cosmos_operator_subclass": _is_cosmos_subclass(task_instance),
@@ -132,10 +130,6 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
         metrics["install_deps"] = install_deps
 
     metrics["has_callback"] = _has_callback(task_instance)
-
-    dag_run = getattr(task_instance, "dag_run", None)
-    if dag_run is not None:
-        metrics["dag_run_id"] = dag_run.run_id
 
     duration = getattr(task_instance, "duration", None)
     if duration is not None:

--- a/tests/listeners/test_task_instance_listener.py
+++ b/tests/listeners/test_task_instance_listener.py
@@ -95,7 +95,6 @@ def test_build_task_metrics_records_core_fields():
     assert metrics["execution_mode"] == "local"
     assert metrics["is_cosmos_operator_subclass"] is False
     assert metrics["is_mapped_task"] is False
-    assert metrics["dag_run_id"] == "run-1"
 
 
 def test_build_task_metrics_detects_mapped_task():


### PR DESCRIPTION
Information such as `dag_id` and `task_id` can have sensitive details, so we are removing them from our telemetry metrics. 

This PR also removes the dag_run_id, since it does not provide relevant insights to help us decide what to deprecate and what not to deprecate in Cosmos, one of the primary motivations for the telemetry collection.
