### PR TITLE
Collect profile metrics for dagrun

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -413,16 +413,16 @@ class DbtToAirflowConverter:
             logger.warning(f"Failed to compute used_automatic_load_mode: {e}")
 
         try:
-            metadata["actual_load_mode"] = self.dbt_graph.load_method.value
+            metadata["actual_load_mode"] = str(self.dbt_graph.load_method.value)
         except Exception as e:
             logger.warning(f"Failed to compute actual_load_mode: {e}")
 
         try:
             invocation_mode = None
             if execution_config.invocation_mode:
-                invocation_mode = execution_config.invocation_mode.value
+                invocation_mode = str(execution_config.invocation_mode.value)
             elif render_config.invocation_mode:
-                invocation_mode = render_config.invocation_mode.value
+                invocation_mode = str(render_config.invocation_mode.value)
             metadata["invocation_mode"] = invocation_mode
         except Exception as e:
             logger.warning(f"Failed to compute invocation_mode: {e}")
@@ -441,12 +441,12 @@ class DbtToAirflowConverter:
             logger.warning(f"Failed to compute uses_node_converter: {e}")
 
         try:
-            metadata["test_behavior"] = render_config.test_behavior.value
+            metadata["test_behavior"] = str(render_config.test_behavior.value)
         except Exception as e:
             logger.warning(f"Failed to compute test_behavior: {e}")
 
         try:
-            metadata["source_behavior"] = render_config.source_rendering_behavior.value
+            metadata["source_behavior"] = str(render_config.source_rendering_behavior.value)
         except Exception as e:
             logger.warning(f"Failed to compute source_behavior: {e}")
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -14,8 +14,6 @@ from warnings import warn
 
 from airflow.models.dag import DAG
 
-from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
-
 try:
     # Airflow 3.1 onwards
     from airflow.sdk import TaskGroup
@@ -30,6 +28,9 @@ from cosmos.dbt.graph import DbtGraph
 from cosmos.dbt.project import has_non_empty_dependencies_file
 from cosmos.dbt.selector import retrieve_by_label
 from cosmos.exceptions import CosmosValueError
+
+# TODO: Move _get_profile_config_attribute at common place
+from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
 from cosmos.log import get_logger
 from cosmos.versioning import _create_folder_version_hash
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -436,7 +436,7 @@ class DbtToAirflowConverter:
                     "database": database,
                 }
             )
-            
+
         # Store metadata in dag.params which is preserved during serialization
         # Using a key that's unlikely to conflict with user params
         dag.params["__cosmos_telemetry_metadata__"] = metadata

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -33,6 +33,8 @@ from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
 
+from cosmos.constants import DbtResourceType
+
 
 def migrate_to_new_interface(
     execution_config: ExecutionConfig, project_config: ProjectConfig, render_config: RenderConfig
@@ -279,6 +281,9 @@ class DbtToAirflowConverter:
             cache_identifier = cache._create_cache_identifier(dag, task_group)
             cache_dir = cache._obtain_cache_dir_path(cache_identifier=cache_identifier)
 
+        # Store the initial load method before it gets resolved by dbt_graph.load()
+        initial_load_method = render_config.load_method
+
         previous_time = time.perf_counter()
         self.dbt_graph = DbtGraph(
             project=project_config,
@@ -293,6 +298,9 @@ class DbtToAirflowConverter:
         self.dbt_graph.load(method=render_config.load_method, execution_mode=execution_config.execution_mode)
 
         self._add_dbt_project_hash_to_dag_docs(dag)
+        self._store_cosmos_telemetry_metadata_on_dag(
+            dag, render_config, execution_config, project_config, operator_args, initial_load_method
+        )
 
         current_time = time.perf_counter()
         elapsed_time = current_time - previous_time
@@ -370,3 +378,91 @@ class DbtToAirflowConverter:
             logger.debug(f"Appended dbt project hash {dbt_project_hash} to DAG {dag.dag_id} documentation")
         except Exception as e:
             logger.warning(f"Failed to append dbt project hash to DAG documentation: {e}")
+
+    def _store_cosmos_telemetry_metadata_on_dag(  # noqa: C901
+        self,
+        dag: DAG | None,
+        render_config: RenderConfig,
+        execution_config: ExecutionConfig,
+        project_config: ProjectConfig,
+        operator_args: dict[str, Any],
+        initial_load_method: LoadMode,
+    ) -> None:
+        """
+        Store Cosmos configuration metadata on the DAG for telemetry purposes.
+
+        This metadata is used by the DAG run listener to emit telemetry metrics
+        about how Cosmos is configured and used.
+
+        :param dag: The Airflow DAG to store metadata on. If None, no action is taken.
+        :param render_config: The render configuration
+        :param execution_config: The execution configuration
+        :param project_config: The project configuration
+        :param operator_args: The operator arguments
+        :param initial_load_method: The load method specified by the user (before automatic resolution)
+        """
+        if dag is None:
+            return
+
+        metadata = {}
+
+        # Compute each metric individually with error handling
+        try:
+            metadata["used_automatic_load_mode"] = initial_load_method == LoadMode.AUTOMATIC
+        except Exception as e:
+            logger.warning(f"Failed to compute used_automatic_load_mode: {e}")
+
+        try:
+            metadata["actual_load_mode"] = self.dbt_graph.load_method.value
+        except Exception as e:
+            logger.warning(f"Failed to compute actual_load_mode: {e}")
+
+        try:
+            invocation_mode = None
+            if execution_config.invocation_mode:
+                invocation_mode = execution_config.invocation_mode.value
+            elif render_config.invocation_mode:
+                invocation_mode = render_config.invocation_mode.value
+            metadata["invocation_mode"] = invocation_mode
+        except Exception as e:
+            logger.warning(f"Failed to compute invocation_mode: {e}")
+
+        try:
+            install_deps = operator_args.get("install_deps")
+            if install_deps is None:
+                install_deps = project_config.install_dbt_deps
+            metadata["install_deps"] = bool(install_deps) if install_deps is not None else True
+        except Exception as e:
+            logger.warning(f"Failed to compute install_deps: {e}")
+
+        try:
+            metadata["uses_node_converter"] = render_config.node_converters is not None
+        except Exception as e:
+            logger.warning(f"Failed to compute uses_node_converter: {e}")
+
+        try:
+            metadata["test_behavior"] = render_config.test_behavior.value
+        except Exception as e:
+            logger.warning(f"Failed to compute test_behavior: {e}")
+
+        try:
+            metadata["source_behavior"] = render_config.source_rendering_behavior.value
+        except Exception as e:
+            logger.warning(f"Failed to compute source_behavior: {e}")
+
+        try:
+            metadata["total_dbt_models"] = sum(
+                1 for node in self.dbt_graph.nodes.values() if node.resource_type == DbtResourceType.MODEL
+            )
+        except Exception as e:
+            logger.warning(f"Failed to compute total_dbt_models: {e}")
+
+        try:
+            metadata["selected_dbt_models"] = sum(
+                1 for node in self.dbt_graph.filtered_nodes.values() if node.resource_type == DbtResourceType.MODEL
+            )
+        except Exception as e:
+            logger.warning(f"Failed to compute selected_dbt_models: {e}")
+
+        dag._cosmos_telemetry_metadata = metadata
+        logger.debug(f"Stored Cosmos telemetry metadata on DAG {dag.dag_id}: {metadata}")

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -423,7 +423,7 @@ class DbtToAirflowConverter:
             metadata["selected_dbt_models"] = sum(
                 1 for node in self.dbt_graph.filtered_nodes.values() if node.resource_type == DbtResourceType.MODEL
             )
-        if profile_config:
+        if profile_config is not None:
             profile_strategy, profile_mapping_class, database = _get_profile_config_attribute(profile_config)
             metadata.update(
                 {

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -464,5 +464,7 @@ class DbtToAirflowConverter:
         except Exception as e:
             logger.warning(f"Failed to compute selected_dbt_models: {e}")
 
-        dag._cosmos_telemetry_metadata = metadata
-        logger.debug(f"Stored Cosmos telemetry metadata on DAG {dag.dag_id}: {metadata}")
+        # Store metadata in dag.params which is preserved during serialization
+        # Using a key that's unlikely to conflict with user params
+        dag.params["__cosmos_telemetry_metadata__"] = metadata
+        logger.debug(f"Stored Cosmos telemetry metadata in DAG {dag.dag_id} params: {metadata}")

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -300,12 +300,7 @@ class DbtToAirflowConverter:
 
         self._add_dbt_project_hash_to_dag_docs(dag)
         self._store_cosmos_telemetry_metadata_on_dag(
-            dag,
-            render_config,
-            execution_config,
-            project_config,
-            profile_config,
-            initial_load_method,
+            dag, render_config, project_config, profile_config, initial_load_method
         )
 
         current_time = time.perf_counter()

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -35,8 +35,6 @@ from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
 
-from cosmos.constants import DbtResourceType
-
 
 def migrate_to_new_interface(
     execution_config: ExecutionConfig, project_config: ProjectConfig, render_config: RenderConfig
@@ -302,7 +300,12 @@ class DbtToAirflowConverter:
 
         self._add_dbt_project_hash_to_dag_docs(dag)
         self._store_cosmos_telemetry_metadata_on_dag(
-          dag, render_config, execution_config, project_config, profile_config, initial_load_method,
+            dag,
+            render_config,
+            execution_config,
+            project_config,
+            profile_config,
+            initial_load_method,
         )
 
         current_time = time.perf_counter()
@@ -387,7 +390,6 @@ class DbtToAirflowConverter:
         self,
         dag: DAG | None,
         render_config: RenderConfig,
-        execution_config: ExecutionConfig,
         project_config: ProjectConfig,
         profile_config: ProfileConfig,
         initial_load_method: LoadMode,
@@ -400,7 +402,6 @@ class DbtToAirflowConverter:
 
         :param dag: The Airflow DAG to store metadata on. If None, no action is taken.
         :param render_config: The render configuration
-        :param execution_config: The execution configuration
         :param project_config: The project configuration
         :param profile_config: The profile configuration
         :param initial_load_method: The load method specified by the user (before automatic resolution)
@@ -427,8 +428,8 @@ class DbtToAirflowConverter:
             metadata["selected_dbt_models"] = sum(
                 1 for node in self.dbt_graph.filtered_nodes.values() if node.resource_type == DbtResourceType.MODEL
             )
-        if profie_config:
-           profile_strategy, profile_mapping_class, database = _get_profile_config_attribute(profile_config)
+        if profile_config:
+            profile_strategy, profile_mapping_class, database = _get_profile_config_attribute(profile_config)
             metadata.update(
                 {
                     "profile_strategy": profile_strategy,

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import hashlib
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from airflow.listeners import hookimpl
 
@@ -57,6 +57,15 @@ def get_execution_modes(dag: DAG) -> str:
     return "__".join(sorted(modes))
 
 
+def get_cosmos_telemetry_metadata(dag: DAG) -> dict[str, Any]:
+    """
+    Extract Cosmos telemetry metadata from a DAG.
+
+    Returns the metadata dictionary stored by the converter, or an empty dict if not present.
+    """
+    return getattr(dag, "_cosmos_telemetry_metadata", {})
+
+
 @hookimpl
 def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
     logger.debug("Running on_dag_run_success")
@@ -81,6 +90,10 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),
         "execution_modes": get_execution_modes(serialized_dag),
     }
+
+    # Add Cosmos telemetry metadata if available
+    cosmos_metadata = get_cosmos_telemetry_metadata(serialized_dag)
+    additional_telemetry_metrics.update(cosmos_metadata)
 
     telemetry.emit_usage_metrics_if_enabled(DAG_RUN, additional_telemetry_metrics)
     logger.debug("Completed on_dag_run_success")
@@ -110,6 +123,10 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
         "cosmos_task_count": total_cosmos_tasks(serialized_dag),
         "execution_modes": get_execution_modes(serialized_dag),
     }
+
+    # Add Cosmos telemetry metadata if available
+    cosmos_metadata = get_cosmos_telemetry_metadata(serialized_dag)
+    additional_telemetry_metrics.update(cosmos_metadata)
 
     telemetry.emit_usage_metrics_if_enabled(DAG_RUN, additional_telemetry_metrics)
     logger.debug("Completed on_dag_run_failed")

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -61,9 +61,11 @@ def get_cosmos_telemetry_metadata(dag: DAG) -> dict[str, Any]:
     """
     Extract Cosmos telemetry metadata from a DAG.
 
-    Returns the metadata dictionary stored by the converter, or an empty dict if not present.
+    Returns the metadata dictionary stored by the converter in dag.params, or an empty dict if not present.
     """
-    return getattr(dag, "_cosmos_telemetry_metadata", {})
+    # Metadata is stored in dag.params to survive serialization
+    metadata = dag.params.get("__cosmos_telemetry_metadata__", {})
+    return metadata if isinstance(metadata, dict) else {}
 
 
 @hookimpl

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -9,6 +9,7 @@ if TYPE_CHECKING:
 
 
 from cosmos import telemetry
+from cosmos.config import ProfileConfig
 from cosmos.constants import InvocationMode
 from cosmos.log import get_logger
 from cosmos.operators.base import AbstractDbtBase
@@ -109,13 +110,7 @@ def _has_callback(task_instance: TaskInstance) -> bool:
     return bool(callback)
 
 
-def get_profile_metrics(task_instance: TaskInstance) -> tuple[str | None, str | None, str | None]:
-    """Extract dbt profile-related telemetry metrics for a Cosmos-powered task."""
-
-    if not _is_cosmos_task(task_instance):
-        return None, None, None
-
-    profile_config = getattr(task_instance.task, "profile_config", None)
+def _get_profile_config_attribute(profile_config: ProfileConfig | None) -> tuple[str | None, str | None, str | None]:
 
     if not profile_config:
         return None, None, None
@@ -138,6 +133,17 @@ def get_profile_metrics(task_instance: TaskInstance) -> tuple[str | None, str | 
         database = None
 
     return profile_strategy, profile_mapping_class, database
+
+
+def get_profile_metrics(task_instance: TaskInstance) -> tuple[str | None, str | None, str | None]:
+    """Extract dbt profile-related telemetry metrics for a Cosmos-powered task."""
+
+    if not _is_cosmos_task(task_instance):
+        return None, None, None
+
+    profile_config = getattr(task_instance.task, "profile_config", None)
+
+    return _get_profile_config_attribute(profile_config)
 
 
 def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, object]:

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -259,8 +259,7 @@ def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_en
         profile_config=profile_config,
         execution_config=ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER),
         render_config=RenderConfig(
-            load_method=LoadMode.DBT_LS,
-            dbt_deps=False,
+            load_method=LoadMode.DBT_MANIFEST,
             test_behavior=TestBehavior.NONE,
             source_rendering_behavior=SourceRenderingBehavior.ALL,
         ),

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -260,6 +260,7 @@ def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_en
         execution_config=ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER),
         render_config=RenderConfig(
             load_method=LoadMode.DBT_LS,
+            dbt_deps=False,
             test_behavior=TestBehavior.NONE,
             source_rendering_behavior=SourceRenderingBehavior.ALL,
         ),

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -232,6 +232,9 @@ def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_e
     assert "source_behavior" in metrics
     assert "total_dbt_models" in metrics
     assert "selected_dbt_models" in metrics
+    assert "profile_strategy" in metrics
+    assert "profile_mapping_class" in metrics
+    assert "database" in metrics
 
     # Verify some expected values
     assert metrics["used_automatic_load_mode"] is True
@@ -240,6 +243,9 @@ def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_e
     assert metrics["uses_node_converter"] is False
     assert metrics["test_behavior"] == "after_each"
     assert metrics["source_behavior"] == "none"
+    assert metrics["profile_strategy"] == "mapping"
+    assert metrics["profile_mapping_class"] == "PostgresUserPasswordProfileMapping"
+    assert metrics["database"] == "postgres"
 
 
 @pytest.mark.skipif(

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -255,6 +255,7 @@ def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_en
     dag = DbtDag(
         project_config=ProjectConfig(
             DBT_ROOT_PATH / "jaffle_shop",
+            manifest_path=DBT_ROOT_PATH / "jaffle_shop" / "target" / "manifest.json",
         ),
         profile_config=profile_config,
         execution_config=ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER),

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -12,7 +12,8 @@ from packaging.version import Version
 from cosmos import DbtRunLocalOperator, ProfileConfig, ProjectConfig
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
-from cosmos.constants import AIRFLOW_VERSION
+from cosmos.config import ExecutionConfig, RenderConfig
+from cosmos.constants import AIRFLOW_VERSION, InvocationMode, LoadMode, SourceRenderingBehavior, TestBehavior
 from cosmos.listeners.dag_run_listener import on_dag_run_failed, on_dag_run_success, total_cosmos_tasks
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
@@ -183,3 +184,115 @@ def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):
     assert "Running on_dag_run_failed" in caplog.text
     assert "Completed on_dag_run_failed" in caplog.text
     assert mock_emit_usage_metrics_if_enabled.call_count == 1
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION >= Version("3.1.0"),
+    reason="TODO: Fix create_dag_run to work with AF 3.1 and remove this skip.",
+)
+@pytest.mark.integration
+@patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, caplog):
+    """Test that DAG run success includes Cosmos telemetry metadata."""
+    caplog.set_level(logging.DEBUG)
+
+    dag = DbtDag(
+        project_config=ProjectConfig(
+            DBT_ROOT_PATH / "jaffle_shop",
+        ),
+        profile_config=profile_config,
+        execution_config=ExecutionConfig(invocation_mode=InvocationMode.SUBPROCESS),
+        render_config=RenderConfig(
+            load_method=LoadMode.AUTOMATIC,
+            test_behavior=TestBehavior.AFTER_EACH,
+            source_rendering_behavior=SourceRenderingBehavior.NONE,
+        ),
+        operator_args={"install_deps": True},
+        start_date=datetime(2023, 1, 1),
+        dag_id="cosmos_dag_with_metadata",
+    )
+    run_id = str(uuid.uuid1())
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    dag_run = create_dag_run(dag, run_id, run_after)
+
+    on_dag_run_success(dag_run, msg="test success")
+    assert mock_emit_usage_metrics_if_enabled.call_count == 1
+
+    # Verify telemetry call includes new metrics
+    call_args = mock_emit_usage_metrics_if_enabled.call_args
+    metrics = call_args[0][1]  # Second argument is the metrics dict
+
+    # Check that Cosmos metadata fields are present
+    assert "used_automatic_load_mode" in metrics
+    assert "actual_load_mode" in metrics
+    assert "invocation_mode" in metrics
+    assert "install_deps" in metrics
+    assert "uses_node_converter" in metrics
+    assert "test_behavior" in metrics
+    assert "source_behavior" in metrics
+    assert "total_dbt_models" in metrics
+    assert "selected_dbt_models" in metrics
+
+    # Verify some expected values
+    assert metrics["used_automatic_load_mode"] is True
+    assert metrics["invocation_mode"] == "subprocess"
+    assert metrics["install_deps"] is True
+    assert metrics["uses_node_converter"] is False
+    assert metrics["test_behavior"] == "after_each"
+    assert metrics["source_behavior"] == "none"
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION >= Version("3.1.0"),
+    reason="TODO: Fix create_dag_run to work with AF 3.1 and remove this skip.",
+)
+@pytest.mark.integration
+@patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, caplog):
+    """Test that DAG run failure includes Cosmos telemetry metadata."""
+    caplog.set_level(logging.DEBUG)
+
+    dag = DbtDag(
+        project_config=ProjectConfig(
+            DBT_ROOT_PATH / "jaffle_shop",
+        ),
+        profile_config=profile_config,
+        execution_config=ExecutionConfig(invocation_mode=InvocationMode.DBT_RUNNER),
+        render_config=RenderConfig(
+            load_method=LoadMode.DBT_LS,
+            test_behavior=TestBehavior.NONE,
+            source_rendering_behavior=SourceRenderingBehavior.ALL,
+        ),
+        operator_args={"install_deps": False},
+        start_date=datetime(2023, 1, 1),
+        dag_id="cosmos_dag_with_metadata_failed",
+    )
+    run_id = str(uuid.uuid1())
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    dag_run = create_dag_run(dag, run_id, run_after)
+
+    on_dag_run_failed(dag_run, msg="test failed")
+    assert mock_emit_usage_metrics_if_enabled.call_count == 1
+
+    # Verify telemetry call includes new metrics
+    call_args = mock_emit_usage_metrics_if_enabled.call_args
+    metrics = call_args[0][1]  # Second argument is the metrics dict
+
+    # Check that Cosmos metadata fields are present
+    assert "used_automatic_load_mode" in metrics
+    assert "actual_load_mode" in metrics
+    assert "invocation_mode" in metrics
+    assert "install_deps" in metrics
+    assert "uses_node_converter" in metrics
+    assert "test_behavior" in metrics
+    assert "source_behavior" in metrics
+    assert "total_dbt_models" in metrics
+    assert "selected_dbt_models" in metrics
+
+    # Verify some expected values for failed case
+    assert metrics["used_automatic_load_mode"] is False
+    assert metrics["invocation_mode"] == "dbt_runner"
+    assert metrics["install_deps"] is False
+    assert metrics["uses_node_converter"] is False
+    assert metrics["test_behavior"] == "none"
+    assert metrics["source_behavior"] == "all"

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,7 +1,7 @@
 import tempfile
 from datetime import datetime
 from pathlib import Path
-from unittest.mock import MagicMock, Mock, PropertyMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 from airflow.models import DAG

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1159,3 +1159,6 @@ def test_telemetry_metadata_storage(mock_load_dbt_graph):
     assert "uses_node_converter" in metadata
     assert "test_behavior" in metadata
     assert "source_behavior" in metadata
+    assert "profile_strategy" in metadata
+    assert "profile_mapping_class" in metadata
+    assert "database" in metadata

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -19,6 +19,12 @@ SAMPLE_DBT_MANIFEST = Path(__file__).parent / "sample/manifest.json"
 MULTIPLE_PARENTS_TEST_DBT_PROJECT = Path(__file__).parent.parent / "dev/dags/dbt/multiple_parents_test/"
 DBT_PROJECTS_PROJ_WITH_DEPS_DIR = Path(__file__).parent.parent / "dev/dags/dbt" / "jaffle_shop"
 
+sample_profile_config = ProfileConfig(
+    profile_name="my_profile_name",
+    target_name="my_target_name",
+    profiles_yml_filepath=SAMPLE_PROFILE_YML,
+)
+
 
 @pytest.mark.parametrize("argument_key", ["tags", "paths"])
 def test_validate_arguments_tags(argument_key):
@@ -446,16 +452,11 @@ def test_converter_creates_dag_with_project_path_str(mock_load_dbt_graph, execut
     project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT.as_posix())
     execution_config = ExecutionConfig(execution_mode=execution_mode)
     render_config = RenderConfig(emit_datasets=True)
-    profile_config = ProfileConfig(
-        profile_name="my_profile_name",
-        target_name="my_target_name",
-        profiles_yml_filepath=SAMPLE_PROFILE_YML,
-    )
     converter = DbtToAirflowConverter(
         dag=DAG("sample_dag", start_date=datetime(2024, 4, 16)),
         nodes=nodes,
         project_config=project_config,
-        profile_config=profile_config,
+        profile_config=sample_profile_config,
         execution_config=execution_config,
         render_config=render_config,
         operator_args=operator_args,
@@ -480,17 +481,12 @@ def test_converter_raises_warning(mock_load_dbt_graph, execution_mode, virtualen
     project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT.as_posix())
     execution_config = ExecutionConfig(execution_mode=execution_mode, virtualenv_dir=virtualenv_dir)
     render_config = RenderConfig(emit_datasets=True)
-    profile_config = ProfileConfig(
-        profile_name="my_profile_name",
-        target_name="my_target_name",
-        profiles_yml_filepath=SAMPLE_PROFILE_YML,
-    )
 
     DbtToAirflowConverter(
         dag=DAG("sample_dag", start_date=datetime(2024, 4, 16)),
         nodes=nodes,
         project_config=project_config,
-        profile_config=profile_config,
+        profile_config=sample_profile_config,
         execution_config=execution_config,
         render_config=render_config,
         operator_args=operator_args,
@@ -520,16 +516,11 @@ def test_converter_fails_execution_config_no_project_dir(mock_load_dbt_graph, ex
     project_config = ProjectConfig(manifest_path=SAMPLE_DBT_MANIFEST.as_posix(), project_name="sample")
     execution_config = ExecutionConfig(execution_mode=execution_mode)
     render_config = RenderConfig(emit_datasets=True)
-    profile_config = ProfileConfig(
-        profile_name="my_profile_name",
-        target_name="my_target_name",
-        profiles_yml_filepath=SAMPLE_PROFILE_YML,
-    )
     with pytest.raises(CosmosValueError) as err_info:
         DbtToAirflowConverter(
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args=operator_args,
@@ -559,16 +550,11 @@ def test_converter_fails_project_config_path_and_execution_config_path(
     project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT.as_posix())
     execution_config = ExecutionConfig(execution_mode=execution_mode, dbt_project_path=SAMPLE_DBT_PROJECT.as_posix())
     render_config = RenderConfig(emit_datasets=True)
-    profile_config = ProfileConfig(
-        profile_name="my_profile_name",
-        target_name="my_target_name",
-        profiles_yml_filepath=SAMPLE_PROFILE_YML,
-    )
     with pytest.raises(CosmosValueError) as err_info:
         DbtToAirflowConverter(
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args=operator_args,
@@ -596,16 +582,11 @@ def test_converter_fails_no_manifest_no_render_config(mock_load_dbt_graph, execu
     project_config = ProjectConfig()
     execution_config = ExecutionConfig(execution_mode=execution_mode, dbt_project_path=SAMPLE_DBT_PROJECT.as_posix())
     render_config = RenderConfig(emit_datasets=True)
-    profile_config = ProfileConfig(
-        profile_name="my_profile_name",
-        target_name="my_target_name",
-        profiles_yml_filepath=SAMPLE_PROFILE_YML,
-    )
     with pytest.raises(CosmosValueError) as err_info:
         DbtToAirflowConverter(
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args=operator_args,
@@ -630,14 +611,13 @@ def test_converter_project_config_dbt_vars_with_custom_load_mode(
     )
     execution_config = ExecutionConfig()
     render_config = RenderConfig(load_method=LoadMode.CUSTOM)
-    profile_config = MagicMock()
 
     with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
         DbtToAirflowConverter(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args={},
@@ -658,7 +638,6 @@ def test_converter_multiple_calls_same_operator_args(mock_dbt_graph, mock_build_
     )
     execution_config = ExecutionConfig()
     render_config = RenderConfig()
-    profile_config = MagicMock()
     operator_args = {
         "install_deps": True,
         "vars": {"key": "value"},
@@ -671,7 +650,7 @@ def test_converter_multiple_calls_same_operator_args(mock_dbt_graph, mock_build_
                 dag=dag,
                 nodes=nodes,
                 project_config=project_config,
-                profile_config=profile_config,
+                profile_config=sample_profile_config,
                 execution_config=execution_config,
                 render_config=render_config,
                 operator_args=operator_args,
@@ -699,7 +678,7 @@ def test_validate_converter_fetches_project_name_from_render_config(
     """
     execution_config = ExecutionConfig(dbt_project_path="/data/project1")
     project_config = ProjectConfig()
-    profile_config = MagicMock()
+
     render_config = RenderConfig(dbt_project_path="/home/usr/airflow/project1")
 
     with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
@@ -707,7 +686,7 @@ def test_validate_converter_fetches_project_name_from_render_config(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
         )
@@ -782,14 +761,13 @@ def test_converter_invocation_mode_added_to_task_args(
     project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
     execution_config = ExecutionConfig(invocation_mode=invocation_mode)
     render_config = MagicMock()
-    profile_config = MagicMock()
 
     with DAG("test-id", start_date=datetime(2024, 1, 1)) as dag:
         DbtToAirflowConverter(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args={},
@@ -815,14 +793,13 @@ def test_converter_uses_cache_dir(
     project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
     execution_config = ExecutionConfig()
     render_config = RenderConfig(enable_mock_profile=False)
-    profile_config = MagicMock()
 
     with DAG("test-id", start_date=datetime(2024, 1, 1)) as dag:
         DbtToAirflowConverter(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args={},
@@ -851,14 +828,13 @@ def test_converter_disable_cache_sets_cache_dir_to_none(
     project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
     execution_config = ExecutionConfig()
     render_config = RenderConfig(enable_mock_profile=False)
-    profile_config = MagicMock()
 
     with DAG("test-id", start_date=datetime(2024, 1, 1)) as dag:
         DbtToAirflowConverter(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args={},

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1112,6 +1112,8 @@ def test_dag_versioning_successful_logging(mock_load_dbt_graph, mock_hash_func, 
         execution_config=execution_config,
     )
 
-    mock_logger.debug.assert_called_once_with(
-        "Appended dbt project hash test_hash_123 to DAG test_dag_logging documentation"
+    # Check that the hash logging call was made (there are multiple debug calls now)
+    debug_calls = [str(call) for call in mock_logger.debug.call_args_list]
+    assert any(
+        "Appended dbt project hash test_hash_123 to DAG test_dag_logging documentation" in call for call in debug_calls
     )

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -733,13 +733,12 @@ def test_project_config_install_dbt_deps_overrides_operator_args(
     project_config.install_dbt_deps = install_dbt_deps
     execution_config = ExecutionConfig(execution_mode=execution_mode)
     render_config = MagicMock()
-    profile_config = MagicMock()
     with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
         DbtToAirflowConverter(
             dag=dag,
             nodes=nodes,
             project_config=project_config,
-            profile_config=profile_config,
+            profile_config=sample_profile_config,
             execution_config=execution_config,
             render_config=render_config,
             operator_args=operator_args,


### PR DESCRIPTION
closes: https://github.com/astronomer/astronomer-cosmos/issues/2216

This PR adds profile metrics collection for DAG runs to enable better telemetry about how Cosmos is configured with different dbt profile strategies. The changes extract profile-related configuration into reusable helper functions and ensure these metrics are stored in DAG metadata for consumption by DAG run listeners.

- Refactored profile metrics extraction into a shared `_get_profile_config_attribute` helper function
- Updated `DbtToAirflowConverter` to store profile metrics (strategy, mapping class, database) in DAG telemetry metadata