### PR TITLE
Add telemetry tracking for dbt docs plugin usage

### DIFF
--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -13,6 +13,7 @@ from flask_appbuilder import AppBuilder, expose
 from cosmos.listeners import dag_run_listener, task_instance_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 from cosmos.settings import dbt_docs_conn_id, dbt_docs_dir, dbt_docs_index_file_name, in_astro_cloud
+from cosmos import telemetry
 
 if in_astro_cloud:
     MENU_ACCESS_PERMISSIONS = [
@@ -136,9 +137,37 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
     @expose("/dbt_docs")  # type: ignore[untyped-decorator]
     @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
     def dbt_docs(self) -> str:
+        # Emit telemetry for dbt docs access
+        storage_type = "not_configured"
+        if dbt_docs_dir is not None:
+            storage_type = self._get_storage_type(dbt_docs_dir)
+            
+        telemetry.emit_usage_metrics_if_enabled(
+            event_type="dbt_docs_access",
+            additional_metrics={
+                "storage_type": storage_type,
+                "is_configured": dbt_docs_dir is not None,
+                "uses_custom_conn": dbt_docs_conn_id is not None,
+            },
+        )
+        
         if dbt_docs_dir is None:
             return self.render_template("dbt_docs_not_set_up.html")  # type: ignore[no-any-return,no-untyped-call]
         return self.render_template("dbt_docs.html")  # type: ignore[no-any-return,no-untyped-call]
+
+    def _get_storage_type(self, path: str) -> str:
+        """Determine the storage type from the path."""
+        path = path.strip()
+        if path.startswith("s3://"):
+            return "s3"
+        elif path.startswith("gs://"):
+            return "gcs"
+        elif path.startswith("wasb://"):
+            return "azure"
+        elif path.startswith("http://") or path.startswith("https://"):
+            return "http"
+        else:
+            return "local"
 
     @expose("/dbt_docs_index.html")  # type: ignore[untyped-decorator]
     @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -10,10 +10,10 @@ from airflow.www.views import AirflowBaseView
 from flask import abort
 from flask_appbuilder import AppBuilder, expose
 
+from cosmos import telemetry
 from cosmos.listeners import dag_run_listener, task_instance_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 from cosmos.settings import dbt_docs_conn_id, dbt_docs_dir, dbt_docs_index_file_name, in_astro_cloud
-from cosmos import telemetry
 
 if in_astro_cloud:
     MENU_ACCESS_PERMISSIONS = [
@@ -141,7 +141,7 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
         storage_type = "not_configured"
         if dbt_docs_dir is not None:
             storage_type = self._get_storage_type(dbt_docs_dir)
-            
+
         telemetry.emit_usage_metrics_if_enabled(
             event_type="dbt_docs_access",
             additional_metrics={
@@ -150,7 +150,7 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
                 "uses_custom_conn": dbt_docs_conn_id is not None,
             },
         )
-        
+
         if dbt_docs_dir is None:
             return self.render_template("dbt_docs_not_set_up.html")  # type: ignore[no-any-return,no-untyped-call]
         return self.render_template("dbt_docs.html")  # type: ignore[no-any-return,no-untyped-call]

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -147,7 +147,7 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
             event_type="dbt_docs_access",
             additional_metrics={
                 "storage_type": storage_type,
-                "is_configured": dbt_docs_dir is not None,
+                "docs_dir_configured": dbt_docs_dir is not None,
                 "uses_custom_conn": dbt_docs_conn_id is not None,
             },
         )

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -163,7 +163,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                 event_type="dbt_docs_access",
                 additional_metrics={
                     "storage_type": storage_type,
-                    "is_configured": docs_dir_local is not None,
+                    "docs_dir_configured": docs_dir_local is not None,
                     "uses_custom_conn": cfg_local.get("conn_id") is not None,
                     "has_custom_name": cfg_local.get("name") is not None,
                 },

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -19,10 +19,10 @@ from fastapi import FastAPI
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from packaging.version import Version
 
+from cosmos import telemetry
 from cosmos.constants import AIRFLOW_OBJECT_STORAGE_PATH_URL_SCHEMES
 from cosmos.listeners import dag_run_listener, task_instance_listener
 from cosmos.plugin.snippets import IFRAME_SCRIPT
-from cosmos import telemetry
 
 # Airflow version gating: External views feature for the plugins used here (CosmosAF3Plugin) exist only in >= 3.1
 # Note: We compute AIRFLOW_VERSION locally here (not from constants) so that tests can patch airflow.__version__ and reload this module
@@ -157,7 +157,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
             storage_type = "not_configured"
             if docs_dir_local is not None:
                 storage_type = _get_storage_type(str(docs_dir_local))
-                
+
             telemetry.emit_usage_metrics_if_enabled(
                 event_type="dbt_docs_access",
                 additional_metrics={
@@ -168,7 +168,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                     "has_custom_name": cfg_local.get("name") is not None,
                 },
             )
-            
+
             conn_id_local = cfg_local.get("conn_id")
             index_local = cfg_local.get("index") or "index.html"
             if not docs_dir_local:

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -165,7 +165,6 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                     "storage_type": storage_type,
                     "is_configured": docs_dir_local is not None,
                     "uses_custom_conn": cfg_local.get("conn_id") is not None,
-                    "project_slug": slug_alias,
                     "has_custom_name": cfg_local.get("name") is not None,
                 },
             )

--- a/cosmos/plugin/storage.py
+++ b/cosmos/plugin/storage.py
@@ -1,0 +1,23 @@
+"""Utility functions for Cosmos plugins."""
+
+
+def get_storage_type_from_path(path: str) -> str:
+    """Determine the storage type from the path.
+
+    Args:
+        path: Storage path (e.g., 's3://bucket/path', '/local/path')
+
+    Returns:
+        Storage type identifier: 's3', 'gcs', 'azure', 'http', or 'local'
+    """
+    path = path.strip()
+    if path.startswith("s3://"):
+        return "s3"
+    elif path.startswith("gs://"):
+        return "gcs"
+    elif path.startswith("wasb://"):
+        return "azure"
+    elif path.startswith("http://") or path.startswith("https://"):
+        return "http"
+    else:
+        return "local"

--- a/tests/plugin/test_plugin_af2.py
+++ b/tests/plugin/test_plugin_af2.py
@@ -446,7 +446,6 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, monkeypatch, app):
     ],
 )
 def test_get_storage_type(path, expected_type):
-    from cosmos.plugin.airflow2 import DbtDocsView
+    from cosmos.plugin.storage import get_storage_type_from_path
 
-    view = DbtDocsView()
-    assert view._get_storage_type(path) == expected_type
+    assert get_storage_type_from_path(path) == expected_type

--- a/tests/plugin/test_plugin_af2.py
+++ b/tests/plugin/test_plugin_af2.py
@@ -390,7 +390,7 @@ def test_dbt_docs_emits_telemetry(mock_emit, monkeypatch, app):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "s3",
-            "is_configured": True,
+            "docs_dir_configured": True,
             "uses_custom_conn": True,
         },
     )
@@ -409,7 +409,7 @@ def test_dbt_docs_emits_telemetry_not_configured(mock_emit, monkeypatch, app):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "not_configured",
-            "is_configured": False,
+            "docs_dir_configured": False,
             "uses_custom_conn": False,
         },
     )
@@ -428,7 +428,7 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, monkeypatch, app):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "local",
-            "is_configured": True,
+            "docs_dir_configured": True,
             "uses_custom_conn": False,
         },
     )

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -445,7 +445,7 @@ def test_dbt_docs_emits_telemetry(mock_emit, tmp_path: Path):
     client = TestClient(app)
 
     with patch("cosmos.plugin.airflow3.open_file", return_value="<head></head><body>dbt</body>"):
-        r = client.get("/my_project/dbt_docs")
+        r = client.get("/my_project/dbt_docs_index.html")
 
     assert r.status_code == 200
     mock_emit.assert_called_once_with(
@@ -468,7 +468,7 @@ def test_dbt_docs_emits_telemetry_not_configured(mock_emit):
     af3, app = _app_with_projects(projects)
     client = TestClient(app)
 
-    r = client.get("/empty/dbt_docs")
+    r = client.get("/empty/dbt_docs_index.html")
 
     assert r.status_code == 200
     mock_emit.assert_called_once_with(
@@ -494,7 +494,7 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
     af3, app = _app_with_projects(projects)
     client = TestClient(app)
 
-    r = client.get("/local/dbt_docs")
+    r = client.get("/local/dbt_docs_index.html")
 
     assert r.status_code == 200
     mock_emit.assert_called_once_with(

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -470,7 +470,7 @@ def test_dbt_docs_emits_telemetry_not_configured(mock_emit):
 
     r = client.get("/empty/dbt_docs_index.html")
 
-    assert r.status_code == 200
+    assert r.status_code == 404
     mock_emit.assert_called_once_with(
         event_type="dbt_docs_access",
         additional_metrics={
@@ -489,6 +489,8 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
     """Test that accessing dbt docs emits telemetry for local storage."""
     docs_dir = tmp_path / "target"
     docs_dir.mkdir(parents=True)
+    index_file = docs_dir / "index.html"
+    index_file.write_text("<head></head><body>dbt</body>")
 
     projects = {"local": {"dir": str(docs_dir), "index": "index.html"}}
     af3, app = _app_with_projects(projects)

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -454,7 +454,6 @@ def test_dbt_docs_emits_telemetry(mock_emit, tmp_path: Path):
             "storage_type": "s3",
             "is_configured": True,
             "uses_custom_conn": True,
-            "project_slug": "my_project",
             "has_custom_name": True,
         },
     )
@@ -477,7 +476,6 @@ def test_dbt_docs_emits_telemetry_not_configured(mock_emit):
             "storage_type": "not_configured",
             "is_configured": False,
             "uses_custom_conn": False,
-            "project_slug": "empty",
             "has_custom_name": False,
         },
     )
@@ -505,7 +503,6 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
             "storage_type": "local",
             "is_configured": True,
             "uses_custom_conn": False,
-            "project_slug": "local",
             "has_custom_name": False,
         },
     )

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -524,5 +524,6 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
 )
 def test_get_storage_type(path, expected_type):
     """Test storage type detection from path."""
-    af3 = _reload_af3_module()
-    assert af3._get_storage_type(path) == expected_type
+    from cosmos.plugin.storage import get_storage_type_from_path
+
+    assert get_storage_type_from_path(path) == expected_type

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -452,7 +452,7 @@ def test_dbt_docs_emits_telemetry(mock_emit, tmp_path: Path):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "s3",
-            "is_configured": True,
+            "docs_dir_configured": True,
             "uses_custom_conn": True,
             "has_custom_name": True,
         },
@@ -474,7 +474,7 @@ def test_dbt_docs_emits_telemetry_not_configured(mock_emit):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "not_configured",
-            "is_configured": False,
+            "docs_dir_configured": False,
             "uses_custom_conn": False,
             "has_custom_name": False,
         },
@@ -501,7 +501,7 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
         event_type="dbt_docs_access",
         additional_metrics={
             "storage_type": "local",
-            "is_configured": True,
+            "docs_dir_configured": True,
             "uses_custom_conn": False,
             "has_custom_name": False,
         },

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -422,3 +422,105 @@ def test_plugin_registers_listeners():
     assert hasattr(plugin, "listeners"), "Plugin must define a `listeners` attribute"
 
     assert dag_run_listener in plugin.listeners, "CosmosAF3Plugin.listeners must include dag_run_listener module"
+
+
+@skip_pre_airflow_31
+@patch("cosmos.telemetry.emit_usage_metrics_if_enabled")
+def test_dbt_docs_emits_telemetry(mock_emit, tmp_path: Path):
+    """Test that accessing dbt docs emits telemetry."""
+    docs_dir = tmp_path / "target"
+    docs_dir.mkdir(parents=True)
+    index_file = docs_dir / "index.html"
+    index_file.write_text("<head></head><body>dbt</body>")
+
+    projects = {
+        "my_project": {
+            "dir": f"s3://my-bucket/docs",
+            "index": "index.html",
+            "name": "My Project",
+            "conn_id": "my_s3_conn",
+        }
+    }
+    af3, app = _app_with_projects(projects)
+    client = TestClient(app)
+
+    with patch("cosmos.plugin.airflow3.open_file", return_value="<head></head><body>dbt</body>"):
+        r = client.get("/my_project/dbt_docs")
+
+    assert r.status_code == 200
+    mock_emit.assert_called_once_with(
+        event_type="dbt_docs_access",
+        additional_metrics={
+            "storage_type": "s3",
+            "is_configured": True,
+            "uses_custom_conn": True,
+            "project_slug": "my_project",
+            "has_custom_name": True,
+        },
+    )
+
+
+@skip_pre_airflow_31
+@patch("cosmos.telemetry.emit_usage_metrics_if_enabled")
+def test_dbt_docs_emits_telemetry_not_configured(mock_emit):
+    """Test that accessing dbt docs emits telemetry when not configured."""
+    projects = {"empty": {}}
+    af3, app = _app_with_projects(projects)
+    client = TestClient(app)
+
+    r = client.get("/empty/dbt_docs")
+
+    assert r.status_code == 200
+    mock_emit.assert_called_once_with(
+        event_type="dbt_docs_access",
+        additional_metrics={
+            "storage_type": "not_configured",
+            "is_configured": False,
+            "uses_custom_conn": False,
+            "project_slug": "empty",
+            "has_custom_name": False,
+        },
+    )
+
+
+@skip_pre_airflow_31
+@patch("cosmos.telemetry.emit_usage_metrics_if_enabled")
+def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
+    """Test that accessing dbt docs emits telemetry for local storage."""
+    docs_dir = tmp_path / "target"
+    docs_dir.mkdir(parents=True)
+
+    projects = {"local": {"dir": str(docs_dir), "index": "index.html"}}
+    af3, app = _app_with_projects(projects)
+    client = TestClient(app)
+
+    r = client.get("/local/dbt_docs")
+
+    assert r.status_code == 200
+    mock_emit.assert_called_once_with(
+        event_type="dbt_docs_access",
+        additional_metrics={
+            "storage_type": "local",
+            "is_configured": True,
+            "uses_custom_conn": False,
+            "project_slug": "local",
+            "has_custom_name": False,
+        },
+    )
+
+
+@pytest.mark.parametrize(
+    "path,expected_type",
+    [
+        ("s3://bucket/path", "s3"),
+        ("gs://bucket/path", "gcs"),
+        ("wasb://container/path", "azure"),
+        ("http://example.com/path", "http"),
+        ("https://example.com/path", "http"),
+        ("/local/path", "local"),
+    ],
+)
+def test_get_storage_type(path, expected_type):
+    """Test storage type detection from path."""
+    af3 = _reload_af3_module()
+    assert af3._get_storage_type(path) == expected_type

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -67,7 +67,7 @@ def test_emit_usage_metrics_is_unsuccessful(mock_httpx_get, caplog):
     )
     assert not is_success
     log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. Status code: 404. Message: Non existent URL"""
-    assert caplog.text.startswith("WARNING")
+    assert "WARNING" in caplog.text
     assert log_msg in caplog.text
 
 
@@ -94,7 +94,7 @@ def test_emit_usage_metrics_fails(mock_httpx_get, caplog):
     )
     assert not is_success
     log_msg = f"""Unable to emit usage metrics to https://astronomer.gateway.scarf.sh/astronomer-cosmos/v3/dag_run?cosmos_version=1.8.0a4&airflow_version=2.10.1&python_version=3.11&platform_system=darwin&platform_machine=amd64&status=success&dag_hash=d151d1fa2f03270ea116cc7494f2c591&task_count=3&cosmos_task_count=3&execution_modes=local. An HTTPX connection error occurred: Something is not right."""
-    assert caplog.text.startswith("WARNING")
+    assert "WARNING" in caplog.text
     assert log_msg in caplog.text
 
 
@@ -125,7 +125,7 @@ def test_emit_usage_metrics_succeeds(caplog):
 def test_emit_usage_metrics_if_enabled_fails(mock_should_emit, caplog):
     caplog.set_level(logging.DEBUG)
     assert not telemetry.emit_usage_metrics_if_enabled("any", {})
-    assert caplog.text.startswith("DEBUG")
+    assert "DEBUG" in caplog.text
     assert "Telemetry is disabled. To enable it, export AIRFLOW__COSMOS__ENABLE_TELEMETRY=True." in caplog.text
 
 


### PR DESCRIPTION
Adds telemetry emission to track dbt docs plugin usage via Scarf, capturing how users access and configure the dbt documentation viewer.

 ## Metrics Tracked

  - `storage_type`: Backend storage type (s3, gcs, azure, http, local, or not_configured)
  - `dbt_docs_configured`: Whether the docs directory is configured
  - `uses_custom_conn`: Whether a custom connection ID is used
  - `has_custom_name`: Whether a custom project name is set (Airflow 3 only)

I have tested that the events are getting emitted to Scarf for both Airflow 2 and Airflow 3 plugins

closes: #2111