### PR TITLE
Fix TestBehavior.AFTER_ALL is missing project_name information when loading project using manifest file

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -334,7 +334,7 @@ class DbtToAirflowConverter:
             execution_mode=execution_config.execution_mode,
             task_args=task_args,
             test_indirect_selection=execution_config.test_indirect_selection,
-            dbt_project_name=render_config.project_name,
+            dbt_project_name=render_config.project_name or project_config.project_name,
             on_warning_callback=on_warning_callback,
             render_config=render_config,
             async_py_requirements=execution_config.async_py_requirements,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -342,6 +342,50 @@ def test_converter_creates_dag_with_test_with_multiple_parents_test_afterall():
 
 
 @pytest.mark.integration
+def test_converter_creates_dag_with_after_all_test_uses_project_name_from_project_config():
+    """
+    Validate that when using LoadMode.DBT_MANIFEST with project_name set in ProjectConfig
+    but no dbt_project_path in RenderConfig, the test task name uses project_config.project_name
+    instead of falling back to an empty string.
+    """
+    project_config = ProjectConfig(manifest_path=SAMPLE_DBT_MANIFEST, project_name="jaffle_shop")
+    execution_config = ExecutionConfig(
+        execution_mode=ExecutionMode.LOCAL,
+        dbt_project_path=SAMPLE_DBT_PROJECT,  # Required for execution, but not used for project_name
+    )
+    render_config = RenderConfig(
+        test_behavior=TestBehavior.AFTER_ALL,
+        load_method=LoadMode.DBT_MANIFEST,
+        # Note: dbt_project_path is NOT set, so render_config.project_name will be empty
+    )
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    with DAG("sample_dag", start_date=datetime(2024, 4, 16)) as dag:
+        DbtToAirflowConverter(
+            dag=dag,
+            project_config=project_config,
+            profile_config=profile_config,
+            execution_config=execution_config,
+            render_config=render_config,
+        )
+
+    # Find the test task created with AFTER_ALL behavior
+    test_tasks = [task for task in dag.tasks if task.task_id.endswith("_test")]
+    assert len(test_tasks) == 1, "Expected exactly one test task with AFTER_ALL behavior"
+    test_task = test_tasks[0]
+
+    # Verify the test task name uses project_config.project_name instead of empty string
+    assert test_task.task_id == "jaffle_shop_test", (
+        f"Expected test task name to be 'jaffle_shop_test' but got '{test_task.task_id}'. "
+        "This validates that dbt_project_name falls back to project_config.project_name "
+        "when render_config.project_name is empty."
+    )
+
+
+@pytest.mark.integration
 def test_converter_creates_dag_with_test_with_multiple_parents_test_none():
     """
     Validate topology of a project that uses the MULTIPLE_PARENTS_TEST_DBT_PROJECT project


### PR DESCRIPTION
## Description

### Problem

When using `LoadMode.DBT_MANIFEST` with project_name set in `ProjectConfig` but no `dbt_project_path` in `RenderConfig`, the test task created with `TestBehavior.AFTER_ALL` was incorrectly named `_test` instead of `{project_name}_test`.

Example DAG:

```
import datetime
from pathlib import Path

from airflow.providers.standard.operators.empty import EmptyOperator
from airflow.providers.standard.operators.python import PythonOperator
from airflow.sdk import DAG, Asset, Param
from cosmos import DbtTaskGroup, ProjectConfig, ProfileConfig, ExecutionConfig, RenderConfig
from cosmos.constants import TestBehavior, ExecutionMode, LoadMode


# Paths configuration
DAGS_DIR = Path("/opt/airflow/dags")
DBT_PROJECT_PATH = DAGS_DIR / "dbt" / "jaffle_shop"
DBT_PROFILES_PATH = DBT_PROJECT_PATH / "profiles.yml"
DBT_MANIFEST_PATH = DBT_PROJECT_PATH / "target" / "manifest.json"
DBT_CATALOG_PATH = DBT_PROJECT_PATH / "target" / "catalog.json"
DBT_RUN_RESULTS_PATH = DBT_PROJECT_PATH / "target" / "run_results.json"


def dbt_datahub_ingestion(**kwargs) -> None:
    """
    Callback to ingest dbt models's metadata into DataHub.
    """
    from datahub.ingestion.run.pipeline import Pipeline
    from datahub_airflow_plugin.hooks.datahub import DatahubRestHook

    datahub_rest_hook = DatahubRestHook.get_connection(conn_id="datahub_rest_default")
    server, token = datahub_rest_hook.host, datahub_rest_hook.password
    pipeline = Pipeline.create(
        {
            "source": {
                "type": "dbt",
                "config": {
                    "manifest_path": str(DBT_MANIFEST_PATH),
                    "catalog_path": str(DBT_CATALOG_PATH),
                    "run_results_paths": [
                        str(DBT_RUN_RESULTS_PATH),
                    ],
                    "target_platform": "postgres",
                },
            },
            "sink": {
                "type": "datahub-rest",
                "config": {
                    "server": server,
                    "token": token,
                    "retry_max_times": 3,
                },
            },
        }
    )

    pipeline.run()
    pipeline.pretty_print_summary()
    pipeline.raise_from_status()


# Default arguments for the DAG
default_args = {'owner': 'data-team', 'depends_on_past': False, 'email_on_failure': False, 'email_on_retry': False, 'retries': 1, 'retry_delay': datetime.timedelta(seconds=300), 'priority_weight': 1, 'weight_rule': 'downstream', 'queue': 'default', 'pool': 'default_pool', 'email': ['data-team@example.com']}

# Profile configuration using profiles.yml file
profile_config = ProfileConfig(
    profile_name="jaffle_shop",
    target_name="production",
    profiles_yml_filepath=DBT_PROFILES_PATH,
)

# Execution configuration
execution_config = ExecutionConfig(
    dbt_project_path=DBT_PROJECT_PATH,
    execution_mode=ExecutionMode.LOCAL
)

# Render configuration - select which models to run
render_config = RenderConfig(
    select=['path:models/staging', 'path:models/intermediate', 'path:models/marts'],
    emit_datasets=True,
    test_behavior=TestBehavior.AFTER_ALL,
    load_method=LoadMode.DBT_MANIFEST,
)

# Operator arguments - full_refresh is templated to use DAG params at runtime
operator_args = {
    # Use Jinja templating to read full_refresh from DAG params at runtime
    "full_refresh": "{{ params.full_refresh }}",
}

schedule="@daily"

# Create the DAG with full_refresh as a runtime parameter
dag = DAG(
    dag_id="dbt_jaffle_shop_core",
    description="Run all dbt transformations for jaffle_shop (4-level lineage)",
    default_args=default_args,
    schedule=schedule,
    start_date=datetime.datetime(2024, 1, 1),
    catchup=False,
    max_active_runs=1,
    tags=['dbt', 'jaffle_shop', 'full-pipeline', 'data-lineage'],
    params={
        "full_refresh": Param(
            default=False,
            type="boolean",
            description="Run dbt with --full-refresh flag to rebuild all incremental models",
        ),
    },
)

outlet_asset = Asset("dbt://dbt_jaffle_shop_core")

with dag:
    dbt_tasks = DbtTaskGroup(
        group_id="dbt_jaffle_shop",
        project_config=ProjectConfig(
            manifest_path=DBT_MANIFEST_PATH,
            project_name="jaffle_shop",
        ),
        profile_config=profile_config,
        execution_config=execution_config,
        render_config=render_config,
        operator_args=operator_args,
    )

    ingest_datahub_metadata = PythonOperator(
        task_id="ingest_datahub_metadata",
        python_callable=dbt_datahub_ingestion,
        trigger_rule="all_done",
    )

    emit_assets = EmptyOperator(
        task_id="emit_assets",
        outlets=[outlet_asset],
        trigger_rule="all_done",
    )

    dbt_tasks >> [ingest_datahub_metadata, emit_assets]
```

### Solution

As we don't specify the parameter `dbt_project_path` of the class `ProjectConfig`, we have to specify `ProjectConfig.manifest_path` and `ProjectConfig.project_name`. Therefore, we can make use of the `ProjectConfig.project_name`.

## Related Issue(s)

Close #1815 

## Additional Information

Before:

<img width="1051" height="413" alt="image" src="https://github.com/user-attachments/assets/7b18ce11-53eb-4c0c-b301-8956d4f90b91" />

After:

<img width="1031" height="413" alt="image" src="https://github.com/user-attachments/assets/b8b99b97-90aa-43ae-a62b-780fc1a72d06" />
