### PR TITLE
Refactor operator `DbtConsumerWatcherSensor` for reusability

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -178,6 +178,9 @@ TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtReso
 DBT_SETUP_ASYNC_TASK_ID = "dbt_setup_async"
 DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 
+WATCHER_TASK_WEIGHT_RULE = "absolute"
+CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT = 2
+PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT = 20
 PRODUCER_WATCHER_TASK_ID = "dbt_producer_watcher"
 
 # Historical telemetry endpoints retained for reference:

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -82,10 +82,10 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
             profiles_dir=profiles_dir,
             **kwargs,
         )
-        self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
         self.project_dir = project_dir
         self.producer_task_id = producer_task_id
         self.deferrable = deferrable
+        self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
 
     @staticmethod
     def _filter_flags(flags: list[str]) -> list[str]:

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -111,7 +111,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
         """
         logger.info(
-            f"Retry attempt #%s – Running model '%s' from project '%s' using {execution_mode}",
+            f"Retry attempt #%s – Running model '%s' from project '%s' using {self.__class__.__name__}",
             try_number - 1,
             self.model_unique_id,
             self.project_dir,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -1,0 +1,279 @@
+import json
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from airflow.exceptions import AirflowException
+
+from cosmos.config import ProfileConfig
+from cosmos.constants import (
+    AIRFLOW_VERSION,
+    CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT,
+    PRODUCER_WATCHER_TASK_ID,
+    WATCHER_TASK_WEIGHT_RULE,
+)
+from cosmos.log import get_logger
+from cosmos.operators._watcher.state import build_producer_state_fetcher, get_xcom_val, safe_xcom_push
+from cosmos.operators._watcher.triggerer import WatcherTrigger, _parse_compressed_xcom
+
+try:
+    from airflow.sdk.bases.sensor import BaseSensorOperator
+except ImportError:  # pragma: no cover
+    from airflow.sensors.base import BaseSensorOperator
+
+
+if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context  # type: ignore[attr-defined]
+
+
+logger = get_logger(__name__)
+
+
+def _store_dbt_resource_status_from_log(line: str, extra_kwargs: Any) -> None:
+    """
+    Parses a single line from dbt JSON logs and stores node status to Airflow XCom.
+
+    This method parses each log line from dbt when --log-format json is used,
+    extracts node status information, and pushes it to XCom for consumption
+    by downstream watcher sensors.
+    """
+    try:
+        log_line = json.loads(line)
+    except json.JSONDecodeError:
+        logger.debug("Failed to parse log: %s", line)
+        log_line = {}
+    node_info = log_line.get("data", {}).get("node_info", {})
+    node_status = node_info.get("node_status")
+    unique_id = node_info.get("unique_id")
+
+    logger.debug("Model: %s is in %s state", unique_id, node_status)
+
+    # TODO: Handle and store all possible node statuses, not just the current success and failed
+    if node_status in ["success", "failed"]:
+        context = extra_kwargs.get("context")
+        assert context is not None  # Make MyPy happy
+        safe_xcom_push(task_instance=context["ti"], key=f"{unique_id.replace('.', '__')}_status", value=node_status)
+
+
+class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
+    template_fields: tuple[str, ...] = ("model_unique_id", "compiled_sql")  # type: ignore[operator]
+    poke_retry_number: int = 0
+
+    def __init__(
+        self,
+        *,
+        profile_config: ProfileConfig | None = None,
+        project_dir: str | None = None,
+        profiles_dir: str | None = None,
+        producer_task_id: str = PRODUCER_WATCHER_TASK_ID,
+        poke_interval: int = 10,
+        timeout: int = 60 * 60,  # 1 h safety valve
+        execution_timeout: timedelta = timedelta(hours=1),
+        deferrable: bool = True,
+        **kwargs: Any,
+    ) -> None:
+        self.compiled_sql = ""
+        extra_context = kwargs.pop("extra_context") if "extra_context" in kwargs else {}
+        kwargs.setdefault("priority_weight", CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
+        kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
+        super().__init__(
+            poke_interval=poke_interval,
+            timeout=timeout,
+            execution_timeout=execution_timeout,
+            profile_config=profile_config,
+            project_dir=project_dir,
+            profiles_dir=profiles_dir,
+            **kwargs,
+        )
+        self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
+        self.project_dir = project_dir
+        self.producer_task_id = producer_task_id
+        self.deferrable = deferrable
+
+    @staticmethod
+    def _filter_flags(flags: list[str]) -> list[str]:
+        """Filters out dbt flags that are incompatible with retry (e.g., --select, --exclude)."""
+        filtered = []
+        skip_next = False
+        for token in flags:
+            if skip_next:
+                if token.startswith("--"):
+                    skip_next = False
+                else:
+                    continue  # skip value of previous flag
+            if token in ("--select", "--exclude"):
+                skip_next = True
+                continue
+            filtered.append(token)
+        return filtered
+
+    def _fallback_to_non_watcher_run(self, try_number: int, context: Context) -> bool:
+        """
+        Handles logic for retrying a failed dbt model execution.
+        Reconstructs the dbt command by cloning the project and re-running the model
+        with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
+        """
+        logger.info(
+            "Retry attempt #%s – Running model '%s' from project '%s' using ExecutionMode.LOCAL",
+            try_number - 1,
+            self.model_unique_id,
+            self.project_dir,
+        )
+
+        upstream_task = context["ti"].task.dag.get_task(self.producer_task_id)
+
+        extra_flags: list[str] = []
+        if upstream_task and hasattr(upstream_task, "add_cmd_flags"):
+            raw_flags = upstream_task.add_cmd_flags()
+            extra_flags = self._filter_flags(raw_flags)
+
+        model_selector = self.model_unique_id.split(".")[-1]
+        cmd_flags = extra_flags + ["--select", model_selector]
+
+        self.build_and_run_cmd(context, cmd_flags=cmd_flags)
+
+        logger.info("dbt run completed successfully on retry for model '%s'", self.model_unique_id)
+        return True
+
+    def _get_status_from_run_results(self, ti: Any, context: Context) -> Any:
+        compressed_b64_run_results = ti.xcom_pull(task_ids=self.producer_task_id, key="run_results")
+
+        if not compressed_b64_run_results:
+            return None
+
+        run_results_json = _parse_compressed_xcom(compressed_b64_run_results)
+
+        logger.debug("Run results: %s", run_results_json)
+
+        results = run_results_json.get("results", [])
+        node_result = next((r for r in results if r.get("unique_id") == self.model_unique_id), None)
+
+        if not node_result:  # pragma: no cover
+            logger.warning("No matching result found for unique_id '%s'", self.model_unique_id)
+            return None
+
+        logger.info("Node Info: %s", run_results_json)
+        self.compiled_sql = node_result.get("compiled_code")
+        if self.compiled_sql:
+            self._override_rtif(context)
+
+        return node_result.get("status")
+
+    def _get_producer_task_status(self, context: Context) -> str | None:
+        """
+        Get the task status of the producer task for both Airflow 2 and Airflow 3.
+
+        Returns the state of the producer task instance, or None if not found.
+        """
+        ti = context["ti"]
+        run_id = context["run_id"]
+        dag_id = ti.dag_id
+
+        fetch_state = build_producer_state_fetcher(
+            airflow_version=AIRFLOW_VERSION,
+            dag_id=dag_id,
+            run_id=run_id,
+            producer_task_id=self.producer_task_id,
+            logger=logger,
+        )
+        if fetch_state is None:
+            return None
+
+        return fetch_state()
+
+    def execute(self, context: Context, **kwargs: Any) -> None:
+        if not self.deferrable:
+            super().execute(context)
+        elif not self.poke(context):
+            self.defer(
+                trigger=WatcherTrigger(
+                    model_unique_id=self.model_unique_id,
+                    producer_task_id=self.producer_task_id,
+                    dag_id=self.dag_id,
+                    run_id=context["run_id"],
+                    map_index=context["task_instance"].map_index,
+                    use_event=self._use_event(),
+                    poke_interval=self.poke_interval,
+                ),
+                timeout=self.execution_timeout,
+                method_name=self.execute_complete.__name__,
+            )
+
+    def execute_complete(self, context: Context, event: dict[str, str]) -> None:
+        status = event.get("status")
+        if status != "failed":
+            return
+
+        reason = event.get("reason")
+        if reason == "model_failed":
+            raise AirflowException(
+                f"dbt model '{self.model_unique_id}' failed. Review the producer task '{self.producer_task_id}' logs for details."
+            )
+
+        if reason == "producer_failed":
+            raise AirflowException(
+                f"Watcher producer task '{self.producer_task_id}' failed before reporting model results. Check its logs for the underlying error."
+            )
+
+    def _use_event(self) -> bool:
+        raise NotImplementedError("Subclasses must implement this method")
+
+    def _get_status_from_events(self, ti: Any, context: Context) -> Any:
+        raise NotImplementedError("Subclasses should implement this method if `_use_event` may return True")
+
+    def _override_rtif(self, context: Context) -> None:
+        raise NotImplementedError(
+            "Subclasses should implement this method, or inherit from a class that implements it (e.g. DbtRunLocalOperator)."
+        )
+
+    def build_and_run_cmd(self, context: Context, cmd_flags: list[str]) -> None:
+        raise NotImplementedError(
+            "Subclasses should implement this method, or inherit from a class that implements it (e.g. DbtRunLocalOperator)."
+        )
+
+    def poke(self, context: Context) -> bool:
+        """
+        Checks the status of a dbt model run by pulling relevant XComs from the master task.
+        Handles retries and checks for successful completion of the model execution.
+        """
+        ti = context["ti"]
+        try_number = ti.try_number
+
+        logger.info(
+            "Try number #%s, poke attempt #%s: Pulling status from task_id '%s' for model '%s'",
+            try_number,
+            self.poke_retry_number,
+            self.producer_task_id,
+            self.model_unique_id,
+        )
+
+        if try_number > 1:
+            return self._fallback_to_non_watcher_run(try_number, context)
+
+        # We have assumption here that both the build producer and the sensor task will have same invocation mode
+        producer_task_state = self._get_producer_task_status(context)
+        if self._use_event():
+            status = self._get_status_from_events(ti, context)
+        else:
+            status = get_xcom_val(ti, self.producer_task_id, f"{self.model_unique_id.replace('.', '__')}_status")
+
+        if status is None:
+
+            if producer_task_state == "failed":
+                if self.poke_retry_number > 0:
+                    raise AirflowException(
+                        f"The dbt build command failed in producer task. Please check the log of task {self.producer_task_id} for details."
+                    )
+                else:
+                    # This handles the scenario of tasks that failed with `State.UPSTREAM_FAILED`
+                    return self._fallback_to_non_watcher_run(try_number, context)
+
+            self.poke_retry_number += 1
+
+            return False
+        elif status == "success":
+            return True
+        else:
+            raise AirflowException(f"Model '{self.model_unique_id}' finished with status '{status}'")

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -111,7 +111,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
         """
         logger.info(
-            "Retry attempt #%s – Running model '%s' from project '%s' using ExecutionMode.LOCAL",
+            f"Retry attempt #%s – Running model '%s' from project '%s' using {execution_mode}",
             try_number - 1,
             self.model_unique_id,
             self.project_dir,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -26,7 +26,7 @@ except ImportError:  # pragma: no cover
 logger = get_logger(__name__)
 
 
-def _store_dbt_resource_status_from_log(line: str, extra_kwargs: Any) -> None:
+def store_dbt_resource_status_from_log(line: str, extra_kwargs: Any) -> None:
     """
     Parses a single line from dbt JSON logs and stores node status to Airflow XCom.
 

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -189,7 +189,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
                     dag_id=self.dag_id,
                     run_id=context["run_id"],
                     map_index=context["task_instance"].map_index,
-                    use_event=self._use_event(),
+                    use_event=self.use_event(),
                     poke_interval=self.poke_interval,
                 ),
                 timeout=self.execution_timeout,
@@ -212,11 +212,11 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
                 f"Watcher producer task '{self.producer_task_id}' failed before reporting model results. Check its logs for the underlying error."
             )
 
-    def _use_event(self) -> bool:
+    def use_event(self) -> bool:
         raise NotImplementedError("Subclasses must implement this method")
 
     def _get_status_from_events(self, ti: Any, context: Context) -> Any:
-        raise NotImplementedError("Subclasses should implement this method if `_use_event` may return True")
+        raise NotImplementedError("Subclasses should implement this method if `use_event` may return True")
 
     def poke(self, context: Context) -> bool:
         """
@@ -239,7 +239,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
 
         # We have assumption here that both the build producer and the sensor task will have same invocation mode
         producer_task_state = self._get_producer_task_status(context)
-        if self._use_event():
+        if self.use_event():
             status = self._get_status_from_events(ti, context)
         else:
             status = get_xcom_val(ti, self.producer_task_id, f"{self.model_unique_id.replace('.', '__')}_status")

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -26,7 +26,7 @@ from cosmos.constants import (
     InvocationMode,
 )
 from cosmos.log import get_logger
-from cosmos.operators._watcher.base import BaseConsumerSensor, _store_dbt_resource_status_from_log
+from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
 from cosmos.operators.base import (
     DbtBuildMixin,
     DbtRunMixin,
@@ -83,7 +83,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     template_fields = DbtLocalBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
     # Use staticmethod to prevent Python's descriptor protocol from binding the function to `self`
     # when accessed via instance, which would incorrectly pass `self` as the first argument
-    _process_log_line_callable = staticmethod(_store_dbt_resource_status_from_log)
+    _process_log_line_callable = staticmethod(store_dbt_resource_status_from_log)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -11,7 +11,6 @@ from typing import TYPE_CHECKING, Any
 from airflow.exceptions import AirflowException
 
 from cosmos.config import ProfileConfig
-from cosmos.constants import CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT
 from cosmos.operators._watcher import _parse_compressed_xcom, safe_xcom_push
 
 try:
@@ -227,10 +226,6 @@ class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type
         deferrable: bool = True,
         **kwargs: Any,
     ) -> None:
-        self.compiled_sql = ""
-        extra_context = kwargs.pop("extra_context") if "extra_context" in kwargs else {}
-        kwargs.setdefault("priority_weight", CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
-        kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
         super().__init__(
             poke_interval=poke_interval,
             timeout=timeout,
@@ -240,9 +235,6 @@ class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type
             profiles_dir=profiles_dir,
             **kwargs,
         )
-        self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
-        self.producer_task_id = producer_task_id
-        self.deferrable = deferrable
 
     def _get_status_from_events(self, ti: Any, context: Context) -> Any:
 

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -259,7 +259,7 @@ class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type
 
         return event_json.get("data", {}).get("run_result", {}).get("status")
 
-    def _use_event(self) -> bool:
+    def use_event(self) -> bool:
         if not self.invocation_mode:
             self._discover_invocation_mode()
         return self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -2,26 +2,17 @@ from __future__ import annotations
 
 import base64
 import json
-import logging
 import zlib
 from collections.abc import Sequence
 from datetime import timedelta
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from cosmos.operators._watcher import WatcherTrigger, _parse_compressed_xcom, get_xcom_val, safe_xcom_push
-
-if TYPE_CHECKING:  # pragma: no cover
-    try:
-        from airflow.sdk.definitions.context import Context
-    except ImportError:
-        from airflow.utils.context import Context  # type: ignore[attr-defined]
-
-try:
-    from airflow.sdk.bases.sensor import BaseSensorOperator
-except ImportError:  # pragma: no cover
-    from airflow.sensors.base import BaseSensorOperator
 from airflow.exceptions import AirflowException
+
+from cosmos.config import ProfileConfig
+from cosmos.constants import CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT
+from cosmos.operators._watcher import _parse_compressed_xcom, safe_xcom_push
 
 try:
     from airflow.providers.standard.operators.empty import EmptyOperator
@@ -29,9 +20,14 @@ except ImportError:  # pragma: no cover
     from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
 
 
-from cosmos.config import ProfileConfig
-from cosmos.constants import AIRFLOW_VERSION, PRODUCER_WATCHER_TASK_ID, InvocationMode
-from cosmos.operators._watcher.state import build_producer_state_fetcher
+from cosmos.constants import (
+    PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT,
+    PRODUCER_WATCHER_TASK_ID,
+    WATCHER_TASK_WEIGHT_RULE,
+    InvocationMode,
+)
+from cosmos.log import get_logger
+from cosmos.operators._watcher.base import BaseConsumerSensor, _store_dbt_resource_status_from_log
 from cosmos.operators.base import (
     DbtBuildMixin,
     DbtRunMixin,
@@ -49,37 +45,15 @@ try:
 except ImportError:  # pragma: no cover
     EventMsg = None
 
-logger = logging.getLogger(__name__)
 
-CONSUMER_OPERATOR_DEFAULT_PRIORITY_WEIGHT = 10
-PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT = 9999
-WEIGHT_RULE = "absolute"  # the default "downstream" does not work with dag.test()
-
-
-def _store_dbt_resource_status_from_log(line: str, extra_kwargs: Any) -> None:
-    """
-    Parses a single line from dbt JSON logs and stores node status to Airflow XCom.
-
-    This method parses each log line from dbt when --log-format json is used,
-    extracts node status information, and pushes it to XCom for consumption
-    by downstream watcher sensors.
-    """
+if TYPE_CHECKING:  # pragma: no cover
     try:
-        log_line = json.loads(line)
-    except json.JSONDecodeError:
-        logger.debug("Failed to parse log: %s", line)
-        log_line = {}
-    node_info = log_line.get("data", {}).get("node_info", {})
-    node_status = node_info.get("node_status")
-    unique_id = node_info.get("unique_id")
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context  # type: ignore[attr-defined]
 
-    logger.debug("Model: %s is in %s state", unique_id, node_status)
 
-    # TODO: Handle and store all possible node statuses, not just the current success and failed
-    if node_status in ["success", "failed"]:
-        context = extra_kwargs.get("context")
-        assert context is not None  # Make MyPy happy
-        safe_xcom_push(task_instance=context["ti"], key=f"{unique_id.replace('.', '__')}_status", value=node_status)
+logger = get_logger(__name__)
 
 
 class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
@@ -113,9 +87,9 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     _process_log_line_callable = staticmethod(_store_dbt_resource_status_from_log)
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
-        kwargs.setdefault("priority_weight", PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT)
-        kwargs.setdefault("weight_rule", WEIGHT_RULE)
+        task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
+        kwargs.setdefault("priority_weight", PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
+        kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
         # Consumer watcher retry logic handles model-level reruns using the LOCAL execution mode; rerunning the producer
         # would repeat the full dbt build and duplicate watcher callbacks which may not be processed by the consumers if
         # they have already processed output XCOMs from the first run of the producer, so we disable retries.
@@ -237,9 +211,8 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             raise
 
 
-class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type: ignore[misc]
-    template_fields: tuple[str, ...] = DbtRunLocalOperator.template_fields + ("model_unique_id",)  # type: ignore[operator]
-    poke_retry_number: int = 0
+class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type: ignore[misc]
+    template_fields: tuple[str, ...] = BaseConsumerSensor.template_fields + DbtRunLocalOperator.template_fields  # type: ignore[operator]
 
     def __init__(
         self,
@@ -256,8 +229,8 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
     ) -> None:
         self.compiled_sql = ""
         extra_context = kwargs.pop("extra_context") if "extra_context" in kwargs else {}
-        kwargs.setdefault("priority_weight", CONSUMER_OPERATOR_DEFAULT_PRIORITY_WEIGHT)
-        kwargs.setdefault("weight_rule", WEIGHT_RULE)
+        kwargs.setdefault("priority_weight", CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
+        kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
         super().__init__(
             poke_interval=poke_interval,
             timeout=timeout,
@@ -270,51 +243,6 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
         self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
         self.producer_task_id = producer_task_id
         self.deferrable = deferrable
-
-    @staticmethod
-    def _filter_flags(flags: list[str]) -> list[str]:
-        """Filters out dbt flags that are incompatible with retry (e.g., --select, --exclude)."""
-        filtered = []
-        skip_next = False
-        for token in flags:
-            if skip_next:
-                if token.startswith("--"):
-                    skip_next = False
-                else:
-                    continue  # skip value of previous flag
-            if token in ("--select", "--exclude"):
-                skip_next = True
-                continue
-            filtered.append(token)
-        return filtered
-
-    def _fallback_to_local_run(self, try_number: int, context: Context) -> bool:
-        """
-        Handles logic for retrying a failed dbt model execution.
-        Reconstructs the dbt command by cloning the project and re-running the model
-        with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
-        """
-        logger.info(
-            "Retry attempt #%s – Running model '%s' from project '%s' using ExecutionMode.LOCAL",
-            try_number - 1,
-            self.model_unique_id,
-            self.project_dir,
-        )
-
-        upstream_task = context["ti"].task.dag.get_task(self.producer_task_id)
-
-        extra_flags: list[str] = []
-        if upstream_task and hasattr(upstream_task, "add_cmd_flags"):
-            raw_flags = upstream_task.add_cmd_flags()
-            extra_flags = self._filter_flags(raw_flags)
-
-        model_selector = self.model_unique_id.split(".")[-1]
-        cmd_flags = extra_flags + ["--select", model_selector]
-
-        self.build_and_run_cmd(context, cmd_flags=cmd_flags)
-
-        logger.info("dbt run completed successfully on retry for model '%s'", self.model_unique_id)
-        return True
 
     def _get_status_from_events(self, ti: Any, context: Context) -> Any:
 
@@ -339,135 +267,10 @@ class DbtConsumerWatcherSensor(BaseSensorOperator, DbtRunLocalOperator):  # type
 
         return event_json.get("data", {}).get("run_result", {}).get("status")
 
-    def _get_status_from_run_results(self, ti: Any, context: Context) -> Any:
-        compressed_b64_run_results = ti.xcom_pull(task_ids=self.producer_task_id, key="run_results")
-
-        if not compressed_b64_run_results:
-            return None
-
-        run_results_json = _parse_compressed_xcom(compressed_b64_run_results)
-
-        logger.debug("Run results: %s", run_results_json)
-
-        results = run_results_json.get("results", [])
-        node_result = next((r for r in results if r.get("unique_id") == self.model_unique_id), None)
-
-        if not node_result:  # pragma: no cover
-            logger.warning("No matching result found for unique_id '%s'", self.model_unique_id)
-            return None
-
-        logger.info("Node Info: %s", run_results_json)
-        self.compiled_sql = node_result.get("compiled_code")
-        if self.compiled_sql:
-            self._override_rtif(context)
-
-        return node_result.get("status")
-
-    def _get_producer_task_status(self, context: Context) -> str | None:
-        """
-        Get the task status of the producer task for both Airflow 2 and Airflow 3.
-
-        Returns the state of the producer task instance, or None if not found.
-        """
-        ti = context["ti"]
-        run_id = context["run_id"]
-        dag_id = ti.dag_id
-
-        fetch_state = build_producer_state_fetcher(
-            airflow_version=AIRFLOW_VERSION,
-            dag_id=dag_id,
-            run_id=run_id,
-            producer_task_id=self.producer_task_id,
-            logger=logger,
-        )
-        if fetch_state is None:
-            return None
-
-        return fetch_state()
-
-    def execute(self, context: Context, **kwargs: Any) -> None:
-        if not self.deferrable:
-            super().execute(context)
-        elif not self.poke(context):
-            self.defer(
-                trigger=WatcherTrigger(
-                    model_unique_id=self.model_unique_id,
-                    producer_task_id=self.producer_task_id,
-                    dag_id=self.dag_id,
-                    run_id=context["run_id"],
-                    map_index=context["task_instance"].map_index,
-                    use_event=self._use_event(),
-                    poke_interval=self.poke_interval,
-                ),
-                timeout=self.execution_timeout,
-                method_name=self.execute_complete.__name__,
-            )
-
-    def execute_complete(self, context: Context, event: dict[str, str]) -> None:
-        status = event.get("status")
-        if status != "failed":
-            return
-
-        reason = event.get("reason")
-        if reason == "model_failed":
-            raise AirflowException(
-                f"dbt model '{self.model_unique_id}' failed. Review the producer task '{self.producer_task_id}' logs for details."
-            )
-
-        if reason == "producer_failed":
-            raise AirflowException(
-                f"Watcher producer task '{self.producer_task_id}' failed before reporting model results. Check its logs for the underlying error."
-            )
-
     def _use_event(self) -> bool:
         if not self.invocation_mode:
             self._discover_invocation_mode()
         return self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None
-
-    def poke(self, context: Context) -> bool:
-        """
-        Checks the status of a dbt model run by pulling relevant XComs from the master task.
-        Handles retries and checks for successful completion of the model execution.
-        """
-        ti = context["ti"]
-        try_number = ti.try_number
-
-        logger.info(
-            "Try number #%s, poke attempt #%s: Pulling status from task_id '%s' for model '%s'",
-            try_number,
-            self.poke_retry_number,
-            self.producer_task_id,
-            self.model_unique_id,
-        )
-
-        if try_number > 1:
-            return self._fallback_to_local_run(try_number, context)
-
-        # We have assumption here that both the build producer and the sensor task will have same invocation mode
-        producer_task_state = self._get_producer_task_status(context)
-        if self._use_event():
-            status = self._get_status_from_events(ti, context)
-        else:
-            status = get_xcom_val(ti, self.producer_task_id, f"{self.model_unique_id.replace('.', '__')}_status")
-
-        if status is None:
-
-            if producer_task_state == "failed":
-                if self.poke_retry_number > 0:
-                    raise AirflowException(
-                        f"The dbt build command failed in producer task. Please check the log of task {self.producer_task_id} for details."
-                    )
-                else:
-                    # This handles the scenario of tasks that failed with `State.UPSTREAM_FAILED`
-                    return self._fallback_to_local_run(try_number, context)
-
-            self.poke_retry_number += 1
-
-            return False
-        elif status == "success":
-            return True
-        else:
-            raise AirflowException(f"Model '{self.model_unique_id}' finished with status '{status}'")
 
 
 # This Operator does not seem to make sense for this particular execution mode, since build is executed by the producer task.

--- a/tests/hooks/test_subprocess.py
+++ b/tests/hooks/test_subprocess.py
@@ -96,7 +96,7 @@ def test_store_dbt_resource_status_from_log_param(status, context, should_push, 
     log_line = {"data": {"node_info": {"node_status": status, "unique_id": "model.jaffle_shop.stg_orders"}}}
     line = json.dumps(log_line)
 
-    with patch("cosmos.operators.watcher.safe_xcom_push") as mock_push:
+    with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
         if expect_assert:
             with pytest.raises(AssertionError):
                 _store_dbt_resource_status_from_log(line, {"context": context})
@@ -113,6 +113,6 @@ def test_store_dbt_resource_status_from_log_param(status, context, should_push, 
 def test_store_dbt_resource_status_from_log_invalid_json():
     invalid_line = "{not a valid json}"
 
-    with patch("cosmos.operators.watcher.safe_xcom_push") as mock_push:
+    with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
         _store_dbt_resource_status_from_log(invalid_line, {"context": {"ti": MagicMock()}})
         mock_push.assert_not_called()

--- a/tests/hooks/test_subprocess.py
+++ b/tests/hooks/test_subprocess.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cosmos.hooks.subprocess import FullOutputSubprocessHook
-from cosmos.operators.watcher import _store_dbt_resource_status_from_log
+from cosmos.operators.watcher import store_dbt_resource_status_from_log
 
 OS_ENV_KEY = "SUBPROCESS_ENV_TEST"
 OS_ENV_VAL = "this-is-from-os-environ"
@@ -91,7 +91,7 @@ def test_send_sigterm(mock_killpg, mock_getpgid):
         ("failed", None, False, True),
     ],
 )
-def test_store_dbt_resource_status_from_log_param(status, context, should_push, expect_assert):
+def teststore_dbt_resource_status_from_log_param(status, context, should_push, expect_assert):
     # Prepare log line
     log_line = {"data": {"node_info": {"node_status": status, "unique_id": "model.jaffle_shop.stg_orders"}}}
     line = json.dumps(log_line)
@@ -99,9 +99,9 @@ def test_store_dbt_resource_status_from_log_param(status, context, should_push, 
     with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
         if expect_assert:
             with pytest.raises(AssertionError):
-                _store_dbt_resource_status_from_log(line, {"context": context})
+                store_dbt_resource_status_from_log(line, {"context": context})
         else:
-            _store_dbt_resource_status_from_log(line, {"context": context})
+            store_dbt_resource_status_from_log(line, {"context": context})
             if should_push:
                 mock_push.assert_called_once_with(
                     task_instance=context["ti"], key="model__jaffle_shop__stg_orders_status", value=status
@@ -110,9 +110,9 @@ def test_store_dbt_resource_status_from_log_param(status, context, should_push, 
                 mock_push.assert_not_called()
 
 
-def test_store_dbt_resource_status_from_log_invalid_json():
+def teststore_dbt_resource_status_from_log_invalid_json():
     invalid_line = "{not a valid json}"
 
     with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
-        _store_dbt_resource_status_from_log(invalid_line, {"context": {"ti": MagicMock()}})
+        store_dbt_resource_status_from_log(invalid_line, {"context": {"ti": MagicMock()}})
         mock_push.assert_not_called()

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -17,10 +17,9 @@ from packaging.version import Version
 
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig, TestBehavior
 from cosmos.config import InvocationMode
-from cosmos.constants import ExecutionMode
+from cosmos.constants import PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT, ExecutionMode
 from cosmos.operators._watcher import WatcherTrigger
 from cosmos.operators.watcher import (
-    PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT,
     DbtBuildWatcherOperator,
     DbtConsumerWatcherSensor,
     DbtProducerWatcherOperator,
@@ -104,7 +103,7 @@ def test_serialize_event(mock_mtd):
 def test_dbt_producer_watcher_operator_priority_weight_default():
     """Test that DbtProducerWatcherOperator uses default priority_weight of 9999."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
-    assert op.priority_weight == PRODUCER_OPERATOR_DEFAULT_PRIORITY_WEIGHT
+    assert op.priority_weight == PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT
 
 
 def test_dbt_producer_watcher_operator_priority_weight_override():
@@ -610,7 +609,7 @@ class TestDbtConsumerWatcherSensor:
         }
 
     @pytest.mark.skipif(AIRFLOW_VERSION >= Version("3.0.0"), reason="RuntimeTaskInstance path in Airflow >= 3.0")
-    @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("2.7.0"))
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("2.7.0"))
     def test_get_producer_task_status_airflow2(self):
         sensor = self.make_sensor()
         sensor._get_producer_task_status = DbtConsumerWatcherSensor._get_producer_task_status.__get__(
@@ -622,7 +621,7 @@ class TestDbtConsumerWatcherSensor:
 
         fetcher = MagicMock(return_value="success")
 
-        with patch("cosmos.operators.watcher.build_producer_state_fetcher", return_value=fetcher) as mock_builder:
+        with patch("cosmos.operators._watcher.base.build_producer_state_fetcher", return_value=fetcher) as mock_builder:
             status = sensor._get_producer_task_status(context)
 
         mock_builder.assert_called_once_with(
@@ -636,7 +635,7 @@ class TestDbtConsumerWatcherSensor:
         assert status == "success"
 
     @pytest.mark.skipif(AIRFLOW_VERSION >= Version("3.0.0"), reason="RuntimeTaskInstance path in Airflow >= 3.0")
-    @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("2.7.0"))
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("2.7.0"))
     def test_get_producer_task_status_airflow2_missing_instance(self):
         sensor = self.make_sensor()
         sensor._get_producer_task_status = DbtConsumerWatcherSensor._get_producer_task_status.__get__(
@@ -648,14 +647,14 @@ class TestDbtConsumerWatcherSensor:
 
         fetcher = MagicMock(return_value=None)
 
-        with patch("cosmos.operators.watcher.build_producer_state_fetcher", return_value=fetcher):
+        with patch("cosmos.operators._watcher.base.build_producer_state_fetcher", return_value=fetcher):
             status = sensor._get_producer_task_status(context)
 
         fetcher.assert_called_once_with()
         assert status is None
 
     @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
-    @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3(self, mock_get_task_states):
         sensor = self.make_sensor()
@@ -676,7 +675,7 @@ class TestDbtConsumerWatcherSensor:
         )
 
     @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
-    @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3_missing_state(self, mock_get_task_states):
         sensor = self.make_sensor()
@@ -697,7 +696,7 @@ class TestDbtConsumerWatcherSensor:
         )
 
     @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
-    @patch("cosmos.operators.watcher.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
     def test_get_producer_task_status_airflow3_import_error(self):
         sensor = self.make_sensor()
         sensor._get_producer_task_status = DbtConsumerWatcherSensor._get_producer_task_status.__get__(
@@ -707,7 +706,7 @@ class TestDbtConsumerWatcherSensor:
         ti.dag_id = "example_dag"
         context = self.make_context(ti, run_id="run_4")
 
-        with patch("cosmos.operators.watcher.build_producer_state_fetcher", return_value=None) as mock_builder:
+        with patch("cosmos.operators._watcher.base.build_producer_state_fetcher", return_value=None) as mock_builder:
             status = sensor._get_producer_task_status(context)
 
         mock_builder.assert_called_once_with(
@@ -748,7 +747,7 @@ class TestDbtConsumerWatcherSensor:
         assert result is True
 
     @patch("cosmos.operators.watcher.DbtConsumerWatcherSensor._get_producer_task_status", return_value=None)
-    def _fallback_to_local_run(self, mock_get_producer_task_status):
+    def _fallback_to_non_watcher_run(self, mock_get_producer_task_status):
         sensor = self.make_sensor()
         sensor.invocation_mode = None
 
@@ -794,14 +793,14 @@ class TestDbtConsumerWatcherSensor:
         sensor.poke(context)
         mock_build_and_run_cmd.assert_called_once()
 
-    def test_fallback_to_local_run(self):
+    def test_fallback_to_non_watcher_run(self):
         sensor = self.make_sensor()
         ti = MagicMock()
         ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--select", "some_model", "--threads", "2"]
         context = self.make_context(ti)
         sensor.build_and_run_cmd = MagicMock()
 
-        result = sensor._fallback_to_local_run(2, context)
+        result = sensor._fallback_to_non_watcher_run(2, context)
 
         assert result is True
         sensor.build_and_run_cmd.assert_called_once()
@@ -863,7 +862,7 @@ class TestDbtConsumerWatcherSensor:
         assert result == "success"
         assert sensor.compiled_sql == "select 42"
 
-    @patch("cosmos.operators.watcher.get_xcom_val")
+    @patch("cosmos.operators._watcher.base.get_xcom_val")
     def test_producer_state_failed(self, mock_get_xcom_val):
         sensor = self.make_sensor()
         sensor._get_producer_task_status.return_value = "failed"
@@ -881,10 +880,10 @@ class TestDbtConsumerWatcherSensor:
         ):
             sensor.poke(context)
 
-    @patch("cosmos.operators.watcher.DbtConsumerWatcherSensor._fallback_to_local_run")
-    @patch("cosmos.operators.watcher.get_xcom_val")
+    @patch("cosmos.operators.watcher.DbtConsumerWatcherSensor._fallback_to_non_watcher_run")
+    @patch("cosmos.operators._watcher.base.get_xcom_val")
     def test_producer_state_does_not_fail_if_previously_upstream_failed(
-        self, mock_get_xcom_val, mock_fallback_to_local_run
+        self, mock_get_xcom_val, mock_fallback_to_non_watcher_run
     ):
         """
         Attempt to run the task using ExecutionMode.LOCAL if State.UPSTREAM_FAILED happens.
@@ -901,7 +900,7 @@ class TestDbtConsumerWatcherSensor:
         context = self.make_context(ti)
 
         sensor.poke(context)
-        mock_fallback_to_local_run.assert_called_once()
+        mock_fallback_to_non_watcher_run.assert_called_once()
 
     @patch("cosmos.operators.local.AbstractDbtLocalBase._override_rtif")
     def test_get_status_from_run_results_with_compiled_sql(self, mock_override_rtif, monkeypatch):


### PR DESCRIPTION
This PR extracts basic watcher operator features that will be reused by the `ExecutionMode.WATCHER_KUBERNETES` implementation in #2207, so that the last PR related to introducing `ExecutionMode.WATCHER_KUBERNETES`   becomes smaller and easier to review.

This PR does not add any new features or functionality. The main changes are:
- Remove definitions that will be shared between `ExecutionMode.WATCHER` and `ExecutionMode.WATCHER_KUBERNETES` from `cosmos.operators.watcher.BaseConsumerSensor` to `cosmos.operators._watcher.base.DbtConsumerWatcherSensor`
- Move `cosmos.operators.watcher._store_dbt_resource_status_from_log` to `cosmos.operators._watchers.base._store_dbt_resource_status_from_log`

**How the changes were validated**

In addition to the automated tests we run in the CI, I ran manually three different DAGs that use `ExecutionMode.WATCHER`:
- `example_watcher` that is in our repo in `dev/dags/example_watcher.py`
- `example_watcher_synchronous` that is in our repo in `dev/dags/example_watcher.py`
- modified version of `example_watcher` to validate subprocess, where I changed `execution_config` to:
```
    execution_config=ExecutionConfig(
        execution_mode=ExecutionMode.WATCHER,
        invocation_mode=InvocationMode.SUBPROCESS,
        dbt_executable_path="/Users/tatiana.alchueyr/Code/astronomer-cosmos/venv/bin/dbt"
        ),
```

Screenshots with the successful runs:

DAG overview:
<img width="976" height="411" alt="Screenshot 2026-01-06 at 12 18 55" src="https://github.com/user-attachments/assets/9df18b0f-cabf-4ecd-ad19-b681ef244c58" />

Using `InvocationMode.DBT_RUNNER`
<img width="1624" height="1056" alt="Screenshot 2026-01-06 at 12 18 33" src="https://github.com/user-attachments/assets/035d3710-b367-412f-83e5-8c46ad46a9c4" />

Using `InvocationMode.SUBPROCESS`
<img width="1624" height="1056" alt="Screenshot 2026-01-06 at 12 22 47" src="https://github.com/user-attachments/assets/c9be08cd-4035-447b-863a-7864a23de11f" />

Consumers continue sensing:
<img width="1624" height="1056" alt="Screenshot 2026-01-06 at 12 18 47" src="https://github.com/user-attachments/assets/d08ac666-367d-4cd1-912d-19f8ae3e9f3f" />

Runs with synchronous sensors:
<img width="1505" height="823" alt="Screenshot 2026-01-06 at 12 26 17" src="https://github.com/user-attachments/assets/59437a0a-ad85-48f0-9c3f-95db47ddc94c" />
