### PR TITLE
Error when `RenderConfig.invocation_mode` is incorrectly set

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -180,7 +180,7 @@ def validate_initial_user_config(
             "please use ProjectConfig.env_vars instead."
         )
 
-    if render_config.invocation_mode == InvocationMode.DBT_RUNNER:
+    if render_config is not None and render_config.invocation_mode == InvocationMode.DBT_RUNNER:
         if not is_dbt_installed_in_same_environment():
             raise CosmosValueError(
                 "RenderConfig.invocation_mode is set to InvocationMode.DBT_RUNNER, but dbt is not installed in the same environment as Airflow. Use InvocationMode.DBT_SUBPROCESS instead."

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -24,7 +24,8 @@ except ImportError:
 from cosmos import cache, settings
 from cosmos.airflow.graph import build_airflow_graph
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import DbtResourceType, ExecutionMode, LoadMode
+from cosmos.constants import DbtResourceType, ExecutionMode, InvocationMode, LoadMode
+from cosmos.dbt.executable import get_system_dbt, is_dbt_installed_in_same_environment
 from cosmos.dbt.graph import DbtGraph
 from cosmos.dbt.project import has_non_empty_dependencies_file
 from cosmos.dbt.selector import retrieve_by_label
@@ -178,6 +179,16 @@ def validate_initial_user_config(
             "Both ProjectConfig.env_vars and RenderConfig.env_vars were provided. RenderConfig.env_vars is deprecated since Cosmos 1.3, "
             "please use ProjectConfig.env_vars instead."
         )
+
+    if render_config.invocation_mode == InvocationMode.DBT_RUNNER:
+        if not is_dbt_installed_in_same_environment():
+            raise CosmosValueError(
+                "RenderConfig.invocation_mode is set to InvocationMode.DBT_RUNNER, but dbt is not installed in the same environment as Airflow. Use InvocationMode.DBT_SUBPROCESS instead."
+            )
+        if render_config.dbt_executable_path and render_config.dbt_executable_path != get_system_dbt():
+            raise CosmosValueError(
+                "RenderConfig.dbt_executable_path is set, but it is not the same as the system dbt executable path. Do not set render_config.dbt_executable_path when using InvocationMode.DBT_RUNNER."
+            )
 
 
 def validate_changed_config_paths(

--- a/cosmos/dbt/executable.py
+++ b/cosmos/dbt/executable.py
@@ -6,3 +6,15 @@ def get_system_dbt() -> str:
     Tries to identify which is the path to the dbt executable, return "dbt" otherwise.
     """
     return shutil.which("dbt") or "dbt"
+
+
+def is_dbt_installed_in_same_environment() -> bool:
+    """
+    Checks if dbt is installed in the same environment as the current one.
+    """
+    try:
+        import dbt  # noqa: F401
+    except ImportError:
+        return False
+    else:
+        return True

--- a/cosmos/dbt/executable.py
+++ b/cosmos/dbt/executable.py
@@ -1,5 +1,5 @@
-import importlib.util
 import shutil
+from importlib.util import find_spec
 
 
 def get_system_dbt() -> str:
@@ -14,7 +14,7 @@ def is_dbt_installed_in_same_environment() -> bool:
     Checks if dbt is installed in the same environment as the current one.
     """
     try:
-        importlib.util.find_spec("dbt")
+        find_spec("dbt")
     except ImportError:
         return False
     else:

--- a/cosmos/dbt/executable.py
+++ b/cosmos/dbt/executable.py
@@ -1,3 +1,4 @@
+import importlib.util
 import shutil
 
 
@@ -13,7 +14,7 @@ def is_dbt_installed_in_same_environment() -> bool:
     Checks if dbt is installed in the same environment as the current one.
     """
     try:
-        import dbt  # noqa: F401
+        importlib.util.find_spec("dbt")
     except ImportError:
         return False
     else:


### PR DESCRIPTION
Make our configuration validation more robust, to guide users when they misconfigure Cosmos `RenderConfig.invocation_mode`.

This configuration should only be used if dbt is installed in the same Python virtualenv as Cosmos.

Recently, I observed a customer incorrectly configuring Cosmos as follows:
```
ExecutionConfig(
  dbt_executable_path=airflowHome + '/dbt_venv/bin/dbt',
  execution_mode=ExecutionMode.WATCHER,
  invocation_mode=InvocationMode.DBT_RUNNER
)
```

Which led to the error:
```
ModuleNotFoundError: No module named 'dbt'
```

This was raised in Cosmos 1.12, when trying to resolve `dbt.version`
```
cosmos/operators/watcher.py:_fallback_to_local_run → build_and_run_cmd → _generate_dbt_flags
```
