### PR TITLE
Fix CI main branch Airflow 2.6 tests

### DIFF
--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -42,14 +42,11 @@ uv pip install "gcsfs<2025.3.0"
 
 
 if [ "$AIRFLOW_VERSION" = "2.6" ]  ; then
-  pip install "uv==0.9.24"
   uv pip install "apache-airflow-providers-amazon" "apache-airflow==$AIRFLOW_VERSION" "urllib3<2"
   uv pip install "apache-airflow-providers-cncf-kubernetes" "apache-airflow==$AIRFLOW_VERSION"
-  uv pip install "apache-airflow-providers-google==10.10.1" "google-api-python-client==2.187.0" "httplib2==0.31.0" "apache-airflow==$AIRFLOW_VERSION"
+  uv pip install "apache-airflow-providers-google<10.11" "httplib2==0.31.0" "apache-airflow==$AIRFLOW_VERSION"
   uv pip install "apache-airflow-providers-microsoft-azure" "apache-airflow==$AIRFLOW_VERSION"
-  uv pip install "apache-airflow-providers-common-sql==1.12.0" "apache-airflow==$AIRFLOW_VERSION"
-  #uv pip install "pydantic<2.0"
-  #uv pip install "pyparsing==2.4.7"
+  uv pip install "pydantic<2.0"
 elif [ "$AIRFLOW_VERSION" = "2.7" ] ; then
   uv pip install "apache-airflow-providers-amazon" --constraint /tmp/constraint.txt
   uv pip install "apache-airflow-providers-cncf-kubernetes" --constraint /tmp/constraint.txt


### PR DESCRIPTION
Cosmos main branch Python 2.6 tests started failing, as observed while testing Python 3.10, AF 2.6 and dbt 1.11:
```
=========================== short test summary info ============================
ERROR tests/operators/_asynchronous/test_base.py - AttributeError: module 'pyparsing' has no attribute 'DelimitedList'. Did you mean: 'delimitedList'?
ERROR tests/operators/_asynchronous/test_bigquery.py - AttributeError: module 'pyparsing' has no attribute 'DelimitedList'. Did you mean: 'delimitedList'?
ERROR tests/test_example_dags_no_connections.py - AssertionError: assert not {'/home/runner/work/astronomer-cosmos/astronomer-cosmos/dev/dags/simple_dag_async.py': 'Traceback (most recent call la...s.operators._asynchronous.bigquery.DbtRunAirflowAsyncBigqueryOperator. Unable to find the specified operator class.\n'}
 +  where {'/home/runner/work/astronomer-cosmos/astronomer-cosmos/dev/dags/simple_dag_async.py': 'Traceback (most recent call la...s.operators._asynchronous.bigquery.DbtRunAirflowAsyncBigqueryOperator. Unable to find the specified operator class.\n'} = <airflow.models.dagbag.DagBag object at 0x7ffa7ee04910>.import_errors
```
https://github.com/astronomer/astronomer-cosmos/actions/runs/20999444973/job/60365156803

The issue seemed to be conflicting dependencies, particularly the installation of "httplib2==0.30.0" (failure) instead of "httplib2==0.31.0" (success)

Example of success after this change:
https://github.com/astronomer/astronomer-cosmos/actions/runs/21002268536/job/60375248518