### PR TITLE
Fix link in watcher execution mode docs

### DIFF
--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -414,7 +414,7 @@ Troubleshooting
 ---------------
 
 Problem: "I changed from ``ExecutionMode.LOCAL`` to ``ExecutionMode.WATCHER``, but my DAG is running slower."
-Answer: Please, check the number of threads that are being used by searching the producer task logs for a message similar to ``Concurrency: 1 threads (target='DEV')``. To leverage the Watcher mode, you should have a high number of threads, at least dbt's default of 4. `Check the dbt docs <dbt threading <https://docs.getdbt.com/docs/running-a-dbt-project/using-threads>`_ for more information on how to set the number of threads.
+Answer: Please, check the number of threads that are being used by searching the producer task logs for a message similar to ``Concurrency: 1 threads (target='DEV')``. To leverage the Watcher mode, you should have a high number of threads, at least dbt's default of 4. Check the `dbt threading docs <https://docs.getdbt.com/docs/running-a-dbt-project/using-threads>`_ for more information on how to set the number of threads.
 
 
 


### PR DESCRIPTION
## Description

There was a malformed link in the watcher execution mode docs.

Before:
<img width="830" height="202" alt="Screenshot 2026-01-21 at 1 40 45 PM" src="https://github.com/user-attachments/assets/be3a5700-0a9f-4026-a7dc-aaffd9a5a953" />

After:
<img width="988" height="240" alt="Screenshot 2026-01-21 at 1 40 33 PM" src="https://github.com/user-attachments/assets/4ef3f4dd-333f-4893-9369-d1a6561a14e9" />




## Related Issue(s)
None.

## Breaking Change?
No.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
