### PR TITLE
Skip storing telemetry metadata when emission is disabled

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -34,7 +34,7 @@ from cosmos.exceptions import CosmosValueError
 # TODO: Move _get_profile_config_attribute at common place
 from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
 from cosmos.log import get_logger
-from cosmos.telemetry import _compress_telemetry_metadata
+from cosmos.telemetry import _compress_telemetry_metadata, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
@@ -413,7 +413,7 @@ class DbtToAirflowConverter:
         :param profile_config: The profile configuration
         :param initial_load_method: The load method specified by the user (before automatic resolution)
         """
-        if dag is None:
+        if dag is None or not should_emit():
             return
 
         metadata: dict[str, Any] = {"used_automatic_load_mode": initial_load_method == LoadMode.AUTOMATIC}

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -216,8 +216,9 @@ def test_on_dag_run_failed(mock_emit_usage_metrics_if_enabled, caplog):
     reason="TODO: Fix create_dag_run to work with AF 3.1 and remove this skip.",
 )
 @pytest.mark.integration
+@patch("cosmos.converter.should_emit", return_value=True)
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
-def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, caplog):
+def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, mock_should_emit, caplog):
     """Test that DAG run success includes Cosmos telemetry metadata."""
     caplog.set_level(logging.DEBUG)
 
@@ -278,8 +279,9 @@ def test_on_dag_run_success_with_telemetry_metadata(mock_emit_usage_metrics_if_e
     reason="TODO: Fix create_dag_run to work with AF 3.1 and remove this skip.",
 )
 @pytest.mark.integration
+@patch("cosmos.converter.should_emit", return_value=True)
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
-def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, caplog):
+def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_enabled, mock_should_emit, caplog):
     """Test that DAG run failure includes Cosmos telemetry metadata."""
     caplog.set_level(logging.DEBUG)
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1229,8 +1229,9 @@ def test_converter_logs_parsing_group_order(mock_load_dbt_graph, mock_logger):
     assert group_start_idx < group_end_idx
 
 
+@patch("cosmos.converter.should_emit", return_value=True)
 @patch("cosmos.converter.DbtGraph.load")
-def test_telemetry_metadata_storage(mock_load_dbt_graph):
+def test_telemetry_metadata_storage(mock_load_dbt_graph, mock_should_emit):
     """Test that telemetry metadata is stored correctly in DAG params."""
     dag = DAG("test_dag_telemetry", start_date=datetime(2024, 1, 1))
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1271,3 +1271,30 @@ def test_telemetry_metadata_storage(mock_load_dbt_graph):
     assert "profile_strategy" in metadata
     assert "profile_mapping_class" in metadata
     assert "database" in metadata
+
+
+@patch("cosmos.converter.DbtGraph.load")
+@patch("cosmos.converter.should_emit", return_value=False)
+def test_telemetry_metadata_not_stored_when_disabled(mock_should_emit, mock_load_dbt_graph):
+    """Test that telemetry metadata is NOT stored when telemetry is disabled."""
+    dag = DAG("test_dag_telemetry_disabled", start_date=datetime(2024, 1, 1))
+
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+    render_config = RenderConfig()
+
+    _ = DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+        render_config=render_config,
+    )
+
+    # Verify metadata is NOT stored when telemetry is disabled
+    assert "__cosmos_telemetry_metadata__" not in dag.params


### PR DESCRIPTION
The _store_dag_telemetry_metadata method in DbtToAirflowConverter was performing unnecessary processing even when telemetry was disabled. This included compressing metadata and storing it in DAG params, which adds overhead without benefit when telemetry collection is turned off.

The PR adds an early return check in `_store_dag_telemetry_metadata` to skip all processing when `should_emit()` returns False. This ensures telemetry-related operations only occur when telemetry is actually enabled.

related: https://github.com/astronomer/astronomer-cosmos/pull/2223
related: https://github.com/astronomer/astronomer-cosmos/issues/2109