### PR TITLE
Fix running empty models or ephemeral nodes in `ExecutionMode.WATCHER`

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,8 +1,22 @@
 Changelog
 =========
 
+1.13.0a2 (2026-01-22)
+---------------------
+
+(Includes more changes)
+
+Features
+
+- Introduce ``ExecutionMode.WATCHER_KUBERNETES`` to use watcher with ``KubernetesPodOperator`` by @tatiana in #2207
+
+Bug Fixes
+
+-  Fix running empty models or ephemeral nodes in ``ExecutionMode.WATCHER`` by @tatiana in #2279
+
+
 1.12.1 (2026-01-14)
-----------------------
+-------------------
 
 Bug Fixes
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from cosmos import settings
 
-__version__ = "1.13.0a1"
+__version__ = "1.13.0a2"
 
 
 if not settings.enable_memory_optimised_imports:

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -203,18 +203,11 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         status = event.get("status")
         reason = event.get("reason")
 
-        if status == "success":
-            try:
-                run_results_status = self._get_status_from_run_results(context["ti"], context)
-            except (KeyError, TypeError):
-                logger.debug("Could not fetch run results.")
-                run_results_status = None
-
-            if reason == "model_not_run" and run_results_status is None:
-                logger.info(
-                    "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
-                    self.model_unique_id,
-                )
+        if status == "success" and reason == "model_not_run":
+            logger.info(
+                "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
+                self.model_unique_id,
+            )
 
         if status != "failed":
             return

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -146,7 +146,10 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         node_result = next((r for r in results if r.get("unique_id") == self.model_unique_id), None)
 
         if not node_result:  # pragma: no cover
-            logger.warning("No matching result found for unique_id '%s'", self.model_unique_id)
+            logger.warning(
+                "The dbt node with unique_id '%s' was not executed by the dbt command run in the producer task. This may happen if it is an ephemeral model or if the model sql file is empty.",
+                self.model_unique_id,
+            )
             return None
 
         logger.info("Node Info: %s", run_results_json)
@@ -198,10 +201,19 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         status = event.get("status")
+        reason = event.get("reason")
+
+        if status == "success":
+            if reason == "model_not_run":
+                status = self._get_status_from_run_results(context["ti"], context)
+                logger.info(
+                    "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
+                    self.model_unique_id,
+                )
+
         if status != "failed":
             return
 
-        reason = event.get("reason")
         if reason == "model_failed":
             raise AirflowException(
                 f"dbt model '{self.model_unique_id}' failed. Review the producer task '{self.producer_task_id}' logs for details."

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -204,7 +204,12 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         reason = event.get("reason")
 
         if status == "success":
-            run_results_status = self._get_status_from_run_results(context["ti"], context)
+            try:
+                run_results_status = self._get_status_from_run_results(context["ti"], context)
+            except KeyError:
+                logger.debug("Could not fetch run results.")
+                run_results_status = None
+
             if reason == "model_not_run" and run_results_status is None:
                 logger.info(
                     "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -205,11 +205,12 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
 
         if status == "success":
             if reason == "model_not_run":
-                status = self._get_status_from_run_results(context["ti"], context)
-                logger.info(
-                    "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
-                    self.model_unique_id,
-                )
+                run_results_status = self._get_status_from_run_results(context["ti"], context)
+                if run_results_status is None:
+                    logger.info(
+                        "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
+                        self.model_unique_id,
+                    )
 
         if status != "failed":
             return

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -204,13 +204,12 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         reason = event.get("reason")
 
         if status == "success":
-            if reason == "model_not_run":
-                run_results_status = self._get_status_from_run_results(context["ti"], context)
-                if run_results_status is None:
-                    logger.info(
-                        "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
-                        self.model_unique_id,
-                    )
+            run_results_status = self._get_status_from_run_results(context["ti"], context)
+            if reason == "model_not_run" and run_results_status is None:
+                logger.info(
+                    "Model '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
+                    self.model_unique_id,
+                )
 
         if status != "failed":
             return

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -206,7 +206,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         if status == "success":
             try:
                 run_results_status = self._get_status_from_run_results(context["ti"], context)
-            except KeyError:
+            except (KeyError, TypeError):
                 logger.debug("Could not fetch run results.")
                 run_results_status = None
 

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -149,6 +149,15 @@ class WatcherTrigger(BaseTrigger):
                 )
                 yield TriggerEvent({"status": "failed", "reason": "producer_failed"})  # type: ignore[no-untyped-call]
                 return
+            elif producer_task_state == "success" and node_status is None:
+                self.log.info(
+                    "The producer task '%s' succeeded. There is no information about the model '%s' execution.",
+                    self.producer_task_id,
+                    self.model_unique_id,
+                )
+                yield TriggerEvent({"status": "success", "reason": "model_not_run"})  # type: ignore[no-untyped-call]
+                return
+
             # Sleep briefly before re-polling
             await asyncio.sleep(self.poke_interval)
             self.log.debug("Polling again for model '%s' status...", self.model_unique_id)

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -12,7 +12,10 @@ from asgiref.sync import sync_to_async
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION
+from cosmos.log import get_logger
 from cosmos.operators._watcher.state import build_producer_state_fetcher
+
+logger = get_logger(__name__)
 
 
 class WatcherTrigger(BaseTrigger):
@@ -82,7 +85,7 @@ class WatcherTrigger(BaseTrigger):
         return await sync_to_async(_get_xcom_val)()
 
     async def get_xcom_val(self, key: str) -> Any | None:
-        self.log.info(
+        logger.info(
             "Trying to retrieve value using XCom key <%s> by task_id <%s>, dag_id <%s>, run_id <%s> and map_index <%s>",
             key,
             self.producer_task_id,
@@ -120,7 +123,7 @@ class WatcherTrigger(BaseTrigger):
             dag_id=self.dag_id,
             run_id=self.run_id,
             producer_task_id=self.producer_task_id,
-            logger=self.log,
+            logger=logger,
         )
         if fetch_state is None:
             return None
@@ -128,21 +131,21 @@ class WatcherTrigger(BaseTrigger):
         return await sync_to_async(fetch_state)()
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
-        self.log.info("Starting WatcherTrigger for model: %s", self.model_unique_id)
+        logger.info("Starting WatcherTrigger for model: %s", self.model_unique_id)
 
         while True:
             producer_task_state = await self._get_producer_task_status()
             node_status = await self._parse_node_status()
             if node_status == "success":
-                self.log.info("Model '%s' succeeded", self.model_unique_id)
+                logger.info("Model '%s' succeeded", self.model_unique_id)
                 yield TriggerEvent({"status": "success"})  # type: ignore[no-untyped-call]
                 return
             elif node_status == "failed":
-                self.log.warning("Model '%s' failed", self.model_unique_id)
+                logger.warning("Model '%s' failed", self.model_unique_id)
                 yield TriggerEvent({"status": "failed", "reason": "model_failed"})  # type: ignore[no-untyped-call]
                 return
             elif producer_task_state == "failed":
-                self.log.error(
+                logger.error(
                     "Watcher producer task '%s' failed before delivering results for model '%s'",
                     self.producer_task_id,
                     self.model_unique_id,
@@ -150,7 +153,7 @@ class WatcherTrigger(BaseTrigger):
                 yield TriggerEvent({"status": "failed", "reason": "producer_failed"})  # type: ignore[no-untyped-call]
                 return
             elif producer_task_state == "success" and node_status is None:
-                self.log.info(
+                logger.info(
                     "The producer task '%s' succeeded. There is no information about the model '%s' execution.",
                     self.producer_task_id,
                     self.model_unique_id,
@@ -160,7 +163,7 @@ class WatcherTrigger(BaseTrigger):
 
             # Sleep briefly before re-polling
             await asyncio.sleep(self.poke_interval)
-            self.log.debug("Polling again for model '%s' status...", self.model_unique_id)
+            logger.debug("Polling again for model '%s' status...", self.model_unique_id)
 
 
 def _parse_compressed_xcom(compressed_b64_event_msg: str) -> Any:

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -121,6 +121,7 @@ class TestWatcherTrigger:
             ("success", "running", {"status": "success"}),
             ("failed", "running", {"status": "failed", "reason": "model_failed"}),
             (None, "failed", {"status": "failed", "reason": "producer_failed"}),
+            (None, "success", {"status": "success", "reason": "model_not_run"}),
         ],
     )
     async def test_run_various_outcomes(self, node_status, producer_state, expected):
@@ -204,6 +205,27 @@ class TestWatcherTrigger:
             state = await self.trigger._get_producer_task_status()
 
         assert state is None
+
+    @pytest.mark.asyncio
+    async def test_run_producer_success_model_not_run(self, caplog):
+        """Test that when producer succeeds but model has no status, trigger yields success with model_not_run reason."""
+        get_producer_status_mock = AsyncMock(return_value="success")
+        parse_node_status_mock = AsyncMock(return_value=None)
+
+        caplog.set_level("INFO")
+
+        with (
+            patch.object(self.trigger, "_get_producer_task_status", get_producer_status_mock),
+            patch.object(self.trigger, "_parse_node_status", parse_node_status_mock),
+        ):
+            events = []
+            async for event in self.trigger.run():
+                events.append(event)
+
+        assert len(events) == 1
+        assert events[0].payload == {"status": "success", "reason": "model_not_run"}
+        assert "The producer task 'task_1' succeeded" in caplog.text
+        assert "There is no information about the model 'model.test' execution" in caplog.text
 
     @pytest.mark.asyncio
     async def test_run_poke_interval_and_debug_log(self, caplog):

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1088,7 +1088,7 @@ def test_dbt_dag_with_watcher_and_empty_model(caplog):
         render_config=RenderConfig(emit_datasets=False, test_behavior=TestBehavior.NONE),
         operator_args={
             "trigger_rule": "all_success",
-            "execution_timeout": datetime.delta(seconds=120) if AIRFLOW_VERSION != Version("2.8") else None,
+            "execution_timeout": timedelta(seconds=120) if AIRFLOW_VERSION != Version("2.8") else None,
         },
     )
     outcome = new_test_dag(watcher_dag)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1088,7 +1088,7 @@ def test_dbt_dag_with_watcher_and_empty_model(caplog):
         render_config=RenderConfig(emit_datasets=False, test_behavior=TestBehavior.NONE),
         operator_args={
             "trigger_rule": "all_success",
-            "execution_timeout": timedelta(seconds=120) if AIRFLOW_VERSION != Version("2.8") else None,
+            "execution_timeout": None,
         },
     )
     outcome = new_test_dag(watcher_dag)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1086,7 +1086,10 @@ def test_dbt_dag_with_watcher_and_empty_model(caplog):
             invocation_mode=InvocationMode.DBT_RUNNER,
         ),
         render_config=RenderConfig(emit_datasets=False, test_behavior=TestBehavior.NONE),
-        operator_args={"trigger_rule": "all_success", "execution_timeout": timedelta(seconds=120)},
+        operator_args={
+            "trigger_rule": "all_success",
+            "execution_timeout": datetime.delta(seconds=120) if AIRFLOW_VERSION != Version("2.8") else None,
+        },
     )
     outcome = new_test_dag(watcher_dag)
     assert outcome.state == DagRunState.SUCCESS

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -33,7 +33,7 @@ from tests.utils import AIRFLOW_VERSION, new_test_dag
 
 DBT_PROJECT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_shop"
 DBT_PROFILES_YAML_FILEPATH = DBT_PROJECT_PATH / "profiles.yml"
-
+DBT_PROJECT_WITH_EMPTY_MODEL_PATH = Path(__file__).parent.parent / "sample/dbt_project_with_empty_model"
 
 project_config = ProjectConfig(
     dbt_project_path=DBT_PROJECT_PATH,
@@ -1039,6 +1039,82 @@ def test_dbt_dag_with_watcher():
         "raw_orders_seed",
         "raw_customers_seed",
     }
+
+
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.7"), reason="Airflow did not have dag.test() until the 2.6 release")
+@pytest.mark.integration
+def test_dbt_dag_with_watcher_and_empty_model(caplog):
+    """
+    Run a DbtDag using `ExecutionMode.WATCHER` and a dbt project with an empty model. This was a situation observed by an Astronomer customer.
+    Confirm the right amount of tasks is created and that tasks are in the expected topological order.
+    Confirm that the producer watcher task is created and that it is the parent of the root dbt nodes.
+    """
+    project_config = ProjectConfig(
+        dbt_project_path=DBT_PROJECT_WITH_EMPTY_MODEL_PATH,
+    )
+    # There are two dbt projects defined in this folder.
+    # When we run `dbt ls`, we can see this:
+    #
+    # 10:32:30  Found 2 models, 464 macros
+    # micro_dbt_project.add_row
+    # micro_dbt_project.empty_model
+    #
+    # However, during `dbt build`, dbt skips running the empty model, and only runs the add_row model:
+    #
+    # 10:29:03  Running with dbt=1.11.2
+    # 10:29:03  Registered adapter: postgres=1.10.0
+    # 10:29:03  Found 2 models, 464 macros
+    # 10:29:03
+    # 10:29:03  Concurrency: 4 threads (target='dev')
+    # 10:29:03
+    # 10:29:03  1 of 1 START sql view model public.add_row ..................................... [RUN]
+    # 10:29:03  1 of 1 OK created sql view model public.add_row ................................ [CREATE VIEW in 0.06s]
+    # 10:29:03
+    # 10:29:03  Finished running 1 view model in 0 hours 0 minutes and 0.19 seconds (0.19s).
+    # 10:29:03
+    # 10:29:03  Completed successfully
+    # 10:29:03
+    # 10:29:03  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
+
+    watcher_dag = DbtDag(
+        project_config=project_config,
+        profile_config=profile_config,
+        start_date=datetime(2023, 1, 1),
+        dag_id="watcher_dag",
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.WATCHER,
+            invocation_mode=InvocationMode.DBT_RUNNER,
+        ),
+        render_config=RenderConfig(emit_datasets=False, test_behavior=TestBehavior.NONE),
+        operator_args={"trigger_rule": "all_success", "execution_timeout": timedelta(seconds=120)},
+    )
+    outcome = new_test_dag(watcher_dag)
+    assert outcome.state == DagRunState.SUCCESS
+
+    assert len(watcher_dag.dbt_graph.filtered_nodes) == 2
+
+    assert len(watcher_dag.task_dict) == 3
+    tasks_names = [task.task_id for task in watcher_dag.topological_sort()]
+    expected_task_names = [
+        "dbt_producer_watcher",
+        "add_row_run",
+        "empty_model_run",
+    ]
+    assert tasks_names == expected_task_names
+
+    assert isinstance(watcher_dag.task_dict["dbt_producer_watcher"], DbtProducerWatcherOperator)
+    assert isinstance(watcher_dag.task_dict["add_row_run"], DbtRunWatcherOperator)
+    assert isinstance(watcher_dag.task_dict["empty_model_run"], DbtRunWatcherOperator)
+
+    assert watcher_dag.task_dict["dbt_producer_watcher"].downstream_task_ids == {
+        "add_row_run",
+        "empty_model_run",
+    }
+
+    assert "Total filtered nodes: 2" in caplog.text
+    assert "Finished running node model.micro_dbt_project.add_row" in caplog.text
+    assert "Finished running node model.micro_dbt_project.empty_model_run" not in caplog.text
+    assert "Model 'model.micro_dbt_project.empty_model' was skipped by the dbt command" in caplog.text
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION < Version("2.7"), reason="Airflow did not have dag.test() until the 2.6 release")

--- a/tests/sample/dbt_project_with_empty_model/dbt_project.yml
+++ b/tests/sample/dbt_project_with_empty_model/dbt_project.yml
@@ -1,0 +1,7 @@
+name: micro_dbt_project
+version: '1.0'
+config-version: 2
+
+profile: default
+
+model-paths: ["models"]

--- a/tests/sample/dbt_project_with_empty_model/models/add_row.sql
+++ b/tests/sample/dbt_project_with_empty_model/models/add_row.sql
@@ -1,0 +1,12 @@
+with base as (
+    select
+        1 as id,
+        'original_row' as description
+
+)
+
+select * from base
+union all
+select
+    2 as id,
+    'added_row' as description

--- a/tests/sample/dbt_project_with_empty_model/models/schema.yml
+++ b/tests/sample/dbt_project_with_empty_model/models/schema.yml
@@ -1,0 +1,8 @@
+version: 2
+
+models:
+  - name: add_row
+    description: "Model that selects data and adds an extra row"
+
+  - name: empty_model
+    description: "Empty model definition"

--- a/tests/sample/dbt_project_with_empty_model/profiles.yml
+++ b/tests/sample/dbt_project_with_empty_model/profiles.yml
@@ -1,0 +1,12 @@
+default:
+  target: dev
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('POSTGRES_HOST') }}"
+      user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4


### PR DESCRIPTION
Avoid consumer tasks that hang indefinitely when using `ExecutionMode.WATCHER` when the associated dbt models are either ephemeral or consist of empty SQL models that are not run by dbt.

## Context

There are circumstances when there is a discrepant number of nodes in the output when we run `dbt ls` and `dbt build`, using the same selectors.

In the following example (`tests/sample/dbt_project_with_empty_model`), we can observe that `dbt ls` returned two models, while the `dbt build` returned a single one:
```
$ dbt ls
10:48:32  Running with dbt=1.11.2
10:48:32  Registered adapter: postgres=1.10.0
10:48:32  Unable to do partial parsing because saved manifest not found. Starting full parse.
10:48:32  Found 2 models, 464 macros
micro_dbt_project.add_row
micro_dbt_project.empty_model

$ dbt build
10:50:21  Running with dbt=1.11.2
10:50:21  Registered adapter: postgres=1.10.0
10:50:21  Found 2 models, 464 macros
10:50:21  
10:50:21  Concurrency: 4 threads (target='dev')
10:50:21  
10:50:21  1 of 1 START sql view model public.add_row ..................................... [RUN]
10:50:21  1 of 1 OK created sql view model public.add_row ................................ [CREATE VIEW in 0.06s]
10:50:21  
10:50:21  Finished running 1 view model in 0 hours 0 minutes and 0.20 seconds (0.20s).
10:50:21  
10:50:21  Completed successfully
10:50:21  
10:50:21  Done. PASS=1 WARN=0 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1
```

So far, we observed this happening in two scenarios:
1. Ephemeral nodes (https://github.com/astronomer/astronomer-cosmos/issues/2266)
2. If the dbt model is not executable (e.g. it is an empty SQL file), both the `dbt build` and the `dbt run` will not display it in their info logs.

Until Cosmos 1.12.1, Cosmos assumed these two commands would return the same number of nodes, and we implemented the `LoadMode.MANIFEST` assuming the same. In the case of `ExecutionMode.LOCAL`, this was not a big issue, because dbt does not run when we select the particular model it's excluding:

```
$  dbt build --select empty_model 
10:53:03  Running with dbt=1.11.2
10:53:03  Registered adapter: postgres=1.10.0
10:53:03  Found 2 models, 464 macros
10:53:03  Nothing to do. Try checking your model configs and model specification args
```

The downside in the case of `ExecutionMode.LOCAL`  is that we waste Airflow resources by potentially parsing a dbt project that wouldn't need to be parsed in those particular tasks. The PR #1625 aims to address this.

However, in the case of `ExecutionMode.WATCHER`, this became a big problem, as the behaviour caused consumer nodes representing ephemeral nodes or empty models to hang indefinitely after the producer task completed successfully. The producer task was not aware of them and would not populate XCom, whereas the consumer tasks would keep checking for updates.

Closes: https://github.com/astronomer/astronomer-cosmos/issues/2266
Closes: https://github.com/astronomer/oss-integrations-private/issues/315
Closes: https://astronomer.zendesk.com/agent/tickets/87180

## About the solution

Ideally, probably, we would know upfront which nodes `dbt build` decides to execute, and we would not render them as Airflow tasks. However, I do not believe this is a simple problem, since there may be other circumstances when `dbt build` skips nodes from being executed - and any custom logic we implement in Cosmos will be affected by changes dbt Core/Fusion implements upstream.

Therefore, it feels - for now - the safest solution is:
- Continue adding those nodes to Cosmos
- Mark them as successful, logging a specific message, if they were not actually run by the dbt command. This is identified by checking the `run_results.json` file.