### PR TITLE
Allow watcher producer retries without erroring

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -155,12 +155,12 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         try_number = getattr(task_instance, "try_number", 1)
 
         if try_number > 1:
-            retry_message = (
+            self.log.info(
                 "Dbt WATCHER producer task does not support Airflow retries. "
-                f"Detected attempt #{try_number}; failing fast to avoid running a second dbt build."
+                "Detected attempt #%s; skipping execution to avoid running a second dbt build.",
+                try_number,
             )
-            self.log.error(retry_message)
-            raise AirflowException(retry_message)
+            return None
 
         self.log.info(
             "Dbt WATCHER producer task forces Airflow retries to 0 so the dbt build only runs once; "

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -104,12 +104,12 @@ class DbtProducerWatcherKubernetesOperator(DbtBuildKubernetesOperator):
         try_number = getattr(task_instance, "try_number", 1)
 
         if try_number > 1:
-            retry_message = (
+            self.log.info(
                 "DbtProducerWatcherKubernetesOperator does not support Airflow retries. "
-                f"Detected attempt #{try_number}; failing fast to avoid running a second dbt build."
+                "Detected attempt #%s; skipping execution to avoid running a second dbt build.",
+                try_number,
             )
-            self.log.error(retry_message)
-            raise AirflowException(retry_message)
+            return None
 
         # This global variable is used to make the task context available to the K8s callback.
         # While the callback is set during the operator initialization, the context is only created during the operator's execution.

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -241,7 +241,9 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 
 - The producer task should still be configured with ``retries=0`` (which Cosmos enforces by default) to avoid unintended duplicate ``dbt build`` runs.
 
-This behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
+- By default, Cosmos sets ``retries`` to ``0`` in``DbtProducerWatcherOperator``. Users can override this by declaring the ``retries`` parameter in ``setup_operator_args``.
+
+The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 
 -------------------------------------------------------------------------------
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -219,15 +219,29 @@ How retries work
 ~~~~~~~~~~~~~~~~
 
 When the ``dbt build`` command run by ``DbtProducerWatcherOperator`` fails, it will notify all the ``DbtConsumerWatcherSensor``.
-Cosmos always sets the producer's Airflow task retries to ``0``; this ensures the failure surfaces immediately and avoids kicking off a second full ``dbt build`` run.
 
 The individual watcher tasks, that subclass ``DbtConsumerWatcherSensor``, can retry the dbt command by themselves using the same behaviour as ``ExecutionMode.LOCAL``.
-This is also the reason why we set ``retries`` to ``0`` in the ``DbtProducerWatcherOperator`` task because rerunning the producer would repeat the full dbt build and duplicate
-watcher callbacks which may not be processed by the consumers if they have already processed output XCOMs from the first run of the producer.
 
 If a branch of the DAG failed, users can clear the status of a failed consumer task, including its downstream tasks, via the Airflow UI - and each of them will run using the ``ExecutionMode.LOCAL``.
 
-Currently, we do not support retrying the ``DbtProducerWatcherOperator`` task itself.
+**Producer retry behavior**
+
+.. versionadded:: 1.12.2
+
+When the ``DbtProducerWatcherOperator`` is triggered for a retry (try_number > 1), it will not re-run the dbt build command and will succeed. In previous versions of Cosmos, the producer task would fail during retries.
+This behavior is designed to support TaskGroup-level retries, as reported in `#2282 <https://github.com/astronomer/astronomer-cosmos/issues/2282>`_.
+
+**Why this matters:**
+
+- In earlier versions, attempting to retry the producer task would raise an ``AirflowException``, causing the retry to fail immediately.
+- Now, the producer gracefully skips execution on retries, logging an informational message explaining that the retry was skipped to avoid running a second ``dbt build``.
+- This allows users to retry entire TaskGroups without the producer task blocking the retry flow.
+
+**Important considerations:**
+
+- The producer task should still be configured with ``retries=0`` (which Cosmos enforces by default) to avoid unintended duplicate ``dbt build`` runs.
+
+This behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 
 -------------------------------------------------------------------------------
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -235,7 +235,7 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 
 - In earlier versions, attempting to retry the producer task would raise an ``AirflowException``, causing the retry to fail immediately.
 - Now, the producer gracefully skips execution on retries, logging an informational message explaining that the retry was skipped to avoid running a second ``dbt build``.
-- This allows users to retry entire TaskGroups without the producer task blocking the retry flow.
+- This allows users to retry entire TaskGroups and/or DAGs without the producer task blocking the retry flow.
 
 **Important considerations:**
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -241,7 +241,7 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 
 - The producer task should still be configured with ``retries=0`` (which Cosmos enforces by default) to avoid unintended duplicate ``dbt build`` runs.
 
-- By default, Cosmos sets ``retries`` to ``0`` in``DbtProducerWatcherOperator``. Users can override this by declaring the ``retries`` parameter in ``setup_operator_args``.
+- By default, Cosmos sets ``retries`` to ``0`` in``DbtProducerWatcherOperator``. Users can retry manually by clearing the status of the producer task and all its downstream tasks, keeping in mind that the producer task will not re-run the ``dbt build`` command and will succeed.
 
 The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 


### PR DESCRIPTION
Aims to overcome retries at a TaskGroup level, is reported in: https://github.com/astronomer/astronomer-cosmos/issues/2282

During retries, the watcher will not execute any operation, but will not fail. We are intentionally changing the behaviour previously implemented in  #2114.

The behaviour will be improved once the following ticket is implemented: https://github.com/astronomer/astronomer-cosmos/issues/1978

Closes: #2282