### PR TITLE
Rename watcher-mode sensor retry queue and reuse it for producer tasks

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -100,7 +100,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         default_args["retries"] = 0
         kwargs["default_args"] = default_args
         kwargs["retries"] = 0
-        kwargs["queue"] = watcher_dbt_execution_queue if watcher_dbt_execution_queue is not None else DEFAULT_QUEUE
+        kwargs["queue"] = watcher_dbt_execution_queue or DEFAULT_QUEUE
         super().__init__(task_id=task_id, *args, **kwargs)
 
         if self.invocation_mode == InvocationMode.SUBPROCESS:

--- a/cosmos/plugin/cluster_policy.py
+++ b/cosmos/plugin/cluster_policy.py
@@ -28,7 +28,7 @@ def _is_watcher_sensor(task_instance: TaskInstance) -> bool:
 
 @hookimpl
 def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
-    from cosmos.settings import watcher_retry_queue
+    from cosmos.settings import watcher_dbt_execution_queue
 
     # In Airflow 3.x the task_instance_mutation_hook try_number starts at None or 0
     # in Airflow 2.x it starts at 1
@@ -37,9 +37,9 @@ def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
     else:
         retry_number = 2
 
-    if watcher_retry_queue and task_instance.try_number and _is_watcher_sensor(task_instance):
+    if watcher_dbt_execution_queue and task_instance.try_number and _is_watcher_sensor(task_instance):
         if task_instance.try_number >= retry_number:
             log.info(
-                f"Setting task {task_instance.task_id} to use watcher retry queue: {watcher_retry_queue}",
+                f"Setting task {task_instance.task_id} to use watcher retry queue: {watcher_dbt_execution_queue}",
             )
-            task_instance.queue = watcher_retry_queue
+            task_instance.queue = watcher_dbt_execution_queue

--- a/cosmos/plugin/cluster_policy.py
+++ b/cosmos/plugin/cluster_policy.py
@@ -40,6 +40,6 @@ def task_instance_mutation_hook(task_instance: TaskInstance) -> None:
     if watcher_dbt_execution_queue and task_instance.try_number and _is_watcher_sensor(task_instance):
         if task_instance.try_number >= retry_number:
             log.info(
-                f"Setting task {task_instance.task_id} to use watcher retry queue: {watcher_dbt_execution_queue}",
+                f"Setting task {task_instance.task_id} to use watcher dbt execution queue: {watcher_dbt_execution_queue}",
             )
             task_instance.queue = watcher_dbt_execution_queue

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -60,7 +60,8 @@ enable_teardown_async_task = conf.getboolean("cosmos", "enable_teardown_async_ta
 # in watcher mode, if the producer watcher fails, the consumer tasks run the individual models on retry.
 # since these tasks are sensors that require low memory/cpu on their first try,
 # this setting allows retries to run on a queue with larger resources, which is often necessary for larger dbt projects
-watcher_retry_queue = conf.get("cosmos", "watcher_retry_queue", fallback=None)
+# this would be also use to run the producer task
+watcher_dbt_execution_queue = conf.get("cosmos", "watcher_dbt_execution_queue", fallback=None)
 
 # The following environment variable is populated in Astro Cloud
 in_astro_cloud = os.getenv("ASTRONOMER_ENVIRONMENT") == "cloud"

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -60,7 +60,7 @@ enable_teardown_async_task = conf.getboolean("cosmos", "enable_teardown_async_ta
 # in watcher mode, if the producer watcher fails, the consumer tasks run the individual models on retry.
 # since these tasks are sensors that require low memory/cpu on their first try,
 # this setting allows retries to run on a queue with larger resources, which is often necessary for larger dbt projects
-# this would be also use to run the producer task
+# this would also be used to run the producer task
 watcher_dbt_execution_queue = conf.get("cosmos", "watcher_dbt_execution_queue", fallback=None)
 
 # The following environment variable is populated in Astro Cloud

--- a/tests/plugin/test_cluster_policy.py
+++ b/tests/plugin/test_cluster_policy.py
@@ -89,7 +89,7 @@ class TestTaskInstanceMutationHook:
             (Version("2.10.0"), 2, True),  # Later Airflow 2.x versions should also work
         ],
     )
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     def test_queue_set_based_on_airflow_version_and_try_number(self, airflow_version, try_number, should_set_queue):
         """Test that queue is set correctly based on Airflow version and try_number."""
         with patch("cosmos.plugin.cluster_policy.AIRFLOW_VERSION", airflow_version):
@@ -109,9 +109,9 @@ class TestTaskInstanceMutationHook:
                 assert task_instance.queue == "default"
 
     @pytest.mark.parametrize("nullish_value", [None, 0, ""])
-    def test_queue_not_set_when_watcher_retry_queue_is_none(self, nullish_value):
-        """Test that queue is not modified when watcher_retry_queue setting is None."""
-        with patch("cosmos.settings.watcher_retry_queue", nullish_value):
+    def test_queue_not_set_when_watcher_dbt_execution_queue_is_none(self, nullish_value):
+        """Test that queue is not modified when watcher_dbt_execution_queue setting is None."""
+        with patch("cosmos.settings.watcher_dbt_execution_queue", nullish_value):
             mock_sensor = MagicMock(spec=BaseConsumerSensor)
             task_instance = SimpleNamespace(
                 task=mock_sensor,
@@ -124,7 +124,7 @@ class TestTaskInstanceMutationHook:
 
             assert task_instance.queue == "default"
 
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     def test_queue_not_set_for_non_watcher_sensor(self):
         """Test that queue is not modified for tasks that are not watcher sensors."""
         mock_operator = MagicMock(spec=EmptyOperator)
@@ -139,7 +139,7 @@ class TestTaskInstanceMutationHook:
 
         assert task_instance.queue == "default"
 
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     def test_queue_not_set_when_try_number_is_none(self):
         """Test that queue is not modified when try_number is None."""
         mock_sensor = MagicMock(spec=BaseConsumerSensor)
@@ -154,7 +154,7 @@ class TestTaskInstanceMutationHook:
 
         assert task_instance.queue == "default"
 
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     def test_queue_not_set_when_try_number_is_zero(self):
         """Test that queue is not modified when try_number is 0."""
         mock_sensor = MagicMock(spec=BaseConsumerSensor)
@@ -169,7 +169,7 @@ class TestTaskInstanceMutationHook:
 
         assert task_instance.queue == "default"
 
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     @patch("cosmos.plugin.cluster_policy.log")
     def test_logging_when_queue_is_set(self, mock_log):
         """Test that appropriate log message is generated when queue is set."""
@@ -187,7 +187,7 @@ class TestTaskInstanceMutationHook:
             "Setting task my_test_task to use watcher retry queue: custom_retry_queue",
         )
 
-    @patch("cosmos.settings.watcher_retry_queue", "custom_retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")
     @patch("cosmos.plugin.cluster_policy.log")
     def test_no_logging_when_queue_not_set(self, mock_log):
         """Test that no log message is generated when queue is not set."""
@@ -215,7 +215,7 @@ class TestTaskInstanceMutationHook:
     @patch("cosmos.plugin.cluster_policy.AIRFLOW_VERSION", AIRFLOW_VERSION)
     def test_various_queue_names(self, queue_name):
         """Test that different queue names are correctly applied."""
-        with patch("cosmos.settings.watcher_retry_queue", queue_name):
+        with patch("cosmos.settings.watcher_dbt_execution_queue", queue_name):
             mock_sensor = MagicMock(spec=BaseConsumerSensor)
             task_instance = SimpleNamespace(
                 task=mock_sensor,
@@ -228,7 +228,7 @@ class TestTaskInstanceMutationHook:
 
             assert task_instance.queue == queue_name
 
-    @patch("cosmos.settings.watcher_retry_queue", "retry_queue")
+    @patch("cosmos.settings.watcher_dbt_execution_queue", "retry_queue")
     @patch("cosmos.plugin.cluster_policy.AIRFLOW_VERSION", AIRFLOW_VERSION)
     def test_queue_already_set_gets_overwritten(self):
         """Test that the queue is overwritten even if it was previously set to a different value."""

--- a/tests/plugin/test_cluster_policy.py
+++ b/tests/plugin/test_cluster_policy.py
@@ -184,7 +184,7 @@ class TestTaskInstanceMutationHook:
         task_instance_mutation_hook(task_instance)
 
         mock_log.info.assert_called_once_with(
-            "Setting task my_test_task to use watcher retry queue: custom_retry_queue",
+            "Setting task my_test_task to use watcher dbt execution queue: custom_retry_queue",
         )
 
     @patch("cosmos.settings.watcher_dbt_execution_queue", "custom_retry_queue")


### PR DESCRIPTION
Implement the [suggestion](https://github.com/astronomer/astronomer-cosmos/pull/2315#pullrequestreview-3751871740) from PR: #2315

This PR renames the `watcher_retry_queue` configuration setting to `watcher_dbt_execution_queue` to better reflect its expanded purpose: not only handling retries for consumer watcher sensors, but also for running the producer task itself.

**Changes:**
- Renamed `watcher_retry_queue` to `watcher_dbt_execution_queue` in settings and all references
- Added queue assignment logic to `DbtProducerWatcherOperator` to use the configured queue
- Updated all test patches and test names to reflect the new setting name