### PR TITLE
Adjust import for Param for Airflow 3

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -15,7 +15,8 @@ from warnings import warn
 from airflow.models.dag import DAG
 
 try:
-    from airflow.sdk import Param
+    # Airflow 3.0 onwards
+    from airflow.sdk.definitions.param import Param
 except ImportError:  # pragma: no cover
     from airflow.models.param import Param
 


### PR DESCRIPTION

This pull request adjusts the import for the `Param` class to support Airflow 3 by adding a try-except block that first attempts to import from `airflow.sdk` (Airflow 3+) and falls back to `airflow.models.param` (Airflow 2).