### PR TITLE
Improve Cosmos README badges

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,19 +48,11 @@
 
 ===========================================================
 
-.. list-table::
-   :widths: 15 85
+|license| |fury| |python| |downloads|
 
-   * - **License**
-     - |license|
-   * - **PyPI**
-     - |fury| |python| |downloads|
-   * - **Community**
-     - |contributors| |commits| |slack| |health|
-   * - **Dev tools**
-     - |pre-commit|
-   * - **Build status**
-     - |build-main|
+|contributors| |commits| |slack| |health|
+
+|pre-commit| |build-main|
 
 Run your dbt Core projects as `Apache Airflow® <https://airflow.apache.org/>`_ DAGs and Task Groups with a few lines of code. Benefits include:
 


### PR DESCRIPTION
Cosmos README currently displays a broken badge
<img width="753" height="227" alt="Screenshot 2026-02-06 at 13 14 16" src="https://github.com/user-attachments/assets/e5f86806-1ca6-4f49-a73e-0d6675e60c0e" />

This PR aims to improve this.

How it looks when using [restview](https://pypi.org/project/restview/) locally:
<img width="573" height="123" alt="Screenshot 2026-02-06 at 13 46 23" src="https://github.com/user-attachments/assets/d7515028-3dcf-4e7b-832f-3496b2c69312" />
