### PR TITLE
Accept int or float for cosmos_debug_max_memory_mb in integration test

### DIFF
--- a/tests/test_debug.py
+++ b/tests/test_debug.py
@@ -235,5 +235,6 @@ def test_dbt_run_local_operator_stores_memory_in_xcom_when_debug_enabled():
         memory_value = ti.xcom_pull(key="cosmos_debug_max_memory_mb")
 
         assert memory_value is not None, "Expected cosmos_debug_max_memory_mb in XCom"
-        assert isinstance(memory_value, float), "Memory value should be a float"
-        assert memory_value > 0, "Memory value should be greater than 0"
+        # XCom JSON serialization can deserialize whole numbers as int (e.g. 10.0 -> 10)
+        assert isinstance(memory_value, (int, float)), "Memory value should be a number (int or float)"
+        assert float(memory_value) > 0, "Memory value should be greater than 0"


### PR DESCRIPTION
It appears XCom JSON serialization can deserialize whole numbers as int (e.g. 10.0 -> 10),
causing intermittent AssertionError on some CI envs (e.g. py3.10, Airflow 3.1, dbt 1.11 CI run [here](https://github.com/astronomer/astronomer-cosmos/actions/runs/21912893530/job/63271736980?pr=2335#step:7:1620)).
Relax assertion to isinstance(memory_value, (int, float)) and use float() for the > 0 check.

