### PR TITLE
Make Watcher DBT Execution Queue heading clickable

### DIFF
--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -247,7 +247,7 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-Watcher DBT Execution Queue
+Watcher dbt Execution Queue
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. versionadded:: 1.14.0


### PR DESCRIPTION

PR: https://github.com/astronomer/astronomer-cosmos/pull/2315 added docs for `watcher_dbt_execution_queue`, but the heading is not clickable. This PR make the heading clickable and improve heading