### PR TITLE
Update `ExecutionMode.WATCHER` documentation regarding test nodes implementation

### DIFF
--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -326,7 +326,7 @@ However, other operators that are available in the ``ExecutionMode.LOCAL`` mode 
 
 The ``DbtBuildWatcherOperator`` is not implemented, since the build command is executed by the producer ``DbtProducerWatcherOperator`` operator.
 
-Test support for `TestBehavior.AFTER_ALL` and `TestBehavior.NONE` modes have been implemented for the ``ExecuteMode.WATCHER`` as part of `#2047 <https://github.com/astronomer/astronomer-cosmos/pull/2047>`_. and `#2049 <https://github.com/astronomer/astronomer-cosmos/pull/2049>`_.
+Test support for ``TestBehavior.AFTER_ALL`` and ``TestBehavior.NONE`` modes have been implemented for the ``ExecuteMode.WATCHER`` as part of `#2047 <https://github.com/astronomer/astronomer-cosmos/pull/2047>`_. and `#2049 <https://github.com/astronomer/astronomer-cosmos/pull/2049>`_.
 
 Tests with ``TestBehavior.AFTER_EACH``, which is the default test behavior, are still being rendered as ``EmptyOperators``.
 


### PR DESCRIPTION
## Description

Previously, #1974 was referenced in the "Watcher" docs (https://astronomer.github.io/astronomer-cosmos/getting_started/watcher-execution-mode.html) as "to be implemented". However, a fix addressing this issue was implemented. As part of #2047 and #2049. This change corrects the documentation to ensure that readers know #1974 was addressed.

## Related Issue(s)

* https://github.com/astronomer/astronomer-cosmos/issues/1974

## Breaking Change?

No, there are no breaking changes as part of this PR.

## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

**No tests have been added, as this is only a docs change.**
