### PR TITLE
Fix inclusion of package models, and selecting/excluding

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -352,6 +352,44 @@ def parse_dbt_ls_output(project_path: Path | None, ls_stdout: str) -> dict[str, 
     return nodes
 
 
+def _parse_manifest_resources_to_nodes(manifest: dict[str, Any], project_path: Path) -> dict[str, DbtNode]:
+    """Build a nodes dict from manifest resources (nodes, sources, exposures) with correct file_path for packages."""
+    resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}
+    packages_subpath = get_dbt_packages_subpath(project_path)
+    manifest_metadata = manifest.get("metadata")
+    manifest_project_name = manifest_metadata.get("project_name") if isinstance(manifest_metadata, dict) else None
+    nodes: dict[str, DbtNode] = {}
+    for unique_id, node_dict in resources.items():
+        original_file_path = node_dict.get("original_file_path")
+        if not original_file_path:
+            logger.debug(
+                "Skipping node `%s` because it has no file path (likely an external reference from dbt-loom or similar)",
+                unique_id,
+            )
+            continue
+        package_name = node_dict.get("package_name")
+        is_root_project_node = manifest_project_name is None or (package_name == manifest_project_name)
+        if package_name and not is_root_project_node:
+            resolved_path = project_path / packages_subpath / package_name / _normalize_path(original_file_path)
+        else:
+            resolved_path = project_path / _normalize_path(original_file_path)
+        resource_type = DbtResourceType(node_dict["resource_type"])
+        node = DbtNode(
+            unique_id=unique_id,
+            package_name=package_name,
+            resource_type=resource_type,
+            depends_on=node_dict.get("depends_on", {}).get("nodes", []),
+            file_path=resolved_path,
+            tags=node_dict.get("tags") or [],
+            config=node_dict.get("config") or {},
+            has_freshness=(
+                is_freshness_effective(node_dict.get("freshness")) if resource_type == DbtResourceType.SOURCE else False
+            ),
+        )
+        nodes[node.unique_id] = node
+    return nodes
+
+
 class DbtGraph:
     """
     A dbt project graph (represented by `nodes` and `filtered_nodes`).
@@ -1129,88 +1167,41 @@ class DbtGraph:
         if not self.execution_config.project_path:
             raise CosmosLoadDbtException("Unable to load manifest without ExecutionConfig.dbt_project_path")
 
-        nodes = {}
-
         if TYPE_CHECKING:
             assert self.project.manifest_path is not None  # pragma: no cover
 
         with self.project.manifest_path.open() as fp:
             manifest = json.load(fp)
+        if manifest is None:
+            manifest = {}
 
-            resources = {**manifest.get("nodes", {}), **manifest.get("sources", {}), **manifest.get("exposures", {})}
-            project_path = self.execution_config.project_path
-            packages_subpath = get_dbt_packages_subpath(project_path)
-            # Root project name from manifest metadata (dbt 1.x); when absent, treat all nodes as root (e.g. old/test manifests)
-            manifest_project_name = (manifest.get("metadata") or {}).get("project_name")
+        nodes = _parse_manifest_resources_to_nodes(manifest, self.execution_config.project_path)
 
-            for unique_id, node_dict in resources.items():
-                # External nodes (e.g., from dbt-loom) may not have a file path - skip them
-                # Check for both None and empty string since dbt-loom may set either
-                original_file_path = node_dict.get("original_file_path")
-                if not original_file_path:
-                    logger.debug(
-                        "Skipping node `%s` because it has no file path (likely an external reference from dbt-loom or similar)",
-                        unique_id,
-                    )
-                    continue
-
-                package_name = node_dict.get("package_name")
-                # For installed-package nodes, original_file_path is relative to the package root (e.g. models/edr/...).
-                # Resolve to project_path/dbt_packages/<package_name>/<original_file_path>.
-                # Root project nodes (manifest_project_name == package_name) use project_path/original_file_path.
-                # When manifest has no project_name (old/test manifests), treat every node as root for backward compatibility.
-                is_root_project_node = manifest_project_name is None or (package_name == manifest_project_name)
-                if package_name and not is_root_project_node:
-                    resolved_path = project_path / packages_subpath / package_name / _normalize_path(original_file_path)
-                else:
-                    resolved_path = project_path / _normalize_path(original_file_path)
-
-                node = DbtNode(
-                    unique_id=unique_id,
-                    package_name=package_name,
-                    resource_type=DbtResourceType(node_dict["resource_type"]),
-                    depends_on=node_dict.get("depends_on", {}).get("nodes", []),
-                    file_path=resolved_path,
-                    tags=node_dict.get("tags") or [],
-                    config=node_dict.get("config") or {},
-                    has_freshness=(
-                        is_freshness_effective(node_dict.get("freshness"))
-                        if DbtResourceType(node_dict["resource_type"]) == DbtResourceType.SOURCE
-                        else False
-                    ),
+        if self.render_config.selector:
+            selector_definitions = manifest.get("selectors", {})
+            if not selector_definitions:
+                raise CosmosLoadDbtException(f"Selectors not found in manifest file `{self.project.manifest_path}`")
+            yaml_selectors = self.load_parsed_selectors(selector_definitions)
+            selections = yaml_selectors.get_parsed(self.render_config.selector)
+            if not selections:
+                raise CosmosLoadDbtException(
+                    f"Selector `{self.render_config.selector}` not found in parsed YAML selectors `{selector_definitions}`"
                 )
-
-                nodes[node.unique_id] = node
-
-            if self.render_config.selector:
-                selector_definitions = manifest.get("selectors", {})
-
-                if not selector_definitions:
-                    raise CosmosLoadDbtException(f"Selectors not found in manifest file `{self.project.manifest_path}`")
-
-                yaml_selectors = self.load_parsed_selectors(selector_definitions)
-                selections = yaml_selectors.get_parsed(self.render_config.selector)
-
-                if not selections:
-                    raise CosmosLoadDbtException(
-                        f"Selector `{self.render_config.selector}` not found in parsed YAML selectors `{selector_definitions}`"
-                    )
-
-                self.nodes = nodes
-                self.filtered_nodes = select_nodes(
-                    project_dir=self.execution_config.project_path,
-                    nodes=nodes,
-                    select=selections["select"],
-                    exclude=selections["exclude"],
-                )
-            else:
-                self.nodes = nodes
-                self.filtered_nodes = select_nodes(
-                    project_dir=self.execution_config.project_path,
-                    nodes=nodes,
-                    select=self.render_config.select,
-                    exclude=self.render_config.exclude,
-                )
+            self.nodes = nodes
+            self.filtered_nodes = select_nodes(
+                project_dir=self.execution_config.project_path,
+                nodes=nodes,
+                select=selections["select"],
+                exclude=selections["exclude"],
+            )
+        else:
+            self.nodes = nodes
+            self.filtered_nodes = select_nodes(
+                project_dir=self.execution_config.project_path,
+                nodes=nodes,
+                select=self.render_config.select,
+                exclude=self.render_config.exclude,
+            )
 
     def update_node_dependency(self) -> None:
         """

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -85,7 +85,8 @@ def get_dbt_packages_subpath(source_folder: Path) -> str:
             except yaml.YAMLError:
                 logger.info(f"Unable to read the {DBT_PROJECT_FILENAME} file")
             else:
-                subpath = dbt_project_file_content.get("packages-install-path", DBT_DEFAULT_PACKAGES_FOLDER)
+                if isinstance(dbt_project_file_content, dict):
+                    subpath = dbt_project_file_content.get("packages-install-path", DBT_DEFAULT_PACKAGES_FOLDER)
     return _resolve_env_var(subpath)
 
 

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -361,7 +361,7 @@ class SelectorConfig:
         self.sources: list[str] = []
         self.exposures: list[str] = []
         self.packages: list[str] = []
-        self.bare_identifiers: list[str] = []  # bare strings: match by package_name or node name (dbt-like)
+        self.bare_identifiers: list[str] = []  # bare strings: match by package_name, node name or folder name (dbt ls-like)
         self.resource_types: list[str] = []
         self.exclude_resource_types: list[str] = []
         self.load_from_statement(statement)

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -5,7 +5,6 @@ import hashlib
 import inspect
 import re
 from collections import defaultdict
-from collections.abc import Callable
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
@@ -400,28 +399,30 @@ class SelectorConfig:
                 else:
                     self._handle_no_precursors_or_descendants(item, node_name)
 
-    def _handle_no_precursors_or_descendants(self, item: str, node_name: str) -> None:
-        """Dispatch to the correct parser based on node_name prefix/pattern. Keeps C901 low via dispatch list."""
-        dispatch: list[tuple[bool, Callable[[], None]]] = [
-            (node_name.startswith(PATH_SELECTOR), lambda: self._parse_path_selector(item)),
-            ("/" in node_name, lambda: self._parse_path_selector(f"{PATH_SELECTOR}{node_name}")),
-            (node_name.startswith(TAG_SELECTOR), lambda: self._parse_tag_selector(item)),
-            (node_name.startswith(CONFIG_SELECTOR), lambda: self._parse_config_selector(item)),
-            (node_name.startswith(SOURCE_SELECTOR), lambda: self._parse_source_selector(item)),
-            (node_name.startswith(EXPOSURE_SELECTOR), lambda: self._parse_exposure_selector(item)),
-            (node_name.startswith(PACKAGE_SELECTOR), lambda: self._parse_package_selector(item)),
-            (node_name.startswith(RESOURCE_TYPE_SELECTOR), lambda: self._parse_resource_type_selector(item)),
-            (
-                node_name.startswith(EXCLUDE_RESOURCE_TYPE_SELECTOR),
-                lambda: self._parse_exclude_resource_type_selector(item),
-            ),
-            (self._is_bare_identifier(node_name), lambda: self._parse_bare_identifier(node_name)),
-        ]
-        for condition, handler in dispatch:
-            if condition:
-                handler()
-                return
-        self._parse_unknown_selector(item)
+    # TODO: Refactor this method to remove the noqa: C901 in a separate PR.
+    def _handle_no_precursors_or_descendants(self, item: str, node_name: str) -> None:  # noqa: C901
+        if node_name.startswith(PATH_SELECTOR):
+            self._parse_path_selector(item)
+        elif "/" in node_name:
+            self._parse_path_selector(f"{PATH_SELECTOR}{node_name}")
+        elif node_name.startswith(TAG_SELECTOR):
+            self._parse_tag_selector(item)
+        elif node_name.startswith(CONFIG_SELECTOR):
+            self._parse_config_selector(item)
+        elif node_name.startswith(SOURCE_SELECTOR):
+            self._parse_source_selector(item)
+        elif node_name.startswith(EXPOSURE_SELECTOR):
+            self._parse_exposure_selector(item)
+        elif node_name.startswith(PACKAGE_SELECTOR):
+            self._parse_package_selector(item)
+        elif node_name.startswith(RESOURCE_TYPE_SELECTOR):
+            self._parse_resource_type_selector(item)
+        elif node_name.startswith(EXCLUDE_RESOURCE_TYPE_SELECTOR):
+            self._parse_exclude_resource_type_selector(item)
+        elif self._is_bare_identifier(node_name):
+            self._parse_bare_identifier(node_name)
+        else:
+            self._parse_unknown_selector(item)
 
     def _is_bare_identifier(self, value: str) -> bool:
         """True if value is a bare selector: no : / + @ .
@@ -574,7 +575,8 @@ class NodeSelector:
             return False
         return True
 
-    def _should_include_node(self, node_id: str, node: DbtNode) -> bool:
+    # TODO: Refactor this method to remove the noqa: C901 in a separate PR.
+    def _should_include_node(self, node_id: str, node: DbtNode) -> bool:  # noqa: C901
         """
         Checks if a single node should be included. Only runs once per node with caching."""
         logger.debug("Inspecting if the node <%s> should be included.", node_id)
@@ -582,60 +584,54 @@ class NodeSelector:
             return node_id in self.selected_nodes
 
         self.visited_nodes.add(node_id)
-        self._inherit_test_node_tags(node_id, node)
+
+        # Disclaimer: this method currently copies the tags from parent nodes to children nodes
+        # that are tests. This can lead to incorrect results in graph node selectors such as reported in
+        # https://github.com/astronomer/astronomer-cosmos/pull/1466
+        if node.resource_type == DbtResourceType.TEST and node.depends_on and len(node.depends_on) > 0:
+            node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
+            logger.debug(
+                "The test node <%s> inherited these tags from the parent node <%s>: %s",
+                node_id,
+                node.depends_on[0],
+                node.tags,
+            )
+
         if not self._is_tags_subset(node):
             logger.debug("Excluding node <%s>", node_id)
             return False
-        if not self._node_passes_config_filters(node):
-            return False
-        if not self._node_passes_type_and_path_filters(node):
-            return False
-        if not self._node_passes_selector_filters(node):
-            return False
-        return True
 
-    def _inherit_test_node_tags(self, node_id: str, node: DbtNode) -> None:
-        """Copy tags from parent to test nodes (see #1466). Mutates node.tags in place."""
-        if node.resource_type != DbtResourceType.TEST or not node.depends_on:
-            return
-        node.tags = getattr(self.nodes.get(node.depends_on[0]), "tags", [])
-        logger.debug(
-            "The test node <%s> inherited these tags from the parent node <%s>: %s",
-            node_id,
-            node.depends_on[0],
-            node.tags,
-        )
-
-    def _node_passes_config_filters(self, node: DbtNode) -> bool:
-        """Check meta and non-meta/non-tag config filters."""
+        # Remove 'tags' as they've already been filtered for
         config_copy = copy.deepcopy(self.config.config)
         config_copy.pop("tags", None)
-        if not self._should_include_based_on_meta(node, config_copy):
-            return False
-        if not self._should_include_based_on_non_meta_and_non_tag_config(node, config_copy):
-            return False
-        return True
 
-    def _node_passes_type_and_path_filters(self, node: DbtNode) -> bool:
-        """Check path, resource_type, and exclude_resource_type filters."""
+        # Handle other config attributes, including meta and general config
+        if not self._should_include_based_on_meta(
+            node, config_copy
+        ) or not self._should_include_based_on_non_meta_and_non_tag_config(node, config_copy):
+            return False
+
         if self.config.paths and not self._is_path_matching(node):
             return False
+
         if self.config.resource_types and not self._is_resource_type_matching(node):
             return False
+
         if self.config.exclude_resource_types and self._is_exclude_resource_type_matching(node):
             return False
-        return True
 
-    def _node_passes_selector_filters(self, node: DbtNode) -> bool:
-        """Check source, exposure, package, and bare-identifier filters."""
         if self.config.sources and not self._is_source_matching(node):
             return False
+
         if self.config.exposures and not self._is_exposure_matching(node):
             return False
+
         if self.config.packages and not self._is_package_matching(node):
             return False
+
         if self.config.bare_identifiers and not self._is_bare_identifier_matching(node):
             return False
+
         return True
 
     def _is_resource_type_matching(self, node: DbtNode) -> bool:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -249,6 +249,13 @@ class GraphSelector:
                 }
             )
 
+        elif self.node_name.startswith(PACKAGE_SELECTOR):
+            package_selection = self.node_name[len(PACKAGE_SELECTOR) :].strip()
+            if package_selection:
+                root_nodes.update(
+                    {node_id for node_id, node in nodes.items() if node.package_name == package_selection}
+                )
+
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
             # currently tags, materialized, schema and meta are the only supported config keys
@@ -673,10 +680,7 @@ class NodeSelector:
         if (node.package_name or "") in self.config.bare_identifiers or node.name in self.config.bare_identifiers:
             return True
         # Match by path segment (folder name): e.g. "folder_a" matches nodes under .../folder_a/...
-        try:
-            path_parts = node.file_path.parts
-        except AttributeError:
-            path_parts = ()
+        path_parts = node.file_path.parts
         return any(bare in path_parts for bare in self.config.bare_identifiers)
 
     def _is_tags_subset(self, node: DbtNode) -> bool:

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -361,7 +361,9 @@ class SelectorConfig:
         self.sources: list[str] = []
         self.exposures: list[str] = []
         self.packages: list[str] = []
-        self.bare_identifiers: list[str] = []  # bare strings: match by package_name, node name or folder name (dbt ls-like)
+        self.bare_identifiers: list[str] = (
+            []
+        )  # bare strings: match by package_name, node name or folder name (dbt ls-like)
         self.resource_types: list[str] = []
         self.exclude_resource_types: list[str] = []
         self.load_from_statement(statement)

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -485,6 +485,10 @@ class SelectorConfig:
     def _parse_package_selector(self, item: str) -> None:
         index = len(PACKAGE_SELECTOR)
         package_name = item[index:].strip()
+        if not package_name:
+            raise CosmosValueError(
+                "package: selector requires a non-empty package name (e.g. select=['package:dbt_artifacts'])"
+            )
         self.packages.append(package_name)
 
     def __repr__(self) -> str:

--- a/docs/configuration/parsing-methods.rst
+++ b/docs/configuration/parsing-methods.rst
@@ -91,6 +91,11 @@ dependencies using the following command: ``pip install "astronomer-cosmos[micro
     :start-after: [START azure_abfs_example]
     :end-before: [END azure_abfs_example]
 
+Package models (e.g. from the Elementary package) are included in the DAG when they are present in the manifest.
+Generate the manifest **after** installing and enabling packages: run ``dbt deps`` then ``dbt compile`` (or ``dbt run``)
+from your project directory. If the manifest was built before a package was added or enabled, package models will not
+appear in the DAG until you regenerate the manifest.
+
 
 ``dbt_ls``
 ----------

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -33,7 +33,7 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``source:my_source.my_table``: include/exclude nodes that have the source ``my_source`` and the table ``my_table``
 - ``exposure:my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and are of resource_type ``exposure``
 - ``exposure:+my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and their parents
-- ``package:package_name``: include/exclude all nodes that belong to the given package (e.g. ``package:dbt_artifacts``). Especially useful with ``LoadMode.DBT_MANIFEST`` when excluding installed packages from the DAG. A bare name without a method prefix (e.g. ``dbt_artifacts`` or ``child``) is resolved like dbt: it matches nodes by package name or by node name (e.g. ``exclude=['dbt_artifacts']`` excludes that package; ``select=['child']`` selects the node named ``child``).
+- ``package:package_name``: include/exclude all nodes that belong to the given package (e.g. ``package:dbt_artifacts``). Especially useful with ``LoadMode.DBT_MANIFEST`` when excluding installed packages from the DAG. A bare name without a method prefix (e.g. ``dbt_artifacts`` or ``child``) is resolved like dbt: it matches nodes by package name, node name, or path segment (folder name). So ``select=['folder_a']`` or ``exclude=['folder_a']`` includes or excludes all models under a folder named ``folder_a``, including when using ``LoadMode.DBT_MANIFEST``.
 
 .. note::
 

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -33,7 +33,10 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``source:my_source.my_table``: include/exclude nodes that have the source ``my_source`` and the table ``my_table``
 - ``exposure:my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and are of resource_type ``exposure``
 - ``exposure:+my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and their parents
-- ``package:package_name``: include/exclude all nodes that belong to the given package (e.g. ``package:dbt_artifacts``). Especially useful with ``LoadMode.DBT_MANIFEST`` when excluding installed packages from the DAG. A bare name without a method prefix (e.g. ``dbt_artifacts`` or ``child``) is resolved like dbt: it matches nodes by package name, node name, or path segment (folder name). So ``select=['folder_a']`` or ``exclude=['folder_a']`` includes or excludes all models under a folder named ``folder_a``, including when using ``LoadMode.DBT_MANIFEST``.
+- ``package:package_name``: include/exclude all nodes that belong to the given package (e.g. ``package:dbt_artifacts``). The package name must be non-empty (use ``package:dbt_artifacts``, not ``package:``).
+- ``package:package_name+``: include/exclude all nodes in the package and their descendants (children).
+- ``+package:package_name``: include/exclude all nodes in the package and their ancestors (parents).
+- A bare name without a method prefix (e.g. ``dbt_artifacts`` or ``child``) is resolved like dbt: it matches nodes by package name, node name, or path segment (folder name). So ``select=['folder_a']`` or ``exclude=['folder_a']`` includes or excludes all models under a folder named ``folder_a``, including when using ``LoadMode.DBT_MANIFEST``.
 
 .. note::
 

--- a/docs/configuration/selecting-excluding.rst
+++ b/docs/configuration/selecting-excluding.rst
@@ -33,6 +33,7 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``source:my_source.my_table``: include/exclude nodes that have the source ``my_source`` and the table ``my_table``
 - ``exposure:my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and are of resource_type ``exposure``
 - ``exposure:+my_exposure``: include/exclude nodes that have the exposure ``my_exposure`` and their parents
+- ``package:package_name``: include/exclude all nodes that belong to the given package (e.g. ``package:dbt_artifacts``). Especially useful with ``LoadMode.DBT_MANIFEST`` when excluding installed packages from the DAG. A bare name without a method prefix (e.g. ``dbt_artifacts`` or ``child``) is resolved like dbt: it matches nodes by package name or by node name (e.g. ``exclude=['dbt_artifacts']`` excludes that package; ``select=['child']`` selects the node named ``child``).
 
 .. note::
 
@@ -102,6 +103,18 @@ Examples:
     jaffle_shop = DbtDag(
         render_config=RenderConfig(
             exclude=["node_name+"],  # node_name and its children
+        )
+    )
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig
+
+    jaffle_shop = DbtDag(
+        render_config=RenderConfig(
+            exclude=[
+                "package:dbt_artifacts"
+            ],  # exclude all nodes from dbt_artifacts package (e.g. when using manifest load mode)
         )
     )
 

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1056,6 +1056,39 @@ def test_select_nodes_by_exclude_bare_package_name():
     assert set(selected_bare.keys()) == set(selected_explicit.keys()) == set(sample_nodes.keys())
 
 
+def test_select_nodes_by_bare_folder_name():
+    """
+    Bare identifier as folder name (path segment) matches nodes under that folder.
+    Ensures select=['folder_a'] / exclude=['folder_a'] work with manifest load mode.
+    """
+    # gen1 contains grandparent, another_grandparent; gen3 contains child, sibling1, sibling2, sibling3, orphaned
+    selected = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH,
+        nodes=sample_nodes,
+        select=["gen1"],
+    )
+    assert set(selected.keys()) == {grandparent_node.unique_id, another_grandparent_node.unique_id}
+
+
+def test_exclude_nodes_by_bare_folder_name():
+    """Exclude by folder name (path segment) excludes all nodes under that folder."""
+    excluded = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH,
+        nodes=sample_nodes,
+        exclude=["gen3"],
+    )
+    gen3_ids = {
+        child_node.unique_id,
+        sibling1_node.unique_id,
+        sibling2_node.unique_id,
+        sibling3_node.unique_id,
+        orphaned_node.unique_id,
+    }
+    assert gen3_ids.isdisjoint(excluded.keys())
+    assert grandparent_node.unique_id in excluded
+    assert parent_node.unique_id in excluded
+
+
 def test_select_exposure_nodes_by_graph_ancestry():
     """
     Test selecting an exposure node and its directs ancestors using the syntax '+exposure:exposure_name'.

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1024,6 +1024,17 @@ def test_select_nodes_by_exclude_package():
     assert set(selected.keys()) == set(sample_nodes.keys())
 
 
+def test_select_nodes_raises_on_empty_package_selector():
+    """Empty package: (e.g. select=['package:']) would match all nodes with package_name None; we raise instead."""
+    with pytest.raises(CosmosValueError) as err_info:
+        select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["package:"])
+    assert "package: selector requires a non-empty package name" in err_info.value.args[0]
+
+    with pytest.raises(CosmosValueError) as err_info:
+        select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, exclude=["package:"])
+    assert "package: selector requires a non-empty package name" in err_info.value.args[0]
+
+
 def test_select_nodes_by_exclude_bare_package_name():
     """
     Bare package name (no 'package:' prefix) is equivalent to 'package:name', matching dbt behavior.


### PR DESCRIPTION
Fixes DAG rendering when using manifest load mode with installed dbt packages (e.g. Elementary, dbt_artifacts): package models are now included and have correct paths (this was not working previously).
Additionally, you can now select/exclude by package which was not working previously.
Also, fixes selecting/excluding models by folder_name which was not working previously.

**Changes**

**Manifest mode – package nodes**
- Correct `file_path` for package nodes: In the manifest, package nodes use `original_file_path` relative to the package root (e.g. `models/edr/...`). Cosmos now resolves them as `project_path/dbt_packages/<package_name>/<original_file_path>` so package models appear in the DAG and path-based logic works.
- Root vs package: Uses manifest `metadata.project_name` to treat root project nodes as `project_path/original_file_path`. When `metadata.project_name` is missing (older/test manifests), all nodes are treated as root for backward compatibility.
- Docs: Parsing-methods doc updated to note that package models are included when present in the manifest and that the manifest should be generated after installing and enabling packages (dbt deps then dbt compile).

**Selectors**
- `package:package_name`: You can include or exclude all nodes from a package (e.g. `exclude=["package:dbt_artifacts"]` or `select=["package:elementary"]`), including when using manifest load mode.
- Bare identifiers: A bare name with no prefix (e.g. `exclude=["dbt_artifacts"]`) is resolved like in dbt: by package name or node name or a folder name containing models.
- Docs and tests: Selecting-excluding doc updated with the new options and an example; tests added for select/exclude by package and bare identifier.

**Robustness and errors**
Empty `dbt_project.yml`: `get_dbt_packages_subpath()` no longer assumes `yaml.safe_load()` returns a dict; handles `None` (e.g. empty file) so manifest loading does not raise when the project dir has an empty dbt_project.yml.
Manifest loading: Handles json.load() returning None and uses metadata only when it is a dict when reading project_name.

closes: #1528 
closes: https://github.com/astronomer/oss-integrations-private/issues/318