### PR TITLE
Update CODEOWNERS to have oss-integrations as first code owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,1 @@
-* @astronomer/astro-cosmos-admins @astronomer/oss-integrations @jbandoro @dwreeves @corsettigyg
+* @astronomer/oss-integrations @jbandoro @dwreeves @corsettigyg


### PR DESCRIPTION
Attempt to fix the issue that PRs are not having automatic reviewers.

In practice, @astronomer/astro-cosmos-admins exists only for organisational reasons, and the people in that group have not been contributing to the project - except me (but I'm part of @astronomer/oss-integrations)