### PR TITLE
Change Snowflake profile mapppings to default to four threads

### DIFF
--- a/cosmos/profiles/snowflake/base.py
+++ b/cosmos/profiles/snowflake/base.py
@@ -7,6 +7,7 @@ from typing import Any
 from cosmos.profiles.base import BaseProfileMapping
 
 DEFAULT_AWS_REGION = "us-west-2"
+DEFAULT_THREADS = 4
 
 
 class SnowflakeBaseProfileMapping(BaseProfileMapping):
@@ -16,6 +17,7 @@ class SnowflakeBaseProfileMapping(BaseProfileMapping):
         """Gets profile."""
         profile_vars = {
             **self.mapped_params,
+            "threads": DEFAULT_THREADS,
             **self.profile_args,
         }
         return profile_vars

--- a/cosmos/profiles/snowflake/base.py
+++ b/cosmos/profiles/snowflake/base.py
@@ -12,12 +12,14 @@ DEFAULT_THREADS = 4
 
 class SnowflakeBaseProfileMapping(BaseProfileMapping):
 
+    profile_defaults: dict[str, Any] = {"threads": DEFAULT_THREADS}
+
     @property
     def profile(self) -> dict[str, Any | None]:
         """Gets profile."""
         profile_vars = {
             **self.mapped_params,
-            "threads": DEFAULT_THREADS,
+            **self.profile_defaults,
             **self.profile_args,
         }
         return profile_vars

--- a/docs/generate_mappings.py
+++ b/docs/generate_mappings.py
@@ -72,6 +72,7 @@ def generate_mapping_docs(
                         "mapping_description": "\n\n".join(docstring.split("\n")),
                         "fields": [field.__dict__ for field in get_fields_from_mapping(mapping=mapping)],
                         "airflow_conn_type": mapping.airflow_connection_type,
+                        "profile_defaults": getattr(mapping, "profile_defaults", {}),
                     }
                 )
             )

--- a/docs/templates/profile_mapping.rst.jinja2
+++ b/docs/templates/profile_mapping.rst.jinja2
@@ -54,3 +54,22 @@ Some notes about the table above:
   For example, if the Airflow field name is ``['password', 'extra.token']``, the profile mapping
   will first look for a field named ``password``. If that field is not present, it will look for
   ``extra.token``.
+{% if profile_defaults %}
+
+Default Values
+--------------
+
+This profile mapping sets the following default values. These can be overridden by passing
+them in ``profile_args``.
+
+.. list-table::
+   :header-rows: 1
+
+   * - Field Name
+     - Default Value
+
+   {% for key, value in profile_defaults.items() %}
+   * - ``{{ key }}``
+     - ``{{ value }}``
+   {% endfor %}
+{% endif %}

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -183,6 +183,7 @@ def test_profile_args(
         "account": f"{mock_account}.{mock_region}",
         "database": mock_snowflake_conn.extra_dejson.get("database"),
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -212,6 +213,7 @@ def test_profile_args_overrides(
         "account": f"{mock_account}.{mock_region}",
         "database": "my_db_override",
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -275,4 +277,5 @@ def test_old_snowflake_format() -> None:
             "account": conn.extra_dejson.get("account"),
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_file.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_file.py
@@ -136,6 +136,7 @@ def test_profile_args(
         "account": f"{mock_account}.{mock_region}",
         "database": mock_snowflake_conn.extra_dejson.get("database"),
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -165,6 +166,7 @@ def test_profile_args_overrides(
         "account": f"{mock_account}.{mock_region}",
         "database": "my_db_override",
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -213,4 +215,5 @@ def test_old_snowflake_format() -> None:
             "account": conn.extra_dejson.get("account"),
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }

--- a/tests/profiles/snowflake/test_snowflake_user_pass.py
+++ b/tests/profiles/snowflake/test_snowflake_user_pass.py
@@ -126,6 +126,7 @@ def test_profile_args(
         "account": mock_snowflake_conn.extra_dejson.get("account"),
         "database": mock_snowflake_conn.extra_dejson.get("database"),
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -151,6 +152,30 @@ def test_profile_args_overrides(
         "account": mock_snowflake_conn.extra_dejson.get("account"),
         "database": "my_db_override",
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
+    }
+
+
+def test_profile_args_overrides_threads(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that you can override the default threads value via profile_args.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+        profile_args={"threads": 8},
+    )
+
+    assert profile_mapping.profile == {
+        "type": mock_snowflake_conn.conn_type,
+        "user": mock_snowflake_conn.login,
+        "password": "{{ env_var('COSMOS_CONN_SNOWFLAKE_PASSWORD') }}",
+        "schema": mock_snowflake_conn.schema,
+        "account": mock_snowflake_conn.extra_dejson.get("account"),
+        "database": mock_snowflake_conn.extra_dejson.get("database"),
+        "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 8,
     }
 
 
@@ -197,6 +222,7 @@ def test_old_snowflake_format() -> None:
             "account": conn.extra_dejson.get("account"),
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }
 
 
@@ -230,6 +256,7 @@ def test_appends_region() -> None:
             "account": f"{conn.extra_dejson.get('account')}.{conn.extra_dejson.get('region')}",
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }
 
 

--- a/tests/profiles/snowflake/test_snowflake_user_privatekey.py
+++ b/tests/profiles/snowflake/test_snowflake_user_privatekey.py
@@ -184,6 +184,7 @@ def test_profile_args(
         "account": mock_snowflake_conn.extra_dejson.get("account"),
         "database": mock_snowflake_conn.extra_dejson.get("database"),
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -209,6 +210,7 @@ def test_profile_args_overrides(
         "account": mock_snowflake_conn.extra_dejson.get("account"),
         "database": "my_db_override",
         "warehouse": mock_snowflake_conn.extra_dejson.get("warehouse"),
+        "threads": 4,
     }
 
 
@@ -269,6 +271,7 @@ def test_old_snowflake_format() -> None:
             "account": conn.extra_dejson.get("account"),
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }
 
 
@@ -302,4 +305,5 @@ def test_appends_region() -> None:
             "account": f"{conn.extra_dejson.get('account')}.{conn.extra_dejson.get('region')}",
             "database": conn.extra_dejson.get("database"),
             "warehouse": conn.extra_dejson.get("warehouse"),
+            "threads": 4,
         }


### PR DESCRIPTION
The [`ExecutionMode.WATCHER`](https://astronomer.github.io/astronomer-cosmos/getting_started/watcher-execution-mode.html) performance improvements are highly dependent on the number of threads the dbt command is run with.
    
While dbt Core default number of [threads is 4](https://docs.getdbt.com/docs/core/connect-data-platform/connection-profiles\#understanding-threads):
    
<img width="1490" height="407" alt="Screenshot 2026-02-17 at 12 36 01" src="https://github.com/user-attachments/assets/b53f873d-92c6-4125-b1b4-a5f4e7a3d54b" />

The [default number of threads set by the Snowflake adapter is 1:](https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup)
    
<img width="1427" height="342" alt="Screenshot 2026-02-17 at 12 36 44" src="https://github.com/user-attachments/assets/305c6b4a-c1e8-4fa6-a318-0de900733374" />


With `ExecutionMode.WATCHER`, setting `threads=1` results in models running sequentially, one a time, leading to worse performance than with `ExecutionMode.LOCAL`.
    
While Cosmos aims to be compatible with dbt Core and dbt adapters' default values, we decided to change this for Snowflake to align with dbt Core's default.

Users can still override customising the number of threads, for instance, via:
```
profile_mapping=SnowflakeUserPasswordProfileMapping(
        conn_id="snowflake_conn",
        profile_args={"threads": 8},
    ),
```