### PR TITLE
Fix Zizmor check

### DIFF
--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -18,7 +18,7 @@ jobs:
       security-events: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
 


### PR DESCRIPTION
Attempt to solve the `impostor-commit` issue created when external contributors attempt to submit PRs to Cosmos. This currently only happens in the recently added `actionlint` workflow.

Example of issue: https://github.com/astronomer/astronomer-cosmos/actions/runs/22107887101/job/63895745154?pr=2316
```
Unable to find image 'ghcr.io/zizmorcore/zizmor:latest@sha256:c04a14fa9efebdae40b7f999127996fcb31dd7eb0163f5d899be301aaab635e2' locally
ghcr.io/zizmorcore/zizmor@sha256:c04a14fa9efebdae40b7f999127996fcb31dd7eb0163f5d899be301aaab635e2: Pulling from zizmorcore/zizmor
073de38e80a9: Pulling fs layer
1f4d10983e62: Pulling fs layer
f8f83eb22e81: Pulling fs layer
ffa8141ea130: Pulling fs layer
a36dbe526a14: Pulling fs layer
18fbe54415b8: Pulling fs layer
2df0b2a291e7: Pulling fs layer
b4e5d0df546e: Pulling fs layer
7c9a487ed6fa: Pulling fs layer
cfd7f31cd3d9: Pulling fs layer
ef414417342b: Pulling fs layer
b4f21e0f00e5: Pulling fs layer
f8f83eb22e81: Download complete
ffa8141ea130: Download complete
7c9a487ed6fa: Download complete
b4f21e0f00e5: Download complete
1f4d10983e62: Download complete
18fbe54415b8: Download complete
073de38e80a9: Download complete
a36dbe526a14: Download complete
ef414417342b: Download complete
2df0b2a291e7: Download complete
b4e5d0df546e: Download complete
cfd7f31cd3d9: Download complete
5d305cb31c3d: Download complete
b4f21e0f00e5: Pull complete
a36dbe526a14: Pull complete
ef414417342b: Pull complete
b4e5d0df546e: Pull complete
cfd7f31cd3d9: Pull complete
f8f83eb22e81: Pull complete
ffa8141ea130: Pull complete
7c9a487ed6fa: Pull complete
1f4d10983e62: Pull complete
18fbe54415b8: Pull complete
2df0b2a291e7: Pull complete
073de38e80a9: Pull complete
Digest: sha256:c04a14fa9efebdae40b7f999127996fcb31dd7eb0163f5d899be301aaab635e2
Status: Downloaded newer image for ghcr.io/zizmorcore/zizmor@sha256:c04a14fa9efebdae40b7f999127996fcb31dd7eb0163f5d899be301aaab635e2
🌈 zizmor v1.22.0
 INFO audit: zizmor: 🌈 completed ./.github/dependabot.yml
fatal: no audit was performed
'impostor-commit' audit failed on file://./.github/workflows/actionlint.yml

Caused by:
    0: error in 'impostor-commit' audit
    1: couldn't list tags for reviewdog/action-actionlint
    2: request error while accessing GitHub API
    3: HTTP status client error (401 Unauthorized) for url (https://github.com/reviewdog/action-actionlint.git/git-upload-pack)
Error: Process completed with exit code 1.