### PR TITLE
Update watcher execution mode docs

### DIFF
--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -348,7 +348,7 @@ As a starting point, this execution mode does not support the ``TestBehavior.AFT
 
 The ``TestBehavior.BUILD`` behavior is embedded to the producer ``DbtProducerWatcherOperator`` operator.
 
-The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similar to ``ExecutionMode.LOCAL``.
+The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similarly to ``ExecutionMode.LOCAL``.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Airflow Datasets and Assets

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -344,9 +344,9 @@ Test behavior
 
 By default, the watcher mode runs tests alongside models via the ``dbt build`` command being executed by the producer ``DbtProducerWatcherOperator`` operator.
 
-As a starting point, this execution mode does not support the ``TestBehavior.AFTER_EACH`` behaviour, since the tests are not run as individual tasks. Since this is the default ``TestBehavior`` in Cosmos, we are injecting ``EmptyOperator`` as a starting point to ensure a seamless transition to the new mode.
+As a starting point, this execution mode does not support the ``TestBehavior.AFTER_EACH`` behavior, since the tests are not run as individual tasks. Since this is the default ``TestBehavior`` in Cosmos, we are injecting ``EmptyOperator`` as a starting point to ensure a seamless transition to the new mode.
 
-The ``TestBehavior.BUILD`` behaviour is embedded to the producer ``DbtProducerWatcherOperator`` operator.
+The ``TestBehavior.BUILD`` behavior is embedded to the producer ``DbtProducerWatcherOperator`` operator.
 
 The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similar to ``ExecutionMode.LOCAL``.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -396,7 +396,7 @@ If you need to override ``operator_args`` for the ``DbtProducerWatcherOperator``
 When using ``ExecutionMode.WATCHER``, you may want to configure specific properties, such as ``retries`` specifically for the ``DbtProducerWatcherOperator`` task. This can be useful for several reasons:
 - Improved resilience - transient issues (e.g., temporary database or network failures) can be automatically retried.
 - Reduced manual intervention - failed producer runs can recover without requiring operator restarts.
-- Better reliability - retry behaviour can be tuned independently from sensor tasks.
+- Better reliability - retry behavior can be tuned independently from sensor tasks.
 
 Example: Configure the producer task with custom retry settings.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -221,7 +221,7 @@ How retries work
 
 When the ``dbt build`` command run by ``DbtProducerWatcherOperator`` fails, it will notify all the ``DbtConsumerWatcherSensor``.
 
-The individual watcher tasks that subclass ``DbtConsumerWatcherSensor`` can retry the dbt command themselves, using the same behaviour as ``ExecutionMode.LOCAL``.
+The individual watcher tasks that subclass ``DbtConsumerWatcherSensor`` can retry the dbt command themselves, using the same behavior as ``ExecutionMode.LOCAL``.
 
 If a branch of the DAG fails, users can clear the status of a failed consumer task, including its downstream tasks, via the Airflow UI, and each of them will run in ``ExecutionMode.LOCAL``.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -364,9 +364,9 @@ Since Cosmos 1.6, it `supports the rendering of source nodes <https://www.astron
 
 We noticed some Cosmos users use this feature alongside `overriding Cosmos source nodes <https://astronomer.github.io/astronomer-cosmos/configuration/render-config.html#customizing-how-nodes-are-rendered-experimental>`_ as sensors or another operator that allows them to skip the following branch of the DAG if the source is not fresh.
 
-This use-case is not currently supported by the ``ExecutionMode.WATCHER``, since the ``dbt build`` command does not run `source freshness checks <https://docs.getdbt.com/reference/commands/build#source-freshness-checks>`_.
+This use case is not currently supported by the ``ExecutionMode.WATCHER``, since the ``dbt build`` command does not run `source freshness checks <https://docs.getdbt.com/reference/commands/build#source-freshness-checks>`_.
 
-We have a follow-up ticket to `further investigate this use-case <https://github.com/astronomer/astronomer-cosmos/issues/2053>`_.
+We have a follow-up ticket to `further investigate this use case <https://github.com/astronomer/astronomer-cosmos/issues/2053>`_.
 
 
 Additional details

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -310,7 +310,7 @@ Known Limitations
 Producer task implementation
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The producer task is implemented as a ``DbtProducerWatcherOperator``and currently relies on dbt being installed alongside the Airflow deployment, as in the ``ExecutionMode.LOCAL`` implementation.
+The producer task is implemented as a ``DbtProducerWatcherOperator`` and currently relies on dbt being installed alongside the Airflow deployment, as in the ``ExecutionMode.LOCAL`` implementation.
 
 The alternative to this implementation is to use ``ExecutionMode.WATCHER_KUBERNETES``, which is built on top of ``ExecutionMode.KUBERNETES``. Check :ref:`watcher-kubernetes-execution-mode` for more information.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -396,7 +396,7 @@ If you need to override ``operator_args`` for the ``DbtProducerWatcherOperator``
 When using ``ExecutionMode.WATCHER``, you may want to configure specific properties, such as `retries` specifically for the ``DbtProducerWatcherOperator`` task. This can be useful for several reasons:
 - Improved resilience - transient issues (e.g., temporary database or network failures) can be automatically retried.
 - Reduced manual intervention - failed producer runs can recover without requiring operator restarts.
-- Better reliability — retry behaviour can be tuned independently from sensor tasks.
+- Better reliability - retry behaviour can be tuned independently from sensor tasks.
 
 Example: Configure the producer task with custom retry settings.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -378,7 +378,7 @@ Callback support
 
 The ``DbtProducerWatcherOperator`` and ``DbtConsumerWatcherSensor`` will use the user-defined callback function similar to ``ExecutionMode.LOCAL`` mode.
 
-It is possible to define different ``callback`` behaviors for producer and consumer nodes by using ``setup_operator_args`, as described below.
+It is possible to define different ``callback`` behaviors for producer and consumer nodes by using ``setup_operator_args``, as described below.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Overriding ``operator_args``

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -348,7 +348,7 @@ As a starting point, this execution mode does not support the ``TestBehavior.AFT
 
 The ``TestBehavior.BUILD`` behaviour is embedded to the producer ``DbtProducerWatcherOperator`` operator.
 
-The ``TestBehaviour.NONE`` and ``TestBehaviour.AFTER_ALL`` behave similar to ``ExecutionMode.LOCAL``.
+The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similar to ``ExecutionMode.LOCAL``.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Airflow Datasets and Assets

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -369,7 +369,7 @@ This use case is not currently supported by the ``ExecutionMode.WATCHER``, since
 We have a follow-up ticket to `further investigate this use case <https://github.com/astronomer/astronomer-cosmos/issues/2053>`_.
 
 
-Additional details
+Advanced config
 -------------------
 
 ~~~~~~~~~~~~~~~~

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -393,7 +393,7 @@ Using Custom Args for the Producer and Watcher
 
 If you need to override ``operator_args`` for the ``DbtProducerWatcherOperator``, you can do so using ``setup_operator_args``.
 
-When using ``ExecutionMode.WATCHER``, you may want to configure specific properties, such as `retries` specifically for the ``DbtProducerWatcherOperator`` task. This can be useful for several reasons:
+When using ``ExecutionMode.WATCHER``, you may want to configure specific properties, such as ``retries`` specifically for the ``DbtProducerWatcherOperator`` task. This can be useful for several reasons:
 - Improved resilience - transient issues (e.g., temporary database or network failures) can be automatically retried.
 - Reduced manual intervention - failed producer runs can recover without requiring operator restarts.
 - Better reliability - retry behaviour can be tuned independently from sensor tasks.

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -419,7 +419,7 @@ This allows you to customize ``DbtProducerWatcherOperator`` retry behavior witho
 If configuring queues, we suggest using the previously mentioned ``watcher_dbt_execution_queue`` configuration instead of the ``setup_operator_args``.
 
 .. note::
-Please note that setup_operator_args is specific to Cosmos and is not related to Airflow setup or teardown task.
+   Please note that setup_operator_args is specific to Cosmos and is not related to Airflow setup or teardown task.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -370,7 +370,7 @@ We have a follow-up ticket to `further investigate this use-case <https://github
 
 
 Additional details
-------------------- 
+-------------------
 
 ~~~~~~~~~~~~~~~~
 Callback support
@@ -407,7 +407,7 @@ Example: Configure the producer task with custom retry settings.
     from cosmos.constants import ExecutionMode
 
     execution_config = ExecutionConfig(
-    execution_mode=ExecutionMode.WATCHER,
+        execution_mode=ExecutionMode.WATCHER,
         setup_operator_args={
             "retries": 0,
             "retry_delay": timedelta(minutes=5),

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -346,7 +346,7 @@ By default, the watcher mode runs tests alongside models via the ``dbt build`` c
 
 As a starting point, this execution mode does not support the ``TestBehavior.AFTER_EACH`` behavior, since the tests are not run as individual tasks. Since this is the default ``TestBehavior`` in Cosmos, we are injecting ``EmptyOperator`` as a starting point to ensure a seamless transition to the new mode.
 
-The ``TestBehavior.BUILD`` behavior is embedded to the producer ``DbtProducerWatcherOperator`` operator.
+The ``TestBehavior.BUILD`` behavior is embedded in the producer ``DbtProducerWatcherOperator`` operator.
 
 The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similarly to ``ExecutionMode.LOCAL``.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -221,7 +221,7 @@ How retries work
 
 When the ``dbt build`` command run by ``DbtProducerWatcherOperator`` fails, it will notify all the ``DbtConsumerWatcherSensor``.
 
-The individual watcher tasks that subclass ``DbtConsumerWatcherSensor``can retry the dbt command themselves, using the same behaviour as ``ExecutionMode.LOCAL``.
+The individual watcher tasks that subclass ``DbtConsumerWatcherSensor`` can retry the dbt command themselves, using the same behaviour as ``ExecutionMode.LOCAL``.
 
 If a branch of the DAG fails, users can clear the status of a failed consumer task, including its downstream tasks, via the Airflow UI, and each of them will run in ``ExecutionMode.LOCAL``.
 

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -378,7 +378,7 @@ Callback support
 
 The ``DbtProducerWatcherOperator`` and ``DbtConsumerWatcherSensor`` will use the user-defined callback function similar to ``ExecutionMode.LOCAL`` mode.
 
-It is possible to define different ``callback`` behaviors for producer and consumer nodes by using ``setup_operator_args``, as described below.
+You can define different ``callback`` behaviors for producer and consumer nodes by using ``operator_args`` to configure the consumer callback and ``setup_operator_args`` to override the callback for the producer, as described below.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Overriding ``operator_args``

--- a/docs/getting_started/watcher-execution-mode.rst
+++ b/docs/getting_started/watcher-execution-mode.rst
@@ -419,7 +419,7 @@ This allows you to customize ``DbtProducerWatcherOperator`` retry behavior witho
 If configuring queues, we suggest using the previously mentioned ``watcher_dbt_execution_queue`` configuration instead of the ``setup_operator_args``.
 
 .. note::
-   Please note that setup_operator_args is specific to Cosmos and is not related to Airflow setup or teardown task.
+   Please note that ``setup_operator_args`` is specific to Cosmos and is not related to Airflow setup or teardown task.
 
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
We had a few outdated and redundant pieces of information. This PR aims to clean up the watcher documentation so it is accurate.