### PR TITLE
Add .airflow-registry.yaml for Airflow Provider Registry

### DIFF
--- a/.airflow-registry.yaml
+++ b/.airflow-registry.yaml
@@ -76,7 +76,7 @@ operators:
   - module: cosmos.operators.kubernetes.DbtSnapshotKubernetesOperator
     description: Run `dbt snapshot` in a Kubernetes pod.
   - module: cosmos.operators.kubernetes.DbtSourceKubernetesOperator
-    description: Run `dbt source` in a Kubernetes pod.
+    description: Run `dbt source freshness` in a Kubernetes pod.
   - module: cosmos.operators.kubernetes.DbtTestKubernetesOperator
     description: Run `dbt test` in a Kubernetes pod.
 


### PR DESCRIPTION
Declares Cosmos modules (operators and others) so the Apache Airflow Provider Registry can discover them automatically instead of relying on a hardcoded listing in the airflow repo.

Each module entry includes a description for display in the registry. Both bare string and object formats are supported — descriptions and docs-url are optional per-module overrides.
