### PR TITLE
Fix KeyError in graph selector when using + operator with dbt-loom ex…

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -169,7 +169,8 @@ class GraphSelector:
                 new_generation: set[str] = set()
                 for node_id in previous_generation:
                     if node_id not in processed_nodes:
-                        new_generation.update(set(nodes[node_id].depends_on))
+                        if node_id in nodes:
+                            new_generation.update(set(nodes[node_id].depends_on))
                         processed_nodes.add(node_id)
                 selected_nodes.update(new_generation)
                 previous_generation = new_generation
@@ -548,6 +549,8 @@ class NodeSelector:
         if self.config.graph_selectors:
             graph_selected_nodes = self.select_by_graph_operator()
             for node_id in graph_selected_nodes:
+                if node_id not in self.nodes:
+                    continue
                 node = self.nodes[node_id]
                 # Since the method below changes the tags of test nodes, it can lead to incorrect
                 # results during the application of graph selectors. Therefore, it is being run within

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -507,6 +507,44 @@ def test_select_node_by_child_and_precursors_no_node():
     assert list(selected.keys()) == expected
 
 
+def test_select_nodes_by_precursors_with_external_dependency():
+    """Test that the + selector handles depends_on references to nodes not in the nodes dict.
+
+    When using dbt-loom for cross-project references, external nodes are filtered out during
+    manifest loading (they have no file path). However, local nodes may still have depends_on
+    entries pointing to these external nodes. The + selector should gracefully skip missing
+    nodes instead of raising a KeyError.
+    """
+    external_upstream_id = "model.upstream_project.external_model"
+
+    local_staging = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.local_staging",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[external_upstream_id],
+        file_path=SAMPLE_PROJ_PATH / "models/local_staging.sql",
+        tags=[],
+        config={},
+    )
+    local_marts = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.local_marts",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[local_staging.unique_id],
+        file_path=SAMPLE_PROJ_PATH / "models/local_marts.sql",
+        tags=[],
+        config={},
+    )
+
+    nodes_with_external_dep = {
+        local_staging.unique_id: local_staging,
+        local_marts.unique_id: local_marts,
+    }
+
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=nodes_with_external_dep, select=["+local_marts"])
+    assert local_marts.unique_id in selected
+    assert local_staging.unique_id in selected
+    assert external_upstream_id not in selected
+
+
 def test_select_node_by_descendants():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["grandparent+"])
     expected = [


### PR DESCRIPTION
## Summary

Fixes a `KeyError` when using the `+` (precursor) graph selector on a project that uses dbt-loom for cross-project references.

cc @pankajkoti @tatiana — This is a follow-up to your dbt-loom support in #2271. The external node skipping works great for basic rendering, but we hit a `KeyError` when combining it with the `+` graph selector. The `+` operator triggers `select_node_precursors` which traverses `depends_on` entries — and those can point to external nodes that were already filtered out during manifest loading. This code path wasn't exercised by the tests in #2271 since the example DAGs don't use graph selectors.

## Problem

The dbt-loom support added in #2271 correctly skips external nodes (those without `original_file_path`) during manifest loading in `load_from_dbt_manifest`. However, local nodes still have `depends_on` entries pointing to these filtered-out external nodes.

When the `+` graph operator traverses upstream dependencies via `select_node_precursors`, it does `nodes[node_id]` on these external node IDs and raises a `KeyError`:

    File "cosmos/dbt/selector.py", line 172, in select_node_precursors
        new_generation.update(set(nodes[node_id].depends_on))
                                  ~~~~~^^^^^^^^^
    KeyError: 'model.upstream_project.external_model'

**Reproduction:** Use `select: ["+downstream_model"]` in `RenderConfig` with `LoadMode.DBT_MANIFEST` on a project that uses dbt-loom with cross-project `{{ ref('upstream_project', 'model_name') }}` references.

## Fix

Adds bounds checks in two locations in `cosmos/dbt/selector.py`:

1. **`GraphSelector.select_node_precursors`** (line 172): Skip node IDs not present in the `nodes` dict during upstream traversal
2. **`NodeSelector.select_nodes_ids_by_intersection`** (line 552): Skip external node IDs that were collected during graph traversal but don't exist in the `nodes` dict

This allows the `+` traversal to gracefully stop at project boundaries — the correct behavior for cross-project setups where external dependencies are managed by their own DAGs/task groups. This is consistent with how `select_node_descendants` already handles missing parents via `defaultdict(set)`.

## Test plan

- [x] Added `test_select_nodes_by_precursors_with_external_dependency` — creates a graph where a local node's `depends_on` includes an external node ID not in the `nodes` dict, verifies `+` selector returns local nodes without `KeyError`
- [x] All 166 existing selector tests pass
- [x] All existing dbt-loom tests in `test_graph.py` pass