### PR TITLE
Improve comments on #2389

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -594,8 +594,6 @@ class NodeSelector:
                 # When using dbt-loom for cross-project references, external nodes are filtered out
                 # during manifest loading but may be collected during graph traversal via depends_on.
                 # Skip these external node IDs that don't exist in the nodes dict.
-=======
->>>>>>> main
                 if node_id not in self.nodes:
                     continue
                 node = self.nodes[node_id]


### PR DESCRIPTION
@tatiana Hello! @award1230 is my coworker. He opened https://github.com/astronomer/astronomer-cosmos/pull/2389. Alex is out on vacation without access to his computer until Mar 1st. I saw your note that his code might go in tomorrow, and I'm hoping it's not too late (also, agreed with @tatiana : Nice work @alex1230, and thanks for jumping right straight to a PR!) 

Per Alex's PR: 
--------------------------

When using dbt-loom for cross-project references, external nodes are filtered out during manifest loading (they have no file path). However, local nodes may still have depends_on entries pointing to these external nodes.

The + graph operator triggers select_node_precursors which traverses depends_on entries, and when it encounters these external node IDs that were filtered out, it raises a KeyError.

Original fix by @award1230 in #2389 
## Description
This fix adds bounds checks in two locations in cosmos/dbt/selector.py:

1. GraphSelector.select_node_precursors: Skip node IDs not present in the nodes dict during upstream traversal
2. NodeSelector.select_nodes_ids_by_intersection: Skip external node IDs that were collected during graph traversal but don't exist in the nodes dict

This allows the + traversal to gracefully stop at project boundaries, which is the correct behavior for cross-project setups where external dependencies are managed by their own DAGs/task groups.

## Checklist

- [ x ] I have made corresponding changes to the documentation (if required)
- [ x ] I have added tests that prove my fix is effective or that my feature works
