### PR TITLE
Refactor load_from_dbt_manifest to reduce code complexity

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -1203,7 +1203,7 @@ class DbtGraph:
 
     def load_from_dbt_manifest(self) -> None:
         """
-        This approach accurately loads `dbt` projects using the `manifest.yml` file.
+        This approach accurately loads `dbt` projects using the `manifest.json` dbt manifest artifact.
 
         However, since the Manifest does not represent filters, it relies on the Custom Cosmos implementation
         to filter out the nodes relevant to the user (based on self.exclude and self.select).


### PR DESCRIPTION
This PR is a refactor to follow up on https://github.com/astronomer/astronomer-cosmos/pull/2357/ to remove the `noqa: C901` applied to the `load_from_dbt_manifest` method in the `cosmos/dbt/graph.py` module

related: #2357 