### PR TITLE
Refactor _handle_no_precursors_or_descendants to reduce code complexity

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -445,19 +445,19 @@ class SelectorConfig:
 
     def _handle_no_precursors_or_descendants(self, item: str, node_name: str) -> None:
         prefix_handlers = {
-            PATH_SELECTOR: "_parse_path_selector",
-            TAG_SELECTOR: "_parse_tag_selector",
-            CONFIG_SELECTOR: "_parse_config_selector",
-            SOURCE_SELECTOR: "_parse_source_selector",
-            EXPOSURE_SELECTOR: "_parse_exposure_selector",
-            PACKAGE_SELECTOR: "_parse_package_selector",
-            RESOURCE_TYPE_SELECTOR: "_parse_resource_type_selector",
-            EXCLUDE_RESOURCE_TYPE_SELECTOR: "_parse_exclude_resource_type_selector",
-            FQN_SELECTOR: "_parse_fqn_selector",
+            PATH_SELECTOR: self._parse_path_selector,
+            TAG_SELECTOR: self._parse_tag_selector,
+            CONFIG_SELECTOR: self._parse_config_selector,
+            SOURCE_SELECTOR: self._parse_source_selector,
+            EXPOSURE_SELECTOR: self._parse_exposure_selector,
+            PACKAGE_SELECTOR: self._parse_package_selector,
+            RESOURCE_TYPE_SELECTOR: self._parse_resource_type_selector,
+            EXCLUDE_RESOURCE_TYPE_SELECTOR: self._parse_exclude_resource_type_selector,
+            FQN_SELECTOR: self._parse_fqn_selector,
         }
-        for prefix, method_name in prefix_handlers.items():
+        for prefix, handler in prefix_handlers.items():
             if node_name.startswith(prefix):
-                getattr(self, method_name)(item)
+                handler(item)
                 return
         if "/" in node_name:
             self._parse_path_selector(f"{PATH_SELECTOR}{node_name}")


### PR DESCRIPTION
This PR is a refactor to follow up on https://github.com/astronomer/astronomer-cosmos/pull/2357/ to remove the `noqa: C901` applied to the `_handle_no_precursors_or_descendants` method in the `cosmos/dbt/selector.py` module

related: #2357 