### PR TITLE
Add a no reload target to serve docs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ dependencies = [
 build = "sphinx-build -b html docs docs/_build"
 serve = "sphinx-autobuild docs docs/_build"
 # Serve without auto-reload: build once, then serve static files on port 8000
-serve-no-reload = "sphinx-build -b html docs docs/_build && python -m http.server 8000 --directory docs/_build"
+serve-no-reload = "sphinx-build -b html docs docs/_build && python -m http.server 8000 --bind 127.0.0.1 --directory docs/_build"
 
 ######################################
 # THIRD PARTY TOOLS


### PR DESCRIPTION
Add a docs serve target that does not auto-reload. Per @lzdanski's suggestion: add a way to serve the docs without the auto-rebuild/reload behaviour from sphinx-autobuild.

New target: `hatch run docs:serve-no-reload`-- builds once and serves the static site (no file watching).

Existing `hatch run docs:serve` (sphinx-autobuild) is unchanged for when live-reload is wanted.
