### PR TITLE
Fix test hash check in macOS

### DIFF
--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2250,7 +2250,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     hash_dir, hash_args = version.split(",")
     assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
     if sys.platform == "darwin":
-        # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
+        # Different macOS versions have produced different hashes for this directory. The first value below is a
+        # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
+        # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
         assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "633a523f295ef0cd496525428815537b")
     else:
         assert hash_dir == "633a523f295ef0cd496525428815537b"


### PR DESCRIPTION
Before there would be two failures when running `hatch run tests.py3.13-3.1-1.11:test-cov`:

```
============================================================================== FAILURES ==============================================================================
_______________________________________________________________________ test_save_dbt_ls_cache _______________________________________________________________________

mock_variable_set = <MagicMock name='set' id='5252336336'>, mock_datetime = <MagicMock name='datetime' id='5252336672'>
tmp_dbt_project_dir = PosixPath('/var/folders/78/cp68zgd94z1gz8934_ck9jmr0000gp/T/tmpnkmxtlgr')

    @patch("cosmos.dbt.graph.datetime")
    @patch("cosmos.dbt.graph.Variable.set")
    def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir):
        mock_datetime.datetime.now.return_value = datetime(2022, 1, 1, 12, 0, 0)
        graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
        dbt_ls_output = "some output"
        graph.save_dbt_ls_cache(dbt_ls_output)
        assert mock_variable_set.call_args[0][0] == "cosmos_cache__something"
        assert mock_variable_set.call_args[0][1]["dbt_ls_compressed"] == "eJwrzs9NVcgvLSkoLQEAGpAEhg=="
        assert mock_variable_set.call_args[0][1]["last_modified"] == "2022-01-01T12:00:00"
        version = mock_variable_set.call_args[0][1].get("version")
        hash_dir, hash_args = version.split(",")
        assert hash_args == "d41d8cd98f00b204e9800998ecf8427e"
        if sys.platform == "darwin":
            # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
>           assert hash_dir in ("74c478329e90725557d095879030b5e8", "fa536d84e2ee6018010e3940a45764e1")
E           AssertionError: assert '9d95cbf6529e2ab51fadd6a3f0a3971f' in ('74c478329e90725557d095879030b5e8', 'fa536d84e2ee6018010e3940a45764e1')

tests/dbt/test_graph.py:2254: AssertionError
------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------
2026-02-25T16:30:34.373055Z [info     ] Cosmos performance: time to calculate cache identifier cosmos_cache__something for current version: 0.43548883288167417 [cosmos.cache] loc=cache.py:329
------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------
INFO     cosmos.cache:cache.py:329 Cosmos performance: time to calculate cache identifier cosmos_cache__something for current version: 0.43548883288167417
___________________________________________________________________ test_save_yaml_selectors_cache ___________________________________________________________________

mock_variable_set = <MagicMock name='set' id='5245801136'>, mock_datetime = <MagicMock name='datetime' id='5245801808'>
tmp_dbt_project_dir = PosixPath('/var/folders/78/cp68zgd94z1gz8934_ck9jmr0000gp/T/tmpxg8ncz89')

    @patch("cosmos.dbt.graph.datetime")
    @patch("cosmos.dbt.graph.Variable.set")
    def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir):
        mock_datetime.datetime.now.return_value = datetime(2022, 1, 1, 12, 0, 0)
        graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
        selectors = YamlSelectors(
            {"staging_orders": {"name": "staging_orders", "definition": {"method": "tag", "value": "tag_a"}}},
            {"select": ["tag:tag_a"], "exclude": None},
        )
        graph.save_yaml_selectors_cache(selectors)
        assert mock_variable_set.call_args[0][0] == "cosmos_cache__something"

        cache_dict = mock_variable_set.call_args[0][1]

        assert "raw_selectors_compressed" in cache_dict
        assert "parsed_selectors_compressed" in cache_dict

        raw_decoded = base64.b64decode(cache_dict["raw_selectors_compressed"].encode())
        raw_decompressed = json.loads(zlib.decompress(raw_decoded).decode())
        assert raw_decompressed == selectors.raw

        parsed_decoded = base64.b64decode(cache_dict["parsed_selectors_compressed"].encode())
        parsed_decompressed = json.loads(zlib.decompress(parsed_decoded).decode())
        assert parsed_decompressed == selectors.parsed

        assert cache_dict["last_modified"] == "2022-01-01T12:00:00"

        version = cache_dict.get("version")
        hash_dir, hash_selectors, hash_impl = version.split(",")

        assert hash_selectors == "43303af03e84e3b51fbfcf598261fae4"
        assert hash_impl == "4c93048c66ca45356e1677511447c7ba"

        if sys.platform == "darwin":
            # We faced inconsistent hashing versions depending on the version of MacOS/Linux - the following line aims to address these.
>           assert hash_dir in ("74c478329e90725557d095879030b5e8", "fa536d84e2ee6018010e3940a45764e1")
E           AssertionError: assert '9d95cbf6529e2ab51fadd6a3f0a3971f' in ('74c478329e90725557d095879030b5e8', 'fa536d84e2ee6018010e3940a45764e1')

tests/dbt/test_graph.py:2294: AssertionError
------------------------------------------------------------------------ Captured stderr call ----------------------------------------------------------------------
```
I validated this change by cloning the Cosmos repo from scratch and running the tests from that directory.

## Description

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
