### PR TITLE
[CI] Pin virtualenv<21 as the latest release breaks hatch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main,pin-virtualenv]
+    branches: [main]
   # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
   # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
   # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.


### PR DESCRIPTION
Our CI runs have become [red](https://github.com/astronomer/astronomer-cosmos/actions/runs/22438360880/job/64974038307#step:6:78) as the latest release for virtualenv breaks hatch and it errors out while installing dependencies with
```
Environment `tests.py3.10-3.0-1.11` is incompatible: module 'virtualenv.discovery.builtin' has no attribute 'propose_interpreters'
```

Hence, pinning the virtualenv<21 when installing hatch to resolve the CI setup failures.


related: https://github.com/pypa/hatch/issues/2193