### PR TITLE
override the build command and use run when watcher execution test behavior is set to NONE or AFTER_ALL

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -694,12 +694,17 @@ def _add_watcher_producer_task(
         producer_task_args["exclude"] = _convert_list_to_str(render_config.exclude)
 
         if render_config.test_behavior in [TestBehavior.NONE, TestBehavior.AFTER_ALL]:
-            additional_excludes = "resource_type:test resource_type:unit_test"
-            current_exclude = producer_task_args.get("exclude")
-            if current_exclude:
-                producer_task_args["exclude"] = f"{current_exclude} {additional_excludes}"
+            # Use `dbt run` instead of `dbt build` so tests are not executed by the
+            # producer (dbt ignores --exclude with --selector).
+            if render_config.selector:
+                producer_task_args["use_run_command"] = True
             else:
-                producer_task_args["exclude"] = additional_excludes
+                additional_excludes = "resource_type:test resource_type:unit_test"
+                current_exclude = producer_task_args.get("exclude")
+                if current_exclude:
+                    producer_task_args["exclude"] = f"{current_exclude} {additional_excludes}"
+                else:
+                    producer_task_args["exclude"] = additional_excludes
 
     class_name = calculate_operator_class(execution_mode, "DbtProducer")
 

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -98,6 +98,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
         self.tests_per_model: dict[str, list[str]] = kwargs.pop("tests_per_model", {})
         self.test_results_per_model: dict[str, list[str]] = {}
+        use_run_command = kwargs.pop("use_run_command", False)
         kwargs.setdefault("priority_weight", PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
         kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
         # Consumer watcher retry logic handles model-level reruns using the LOCAL execution mode; rerunning the producer
@@ -109,6 +110,10 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         kwargs["retries"] = 0
         kwargs["queue"] = watcher_dbt_execution_queue or kwargs.get("queue") or DEFAULT_QUEUE
         super().__init__(task_id=task_id, *args, **kwargs)
+
+        if use_run_command:
+            # Override the base command to use the run command
+            self.base_cmd = ["run"]
 
         if self.invocation_mode == InvocationMode.SUBPROCESS:
             self.log_format = "json"

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -80,6 +80,7 @@ class DbtProducerWatcherKubernetesOperator(DbtBuildKubernetesOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
+        use_run_command = kwargs.pop("use_run_command", False)
 
         # Disable retries on producer task
         default_args = dict(kwargs.get("default_args", {}) or {})
@@ -98,6 +99,9 @@ class DbtProducerWatcherKubernetesOperator(DbtBuildKubernetesOperator):
         kwargs["callbacks"] = normalized_callbacks
         super().__init__(task_id=task_id, *args, **kwargs)
         self.dbt_cmd_flags += ["--log-format", "json"]
+
+        if use_run_command:
+            self.base_cmd = ["run"]
 
     @cached_property
     def pod_manager(self) -> CosmosKubernetesPodManager:

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1868,7 +1868,7 @@ def test_dbt_task_group_with_watcher_has_correct_dbt_cmd():
         )
 
     producer_operator = dag_dbt_task_group_watcher_flags.task_dict["dbt_task_group.dbt_producer_watcher"]
-    assert producer_operator.base_cmd == ["build"]
+    assert producer_operator.base_cmd == ["run"]
 
     cmd_flags = producer_operator.add_cmd_flags()
 
@@ -1876,7 +1876,7 @@ def test_dbt_task_group_with_watcher_has_correct_dbt_cmd():
     full_cmd, env = producer_operator.build_cmd(context=context, cmd_flags=cmd_flags)
 
     # Verify the command was built correctly
-    assert full_cmd[1] == "build"  # dbt build command
+    assert full_cmd[1] == "run"  # dbt run command (not build) when test_behavior is NONE
     assert "--full-refresh" in full_cmd
 
 
@@ -1923,12 +1923,12 @@ def test_dbt_task_group_with_watcher_has_correct_templated_dbt_cmd():
     # Basic check for producer task
     producer_operator = dag_dbt_task_group_watcher_flags.task_dict["dbt_task_group.dbt_producer_watcher"]
     producer_operator.render_template_fields(context=context)  # Render the templated fields
-    assert producer_operator.base_cmd == ["build"]
+    assert producer_operator.base_cmd == ["run"]
 
     # Build the command without executing it and verify it was built correctly
     cmd_flags = producer_operator.add_cmd_flags()
     full_cmd, _ = producer_operator.build_cmd(context=context, cmd_flags=cmd_flags)
-    assert full_cmd[1] == "build"  # dbt build command
+    assert full_cmd[1] == "run"  # dbt run command (not build) when test_behavior is NONE
 
     cmd = " ".join(full_cmd)
     assert "--full-refresh" in full_cmd


### PR DESCRIPTION
## Description
Watcher execution mode uses `dbt build` as its base operator, and uses `--exclude` flags when the test behavior is set to `NONE` or `AFTER_ALL` to exclude tests from the producer task. When we use `selector`, the `exclude` flags are ignored by dbt, so tests will be run in unintentionally in the producer task. 

This updates the watcher operator to conditionally use the `run` command, and override the `build_cmd` if set to true.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
Closes: #2415

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
