### PR TITLE
cache manifest file

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -65,6 +65,7 @@ from cosmos.log import get_logger
 
 logger = get_logger(__name__)
 
+
 def _get_cached_manifest(manifest_path: Path) -> dict[str, Any]:
     """Load manifest JSON with a disk-based pickle cache.
 
@@ -91,6 +92,7 @@ def _get_cached_manifest(manifest_path: Path) -> dict[str, Any]:
     with open(cache_file, "wb") as f:
         pickle.dump(data, f)
     return data
+
 
 def _normalize_path(path: str) -> str:
     """


### PR DESCRIPTION
## Description

This updates the `DbtGraph.load_from_dbt_manifest` function to load from a cached pkl manifest file, rather than calling `json.load` every time. This should reduce dag parse time and the load on the webserver and scheduler.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
