### PR TITLE
Add version comment for commit SHA pinned GitHub actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       # retrieve your distributions here
-      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+      - uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
         with:
           name: artifacts
           path: dist

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -761,7 +761,7 @@ jobs:
         run: |
           pip3 install coverage
       - name: Download all coverage artifacts
-        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3
+        uses: actions/download-artifact@70fc10c6e5e1ce46ad2ea6f2b72d43f7d47b13c3  # v8.0.0
         with:
           path: ./coverage
       - name: Combine coverage


### PR DESCRIPTION
Following up on #2425, where we pinned GitHub Actions to commit SHAs to resolve Zizmor alerts, this PR adds the corresponding version comments for those actions.

While the workflows now reference immutable commit SHAs, adding the version comments helps map those SHAs back to the corresponding release versions. This improves human readability and makes it easier to understand what version of an action is being used when reviewing or updating the workflows. We have tried to do so across our workflows for various actions so far.

I am not sure if it is strictly required by automation tools such as Dependabot, zizmor, or CodeQL, but many repositories follow this convention and documentation examples often include it. This PR aligns with that convention.

Examples:
- https://github.com/google/go-github/pull/2049/changes
- https://github.com/kyma-project/lifecycle-manager/pull/2988/changes
- https://github.com/ossf/scorecard/blob/f55b86d6627cc3717e3a0395e03305e81b9a09be/.github/workflows/main.yml#L27