### PR TITLE
Fix documentation left menu overflow

### DIFF
--- a/docs/_static/css/custom.css
+++ b/docs/_static/css/custom.css
@@ -219,14 +219,19 @@ blockquote div[class^="highlight-"] {
   margin: 0;
 }
 
-/* Sidebar */
+/* Sidebar: allow left TOC to scroll so expanded items are not hidden by the footer.
+   Compatible with pydata-sphinx-theme >= 0.16. */
 
 .bd-sidebar-primary {
-  overflow: hidden;
+  overflow-y: auto !important;
+  overflow-x: hidden !important;
   width: 20%;
+  max-height: calc(100vh - 6rem) !important;
+  min-height: 0; /* allow flex child to shrink and show scrollbar */
   font-weight: var(--bs-body-font-weight);
   padding: 1rem 1rem 1rem;
 }
+
 
 .sidebar-primary-item {
   padding: 0 .25rem !important;

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,7 +2,7 @@ aenum
 deprecation
 msgpack
 apache-airflow>=2.9.0
-pydata-sphinx-theme
+pydata-sphinx-theme>=0.16.0
 sphinx
 sphinx-autoapi
 sphinx-autobuild

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -95,7 +95,7 @@ all = [
 ]
 docs = [
     "sphinx",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.16.0",
     "sphinx-autobuild",
     "sphinx-autoapi",
     "apache-airflow-providers-cncf-kubernetes>=7.14.0",
@@ -214,7 +214,7 @@ dependencies = [
     "aenum",
     "msgpack",
     "apache-airflow",
-    "pydata-sphinx-theme",
+    "pydata-sphinx-theme>=0.16.0",
     "sphinx",
     "sphinx-autoapi",
     "sphinx-autobuild",


### PR DESCRIPTION
Add support to scroll on the left side menu, so items don't get hidden by the footer' is not a valid branch name.

The problem became very evident in PR #2418.

This is how it looks now if users scroll:
<img width="1624" height="1061" alt="Screenshot 2026-03-05 at 12 28 15" src="https://github.com/user-attachments/assets/a2de80d7-ed1c-4369-baf0-bc2ca3307d2d" />
