### PR TITLE
Fix: do not set `compiled_sql` on `ExecutionMode.WATCHER` producer

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -98,6 +98,10 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
         self.tests_per_model: dict[str, list[str]] = kwargs.pop("tests_per_model", {})
         self.test_results_per_model: dict[str, list[str]] = {}
+        # Do not publish compiled_sql to the producer's rendered_template: it would contain SQL for
+        # all models run by the producer, is often truncated in the UI due to size, and is of no use
+        # there; individual sensor tasks show the corresponding rendered_template per model.
+        kwargs["should_store_compiled_sql"] = False
         kwargs.setdefault("priority_weight", PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
         kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
         # Consumer watcher retry logic handles model-level reruns using the LOCAL execution mode; rerunning the producer

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -115,6 +115,12 @@ def test_dbt_producer_watcher_operator_priority_weight_default():
     assert op.priority_weight == PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT
 
 
+def test_dbt_producer_watcher_operator_does_not_store_compiled_sql_on_template():
+    """Producer does not publish compiled_sql to its rendered_template; sensors show it per model."""
+    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+    assert op.should_store_compiled_sql is False
+
+
 @pytest.mark.parametrize(
     "queue_override, expected_queue",
     [


### PR DESCRIPTION
The producer runs the full dbt build, so its `compiled_sql` would contain SQL for every model. That is often truncated in the UI and is not useful. Individual sensor tasks already show the rendered_template (compiled_sql) per model; keep pushing per-model compiled_sql to XCom so sensors can set it. Disable by setting `should_store_compiled_sql=False` on `DbtProducerWatcherOperator`.

closes: #2260 