### PR TITLE
Store Cosmos telemetry metadata in Airflow Variable instead of DAG param

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -12,14 +12,7 @@ from collections.abc import Callable
 from typing import Any
 from warnings import warn
 
-from airflow.exceptions import ParamValidationError
 from airflow.models.dag import DAG
-
-try:
-    # Airflow 3.0 onwards
-    from airflow.sdk.definitions.param import Param
-except ImportError:  # pragma: no cover
-    from airflow.models.param import Param
 
 try:
     # Airflow 3.1 onwards
@@ -40,7 +33,7 @@ from cosmos.exceptions import CosmosValueError
 # TODO: Move _get_profile_config_attribute at common place
 from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
 from cosmos.log import get_logger
-from cosmos.telemetry import _compress_telemetry_metadata, should_emit
+from cosmos.telemetry import _compress_telemetry_metadata, set_cosmos_telemetry_metadata_variable, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
@@ -452,17 +445,10 @@ class DbtToAirflowConverter:
                 }
             )
 
-        # Store metadata in dag.params which is preserved during serialization
-        # Using a key that's unlikely to conflict with user params
+        # Store metadata in an Airflow Variable (per-DAG key) so the listener can read it.
         compressed_metadata = _compress_telemetry_metadata(metadata)
-        stored_metadata = False
-        try:
-            dag.params["__cosmos_telemetry_metadata__"] = Param(default=compressed_metadata, const=compressed_metadata)
-            stored_metadata = True
-        except ParamValidationError as e:
-            logger.warning(f"Failed to store compressed Cosmos telemetry metadata in DAG {dag.dag_id} params: {e}")
-
-        if stored_metadata:
-            logger.debug(
-                f"Stored compressed Cosmos telemetry metadata in DAG {dag.dag_id} params (original size: {len(str(metadata))} bytes, compressed: {len(compressed_metadata)} bytes)"
-            )
+        set_cosmos_telemetry_metadata_variable(dag.dag_id, compressed_metadata)
+        logger.debug(
+            f"Stored Cosmos telemetry metadata in Variable for DAG {dag.dag_id} "
+            f"(original size: {len(str(metadata))} bytes, compressed: {len(compressed_metadata)} bytes)"
+        )

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
-import binascii
 import hashlib
-import json
-import zlib
 from typing import TYPE_CHECKING, Any
 
 from airflow.listeners import hookimpl
@@ -15,7 +12,7 @@ if TYPE_CHECKING:
 from cosmos import telemetry
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 from cosmos.log import get_logger
-from cosmos.telemetry import _decompress_telemetry_metadata
+from cosmos.telemetry import get_cosmos_telemetry_metadata_from_variable
 
 AIRFLOW_VERSION_MAJOR = AIRFLOW_VERSION.major
 
@@ -63,21 +60,12 @@ def get_execution_modes(dag: DAG) -> str:
 
 def get_cosmos_telemetry_metadata(dag: DAG) -> dict[str, Any]:
     """
-    Extract Cosmos telemetry metadata from a DAG.
+    Extract Cosmos telemetry metadata for a DAG.
 
-    Returns the metadata dictionary stored by the converter in dag.params, or an empty dict if not present.
+    Reads from the Airflow Variable set by the converter (key cosmos_telemetry__<dag_id>).
+    Returns an empty dict if the variable is missing or invalid.
     """
-    # Metadata is stored as compressed string in dag.params to survive serialization
-    compressed_metadata = dag.params.get("__cosmos_telemetry_metadata__")
-
-    if not compressed_metadata:
-        return {}
-
-    try:
-        return _decompress_telemetry_metadata(compressed_metadata)
-    except (binascii.Error, zlib.error, json.JSONDecodeError, UnicodeDecodeError) as e:
-        logger.warning(f"Failed to decompress telemetry metadata: {type(e).__name__}: {e}")
-        return {}
+    return get_cosmos_telemetry_metadata_from_variable(dag.dag_id)
 
 
 @hookimpl

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import binascii
 import json
 import platform
 import zlib
@@ -10,6 +11,7 @@ from urllib.parse import urlencode
 
 import httpx
 from airflow import __version__ as airflow_version
+from airflow.models import Variable
 
 import cosmos
 from cosmos import constants, settings
@@ -117,3 +119,54 @@ def _decompress_telemetry_metadata(compressed_data: str) -> dict[str, Any]:
     json_bytes = zlib.decompress(compressed_bytes)
     result: dict[str, Any] = json.loads(json_bytes.decode("utf-8"))
     return result
+
+
+# Variable key prefix for Cosmos telemetry metadata (per-DAG, same pattern as cosmos_cache__)
+COSMOS_TELEMETRY_VAR_PREFIX = "cosmos_telemetry__"
+
+
+def get_cosmos_telemetry_variable_key(dag_id: str) -> str:
+    """Return the Airflow Variable key used to store telemetry metadata for a DAG."""
+    return f"{COSMOS_TELEMETRY_VAR_PREFIX}{dag_id}"
+
+
+def get_cosmos_telemetry_metadata_from_variable(dag_id: str) -> dict[str, Any]:
+    """
+    Load Cosmos telemetry metadata from an Airflow Variable.
+
+    Returns an empty dict if the variable is missing, invalid, or decompression fails.
+
+    :param dag_id: DAG ID (used to build the variable key)
+    :returns: Telemetry metadata dict, or {} if not present or on any error
+    """
+    variable_exceptions: tuple[type[BaseException], ...] = (json.decoder.JSONDecodeError, KeyError)
+    try:
+        from airflow.sdk.exceptions import AirflowRuntimeError
+    except ImportError:
+        pass
+    else:
+        variable_exceptions = (*variable_exceptions, AirflowRuntimeError)
+
+    key = get_cosmos_telemetry_variable_key(dag_id)
+    try:
+        raw = Variable.get(key, default_var=None)
+    except variable_exceptions:
+        return {}
+    if not raw or not isinstance(raw, str):
+        return {}
+    try:
+        return _decompress_telemetry_metadata(raw)
+    except (binascii.Error, zlib.error, json.JSONDecodeError, UnicodeDecodeError) as e:
+        logger.warning("Failed to decompress Cosmos telemetry metadata from Variable %s: %s", key, e)
+        return {}
+
+
+def set_cosmos_telemetry_metadata_variable(dag_id: str, compressed_metadata: str) -> None:
+    """
+    Store compressed telemetry metadata in an Airflow Variable.
+
+    :param dag_id: DAG ID (used to build the variable key)
+    :param compressed_metadata: Base64-encoded zlib-compressed JSON string
+    """
+    key = get_cosmos_telemetry_variable_key(dag_id)
+    Variable.set(key, compressed_metadata)

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -88,19 +88,20 @@ def test_not_cosmos_dag():
     assert total_cosmos_tasks(dag) == 0
 
 
-def test_get_cosmos_telemetry_metadata_with_invalid_data():
-    """Test that get_cosmos_telemetry_metadata handles invalid compressed data gracefully."""
+@patch("cosmos.telemetry.Variable.get", return_value="invalid_base64_data!")
+def test_get_cosmos_telemetry_metadata_with_invalid_data(mock_variable_get):
+    """Test that get_cosmos_telemetry_metadata handles invalid Variable data gracefully."""
     with DAG("test-dag", start_date=datetime(2022, 1, 1)) as dag:
-        # Set invalid base64 data that will fail decompression
-        dag.params["__cosmos_telemetry_metadata__"] = "invalid_base64_data!"
+        pass
 
     # Should return empty dict instead of raising exception
     result = get_cosmos_telemetry_metadata(dag)
     assert result == {}
 
 
-def test_get_cosmos_telemetry_metadata_with_no_metadata():
-    """Test that get_cosmos_telemetry_metadata returns empty dict when no metadata present."""
+@patch("cosmos.telemetry.Variable.get", return_value=None)
+def test_get_cosmos_telemetry_metadata_with_no_metadata(mock_variable_get):
+    """Test that get_cosmos_telemetry_metadata returns empty dict when Variable is missing."""
     with DAG("test-dag", start_date=datetime(2022, 1, 1)) as dag:
         pass
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,11 +1,9 @@
-import logging
 import tempfile
 from datetime import datetime
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
-from airflow.exceptions import ParamValidationError
 from airflow.models import DAG
 
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
@@ -14,7 +12,10 @@ from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
-from cosmos.telemetry import _decompress_telemetry_metadata
+from cosmos.telemetry import (
+    _decompress_telemetry_metadata,
+    get_cosmos_telemetry_variable_key,
+)
 
 SAMPLE_PROFILE_YML = Path(__file__).parent / "sample/profiles.yml"
 SAMPLE_DBT_PROJECT = Path(__file__).parent / "sample/"
@@ -1238,9 +1239,10 @@ def test_converter_logs_parsing_group_order(mock_load_dbt_graph, mock_logger):
 
 
 @patch("cosmos.converter.should_emit", return_value=True)
+@patch("cosmos.telemetry.Variable.set")
 @patch("cosmos.converter.DbtGraph.load")
-def test_telemetry_metadata_storage(mock_load_dbt_graph, mock_should_emit):
-    """Test that telemetry metadata is stored correctly in DAG params."""
+def test_telemetry_metadata_storage(mock_load_dbt_graph, mock_variable_set, mock_should_emit):
+    """Test that telemetry metadata is stored in an Airflow Variable."""
     dag = DAG("test_dag_telemetry", start_date=datetime(2024, 1, 1))
 
     project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
@@ -1260,11 +1262,11 @@ def test_telemetry_metadata_storage(mock_load_dbt_graph, mock_should_emit):
         render_config=render_config,
     )
 
-    # Verify metadata is stored in dag.params
-    assert "__cosmos_telemetry_metadata__" in dag.params
-    compressed_metadata = dag.params["__cosmos_telemetry_metadata__"]
-
-    # Verify it's compressed (should be a string)
+    # Verify Variable.set was called with the correct key and compressed value
+    assert mock_variable_set.call_count == 1
+    call_args = mock_variable_set.call_args
+    assert call_args[0][0] == get_cosmos_telemetry_variable_key("test_dag_telemetry")
+    compressed_metadata = call_args[0][1]
     assert isinstance(compressed_metadata, str)
 
     # Decompress to verify the contents
@@ -1282,14 +1284,14 @@ def test_telemetry_metadata_storage(mock_load_dbt_graph, mock_should_emit):
     assert "database" in metadata
 
 
-@patch("cosmos.converter.Param", side_effect=ParamValidationError("Invalid param"))
 @patch("cosmos.converter.should_emit", return_value=True)
+@patch("cosmos.telemetry.Variable.set", side_effect=Exception("DB unavailable"))
 @patch("cosmos.converter.DbtGraph.load")
-def test_telemetry_metadata_storage_handles_param_validation_error(
-    mock_load_dbt_graph, mock_should_emit, mock_param, caplog
+def test_telemetry_metadata_storage_variable_set_failure_propagates(
+    mock_load_dbt_graph, mock_variable_set, mock_should_emit
 ):
-    """Test that ParamValidationError during telemetry metadata storage is caught and logged as a warning."""
-    dag = DAG("test_dag_telemetry_param_error", start_date=datetime(2024, 1, 1))
+    """Test that failure to set the telemetry Variable propagates (no try/except in telemetry)."""
+    dag = DAG("test_dag_telemetry_var_error", start_date=datetime(2024, 1, 1))
 
     project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
     profile_config = ProfileConfig(
@@ -1300,8 +1302,7 @@ def test_telemetry_metadata_storage_handles_param_validation_error(
     execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
     render_config = RenderConfig()
 
-    with caplog.at_level(logging.WARNING, logger="cosmos.converter"):
-        # Should NOT raise, even though Param raises ParamValidationError
+    with pytest.raises(Exception, match="DB unavailable"):
         _ = DbtToAirflowConverter(
             dag=dag,
             project_config=project_config,
@@ -1310,16 +1311,11 @@ def test_telemetry_metadata_storage_handles_param_validation_error(
             render_config=render_config,
         )
 
-    # Verify a warning was logged
-    "Failed to store compressed Cosmos telemetry metadata in DAG test_dag_telemetry_param_error params" in caplog.text
-
-    # Verify metadata was NOT stored in dag.params (since the assignment failed)
-    assert "__cosmos_telemetry_metadata__" not in dag.params
-
 
 @patch("cosmos.converter.DbtGraph.load")
 @patch("cosmos.converter.should_emit", return_value=False)
-def test_telemetry_metadata_not_stored_when_disabled(mock_should_emit, mock_load_dbt_graph):
+@patch("cosmos.telemetry.Variable.set")
+def test_telemetry_metadata_not_stored_when_disabled(mock_variable_set, mock_should_emit, mock_load_dbt_graph):
     """Test that telemetry metadata is NOT stored when telemetry is disabled."""
     dag = DAG("test_dag_telemetry_disabled", start_date=datetime(2024, 1, 1))
 
@@ -1340,5 +1336,5 @@ def test_telemetry_metadata_not_stored_when_disabled(mock_should_emit, mock_load
         render_config=render_config,
     )
 
-    # Verify metadata is NOT stored when telemetry is disabled
-    assert "__cosmos_telemetry_metadata__" not in dag.params
+    # Variable.set should not be called when telemetry is disabled
+    mock_variable_set.assert_not_called()

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -46,6 +46,33 @@ def test_compress_decompress_telemetry_metadata_roundtrip():
     assert decompressed == original_metadata
 
 
+def test_get_cosmos_telemetry_variable_key():
+    """Test that the Variable key is derived from the DAG id."""
+    assert telemetry.get_cosmos_telemetry_variable_key("my_dag") == "cosmos_telemetry__my_dag"
+    assert telemetry.get_cosmos_telemetry_variable_key("basic_cosmos_dag") == "cosmos_telemetry__basic_cosmos_dag"
+
+
+@patch("cosmos.telemetry.Variable.get", return_value=None)
+def test_get_cosmos_telemetry_metadata_from_variable_missing(mock_variable_get):
+    """Test that missing Variable returns empty dict."""
+    assert telemetry.get_cosmos_telemetry_metadata_from_variable("some_dag") == {}
+    mock_variable_get.assert_called_once()
+
+
+@patch("cosmos.telemetry.Variable.get", return_value="invalid_base64!")
+def test_get_cosmos_telemetry_metadata_from_variable_invalid(mock_variable_get):
+    """Test that invalid compressed data returns empty dict."""
+    assert telemetry.get_cosmos_telemetry_metadata_from_variable("some_dag") == {}
+
+
+@patch("cosmos.telemetry.Variable.get")
+def test_get_cosmos_telemetry_metadata_from_variable_roundtrip(mock_variable_get):
+    """Test that valid Variable data is decompressed and returned."""
+    compressed = telemetry._compress_telemetry_metadata({"key": "value"})
+    mock_variable_get.return_value = compressed
+    assert telemetry.get_cosmos_telemetry_metadata_from_variable("my_dag") == {"key": "value"}
+
+
 def test_should_emit_is_true_by_default():
     assert telemetry.should_emit()
 


### PR DESCRIPTION
- Store __cosmos_telemetry_metadata__ in Variable (key: cosmos_telemetry__<dag_id>) to avoid Param validation issues when DAG is re-parsed.
- Listener reads from Variable via get_cosmos_telemetry_metadata_from_variable(); returns empty dict if Variable is missing or invalid.
- Remove Param/ParamValidationError usage from the converter for telemetry.

closes: #2421