### PR TITLE
Add config to allow disabling dag versioning

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -386,6 +386,8 @@ class DbtToAirflowConverter:
         """
         if dag is None:
             return
+        if not settings.enable_dag_versioning:
+            return
 
         try:
             dbt_project_hash = _create_folder_version_hash(self.dbt_graph.project_path)

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -30,7 +30,14 @@ except ImportError:
 from cosmos import cache, settings
 from cosmos.airflow.graph import build_airflow_graph
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import DbtResourceType, ExecutionMode, InvocationMode, LoadMode
+from cosmos.constants import (
+    _AIRFLOW3_MAJOR_VERSION,
+    AIRFLOW_VERSION,
+    DbtResourceType,
+    ExecutionMode,
+    InvocationMode,
+    LoadMode,
+)
 from cosmos.dbt.executable import get_system_dbt, is_dbt_installed_in_same_environment
 from cosmos.dbt.graph import DbtGraph
 from cosmos.dbt.project import has_non_empty_dependencies_file
@@ -380,11 +387,13 @@ class DbtToAirflowConverter:
         Add dbt project content hash to DAG documentation for Airflow 3 dag versioning support.
 
         This enables Airflow 3's automatic DAG versioning to detect when dbt project
-        files change, ensuring proper DAG version updates.
+        files change, ensuring proper DAG version updates. On Airflow 2.x this is a no-op.
 
         :param dag: The Airflow DAG to add versioning information to. If None, no action is taken.
         """
         if dag is None:
+            return
+        if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
             return
         if not settings.enable_dag_versioning:
             return

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -16,6 +16,7 @@ from cosmos.constants import (
 DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache = conf.getboolean("cosmos", "enable_cache", fallback=True)
+enable_dag_versioning = conf.getboolean("cosmos", "enable_dag_versioning", fallback=True)
 enable_dataset_alias = conf.getboolean("cosmos", "enable_dataset_alias", fallback=True)
 enable_uri_xcom = conf.getboolean("cosmos", "enable_uri_xcom", fallback=False)
 use_dataset_airflow3_uri_standard = conf.getboolean(

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -35,10 +35,11 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 .. _enable_dag_versioning:
 
 `enable_dag_versioning`_:
-    When enabled (default), Cosmos computes a hash of the dbt project directory and appends it to the DAG's
-    ``doc_md`` for Airflow 3 DAG versioning, so that DAG versions update when dbt project files change.
-    When disabled, this computation is skipped to improve DAG parsing performance (e.g. on Airflow 2.x or when
-    versioning is not needed). On Airflow 3, DAG versioning will not reflect dbt project content changes when disabled.
+    **Airflow 3+ only:** when enabled (default), Cosmos computes a hash of the dbt project directory and appends
+    it to the DAG's ``doc_md`` so that Airflow 3's DAG versioning can detect when dbt project files change.
+    On Airflow 2.x, ``doc_md`` is not modified for this purpose (the setting has no effect there).
+    When disabled on Airflow 3+, the hash is not computed (faster DAG parsing) and DAG versioning will not
+    reflect dbt project content changes from this mechanism.
 
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_DAG_VERSIONING``

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -32,6 +32,17 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE``
 
+.. _enable_dag_versioning:
+
+`enable_dag_versioning`_:
+    When enabled (default), Cosmos computes a hash of the dbt project directory and appends it to the DAG's
+    ``doc_md`` for Airflow 3 DAG versioning, so that DAG versions update when dbt project files change.
+    When disabled, this computation is skipped to improve DAG parsing performance (e.g. on Airflow 2.x or when
+    versioning is not needed). On Airflow 3, DAG versioning will not reflect dbt project content changes when disabled.
+
+    - Default: ``True``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_DAG_VERSIONING``
+
 .. _enable_cache_dbt_ls:
 
 `enable_cache_dbt_ls`_:

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1224,6 +1224,7 @@ def test_dag_versioning_successful_logging(mock_load_dbt_graph, mock_hash_func, 
     )
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter.settings.enable_dag_versioning", False)
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1206,6 +1206,33 @@ def test_dag_versioning_successful_logging(mock_load_dbt_graph, mock_hash_func, 
     )
 
 
+@patch("cosmos.converter.settings.enable_dag_versioning", False)
+@patch("cosmos.converter._create_folder_version_hash")
+@patch("cosmos.converter.DbtGraph.load")
+def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_hash_func):
+    """Test that dbt project hash is not computed or appended when enable_dag_versioning is False."""
+    dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
+    assert dag.doc_md is None
+
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="my_profile_name",
+        target_name="my_target_name",
+        profiles_yml_filepath=SAMPLE_PROFILE_YML,
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+
+    DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+    )
+
+    assert dag.doc_md is None
+    mock_hash_func.assert_not_called()
+
+
 @patch("cosmos.converter.logger")
 @patch("cosmos.converter.DbtGraph.load")
 def test_converter_logs_parsing_group_order(mock_load_dbt_graph, mock_logger):

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -7,9 +7,17 @@ from unittest.mock import MagicMock, patch
 import pytest
 from airflow.exceptions import ParamValidationError
 from airflow.models import DAG
+from packaging.version import Version
 
 from cosmos.config import ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import DbtResourceType, ExecutionMode, InvocationMode, LoadMode, TestBehavior
+from cosmos.constants import (
+    AIRFLOW_VERSION,
+    DbtResourceType,
+    ExecutionMode,
+    InvocationMode,
+    LoadMode,
+    TestBehavior,
+)
 from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
@@ -21,6 +29,11 @@ SAMPLE_DBT_PROJECT = Path(__file__).parent / "sample/"
 SAMPLE_DBT_MANIFEST = Path(__file__).parent / "sample/manifest.json"
 MULTIPLE_PARENTS_TEST_DBT_PROJECT = Path(__file__).parent.parent / "dev/dags/dbt/multiple_parents_test/"
 DBT_PROJECTS_PROJ_WITH_DEPS_DIR = Path(__file__).parent.parent / "dev/dags/dbt" / "jaffle_shop"
+
+skipif_airflow_lt_3_dag_doc_hash = pytest.mark.skipif(
+    AIRFLOW_VERSION < Version("3.0.0"),
+    reason="dbt project hash in doc_md is only applied on Airflow 3+",
+)
 
 sample_profile_config = ProfileConfig(
     profile_name="my_profile_name",
@@ -1060,6 +1073,7 @@ def test_converter_creates_model_with_pre_dbt_fusion(mock_load_dbt_graph):
     assert converter.tasks_map["sample_model"].select is None
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
 def test_dag_versioning_hash_appended_to_empty_doc_md(mock_load_dbt_graph, mock_hash_func):
@@ -1087,6 +1101,7 @@ def test_dag_versioning_hash_appended_to_empty_doc_md(mock_load_dbt_graph, mock_
     mock_hash_func.assert_called_once()
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
 def test_dag_versioning_hash_appended_to_existing_doc_md(mock_load_dbt_graph, mock_hash_func):
@@ -1115,6 +1130,7 @@ def test_dag_versioning_hash_appended_to_existing_doc_md(mock_load_dbt_graph, mo
     mock_hash_func.assert_called_once()
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter.logger")
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
@@ -1149,6 +1165,7 @@ def test_dag_versioning_hash_error_handling(mock_load_dbt_graph, mock_hash_func,
     assert "File system error" in warning_call
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
 def test_dag_versioning_hash_with_special_characters(mock_load_dbt_graph, mock_hash_func):
@@ -1176,6 +1193,7 @@ def test_dag_versioning_hash_with_special_characters(mock_load_dbt_graph, mock_h
     assert dag.doc_md == expected_doc
 
 
+@skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter.logger")
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
@@ -1230,6 +1248,34 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
     )
 
     assert dag.doc_md is None
+    mock_hash_func.assert_not_called()
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION >= Version("3.0.0"),
+    reason="Airflow 2.x skips dbt project hash; behavior asserted only on Airflow 2",
+)
+@patch("cosmos.converter._create_folder_version_hash")
+@patch("cosmos.converter.DbtGraph.load")
+def test_dag_versioning_skipped_on_airflow_2(mock_load_dbt_graph, mock_hash_func):
+    """Hash is only for Airflow 3+ DAG versioning; Airflow 2.x skips hash computation."""
+    dag = DAG("test_dag", start_date=datetime(2024, 1, 1), doc_md="Existing docs")
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="my_profile_name",
+        target_name="my_target_name",
+        profiles_yml_filepath=SAMPLE_PROFILE_YML,
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+
+    DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+    )
+
+    assert dag.doc_md == "Existing docs"
     mock_hash_func.assert_not_called()
 
 


### PR DESCRIPTION
Adds a Cosmos setting to disable DAG versioning (dbt project hash in `doc_md`) to improve DAG parsing performance, especially on Airflow 2.x.

New `airflow.cfg` setting: `enable_dag_versioning` in the `[cosmos]` section (default: `True`).
When False, Cosmos skips computing the dbt project hash and does not update dag.doc_md. Parsing is faster; on Airflow 3, DAG versioning will no longer reflect dbt project changes.

## Changes
 - `cosmos/settings.py`: Added `enable_dag_versioning = conf.getboolean("cosmos", "enable_dag_versioning", fallback=True)`.
- `cosmos/converter.py`: In `_add_dbt_project_hash_to_dag_docs`, return early when `settings.enable_dag_versioning` is `False`.
- `tests/test_converter.py`: Added `test_dag_versioning_skipped_when_setting_disabled` to assert the hash is not computed and `doc_md` is unchanged when the setting is disabled.
- `docs/reference/configs/cosmos-conf.rst`: Documented `enable_dag_versioning` (default, env var, behaviour when disabled).

## Usage
No DAG code changes. Configure once via `airflow.cfg` or with the corresponding environment variable:

**airflow.cfg:**
```
[cosmos]
enable_dag_versioning = False
```
or

**Environment variable:**
```
export AIRFLOW__COSMOS__ENABLE_DAG_VERSIONING=false
```

closes: #2386 