### PR TITLE
Remove timeout override from Cosmos watcher sensors

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import json
 import logging
-from datetime import timedelta
 from pathlib import Path
 from typing import Any
 
@@ -288,8 +287,6 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         profiles_dir: str | None = None,
         producer_task_id: str = PRODUCER_WATCHER_TASK_ID,
         poke_interval: int = 10,
-        timeout: int = 60 * 60,  # 1 h safety valve
-        execution_timeout: timedelta = timedelta(hours=1),
         deferrable: bool = True,
         **kwargs: Any,
     ) -> None:
@@ -303,8 +300,6 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         extra_context = kwargs.pop("extra_context") if "extra_context" in kwargs else {}
         super().__init__(
             poke_interval=poke_interval,
-            timeout=timeout,
-            execution_timeout=execution_timeout,
             profile_config=profile_config,
             project_dir=project_dir,
             profiles_dir=profiles_dir,

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -5,7 +5,6 @@ import functools
 import json
 import zlib
 from collections.abc import Callable, Sequence
-from datetime import timedelta
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException
@@ -254,15 +253,11 @@ class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type
         profiles_dir: str | None = None,
         producer_task_id: str = PRODUCER_WATCHER_TASK_ID,
         poke_interval: int = 10,
-        timeout: int = 60 * 60,  # 1 h safety valve
-        execution_timeout: timedelta = timedelta(hours=1),
         deferrable: bool = True,
         **kwargs: Any,
     ) -> None:
         super().__init__(
             poke_interval=poke_interval,
-            timeout=timeout,
-            execution_timeout=execution_timeout,
             profile_config=profile_config,
             project_dir=project_dir,
             profiles_dir=profiles_dir,


### PR DESCRIPTION
Cosmos was hard-coding default sensor timeouts, and this sometimes caused unexpected behaviours.
With this change, sensors will use the default timeout definitions from Airflow unless users explicitly want to override them.

Closes: #2476
Relates to: https://github.com/astronomer/oss-integrations-private/issues/359
