### PR TITLE
Remove forced `retries=0` from watcher producer operators

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -106,13 +106,6 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         kwargs["should_store_compiled_sql"] = False
         kwargs.setdefault("priority_weight", PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT)
         kwargs.setdefault("weight_rule", WATCHER_TASK_WEIGHT_RULE)
-        # Consumer watcher retry logic handles model-level reruns using the LOCAL execution mode; rerunning the producer
-        # would repeat the full dbt build and duplicate watcher callbacks which may not be processed by the consumers if
-        # they have already processed output XCOMs from the first run of the producer, so we disable retries.
-        default_args = dict(kwargs.get("default_args", {}) or {})
-        default_args["retries"] = 0
-        kwargs["default_args"] = default_args
-        kwargs["retries"] = 0
         kwargs["queue"] = watcher_dbt_execution_queue or kwargs.get("queue") or DEFAULT_QUEUE
         super().__init__(task_id=task_id, *args, **kwargs)
 
@@ -192,11 +185,6 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
                 try_number,
             )
             return None
-
-        self.log.info(
-            "Dbt WATCHER producer task forces Airflow retries to 0 so the dbt build only runs once; "
-            "downstream sensors own model-level retries."
-        )
 
         try:
             use_events = self.invocation_mode == InvocationMode.DBT_RUNNER and EventMsg is not None

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -81,12 +81,6 @@ class DbtProducerWatcherKubernetesOperator(DbtBuildKubernetesOperator):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
 
-        # Disable retries on producer task
-        default_args = dict(kwargs.get("default_args", {}) or {})
-        default_args["retries"] = 0
-        kwargs["default_args"] = default_args
-        kwargs["retries"] = 0
-
         existing_callbacks = kwargs.get("callbacks")
         if existing_callbacks is None:
             normalized_callbacks: list[Any] = []

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -240,9 +240,7 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 
 **Important considerations:**
 
-- The producer task should still be configured with ``retries=0`` (which Cosmos enforces by default) to avoid unintended duplicate ``dbt build`` runs.
-
-- By default, Cosmos sets ``retries`` to ``0`` in``DbtProducerWatcherOperator``. Users can retry manually by clearing the status of the producer task and all its downstream tasks, keeping in mind that the producer task will not re-run the ``dbt build`` command and will succeed.
+- Retries are no longer forced to ``0`` by Cosmos. Users may configure ``retries`` freely on the producer task. On any retry attempt (``try_number > 1``), the producer gracefully skips execution and returns success — it will not re-run the ``dbt build`` command. This means retrying the producer (or clearing an entire TaskGroup) is safe and will not cause duplicate dbt builds.
 
 The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 
@@ -406,6 +404,8 @@ When using ``ExecutionMode.WATCHER``, you may want to configure specific propert
 - Reduced manual intervention - failed producer runs can recover without requiring operator restarts.
 - Better reliability - retry behavior can be tuned independently from sensor tasks.
 
+Because the producer gracefully skips re-execution on retries (returning success without re-running the dbt build), it is safe to set ``retries`` to any value you wish.
+
 Example: Configure the producer task with custom retry settings.
 
 .. code-block:: python
@@ -417,7 +417,7 @@ Example: Configure the producer task with custom retry settings.
     execution_config = ExecutionConfig(
         execution_mode=ExecutionMode.WATCHER,
         setup_operator_args={
-            "retries": 0,
+            "retries": 3,
             "retry_delay": timedelta(minutes=5),
         },
     )

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -404,7 +404,7 @@ When using ``ExecutionMode.WATCHER``, you may want to configure specific propert
 - Reduced manual intervention - failed producer runs can recover without requiring operator restarts.
 - Better reliability - retry behavior can be tuned independently from sensor tasks.
 
-Because the producer gracefully skips re-execution on retries (returning success without re-running the dbt build), it is safe to set ``retries`` to any value you wish.
+Because the producer gracefully skips re-execution on retries (returning success without re-running the dbt build), it is safe to set ``retries`` to any value you wish. Currently, retries work for sensor tasks, which, after a first failed attempt, will effectively run the corresponding dbt command.
 
 Example: Configure the producer task with custom retry settings.
 

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -240,7 +240,7 @@ This behavior is designed to support TaskGroup-level retries, as reported in `#2
 
 **Important considerations:**
 
-- Retries are no longer forced to ``0`` by Cosmos. Users may configure ``retries`` freely on the producer task. On any retry attempt (``try_number > 1``), the producer gracefully skips execution and returns success — it will not re-run the ``dbt build`` command. This means retrying the producer (or clearing an entire TaskGroup) is safe and will not cause duplicate dbt builds.
+- Retries are no longer forced to ``0`` by Cosmos, since 1.14.0. Users may configure ``retries`` freely on the producer task. On any retry attempt (``try_number > 1``), the producer gracefully skips execution and returns success — it will not re-run the ``dbt build`` command. This means retrying the producer (or clearing an entire TaskGroup) is safe and will not cause duplicate dbt builds. During the retry of the sensor tasks, they will effectively run the correspondent dbt commands.
 
 The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -192,11 +192,6 @@ def test_dbt_producer_watcher_operator_priority_weight_override():
     assert op.priority_weight == 100
 
 
-def test_dbt_producer_watcher_operator_retries_forced_to_zero():
-    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
-    assert op.retries == 0
-
-
 @pytest.mark.parametrize(
     "invocation_mode, expected_log_format",
     (
@@ -207,19 +202,6 @@ def test_dbt_producer_watcher_operator_retries_forced_to_zero():
 def test_dbt_producer_log_format_adjusts_with_invocation(invocation_mode, expected_log_format):
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None, invocation_mode=invocation_mode)
     assert getattr(op, "log_format", None) == expected_log_format
-
-
-def test_dbt_producer_watcher_operator_retries_ignores_user_input():
-    user_default_args = {"retries": 5}
-    op = DbtProducerWatcherOperator(
-        project_dir=".",
-        profile_config=None,
-        default_args=user_default_args,
-        retries=3,
-    )
-
-    assert op.retries == 0
-    assert user_default_args["retries"] == 5
 
 
 def test_dbt_producer_watcher_operator_pushes_completion_status():
@@ -299,20 +281,6 @@ def test_dbt_consumer_watcher_sensor_execute_complete_model_not_run_logs_message
         "Model 'model.pkg.skipped_model' was skipped by the dbt command" in message for message in caplog.messages
     )
     assert any("ephemeral model or if the model sql file is empty" in message for message in caplog.messages)
-
-
-def test_dbt_producer_watcher_operator_logs_retry_message(caplog):
-    op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
-    ti = _MockTI()
-    ti.try_number = 1
-    context = {"ti": ti}
-
-    with patch("cosmos.operators.local.DbtLocalBaseOperator.execute", return_value="ok") as mock_execute:
-        with caplog.at_level(logging.INFO):
-            op.execute(context=context)
-
-    mock_execute.assert_called_once()
-    assert any("forces Airflow retries to 0" in message for message in caplog.messages)
 
 
 def test_dbt_producer_watcher_operator_skips_retry_attempt(caplog):

--- a/tests/operators/test_watcher_kubernetes_unit.py
+++ b/tests/operators/test_watcher_kubernetes_unit.py
@@ -77,31 +77,6 @@ project_config = ProjectConfig(
 render_config = RenderConfig(load_method=LoadMode.DBT_MANIFEST, test_behavior=TestBehavior.NONE)
 
 
-def test_retries_set_to_zero_on_init():
-    """
-    Test that the operator sets retries to 0 during initialization.
-    """
-    op = DbtProducerWatcherKubernetesOperator(
-        project_dir=".",
-        profile_config=None,
-        image="dbt-image:latest",
-    )
-    assert op.retries == 0
-
-
-def test_retries_overridden_even_if_user_sets_them():
-    """
-    Test that even if a user explicitly sets retries, they are overridden to 0.
-    """
-    op = DbtProducerWatcherKubernetesOperator(
-        project_dir=".",
-        profile_config=None,
-        image="dbt-image:latest",
-        retries=5,
-    )
-    assert op.retries == 0
-
-
 @patch("cosmos.operators.kubernetes.DbtBuildKubernetesOperator.execute")
 def test_skips_retry_attempt(mock_execute, caplog):
     """


### PR DESCRIPTION
Since v1.12.2 (da39a567), the producer task "skips" (does not fail) execution gracefully on retry (`try_number > 1`) instead of failing. Retrying is therefore safe and harmless, so there is no longer a reason to override the user-supplied retries value to 0. Users can now configure retries freely on `DbtProducerWatcherOperator` and `DbtProducerWatcherKubernetesOperator`.

Closes: https://github.com/astronomer/astronomer-cosmos/issues/2429

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>