### PR TITLE
Implement ECS watcher execution mode

### DIFF
--- a/.airflow-registry.yaml
+++ b/.airflow-registry.yaml
@@ -212,6 +212,8 @@ operators:
   - module: cosmos.operators.watcher_kubernetes.DbtTestWatcherKubernetesOperator
     description: Runs `dbt test` using the Kubernetes execution pattern, or acts as an `EmptyOperator` for `TestBehavior.AFTER_EACH`.
 
+  # TODO: update for AWS ECS Watcher?
+
 other:
   - module: cosmos.airflow.dag.DbtDag
     description: Render a complete dbt project as an Airflow DAG

--- a/.airflow-registry.yaml
+++ b/.airflow-registry.yaml
@@ -212,7 +212,19 @@ operators:
   - module: cosmos.operators.watcher_kubernetes.DbtTestWatcherKubernetesOperator
     description: Runs `dbt test` using the Kubernetes execution pattern, or acts as an `EmptyOperator` for `TestBehavior.AFTER_EACH`.
 
-  # TODO: update for AWS ECS Watcher?
+  # Watcher pattern (AWS ECS)
+  # Run a single `dbt build` or `dbt run` command per pipeline (producer), via an ECS Task, and have Airflow deferrable sensors (consumers) tracking progress for individual dbt nodes.
+  - module: cosmos.operators.watcher_aws_ecs.DbtProducerWatcherOperator
+    description: Run a single dbt command (build or run) via a `ECSRunTaskOperator` for the entire dbt project and produce one XCom containing the status of each dbt node (model, seed, snapshot).
+  - module: cosmos.operators.watcher_aws_ecs.DbtRunWatcherAwsEcsOperator
+    description: Monitor a dbt model using Airflow XCom polling sensors. On retry, executes `dbt run` for the specific model via `DbtRunAwsEcsOperator`.
+  - module: cosmos.operators.watcher_aws_ecs.DbtSeedWatcherAwsEcsOperator
+    description: Monitor a dbt seed using Airflow XCom polling sensors. On retry, executes `dbt seed` for the specific seed via `DbtSeedAwsEcsOperator`.
+  - module: cosmos.operators.watcher_aws_ecs.DbtSnapshotWatcherAwsEcsOperator
+    description: Monitor a dbt snapshot using Airflow XCom polling sensors. On retry, executes `dbt snapshot` for the specific snapshot via `DbtSnapshotAwsEcsOperator`.
+  - module: cosmos.operators.watcher_aws_ecs.DbtTestWatcherAwsEcsOperator
+    description: Runs `dbt test` using the Kubernetes execution pattern, or acts as an `EmptyOperator` for `TestBehavior.AFTER_EACH`.
+
 
 other:
   - module: cosmos.airflow.dag.DbtDag

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -227,11 +227,12 @@ def create_test_task_metadata(
     watcher_to_test_execution_mode = {
         ExecutionMode.WATCHER: ExecutionMode.LOCAL,
         ExecutionMode.WATCHER_KUBERNETES: ExecutionMode.KUBERNETES,
+        ExecutionMode.WATCHER_AWS_ECS: ExecutionMode.AWS_ECS,
     }
     if (
         render_config is not None
         and render_config.test_behavior == TestBehavior.AFTER_ALL
-        and execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES)
+        and execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES, ExecutionMode.WATCHER_AWS_ECS)
     ):
         test_execution_mode = watcher_to_test_execution_mode[execution_mode]
         operator_class = calculate_operator_class(execution_mode=test_execution_mode, dbt_class=dbt_class)
@@ -926,7 +927,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
     if execution_mode == ExecutionMode.AIRFLOW_ASYNC:
         # This property is only relevant for the setup task, not the other tasks:
         virtualenv_dir = task_args.pop("virtualenv_dir", None)
-    elif execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES):
+    elif execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES, ExecutionMode.WATCHER_AWS_ECS):
         setup_operator_args = getattr(execution_config, "setup_operator_args", None) or {}
         # We are intentionally creating the producer task ahead of the consumer tasks
         # Airflow priority weight is not being respected in multiple versions of the library, including 3.1

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -107,6 +107,7 @@ class ExecutionMode(Enum):
     KUBERNETES = "kubernetes"
     AWS_EKS = "aws_eks"
     AWS_ECS = "aws_ecs"
+    WATCHER_AWS_ECS = "watcher_aws_ecs"
     VIRTUALENV = "virtualenv"
     AZURE_CONTAINER_INSTANCE = "azure_container_instance"
     GCP_CLOUD_RUN_JOB = "gcp_cloud_run_job"

--- a/cosmos/operators/watcher_aws_ecs.py
+++ b/cosmos/operators/watcher_aws_ecs.py
@@ -19,7 +19,6 @@ except ImportError:  # pragma: no cover
 
 try:
     from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
-    from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
     from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
 except ImportError:  # pragma: no cover
     raise ImportError(
@@ -43,7 +42,7 @@ from cosmos.operators.base import (
 logger = get_logger(__name__)
 
 
-class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):
+class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):  # type: ignore[misc]
     """
     Extends ``AwsTaskLogFetcher`` to intercept each CloudWatch log line as it
     arrives and forward it to a caller-supplied ``on_log_line`` callback.
@@ -127,6 +126,8 @@ class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
         self,
         context: Context,
         cmd_flags: list[str] | None = None,
+        run_as_async: bool = False,
+        async_context: dict[str, Any] | None = None,
         **kwargs: Any,
     ) -> Any:
         # DbtAwsEcsBaseOperator.build_and_run_cmd calls EcsRunTaskOperator.execute(self, context)
@@ -142,7 +143,7 @@ class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
     # ------------------------------------------------------------------
 
     def _get_task_log_fetcher(self) -> DbtAwsTaskLogFetcher:
-        # TODO: consistenly use self.log vs logger in this class (and the fetcher) — currently a mix of both.
+        # TODO: consistently use self.log vs logger in this class (and the fetcher) — currently a mix of both.
         self.log.debug(
             "_get_task_log_fetcher called — context available: %s, ecs_task_id: %s",
             self._current_context is not None,
@@ -222,8 +223,8 @@ class DbtConsumerWatcherAwsEcsSensor(BaseConsumerSensor, DbtRunAwsEcsOperator):
     falls back to running the model directly via a new ECS task.
     """
 
-    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
-        BaseConsumerSensor.template_fields + DbtRunAwsEcsOperator.template_fields
+    template_fields: tuple[str, ...] = tuple(
+        BaseConsumerSensor.template_fields + DbtRunAwsEcsOperator.template_fields  # type: ignore[operator]
     )
 
     def use_event(self) -> bool:
@@ -258,8 +259,8 @@ class DbtSeedWatcherAwsEcsOperator(DbtSeedMixin, DbtConsumerWatcherAwsEcsSensor)
     Falls back to running the seed directly on ECS when a retry is detected.
     """
 
-    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
-        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtSeedMixin.template_fields
+    template_fields: tuple[str, ...] = tuple(  # type: ignore[assignment]
+        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
@@ -296,8 +297,8 @@ class DbtRunWatcherAwsEcsOperator(DbtConsumerWatcherAwsEcsSensor):
     Falls back to running the model directly on ECS when a retry is detected.
     """
 
-    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
-        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtRunMixin.template_fields
+    template_fields: tuple[str, ...] = tuple(  # type: ignore[assignment]
+        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
     )
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:

--- a/cosmos/operators/watcher_aws_ecs.py
+++ b/cosmos/operators/watcher_aws_ecs.py
@@ -1,0 +1,319 @@
+from __future__ import annotations
+
+import time
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context  # type: ignore[attr-defined]
+
+from airflow.exceptions import AirflowException
+
+try:
+    from airflow.providers.standard.operators.empty import EmptyOperator
+except ImportError:  # pragma: no cover
+    from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
+
+try:
+    from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
+    from airflow.providers.amazon.aws.operators.ecs import EcsRunTaskOperator
+    from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
+except ImportError:  # pragma: no cover
+    raise ImportError(
+        "Could not import EcsRunTaskOperator or AwsTaskLogFetcher. Ensure you've installed the Amazon "
+        "Web Services provider separately or with `pip install astronomer-cosmos[...,aws-ecs]`."
+    )
+
+from cosmos.log import get_logger
+from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
+from cosmos.operators.aws_ecs import (
+    DbtBuildAwsEcsOperator,
+    DbtRunAwsEcsOperator,
+    DbtSourceAwsEcsOperator,
+)
+from cosmos.operators.base import (
+    DbtRunMixin,
+    DbtSeedMixin,
+    DbtSnapshotMixin,
+)
+
+logger = get_logger(__name__)
+
+
+class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):
+    """
+    Extends ``AwsTaskLogFetcher`` to intercept each CloudWatch log line as it
+    arrives and forward it to a caller-supplied ``on_log_line`` callback.
+
+    The base class polls CloudWatch on ``fetch_interval``, logs each event via
+    ``self.logger.info(self.event_to_str(log_event))``, and then sleeps.  We
+    preserve that behaviour exactly and additionally call ``on_log_line`` with
+    the raw message so that ``store_dbt_resource_status_from_log`` can parse
+    dbt JSON log lines and push per-node status to XCom *while the ECS task is
+    still running*.
+    """
+
+    def __init__(
+        self,
+        *args: Any,
+        on_log_line: Callable[[str], None],
+        **kwargs: Any,
+    ) -> None:
+        super().__init__(*args, **kwargs)
+        self.logger.debug("Initializing DbtAwsTaskLogFetcher with args %s kwargs %s", args, kwargs)
+        self.on_log_line = on_log_line
+
+    def run(self) -> None:
+        continuation_token = AwsLogsHook.ContinuationToken()
+        self.logger.info(
+            "Starting DbtAwsTaskLogFetcher with log group '%s' and stream '%s'", self.log_group, self.log_stream_name
+        )
+        while not self.is_stopped():
+            time.sleep(self.fetch_interval.total_seconds())
+            for log_event in self._get_log_events(continuation_token):
+                self.on_log_line(log_event["message"])
+
+
+class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
+    """
+    Executes a full ``dbt build`` command on AWS ECS and publishes per-node
+    status to Airflow XCom as each model / seed / snapshot finishes, so that
+    downstream consumer sensor tasks can start as soon as their upstream node
+    completes — even while other nodes are still running in the same ECS task.
+
+    Log interception works by overriding ``_get_task_log_fetcher`` to return a
+    ``DbtAwsTaskLogFetcher`` that calls ``store_dbt_resource_status_from_log``
+    on every CloudWatch log line while the ECS task is running.  This requires
+    the standard ``awslogs_group``, ``awslogs_region``, and
+    ``awslogs_stream_prefix`` parameters that ``EcsRunTaskOperator`` already
+    accepts.
+
+    Retries are intentionally disabled: a second ECS task launch could re-run
+    nodes that already succeeded.  Consumer tasks handle their own retry logic
+    by falling back to a direct ``dbt run`` when ``try_number > 1``.
+    """
+
+    template_fields: tuple[str, ...] = tuple(DbtBuildAwsEcsOperator.template_fields)
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
+
+        # Disable retries to avoid running dbt build twice.
+        default_args = dict(kwargs.get("default_args", {}) or {})
+        default_args["retries"] = 0
+        kwargs["deferrable"] = False  # log fetcher path requires non-deferrable
+        kwargs["default_args"] = default_args
+        kwargs["retries"] = 0
+
+        super().__init__(task_id=task_id, *args, **kwargs)
+
+        # JSON log format is required so store_dbt_resource_status_from_log
+        # can parse structured node status lines.
+        self.dbt_cmd_flags += ["--log-format", "json"]
+
+        # Stash for use inside _get_task_log_fetcher, which is called by
+        # EcsRunTaskOperator.execute() before we have a chance to pass context
+        # through any other mechanism.
+        self._current_context: Context | None = None
+
+    # ------------------------------------------------------------------
+    # build_and_run_cmd override — stash context before ECS execute
+    # ------------------------------------------------------------------
+
+    def build_and_run_cmd(
+        self,
+        context: Context,
+        cmd_flags: list[str] | None = None,
+        **kwargs: Any,
+    ) -> Any:
+        # DbtAwsEcsBaseOperator.build_and_run_cmd calls EcsRunTaskOperator.execute(self, context)
+        # as a direct unbound class call, bypassing our execute() override entirely.
+        # _get_task_log_fetcher is invoked from within that call, so we must stash
+        # context here — before super().build_and_run_cmd — rather than in execute().
+        self.log.info("Stashing execution context in build_and_run_cmd: %s", context)
+        self._current_context = context
+        return super().build_and_run_cmd(context, cmd_flags=cmd_flags, **kwargs)
+
+    # ------------------------------------------------------------------
+    # Log fetcher override — the core of the watcher pattern for ECS
+    # ------------------------------------------------------------------
+
+    def _get_task_log_fetcher(self) -> DbtAwsTaskLogFetcher:
+        # TODO: consistenly use self.log vs logger in this class (and the fetcher) — currently a mix of both.
+        self.log.debug(
+            "_get_task_log_fetcher called — context available: %s, ecs_task_id: %s",
+            self._current_context is not None,
+            getattr(self, "ecs_task_id", None),
+        )
+        """
+        Return a ``DbtAwsTaskLogFetcher`` instead of the stock
+        ``AwsTaskLogFetcher``.
+
+        ``EcsRunTaskOperator.execute()`` calls this method and assigns the
+        result to ``self.task_log_fetcher`` before starting the background
+        polling thread, so overriding it is sufficient — no patching required.
+        """
+        if not self.awslogs_group or not self.awslogs_stream_prefix:
+            raise AirflowException(
+                "DbtProducerWatcherAwsEcsOperator requires 'awslogs_group' and "
+                "'awslogs_stream_prefix' to be set so that dbt JSON logs can be "
+                "read from CloudWatch and per-node status pushed to XCom incrementally."
+            )
+
+        context = self._current_context
+
+        def _on_log_line(message: str) -> None:
+            store_dbt_resource_status_from_log(
+                message,
+                {
+                    "context": context,
+                    "project_dir": self.project_dir,
+                },
+            )
+
+        return DbtAwsTaskLogFetcher(
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.awslogs_region,
+            log_group=self.awslogs_group,
+            log_stream_name=self._get_logs_stream_name(),
+            fetch_interval=self.awslogs_fetch_interval,
+            logger=self.log,
+            on_log_line=_on_log_line,
+        )
+
+    # ------------------------------------------------------------------
+    # Execute
+    # ------------------------------------------------------------------
+
+    def execute(self, context: Context, **kwargs: Any) -> Any:  # type: ignore[override]
+        logger.info("DbtProducerWatcherAwsEcsOperator execute called with context: %s", context)
+        task_instance = context.get("ti")
+        if task_instance is None:
+            raise AirflowException("DbtProducerWatcherAwsEcsOperator expects a task instance in the execution context.")
+
+        try_number = getattr(task_instance, "try_number", 1)
+        if try_number > 1:
+            self.log.info(
+                "DbtProducerWatcherAwsEcsOperator does not support Airflow retries. "
+                "Detected attempt #%s; skipping execution to avoid running a second dbt build.",
+                try_number,
+            )
+            return None
+
+        # Go through the full mixin chain:
+        #   DbtBuildMixin.execute -> build_and_run_cmd (our override, stashes context)
+        #   -> DbtAwsEcsBaseOperator.build_and_run_cmd -> build_command (sets self.overrides)
+        #   -> EcsRunTaskOperator.execute -> _get_task_log_fetcher (our override)
+        return super().execute(context)
+
+
+# ---------------------------------------------------------------------------
+# Consumer sensor base
+# ---------------------------------------------------------------------------
+
+
+class DbtConsumerWatcherAwsEcsSensor(BaseConsumerSensor, DbtRunAwsEcsOperator):
+    """
+    Base sensor that watches XCom for per-node dbt status written by
+    ``DbtProducerWatcherAwsEcsOperator`` and, when a retry is required,
+    falls back to running the model directly via a new ECS task.
+    """
+
+    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
+        BaseConsumerSensor.template_fields + DbtRunAwsEcsOperator.template_fields
+    )
+
+    def use_event(self) -> bool:
+        # ECS watcher uses XCom polling (same approach as the Kubernetes watcher).
+        return False
+
+
+# ---------------------------------------------------------------------------
+# This operator does not make sense for WATCHER mode — raise clearly.
+# ---------------------------------------------------------------------------
+
+
+class DbtBuildWatcherAwsEcsOperator:
+    """Placeholder that raises NotImplementedError on instantiation."""
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        raise NotImplementedError(
+            "`ExecutionMode.WATCHER` does not expose a DbtBuild operator for AWS ECS, "
+            "since the build command is executed by the producer task "
+            "(DbtProducerWatcherAwsEcsOperator)."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Concrete consumer operators
+# ---------------------------------------------------------------------------
+
+
+class DbtSeedWatcherAwsEcsOperator(DbtSeedMixin, DbtConsumerWatcherAwsEcsSensor):  # type: ignore[misc]
+    """
+    Watches for the progress of a dbt seed execution run by the producer task.
+    Falls back to running the seed directly on ECS when a retry is detected.
+    """
+
+    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
+        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtSeedMixin.template_fields
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtSnapshotWatcherAwsEcsOperator(DbtSnapshotMixin, DbtConsumerWatcherAwsEcsSensor):  # type: ignore[misc]
+    """
+    Watches for the progress of a dbt snapshot execution run by the producer task.
+    Falls back to running the snapshot directly on ECS when a retry is detected.
+    """
+
+    template_fields: tuple[str, ...] = DbtConsumerWatcherAwsEcsSensor.template_fields  # type: ignore[assignment]
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtSourceWatcherAwsEcsOperator(DbtSourceAwsEcsOperator):
+    """
+    Executes a dbt source freshness command synchronously on ECS.
+
+    Unlike the other watcher consumers this operator is *not* a sensor —
+    source freshness does not produce node_status events that can be watched,
+    so we run the command directly (same behaviour as ExecutionMode.AWS_ECS).
+    """
+
+    template_fields: tuple[str, ...] = tuple(DbtSourceAwsEcsOperator.template_fields)  # type: ignore[arg-type]
+
+
+class DbtRunWatcherAwsEcsOperator(DbtConsumerWatcherAwsEcsSensor):
+    """
+    Watches for the progress of a dbt model execution run by the producer task.
+    Falls back to running the model directly on ECS when a retry is detected.
+    """
+
+    template_fields: tuple[str, ...] = (  # type: ignore[assignment]
+        DbtConsumerWatcherAwsEcsSensor.template_fields + DbtRunMixin.template_fields
+    )
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
+
+class DbtTestWatcherAwsEcsOperator(EmptyOperator):
+    """
+    No-op test operator for the WATCHER execution mode on AWS ECS.
+
+    Tests are executed as part of the dbt build command in the producer task;
+    there is nothing to watch independently.  A proper implementation is
+    tracked in https://github.com/astronomer/astronomer-cosmos/issues/1974.
+    """
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        desired_keys = ("dag", "task_group", "task_id")
+        new_kwargs = {key: value for key, value in kwargs.items() if key in desired_keys}
+        super().__init__(**new_kwargs)  # type: ignore[no-untyped-call]

--- a/cosmos/operators/watcher_aws_ecs.py
+++ b/cosmos/operators/watcher_aws_ecs.py
@@ -48,7 +48,7 @@ class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):  # type: ignore[misc]
     arrives and forward it to a caller-supplied ``on_log_line`` callback.
 
     The base class polls CloudWatch on ``fetch_interval``, logs each event via
-    ``self.logger.info(self.event_to_str(log_event))``, and then sleeps.  We
+    ``self.log.info(self.event_to_str(log_event))``, and then sleeps.  We
     preserve that behaviour exactly and additionally call ``on_log_line`` with
     the raw message so that ``store_dbt_resource_status_from_log`` can parse
     dbt JSON log lines and push per-node status to XCom *while the ECS task is
@@ -62,12 +62,12 @@ class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):  # type: ignore[misc]
         **kwargs: Any,
     ) -> None:
         super().__init__(*args, **kwargs)
-        self.logger.debug("Initializing DbtAwsTaskLogFetcher with args %s kwargs %s", args, kwargs)
+        self.log.debug("Initializing DbtAwsTaskLogFetcher with args %s kwargs %s", args, kwargs)
         self.on_log_line = on_log_line
 
     def run(self) -> None:
         continuation_token = AwsLogsHook.ContinuationToken()
-        self.logger.info(
+        self.log.info(
             "Starting DbtAwsTaskLogFetcher with log group '%s' and stream '%s'", self.log_group, self.log_stream_name
         )
         while not self.is_stopped():
@@ -76,7 +76,7 @@ class DbtAwsTaskLogFetcher(AwsTaskLogFetcher):  # type: ignore[misc]
                 self.on_log_line(log_event["message"])
 
 
-class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
+class DbtProducerWatcherOperator(DbtBuildAwsEcsOperator):
     """
     Executes a full ``dbt build`` command on AWS ECS and publishes per-node
     status to Airflow XCom as each model / seed / snapshot finishes, so that
@@ -143,7 +143,6 @@ class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
     # ------------------------------------------------------------------
 
     def _get_task_log_fetcher(self) -> DbtAwsTaskLogFetcher:
-        # TODO: consistently use self.log vs logger in this class (and the fetcher) — currently a mix of both.
         self.log.debug(
             "_get_task_log_fetcher called — context available: %s, ecs_task_id: %s",
             self._current_context is not None,
@@ -190,7 +189,7 @@ class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
     # ------------------------------------------------------------------
 
     def execute(self, context: Context, **kwargs: Any) -> Any:  # type: ignore[override]
-        logger.info("DbtProducerWatcherAwsEcsOperator execute called with context: %s", context)
+        self.log.info("DbtProducerWatcherAwsEcsOperator execute called with context: %s", context)
         task_instance = context.get("ti")
         if task_instance is None:
             raise AirflowException("DbtProducerWatcherAwsEcsOperator expects a task instance in the execution context.")

--- a/tests/operators/test_watcher_aws_ecs_unit.py
+++ b/tests/operators/test_watcher_aws_ecs_unit.py
@@ -297,7 +297,7 @@ def test_build_and_run_cmd_stashes_context_before_ecs_execute(mock_store):
 
 
 @patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
-def test_build_and_run_cmd_forwards_log_lines_to_store_1(mock_store):
+def test_build_and_run_cmd_forwards_log_lines_to_store(mock_store):
     op = make_producer()
     context = make_context(MagicMock())
 
@@ -312,10 +312,6 @@ def test_build_and_run_cmd_forwards_log_lines_to_store_1(mock_store):
     with (
         patch.object(op, "_start_task"),
         patch.object(op, "_wait_for_task_ended"),
-        patch("cosmos.operators.watcher_aws_ecs.EcsRunTaskOperator._check_success_task"),
-        patch(
-            "cosmos.operators.watcher_aws_ecs.EcsRunTaskOperator._get_logs_stream_name", return_value="ecs/dbt/task-123"
-        ),
         patch(
             "cosmos.operators.watcher_aws_ecs.DbtAwsTaskLogFetcher.is_stopped",
             side_effect=is_stopped_after_one_iteration,

--- a/tests/operators/test_watcher_aws_ecs_unit.py
+++ b/tests/operators/test_watcher_aws_ecs_unit.py
@@ -10,12 +10,12 @@ os.environ.setdefault("AWS_DEFAULT_REGION", "eu-central-1")
 os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
 os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
 
+from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY
 from cosmos.operators.watcher_aws_ecs import (
     DbtBuildWatcherAwsEcsOperator,
     DbtConsumerWatcherAwsEcsSensor,
     DbtProducerWatcherAwsEcsOperator,
 )
-from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY
 
 # ---------------------------------------------------------------------------
 # Shared fixtures

--- a/tests/operators/test_watcher_aws_ecs_unit.py
+++ b/tests/operators/test_watcher_aws_ecs_unit.py
@@ -1,0 +1,335 @@
+import logging
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+from airflow.exceptions import AirflowException
+
+# Prevent boto3 from trying to resolve credentials or region from the environment
+os.environ.setdefault("AWS_DEFAULT_REGION", "eu-central-1")
+os.environ.setdefault("AWS_ACCESS_KEY_ID", "testing")
+os.environ.setdefault("AWS_SECRET_ACCESS_KEY", "testing")
+
+from cosmos.operators.watcher_aws_ecs import (
+    DbtBuildWatcherAwsEcsOperator,
+    DbtConsumerWatcherAwsEcsSensor,
+    DbtProducerWatcherAwsEcsOperator,
+)
+from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+OPERATOR_ARGS = {
+    "aws_conn_id": "my-aws-conn-id",
+    "cluster": "test-cluster",
+    "task_definition": "test-task",
+    "container_name": "dbt",
+    "overrides": {},
+    "awslogs_group": "/ecs/dbt",
+    "awslogs_stream_prefix": "ecs/dbt",
+    "awslogs_region": "eu-central-1",
+    "project_dir": "/tmp/project",
+    "profile_args": {},
+}
+
+
+def make_producer(**kwargs):
+    return DbtProducerWatcherAwsEcsOperator(
+        **{**OPERATOR_ARGS, **kwargs},
+    )
+
+
+def make_sensor(**kwargs):
+    extra_context = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
+    kwargs["extra_context"] = extra_context
+    sensor = DbtConsumerWatcherAwsEcsSensor(
+        task_id="model.my_model",
+        **{**OPERATOR_ARGS, **kwargs},
+    )
+    sensor._get_producer_task_status = MagicMock(return_value=None)
+    return sensor
+
+
+def make_context(ti_mock, *, run_id: str = "test-run", map_index: int = 0):
+    return {
+        "ti": ti_mock,
+        "run_id": run_id,
+        "task_instance": MagicMock(map_index=map_index),
+    }
+
+
+# ---------------------------------------------------------------------------
+# DbtProducerWatcherAwsEcsOperator -- __init__ invariants
+# ---------------------------------------------------------------------------
+
+
+def test_retries_set_to_zero_on_init():
+    op = make_producer()
+    assert op.retries == 0
+
+
+def test_retries_overridden_even_if_user_sets_them():
+    op = make_producer(retries=5)
+    assert op.retries == 0
+
+
+def test_deferrable_always_false():
+    op = make_producer(deferrable=True)
+    assert op.deferrable is False
+
+
+def test_log_format_json_appended():
+    op = make_producer()
+    assert "--log-format" in op.dbt_cmd_flags
+    idx = op.dbt_cmd_flags.index("--log-format")
+    assert op.dbt_cmd_flags[idx + 1] == "json"
+
+
+def test_aws_logs_enabled_true_with_valid_params():
+    """If _aws_logs_enabled() returns False, _get_task_log_fetcher is never called."""
+    op = make_producer()
+    assert op._aws_logs_enabled()
+
+
+# ---------------------------------------------------------------------------
+# DbtProducerWatcherAwsEcsOperator -- execute retry guard
+# ---------------------------------------------------------------------------
+
+
+@patch("cosmos.operators.aws_ecs.DbtBuildAwsEcsOperator.execute")
+def test_skips_retry_attempt(mock_execute, caplog):
+    op = make_producer()
+
+    ti = MagicMock()
+    ti.try_number = 2
+    context = {"ti": ti}
+
+    with caplog.at_level(logging.INFO):
+        result = op.execute(context=context)
+
+    mock_execute.assert_not_called()
+    assert result is None
+    assert any("does not support Airflow retries" in m for m in caplog.messages)
+    assert any("skipping execution" in m for m in caplog.messages)
+
+
+def test_raises_exception_when_task_instance_missing():
+    op = make_producer()
+    with pytest.raises(AirflowException, match="task instance"):
+        op.execute(context={"ti": None})
+
+
+# ---------------------------------------------------------------------------
+# DbtProducerWatcherAwsEcsOperator -- build_and_run_cmd validation
+# ---------------------------------------------------------------------------
+
+
+def test_get_task_log_fetcher_raises_without_awslogs_group():
+    # _get_task_log_fetcher contains the validation; call it directly since
+    # EcsRunTaskOperator.execute only calls it when _aws_logs_enabled() is True,
+    # which requires awslogs_group to already be set.
+    op = make_producer()
+    op.awslogs_group = None
+    with pytest.raises(AirflowException, match="awslogs_group"):
+        op._get_task_log_fetcher()
+
+
+def test_get_task_log_fetcher_raises_without_awslogs_stream_prefix():
+    op = make_producer()
+    op.awslogs_stream_prefix = None
+    with pytest.raises(AirflowException, match="awslogs_stream_prefix"):
+        op._get_task_log_fetcher()
+
+
+# ---------------------------------------------------------------------------
+# DbtBuildWatcherAwsEcsOperator -- NotImplementedError
+# ---------------------------------------------------------------------------
+
+
+def test_dbt_build_watcher_aws_ecs_operator_raises_not_implemented_error():
+    expected_message = "`ExecutionMode.WATCHER` does not expose a DbtBuild operator"
+    with pytest.raises(NotImplementedError, match=expected_message):
+        DbtBuildWatcherAwsEcsOperator()
+
+
+# ---------------------------------------------------------------------------
+# DbtConsumerWatcherAwsEcsSensor
+# ---------------------------------------------------------------------------
+
+
+def test_use_event_returns_false():
+    sensor = make_sensor()
+    assert sensor.use_event() is False
+
+
+def test_first_execution_behaves_as_base_consumer_sensor():
+    sensor = make_sensor()
+
+    ti = MagicMock()
+    ti.try_number = 1
+
+    # xcom_pull is called twice: once for startup events (expects list of dicts)
+    # and once for node status (expects a string). Return the right type per key.
+    def xcom_pull_side_effect(*args, **kwargs):
+        if kwargs.get("key") == _DBT_STARTUP_EVENTS_XCOM_KEY:
+            return []
+        return "success"
+
+    ti.xcom_pull.side_effect = xcom_pull_side_effect
+    context = make_context(ti)
+
+    result = sensor.poke(context)
+
+    assert result is True
+    ti.xcom_pull.assert_called()
+
+
+@patch("cosmos.operators.aws_ecs.DbtRunAwsEcsOperator.build_and_run_cmd")
+def test_retry_executes_as_dbt_run_aws_ecs_operator(mock_build_and_run_cmd):
+    sensor = make_sensor()
+
+    ti = MagicMock()
+    ti.try_number = 2
+    ti.xcom_pull.return_value = None
+    ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--threads", "2"]
+    context = make_context(ti)
+
+    result = sensor.poke(context)
+
+    assert result is True
+    mock_build_and_run_cmd.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# DbtProducerWatcherAwsEcsOperator -- log fetcher integration
+# ---------------------------------------------------------------------------
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_get_task_log_fetcher_returns_dbt_aws_task_log_fetcher(mock_store):
+    """_get_task_log_fetcher returns a DbtAwsTaskLogFetcher (not the stock one)."""
+    from cosmos.operators.watcher_aws_ecs import DbtAwsTaskLogFetcher
+
+    op = make_producer()
+    op._current_context = make_context(MagicMock())
+
+    fetcher = op._get_task_log_fetcher()
+
+    assert isinstance(fetcher, DbtAwsTaskLogFetcher)
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_on_log_line_callback_calls_store_dbt_resource_status(mock_store):
+    """The on_log_line closure produced by _get_task_log_fetcher delegates to
+    store_dbt_resource_status_from_log with the correct context shape."""
+    op = make_producer()
+    context = make_context(MagicMock())
+    op._current_context = context
+
+    with patch.object(op, "_get_logs_stream_name", return_value="ecs/dbt/task-123"):
+        fetcher = op._get_task_log_fetcher()
+
+    log_line = '{"info": {"name": "NodeFinished"}, "data": {"node_info": {"unique_id": "model.x.y", "node_status": "success"}}}'
+    fetcher.on_log_line(log_line)
+
+    mock_store.assert_called_once_with(
+        log_line,
+        {"context": context, "project_dir": op.project_dir},
+    )
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_on_log_line_called_for_each_log_event(mock_store):
+    """on_log_line is invoked once per log event emitted by the fetcher's run loop."""
+
+    op = make_producer()
+    op._current_context = make_context(MagicMock())
+
+    # with patch.object(op, "_get_logs_stream_name", return_value="ecs/dbt/task-123"):
+    fetcher = op._get_task_log_fetcher()
+
+    fake_events = [
+        {"message": "line-one"},
+        {"message": "line-two"},
+        {"message": "line-three"},
+    ]
+
+    stop_flag = {"count": 0}
+
+    def is_stopped():
+        stop_flag["count"] += 1
+        return stop_flag["count"] > 1  # run the loop body exactly once
+
+    with (
+        patch.object(fetcher, "is_stopped", side_effect=is_stopped),
+        patch.object(fetcher, "_get_log_events", return_value=iter(fake_events)),
+        patch("time.sleep"),
+    ):
+        fetcher.run()
+
+    assert mock_store.call_count == 3
+    called_messages = [call.args[0] for call in mock_store.call_args_list]
+    assert called_messages == ["line-one", "line-two", "line-three"]
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_build_and_run_cmd_stashes_context_before_ecs_execute(mock_store):
+    """build_and_run_cmd must populate _current_context before the ECS operator
+    calls _get_task_log_fetcher, which depends on it."""
+    op = make_producer()
+    context = make_context(MagicMock())
+
+    captured = {}
+
+    def fake_super_build_and_run_cmd(ctx, **kwargs):
+        # Simulate ECS internals calling _get_task_log_fetcher mid-execute.
+        captured["context_at_call_time"] = op._current_context
+
+    with patch(
+        "cosmos.operators.aws_ecs.DbtBuildAwsEcsOperator.build_and_run_cmd",
+        side_effect=fake_super_build_and_run_cmd,
+    ):
+        op.build_and_run_cmd(context)
+
+    assert captured["context_at_call_time"] is context
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_build_and_run_cmd_forwards_log_lines_to_store_1(mock_store):
+    op = make_producer()
+    context = make_context(MagicMock())
+
+    fake_log_line = '{"info": {"name": "NodeFinished"}, "data": {"node_info": {"unique_id": "model.x.y", "node_status": "success"}}}'
+
+    stop_calls = {"count": 0}
+
+    def is_stopped_after_one_iteration():
+        stop_calls["count"] += 1
+        return stop_calls["count"] > 1
+
+    with (
+        patch.object(op, "_start_task"),
+        patch.object(op, "_wait_for_task_ended"),
+        patch("cosmos.operators.watcher_aws_ecs.EcsRunTaskOperator._check_success_task"),
+        patch(
+            "cosmos.operators.watcher_aws_ecs.EcsRunTaskOperator._get_logs_stream_name", return_value="ecs/dbt/task-123"
+        ),
+        patch(
+            "cosmos.operators.watcher_aws_ecs.DbtAwsTaskLogFetcher.is_stopped",
+            side_effect=is_stopped_after_one_iteration,
+        ),
+        patch(
+            "cosmos.operators.watcher_aws_ecs.DbtAwsTaskLogFetcher._get_log_events",
+            return_value=iter([{"message": fake_log_line}]),
+        ),
+        patch("cosmos.operators.watcher_aws_ecs.DbtAwsTaskLogFetcher.get_last_log_message"),
+        patch("time.sleep"),
+    ):
+        op.build_and_run_cmd(context)
+
+    mock_store.assert_called_once_with(
+        fake_log_line,
+        {"context": context, "project_dir": op.project_dir},
+    )


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
Added watcher executionmode for AWS ECS, taking inspiration from the Kubernetes watcher executionmode. I tested the new feature in my own AWS account. Ideally there would also be integration tests in the shape of an example DAG, but it seems you don't have integration testing set up for AWS at this point. 
I did add unit tests to cover as much as possible, though that came with a fair amount of mocking/patching involved.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
