### PR TITLE
fix(config): unify postgres profiles.yml across dbt example projects

### DIFF
--- a/dev/dags/dbt/altered_jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/altered_jaffle_shop/profiles.yml
@@ -16,9 +16,10 @@ postgres_profile:
   outputs:
     dev:
       type: postgres
-      dbname: "{{ env_var('POSTGRES_DB') }}"
       host: "{{ env_var('POSTGRES_HOST') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4

--- a/dev/dags/dbt/altered_jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/altered_jaffle_shop/profiles.yml
@@ -1,16 +1,3 @@
-default:
-  target: dev
-  outputs:
-    dev:
-      type: postgres
-      host: "{{ env_var('POSTGRES_HOST') }}"
-      user: "{{ env_var('POSTGRES_USER') }}"
-      password: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: "{{ env_var('POSTGRES_PORT') | int }}"
-      dbname: "{{ env_var('POSTGRES_DB') }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
-      threads: 4
-
 postgres_profile:
   target: dev
   outputs:

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -30,9 +30,10 @@ postgres_profile:
   outputs:
     dev:
       type: postgres
-      dbname: "{{ env_var('POSTGRES_DB') }}"
       host: "{{ env_var('POSTGRES_HOST') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -24,16 +24,3 @@ snowflake_profile:
       database: "{{ env_var('SNOWFLAKE_DATABASE') }}"
   config:
     send_anonymous_usage_stats: false
-
-postgres_profile:
-  target: dev
-  outputs:
-    dev:
-      type: postgres
-      host: "{{ env_var('POSTGRES_HOST') }}"
-      user: "{{ env_var('POSTGRES_USER') }}"
-      password: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: "{{ env_var('POSTGRES_PORT') | int }}"
-      dbname: "{{ env_var('POSTGRES_DB') }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
-      threads: 4

--- a/dev/dags/jaffle_shop_kubernetes.py
+++ b/dev/dags/jaffle_shop_kubernetes.py
@@ -72,7 +72,7 @@ with DAG(
         is_delete_operator_pod=False,
         secrets=[postgres_password_secret, postgres_host_secret],
         profile_config=ProfileConfig(
-            profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="postgres_profile", target_name="dev"
+            profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="default", target_name="dev"
         ),
         env_vars={
             "POSTGRES_DB": "postgres",
@@ -108,7 +108,7 @@ with DAG(
     run_models = DbtTaskGroup(
         project_config=ProjectConfig(),
         profile_config=ProfileConfig(
-            profile_name="postgres_profile",
+            profile_name="default",
             target_name="dev",
             # The following profile mapping works for the DAG parsing
             # However, it is not exposed during the K8s pod operators execution

--- a/dev/dags/jaffle_shop_kubernetes.py
+++ b/dev/dags/jaffle_shop_kubernetes.py
@@ -78,6 +78,7 @@ with DAG(
             "POSTGRES_DB": "postgres",
             "POSTGRES_SCHEMA": "public",
             "POSTGRES_USER": "postgres",
+            "POSTGRES_PORT": "5432",
         },
     )
     # [END kubernetes_seed_example]
@@ -95,6 +96,7 @@ with DAG(
             "POSTGRES_DB": "postgres",
             "POSTGRES_SCHEMA": "public",
             "POSTGRES_USER": "postgres",
+            "POSTGRES_PORT": "5432",
         },
         bucket_name="cosmos-ci-docs",
         install_deps=True,
@@ -130,6 +132,7 @@ with DAG(
                 "POSTGRES_DB": "postgres",
                 "POSTGRES_SCHEMA": "public",
                 "POSTGRES_USER": "postgres",
+                "POSTGRES_PORT": "5432",
             },
         },
     )

--- a/dev/dags/jaffle_shop_kubernetes.py
+++ b/dev/dags/jaffle_shop_kubernetes.py
@@ -90,7 +90,7 @@ with DAG(
         connection_id="aws_s3_conn",
         secrets=[postgres_host_secret, postgres_password_secret],
         profile_config=ProfileConfig(
-            profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="postgres_profile", target_name="dev"
+            profiles_yml_filepath="/root/.dbt/profiles.yml", profile_name="default", target_name="dev"
         ),
         env_vars={
             "POSTGRES_DB": "postgres",

--- a/dev/dags/jaffle_shop_watcher_kubernetes.py
+++ b/dev/dags/jaffle_shop_watcher_kubernetes.py
@@ -69,6 +69,7 @@ operator_args = {
         "POSTGRES_DB": "postgres",
         "POSTGRES_SCHEMA": "public",
         "POSTGRES_USER": "postgres",
+        "POSTGRES_PORT": "5432",
     },
     "retry": 0,
 }

--- a/dev/dags/jaffle_shop_watcher_kubernetes.py
+++ b/dev/dags/jaffle_shop_watcher_kubernetes.py
@@ -74,7 +74,7 @@ operator_args = {
 }
 
 profile_config = ProfileConfig(
-    profile_name="postgres_profile", target_name="dev", profiles_yml_filepath=KBS_DBT_PROFILES_YAML_FILEPATH
+    profile_name="default", target_name="dev", profiles_yml_filepath=KBS_DBT_PROFILES_YAML_FILEPATH
 )
 
 project_config = ProjectConfig(

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2365,9 +2365,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "39a5f27ad840d837ca9f86515e605ed6")
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "39a5f27ad840d837ca9f86515e605ed6"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2407,9 +2407,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "39a5f27ad840d837ca9f86515e605ed6")
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "39a5f27ad840d837ca9f86515e605ed6"
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")


### PR DESCRIPTION
## Description

This PR unifies the postgres_profile configuration between:

- dev/dags/dbt/jaffle_shop
- dev/dags/dbt/altered_jaffle_shop

Changes:
- Replaced incorrect 'pass' field with 'password' (dbt standard)
- Standardized port configuration using env_var
- Aligned both profiles.yml files for consistency

This ensures consistent configuration across examples and prevents potential dbt connection issues.

## Related Issue(s)

Closes #1384 

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
