### PR TITLE
Fix `cosmos_debug_max_memory_mb` XCom not pushed in Watcher sensor tasks

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+1.14.0a6 (2026-03-25)
+------------------
+
+* Fix ``cosmos_debug_max_memory_mb`` XCom not pushed in Watcher sensor tasks by @tatiana in #2503
+
 1.13.1 (2026-02-25)
 -------------------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,7 +2,7 @@ Changelog
 =========
 
 1.14.0a6 (2026-03-25)
-------------------
+---------------------
 
 * Fix ``cosmos_debug_max_memory_mb`` XCom not pushed in Watcher sensor tasks by @tatiana in #2503
 

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 from cosmos import settings
 
-__version__ = "1.14.0a3"
+__version__ = "1.14.0a6"
 
 
 if not settings.enable_memory_optimised_imports:

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -431,52 +431,40 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
 
         return fetch_state()
 
+    def _execute_core(self, context: Context) -> None:
+        """Run or defer the sensor. Extracted so execute() can wrap it with debug tracking."""
+        if not self.deferrable:
+            super().execute(context)
+        elif not self.poke(context):
+            self.defer(
+                trigger=WatcherTrigger(
+                    model_unique_id=self.model_unique_id,
+                    producer_task_id=self.producer_task_id,
+                    dag_id=self.dag_id,
+                    run_id=context["run_id"],
+                    map_index=context["task_instance"].map_index,
+                    use_event=self.use_event(),
+                    poke_interval=self.poke_interval,
+                    is_test_sensor=self.is_test_sensor,
+                ),
+                timeout=self.execution_timeout,
+                method_name=self.execute_complete.__name__,
+            )
+
     def execute(self, context: Context, **kwargs: Any) -> None:
         if settings.enable_debug_mode:
             from cosmos.debug import start_memory_tracking, stop_memory_tracking
 
             start_memory_tracking(context)
             try:
-                if not self.deferrable:
-                    super().execute(context)
-                elif not self.poke(context):
-                    self.defer(
-                        trigger=WatcherTrigger(
-                            model_unique_id=self.model_unique_id,
-                            producer_task_id=self.producer_task_id,
-                            dag_id=self.dag_id,
-                            run_id=context["run_id"],
-                            map_index=context["task_instance"].map_index,
-                            use_event=self.use_event(),
-                            poke_interval=self.poke_interval,
-                            is_test_sensor=self.is_test_sensor,
-                        ),
-                        timeout=self.execution_timeout,
-                        method_name=self.execute_complete.__name__,
-                    )
+                self._execute_core(context)
             finally:
                 # Use finally (not except Exception) because self.defer() raises TaskDeferred,
                 # a BaseException subclass, which would bypass an except-Exception block and
                 # leave the tracker running. Deferring is normal execution, not an error.
                 stop_memory_tracking(context)
         else:
-            if not self.deferrable:
-                super().execute(context)
-            elif not self.poke(context):
-                self.defer(
-                    trigger=WatcherTrigger(
-                        model_unique_id=self.model_unique_id,
-                        producer_task_id=self.producer_task_id,
-                        dag_id=self.dag_id,
-                        run_id=context["run_id"],
-                        map_index=context["task_instance"].map_index,
-                        use_event=self.use_event(),
-                        poke_interval=self.poke_interval,
-                        is_test_sensor=self.is_test_sensor,
-                    ),
-                    timeout=self.execution_timeout,
-                    method_name=self.execute_complete.__name__,
-                )
+            self._execute_core(context)
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         status = event.get("status")

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -7,6 +7,7 @@ from typing import Any
 
 from airflow.exceptions import AirflowException
 
+from cosmos import settings
 from cosmos.config import ProfileConfig
 from cosmos.constants import (
     _DBT_STARTUP_EVENTS_XCOM_KEY,
@@ -431,23 +432,51 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         return fetch_state()
 
     def execute(self, context: Context, **kwargs: Any) -> None:
-        if not self.deferrable:
-            super().execute(context)
-        elif not self.poke(context):
-            self.defer(
-                trigger=WatcherTrigger(
-                    model_unique_id=self.model_unique_id,
-                    producer_task_id=self.producer_task_id,
-                    dag_id=self.dag_id,
-                    run_id=context["run_id"],
-                    map_index=context["task_instance"].map_index,
-                    use_event=self.use_event(),
-                    poke_interval=self.poke_interval,
-                    is_test_sensor=self.is_test_sensor,
-                ),
-                timeout=self.execution_timeout,
-                method_name=self.execute_complete.__name__,
-            )
+        if settings.enable_debug_mode:
+            from cosmos.debug import start_memory_tracking, stop_memory_tracking
+
+            start_memory_tracking(context)
+            try:
+                if not self.deferrable:
+                    super().execute(context)
+                elif not self.poke(context):
+                    self.defer(
+                        trigger=WatcherTrigger(
+                            model_unique_id=self.model_unique_id,
+                            producer_task_id=self.producer_task_id,
+                            dag_id=self.dag_id,
+                            run_id=context["run_id"],
+                            map_index=context["task_instance"].map_index,
+                            use_event=self.use_event(),
+                            poke_interval=self.poke_interval,
+                            is_test_sensor=self.is_test_sensor,
+                        ),
+                        timeout=self.execution_timeout,
+                        method_name=self.execute_complete.__name__,
+                    )
+            finally:
+                # Use finally (not except Exception) because self.defer() raises TaskDeferred,
+                # a BaseException subclass, which would bypass an except-Exception block and
+                # leave the tracker running. Deferring is normal execution, not an error.
+                stop_memory_tracking(context)
+        else:
+            if not self.deferrable:
+                super().execute(context)
+            elif not self.poke(context):
+                self.defer(
+                    trigger=WatcherTrigger(
+                        model_unique_id=self.model_unique_id,
+                        producer_task_id=self.producer_task_id,
+                        dag_id=self.dag_id,
+                        run_id=context["run_id"],
+                        map_index=context["task_instance"].map_index,
+                        use_event=self.use_event(),
+                        poke_interval=self.poke_interval,
+                        is_test_sensor=self.is_test_sensor,
+                    ),
+                    timeout=self.execution_timeout,
+                    method_name=self.execute_complete.__name__,
+                )
 
     def execute_complete(self, context: Context, event: dict[str, str]) -> None:
         status = event.get("status")

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1457,6 +1457,25 @@ class TestDbtConsumerWatcherSensor:
         mock_start.assert_called_once_with(context)
         mock_stop.assert_called_once_with(context)
 
+    @patch("cosmos.operators._watcher.base.settings")
+    def test_execute_debug_mode_tracks_memory_non_deferrable(self, mock_settings):
+        """Memory tracking is started and stopped on the non-deferrable path (super().execute() loop)."""
+        mock_settings.enable_debug_mode = True
+        sensor = self.make_sensor(deferrable=False)
+        ti = MagicMock()
+        context = self.make_context(ti)
+
+        with (
+            patch("cosmos.debug.start_memory_tracking") as mock_start,
+            patch("cosmos.debug.stop_memory_tracking") as mock_stop,
+            patch("airflow.sensors.base.BaseSensorOperator.execute") as mock_super_execute,
+        ):
+            sensor.execute(context=context)
+
+        mock_super_execute.assert_called_once_with(context)
+        mock_start.assert_called_once_with(context)
+        mock_stop.assert_called_once_with(context)
+
 
 class TestDbtBuildWatcherOperator:
     def test_dbt_build_watcher_operator_raises_not_implemented_error(self):

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1468,7 +1468,7 @@ class TestDbtConsumerWatcherSensor:
         with (
             patch("cosmos.debug.start_memory_tracking") as mock_start,
             patch("cosmos.debug.stop_memory_tracking") as mock_stop,
-            patch("airflow.sensors.base.BaseSensorOperator.execute") as mock_super_execute,
+            patch("cosmos.operators._watcher.base.BaseSensorOperator.execute") as mock_super_execute,
         ):
             sensor.execute(context=context)
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1420,6 +1420,43 @@ class TestDbtConsumerWatcherSensor:
 
         assert sensor.compiled_sql == ""  # Should remain empty
 
+    @patch("cosmos.operators._watcher.base.settings")
+    def test_execute_debug_mode_tracks_memory_on_success(self, mock_settings):
+        """Memory tracking is started and stopped when poke() returns True (task completes without deferral)."""
+        mock_settings.enable_debug_mode = True
+        sensor = self.make_sensor()
+        ti = MagicMock()
+        context = self.make_context(ti)
+
+        with (
+            patch("cosmos.debug.start_memory_tracking") as mock_start,
+            patch("cosmos.debug.stop_memory_tracking") as mock_stop,
+            patch.object(sensor, "poke", return_value=True),
+        ):
+            sensor.execute(context=context)
+
+        mock_start.assert_called_once_with(context)
+        mock_stop.assert_called_once_with(context)
+
+    @patch("cosmos.operators._watcher.base.settings")
+    def test_execute_debug_mode_tracks_memory_on_defer(self, mock_settings):
+        """Memory tracking is started and stopped even when the task defers (TaskDeferred is BaseException)."""
+        mock_settings.enable_debug_mode = True
+        sensor = self.make_sensor(deferrable=True)
+        ti = MagicMock()
+        context = self.make_context(ti)
+
+        with (
+            patch("cosmos.debug.start_memory_tracking") as mock_start,
+            patch("cosmos.debug.stop_memory_tracking") as mock_stop,
+            patch.object(sensor, "poke", return_value=False),
+            pytest.raises(TaskDeferred),
+        ):
+            sensor.execute(context=context)
+
+        mock_start.assert_called_once_with(context)
+        mock_stop.assert_called_once_with(context)
+
 
 class TestDbtBuildWatcherOperator:
     def test_dbt_build_watcher_operator_raises_not_implemented_error(self):


### PR DESCRIPTION
Somewhere between [1.14.0a2](https://github.com/astronomer/astronomer-cosmos/releases/tag/astronomer-cosmos-v1.14.0a2) and [1.14.0a5](https://github.com/astronomer/astronomer-cosmos/releases/tag/astronomer-cosmos-v1.14.0a5), Cosmos stopped creating XCom `cosmos_debug_max_memory_mb` when users attempted to use `AIRFLOW__COSMOS__ENABLE_DEBUG_MODE=1`.

There was some change in between that caused `BaseConsumerSensor.execute()` not to go through `DbtBaseOperator.execute()`, so' start_memory_tracking' and' stop_memory_tracking' were never called for watcher consumer tasks.

This PR wraps `BaseConsumerSensor.execute()` with the same debug-mode tracking pattern. Use `finally` instead of `except Exception` because `self.defer()` raises `TaskDeferred` (a BaseException subclass), which an except-Exception block would silently bypass, leaving the background tracker thread running.

I created tests to better cover this use-case and also validated the before and after change by running Airflow and confirming the XComs are back to being populated both in the producer and consumer tasks

Sample of the XCom being correctly populated in a consumer node:
<img width="1351" height="325" alt="Screenshot 2026-03-25 at 17 28 56" src="https://github.com/user-attachments/assets/251a9eed-76eb-48b7-a808-e8d3ef1d5d46" />

Confirmation that things continue working on the producer node:
<img width="1490" height="517" alt="Screenshot 2026-03-25 at 17 29 53" src="https://github.com/user-attachments/assets/1dc652c2-b6d7-41a3-b963-b5545545c799" />

