### PR TITLE
feat: handle tests for `WATCHER_KUBERNETES` mode

### DIFF
--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -172,8 +172,12 @@ class DbtTestWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):
 
     The producer task collects individual test results as they finish and,
     once every test for a given model has reported, pushes a single
-    aggregated XCom (``"pass"`` or ``"fail"``) under the key
-    ``<model_unique_id>_tests_status``.
+    aggregated XCom (``"pass"`` or ``"fail"``) under the key returned by
+    ``get_tests_status_xcom_key(model_uid)``. This key sanitizes the dbt
+    model unique ID by replacing ``.`` with ``__`` before appending
+    ``_tests_status`` (for example,
+    ``model.jaffle_shop.stg_orders`` becomes
+    ``model__jaffle_shop__stg_orders_tests_status``).
 
     This sensor polls that key and returns success when ``"pass"`` or raises
     ``AirflowException`` when ``"fail"``.

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -16,11 +16,6 @@ import kubernetes.client as k8s
 from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback, client_type
 
-try:
-    from airflow.providers.standard.operators.empty import EmptyOperator
-except ImportError:  # pragma: no cover
-    from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
-
 from cosmos.airflow._override import CosmosKubernetesPodManager
 from cosmos.log import get_logger
 from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
@@ -172,13 +167,20 @@ class DbtRunWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):
         super().__init__(*args, **kwargs)
 
 
-class DbtTestWatcherKubernetesOperator(EmptyOperator):
-    """
-    As a starting point, this operator does nothing.
-    We'll be implementing this operator as part of: https://github.com/astronomer/astronomer-cosmos/issues/1974
+class DbtTestWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):  # type: ignore[misc]
+    """Sensor that watches the aggregated test status for a dbt model in WATCHER_KUBERNETES execution mode.
+
+    The producer task collects individual test results as they finish and,
+    once every test for a given model has reported, pushes a single
+    aggregated XCom (``"pass"`` or ``"fail"``) under the key
+    ``<model_unique_id>_tests_status``.
+
+    This sensor polls that key and returns success when ``"pass"`` or raises
+    ``AirflowException`` when ``"fail"``.
     """
 
-    def __init__(self, *args: Any, **kwargs: Any):
-        desired_keys = ("dag", "task_group", "task_id")
-        new_kwargs = {key: value for key, value in kwargs.items() if key in desired_keys}
-        super().__init__(**new_kwargs)  # type: ignore[no-untyped-call]
+    template_fields: tuple[str, ...] = DbtConsumerWatcherKubernetesSensor.template_fields
+
+    @property
+    def is_test_sensor(self) -> bool:
+        return True

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -167,7 +167,7 @@ class DbtRunWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):
         super().__init__(*args, **kwargs)
 
 
-class DbtTestWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):  # type: ignore[misc]
+class DbtTestWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):
     """Sensor that watches the aggregated test status for a dbt model in WATCHER_KUBERNETES execution mode.
 
     The producer task collects individual test results as they finish and,

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -339,13 +339,13 @@ You can still invoke these operators using the default ``ExecutionMode.LOCAL`` m
 Test behavior
 '''''''''''''
 
-By default, the watcher mode runs tests alongside models via the ``dbt build`` command being executed by the producer ``DbtProducerWatcherOperator`` operator.
+``TestBehavior.AFTER_EACH`` (the default) creates a ``DbtTestWatcherOperator`` sensor per model that polls the producer's aggregated test results via XCom.
 
-As a starting point, this execution mode does not support the ``TestBehavior.AFTER_EACH`` behavior, since the tests are not run as individual tasks. Since this is the default ``TestBehavior`` in Cosmos, we are injecting ``EmptyOperator`` as a starting point to ensure a seamless transition to the new mode.
+``TestBehavior.AFTER_ALL`` creates a single ``DbtTestLocalOperator`` that runs ``dbt test`` independently after all models complete, behaving similarly to ``ExecutionMode.LOCAL``.
+
+``TestBehavior.NONE`` disables test tasks.
 
 The ``TestBehavior.BUILD`` behavior is embedded in the producer ``DbtProducerWatcherOperator`` operator.
-
-The ``TestBehavior.NONE`` and ``TestBehavior.AFTER_ALL`` behave similarly to ``ExecutionMode.LOCAL``.
 
 Airflow Datasets and Assets
 '''''''''''''''''''''''''''

--- a/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
@@ -163,9 +163,9 @@ Other Inherited Limitations
 
 The following limitations from ``ExecutionMode.WATCHER`` also apply to ``ExecutionMode.WATCHER_KUBERNETES``:
 
-* **Individual dbt Operators**: Only ``DbtSeedWatcherKubernetesOperator``, ``DbtSnapshotWatcherKubernetesOperator``, and ``DbtRunWatcherKubernetesOperator`` are implemented. The ``DbtTestWatcherKubernetesOperator`` is currently a placeholder.
+* **Individual dbt Operators**: ``DbtSeedWatcherKubernetesOperator``, ``DbtSnapshotWatcherKubernetesOperator``, ``DbtRunWatcherKubernetesOperator``, and ``DbtTestWatcherKubernetesOperator`` are implemented.
 
-* **Test behavior**: The ``TestBehavior.AFTER_EACH`` is not supported. Tests are run as part of the ``dbt build`` command by the producer task.
+* **Test behavior**: ``TestBehavior.AFTER_EACH`` (the default) creates a ``DbtTestWatcherKubernetesOperator`` sensor per model that polls the producer's aggregated test results via XCom. ``TestBehavior.AFTER_ALL`` creates a single ``DbtTestKubernetesOperator`` that runs ``dbt test`` in a dedicated Kubernetes pod after all models complete. ``TestBehavior.NONE`` disables test tasks.
 
 * **Source freshness nodes**: The ``dbt build`` command does not run source freshness checks.
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -1822,6 +1822,49 @@ def test_skip_test_task_when_only_detached_tests_exist():
         assert list(tasks_map.keys()) == expected_task_ids
 
 
+@pytest.mark.parametrize("test_behavior", [TestBehavior.NONE, TestBehavior.AFTER_EACH, TestBehavior.AFTER_ALL])
+def test_test_behavior_for_watcher_kubernetes_mode(test_behavior: TestBehavior) -> None:
+    with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
+        task_args = {
+            "project_dir": SAMPLE_PROJ_PATH,
+            "conn_id": "fake_conn",
+            "image": "dbt-image:latest",
+            "profile_config": ProfileConfig(
+                profile_name="default",
+                target_name="default",
+                profile_mapping=PostgresUserPasswordProfileMapping(
+                    conn_id="fake_conn",
+                    profile_args={"schema": "public"},
+                ),
+            ),
+        }
+
+    build_airflow_graph(
+        nodes=sample_nodes,
+        dag=dag,
+        execution_mode=ExecutionMode.WATCHER_KUBERNETES,
+        test_indirect_selection=TestIndirectSelection.EAGER,
+        task_args=task_args,
+        render_config=RenderConfig(
+            test_behavior=test_behavior,
+        ),
+        dbt_project_name="astro_shop",
+    )
+    tasks = dag.tasks
+    if test_behavior == TestBehavior.NONE:
+        assert len(tasks) == 5
+    if test_behavior == TestBehavior.AFTER_EACH:
+        from cosmos.operators.watcher_kubernetes import DbtTestWatcherKubernetesOperator
+
+        assert any(isinstance(task, DbtTestWatcherKubernetesOperator) for task in tasks)
+        assert len(tasks) == 6
+    if test_behavior == TestBehavior.AFTER_ALL:
+        from cosmos.operators.kubernetes import DbtTestKubernetesOperator
+
+        assert any(isinstance(task, DbtTestKubernetesOperator) for task in tasks)
+        assert len(tasks) == 6
+
+
 def test_create_test_task_metadata_watcher_kubernetes_after_all():
     """
     Test that create_test_task_metadata creates a DbtTestKubernetesOperator

--- a/tests/operators/test_watcher_kubernetes_unit.py
+++ b/tests/operators/test_watcher_kubernetes_unit.py
@@ -192,16 +192,35 @@ def test_retry_executes_as_dbt_run_kubernetes_operator(mock_build_and_run_cmd):
     mock_build_and_run_cmd.assert_called_once()
 
 
-def test_producer_uses_watcher_kubernetes_callback():
-    """Test that the WatcherKubernetesCallback is included in the producer's callbacks."""
+class _CustomCallback:
+    pass
+
+
+class _CustomCallback2:
+    pass
+
+
+@pytest.mark.parametrize(
+    "callbacks_kwarg, expected_before_watcher",
+    [
+        pytest.param(None, [], id="none"),
+        pytest.param([], [], id="empty_list"),
+        pytest.param([_CustomCallback], [_CustomCallback], id="list"),
+        pytest.param((_CustomCallback,), [_CustomCallback], id="tuple"),
+        pytest.param(_CustomCallback, [_CustomCallback], id="single"),
+        pytest.param([_CustomCallback, _CustomCallback2], [_CustomCallback, _CustomCallback2], id="multiple"),
+    ],
+)
+def test_producer_normalizes_and_appends_watcher_callback(callbacks_kwarg, expected_before_watcher):
+    """User-supplied callbacks are preserved and WatcherKubernetesCallback is appended."""
     from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
 
-    op = DbtProducerWatcherKubernetesOperator(
-        project_dir=".",
-        profile_config=None,
-        image="dbt-image:latest",
-    )
-    assert WatcherKubernetesCallback in op.callbacks
+    kwargs = {"project_dir": ".", "profile_config": None, "image": "dbt-image:latest"}
+    if callbacks_kwarg is not None:
+        kwargs["callbacks"] = callbacks_kwarg
+
+    op = DbtProducerWatcherKubernetesOperator(**kwargs)
+    assert op.callbacks == expected_before_watcher + [WatcherKubernetesCallback]
 
 
 def make_test_sensor(**kwargs):

--- a/tests/operators/test_watcher_kubernetes_unit.py
+++ b/tests/operators/test_watcher_kubernetes_unit.py
@@ -22,6 +22,7 @@ else:
         DbtBuildWatcherKubernetesOperator,
         DbtConsumerWatcherKubernetesSensor,
         DbtProducerWatcherKubernetesOperator,
+        DbtTestWatcherKubernetesOperator,
     )
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt"
@@ -191,142 +192,71 @@ def test_retry_executes_as_dbt_run_kubernetes_operator(mock_build_and_run_cmd):
     mock_build_and_run_cmd.assert_called_once()
 
 
-class TestCallbacksNormalization:
-    """Tests for the callbacks normalization logic in DbtProducerWatcherKubernetesOperator."""
-
-    def test_callbacks_none_adds_watcher_callback(self):
-        """
-        Test that when callbacks is None, WatcherKubernetesCallback is added.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=None,
-        )
-        assert op.callbacks == [WatcherKubernetesCallback]
-
-    def test_callbacks_not_provided_adds_watcher_callback(self):
-        """
-        Test that when callbacks is not provided, WatcherKubernetesCallback is added.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-        )
-        assert op.callbacks == [WatcherKubernetesCallback]
-
-    def test_callbacks_list_appends_watcher_callback(self):
-        """
-        Test that when callbacks is a list, WatcherKubernetesCallback is appended.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        class CustomCallback:
-            pass
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=[CustomCallback],
-        )
-        assert op.callbacks == [CustomCallback, WatcherKubernetesCallback]
-
-    def test_callbacks_tuple_appends_watcher_callback(self):
-        """
-        Test that when callbacks is a tuple, WatcherKubernetesCallback is appended.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        class CustomCallback:
-            pass
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=(CustomCallback,),
-        )
-        assert op.callbacks == [CustomCallback, WatcherKubernetesCallback]
-
-    def test_callbacks_single_value_wraps_and_appends_watcher_callback(self):
-        """
-        Test that when callbacks is a single value (not list/tuple), it is wrapped in a list
-        and WatcherKubernetesCallback is appended.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        class CustomCallback:
-            pass
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=CustomCallback,
-        )
-        assert op.callbacks == [CustomCallback, WatcherKubernetesCallback]
-
-    def test_callbacks_empty_list_adds_watcher_callback(self):
-        """
-        Test that when callbacks is an empty list, WatcherKubernetesCallback is added.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=[],
-        )
-        assert op.callbacks == [WatcherKubernetesCallback]
-
-    def test_callbacks_multiple_values_appends_watcher_callback(self):
-        """
-        Test that when callbacks contains multiple values, WatcherKubernetesCallback is appended.
-        """
-        from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
-
-        class CustomCallback1:
-            pass
-
-        class CustomCallback2:
-            pass
-
-        op = DbtProducerWatcherKubernetesOperator(
-            project_dir=".",
-            profile_config=None,
-            image="dbt-image:latest",
-            callbacks=[CustomCallback1, CustomCallback2],
-        )
-        assert op.callbacks == [CustomCallback1, CustomCallback2, WatcherKubernetesCallback]
-
-
-def test_callbacks_included_in_producer_operator():
-    """
-    Test that the WatcherKubernetesCallback is included in the callbacks of the DbtProducerWatcherKubernetesOperator.
-    """
-    op = DbtProducerWatcherKubernetesOperator(
-        project_dir=".",
-        profile_config=None,
-        image="dbt-image:latest",
-        callbacks=MagicMock,
-    )
-    callback_classes = [callback.__name__ for callback in op.callbacks]
-    assert "WatcherKubernetesCallback" in callback_classes
-    assert "MagicMock" in callback_classes
+def test_producer_uses_watcher_kubernetes_callback():
+    """Test that the WatcherKubernetesCallback is included in the producer's callbacks."""
+    from cosmos.operators.watcher_kubernetes import WatcherKubernetesCallback
 
     op = DbtProducerWatcherKubernetesOperator(
         project_dir=".",
         profile_config=None,
         image="dbt-image:latest",
-        callbacks=[MagicMock],
     )
-    callback_classes = [callback.__name__ for callback in op.callbacks]
-    assert "WatcherKubernetesCallback" in callback_classes
+    assert WatcherKubernetesCallback in op.callbacks
+
+
+def make_test_sensor(**kwargs):
+    extra_context = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
+    kwargs["extra_context"] = extra_context
+    sensor = DbtTestWatcherKubernetesOperator(
+        task_id="test.stg_orders",
+        project_dir="/tmp/project",
+        profile_config=None,
+        deferrable=False,
+        image="dbt-image:latest",
+        **kwargs,
+    )
+    sensor._get_producer_task_status = MagicMock(return_value=None)
+    return sensor
+
+
+def test_test_sensor_is_test_sensor_property():
+    """DbtTestWatcherKubernetesOperator should report is_test_sensor=True."""
+    sensor = make_test_sensor()
+    assert sensor.is_test_sensor is True
+
+
+@pytest.mark.parametrize(
+    "xcom_return, expected",
+    [
+        pytest.param("pass", True, id="pass"),
+        pytest.param("fail", AirflowException, id="fail"),
+        pytest.param(None, False, id="waiting"),
+    ],
+)
+def test_test_sensor_poke_status(xcom_return, expected):
+    """Test that the test sensor correctly handles each aggregated test status."""
+    sensor = make_test_sensor()
+
+    ti = MagicMock()
+    ti.try_number = 1
+    ti.xcom_pull.return_value = xcom_return
+    context = make_context(ti)
+
+    if expected is AirflowException:
+        with pytest.raises(AirflowException):
+            sensor.poke(context)
+    else:
+        assert sensor.poke(context) is expected
+
+
+def test_test_sensor_raises_on_retry():
+    """On retry (try_number > 1), poke should raise because test re-execution is not supported."""
+    sensor = make_test_sensor()
+
+    ti = MagicMock()
+    ti.try_number = 2
+    ti.xcom_pull.return_value = None
+    context = make_context(ti)
+
+    with pytest.raises(AirflowException, match="not yet supported"):
+        sensor.poke(context)


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

Following https://github.com/astronomer/astronomer-cosmos/issues/2441 and https://github.com/astronomer/astronomer-cosmos/pull/2447, this PR implements test handling for `WATCHER_KUBERNETES` mode.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

closes https://github.com/astronomer/astronomer-cosmos/issues/2427

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
