### PR TITLE
Switch to lazy imports in cosmos/__init__.py

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -8,319 +8,134 @@ Contains dags, task groups, and operators.
 
 from __future__ import annotations
 
-from cosmos import settings
+import importlib
 
 __version__ = "1.14.0a6"
 
 
-if not settings.enable_memory_optimised_imports:
-    from cosmos.airflow.dag import DbtDag
-    from cosmos.airflow.task_group import DbtTaskGroup
-    from cosmos.config import (
-        ExecutionConfig,
-        ProfileConfig,
-        ProjectConfig,
-        RenderConfig,
-    )
-    from cosmos.constants import (
-        DbtResourceType,
-        ExecutionMode,
-        InvocationMode,
-        LoadMode,
-        SourceRenderingBehavior,
-        TestBehavior,
-        TestIndirectSelection,
-    )
-    from cosmos.log import get_logger
-    from cosmos.operators.lazy_load import MissingPackage
-    from cosmos.operators.local import (
-        DbtBuildLocalOperator,
-        DbtCloneLocalOperator,
-        DbtDepsLocalOperator,
-        DbtLSLocalOperator,
-        DbtRunLocalOperator,
-        DbtRunOperationLocalOperator,
-        DbtSeedLocalOperator,
-        DbtSnapshotLocalOperator,
-        DbtTestLocalOperator,
-    )
+# Mapping of public names to their module paths for lazy loading via __getattr__.
+# Imports are deferred until first access, which avoids circular imports during
+# Airflow >= 3.2 provider discovery (where airflow.configuration is not yet
+# initialized) and reduces memory footprint by only loading what is actually used.
+_LAZY_IMPORTS: dict[str, str] = {
+    "DbtDag": "cosmos.airflow.dag",
+    "DbtTaskGroup": "cosmos.airflow.task_group",
+    "ExecutionConfig": "cosmos.config",
+    "ProfileConfig": "cosmos.config",
+    "ProjectConfig": "cosmos.config",
+    "RenderConfig": "cosmos.config",
+    "DbtResourceType": "cosmos.constants",
+    "ExecutionMode": "cosmos.constants",
+    "InvocationMode": "cosmos.constants",
+    "LoadMode": "cosmos.constants",
+    "SourceRenderingBehavior": "cosmos.constants",
+    "TestBehavior": "cosmos.constants",
+    "TestIndirectSelection": "cosmos.constants",
+    "MissingPackage": "cosmos.operators.lazy_load",
+    # Local
+    "DbtBuildLocalOperator": "cosmos.operators.local",
+    "DbtCloneLocalOperator": "cosmos.operators.local",
+    "DbtDepsLocalOperator": "cosmos.operators.local",
+    "DbtLSLocalOperator": "cosmos.operators.local",
+    "DbtRunLocalOperator": "cosmos.operators.local",
+    "DbtRunOperationLocalOperator": "cosmos.operators.local",
+    "DbtSeedLocalOperator": "cosmos.operators.local",
+    "DbtSnapshotLocalOperator": "cosmos.operators.local",
+    "DbtTestLocalOperator": "cosmos.operators.local",
+    # Docker
+    "DbtBuildDockerOperator": "cosmos.operators.docker",
+    "DbtCloneDockerOperator": "cosmos.operators.docker",
+    "DbtLSDockerOperator": "cosmos.operators.docker",
+    "DbtRunDockerOperator": "cosmos.operators.docker",
+    "DbtRunOperationDockerOperator": "cosmos.operators.docker",
+    "DbtSeedDockerOperator": "cosmos.operators.docker",
+    "DbtSnapshotDockerOperator": "cosmos.operators.docker",
+    "DbtTestDockerOperator": "cosmos.operators.docker",
+    # Kubernetes
+    "DbtBuildKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtCloneKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtLSKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtRunKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtRunOperationKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtSeedKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtSnapshotKubernetesOperator": "cosmos.operators.kubernetes",
+    "DbtTestKubernetesOperator": "cosmos.operators.kubernetes",
+    # Azure Container Instance
+    "DbtBuildAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtCloneAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtLSAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtRunAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtRunOperationAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtSeedAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtSnapshotAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    "DbtTestAzureContainerInstanceOperator": "cosmos.operators.azure_container_instance",
+    # AWS EKS
+    "DbtBuildAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtCloneAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtLSAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtRunAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtRunOperationAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtSeedAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtSnapshotAwsEksOperator": "cosmos.operators.aws_eks",
+    "DbtTestAwsEksOperator": "cosmos.operators.aws_eks",
+    # AWS ECS
+    "DbtBuildAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtLSAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtRunAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtRunOperationAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtSeedAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtSnapshotAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtTestAwsEcsOperator": "cosmos.operators.aws_ecs",
+    "DbtSourceAwsEcsOperator": "cosmos.operators.aws_ecs",
+    # GCP Cloud Run Job
+    "DbtBuildGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtCloneGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtLSGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtRunGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtRunOperationGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtSeedGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtSnapshotGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+    "DbtTestGcpCloudRunJobOperator": "cosmos.operators.gcp_cloud_run_job",
+}
 
-    logger = get_logger(__name__)
 
+_OPTIONAL_DEPS: dict[str, str] = {
+    "cosmos.operators.docker": "docker",
+    "cosmos.operators.kubernetes": "kubernetes",
+    "cosmos.operators.azure_container_instance": "azure-container-instance",
+    "cosmos.operators.aws_eks": "aws_eks",
+    "cosmos.operators.aws_ecs": "aws-ecs",
+    "cosmos.operators.gcp_cloud_run_job": "gcp-cloud-run-job",
+}
+
+
+def __getattr__(name: str) -> object:
+    """Lazy import: resolve public names on first access."""
+    if name in _LAZY_IMPORTS:
+        module_path = _LAZY_IMPORTS[name]
+        try:
+            module = importlib.import_module(module_path)
+            value = getattr(module, name)
+        except (ImportError, AttributeError):
+            if module_path in _OPTIONAL_DEPS:
+                from cosmos.operators.lazy_load import MissingPackage
+
+                value = MissingPackage(f"{module_path}.{name}", _OPTIONAL_DEPS[module_path])
+            else:
+                raise
+        globals()[name] = value
+        return value
+
+    # Submodule access (e.g. cosmos.settings)
     try:
-        from cosmos.operators.docker import (
-            DbtBuildDockerOperator,
-            DbtCloneDockerOperator,
-            DbtLSDockerOperator,
-            DbtRunDockerOperator,
-            DbtRunOperationDockerOperator,
-            DbtSeedDockerOperator,
-            DbtSnapshotDockerOperator,
-            DbtTestDockerOperator,
-        )
-    except ImportError:  # pragma: no cover
-        DbtLSDockerOperator = MissingPackage("cosmos.operators.docker.DbtLSDockerOperator", "docker")
-        DbtRunDockerOperator = MissingPackage("cosmos.operators.docker.DbtRunDockerOperator", "docker")
-        DbtRunOperationDockerOperator = MissingPackage(
-            "cosmos.operators.docker.DbtRunOperationDockerOperator",
-            "docker",
-        )
-        DbtSeedDockerOperator = MissingPackage("cosmos.operators.docker.DbtSeedDockerOperator", "docker")
-        DbtSnapshotDockerOperator = MissingPackage("cosmos.operators.docker.DbtSnapshotDockerOperator", "docker")
-        DbtTestDockerOperator = MissingPackage("cosmos.operators.docker.DbtTestDockerOperator", "docker")
+        return importlib.import_module(f"{__name__}.{name}")
+    except ImportError:
+        pass
 
-    try:
-        from cosmos.operators.kubernetes import (
-            DbtBuildKubernetesOperator,
-            DbtCloneKubernetesOperator,
-            DbtLSKubernetesOperator,
-            DbtRunKubernetesOperator,
-            DbtRunOperationKubernetesOperator,
-            DbtSeedKubernetesOperator,
-            DbtSnapshotKubernetesOperator,
-            DbtTestKubernetesOperator,
-        )
-    except ImportError:  # pragma: no cover
-        logger.debug("To import Kubernetes modules, install astronomer-cosmos[kubernetes].", stack_info=True)
-        DbtBuildKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtBuildKubernetesOperator",
-            "kubernetes",
-        )
-        DbtLSKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtLSKubernetesOperator",
-            "kubernetes",
-        )
-        DbtRunKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtRunKubernetesOperator",
-            "kubernetes",
-        )
-        DbtRunOperationKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtRunOperationKubernetesOperator",
-            "kubernetes",
-        )
-        DbtSeedKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtSeedKubernetesOperator",
-            "kubernetes",
-        )
-        DbtSnapshotKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtSnapshotKubernetesOperator",
-            "kubernetes",
-        )
-        DbtTestKubernetesOperator = MissingPackage(
-            "cosmos.operators.kubernetes.DbtTestKubernetesOperator",
-            "kubernetes",
-        )
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
 
-    try:
-        from cosmos.operators.azure_container_instance import (
-            DbtBuildAzureContainerInstanceOperator,
-            DbtCloneAzureContainerInstanceOperator,
-            DbtLSAzureContainerInstanceOperator,
-            DbtRunAzureContainerInstanceOperator,
-            DbtRunOperationAzureContainerInstanceOperator,
-            DbtSeedAzureContainerInstanceOperator,
-            DbtSnapshotAzureContainerInstanceOperator,
-            DbtTestAzureContainerInstanceOperator,
-        )
-    except ImportError:  # pragma: no cover
-        DbtBuildAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtBuildAzureContainerInstanceOperator",
-            "azure-container-instance",
-        )
-        DbtLSAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtLSAzureContainerInstanceOperator", "azure-container-instance"
-        )
-        DbtRunAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtRunAzureContainerInstanceOperator", "azure-container-instance"
-        )
-        DbtRunOperationAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtRunOperationAzureContainerInstanceOperator",
-            "azure-container-instance",
-        )
-        DbtSeedAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtSeedAzureContainerInstanceOperator",
-            "azure-container-instance",
-        )
-        DbtSnapshotAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtSnapshotAzureContainerInstanceOperator",
-            "azure-container-instance",
-        )
-        DbtTestAzureContainerInstanceOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtTestAzureContainerInstanceOperator",
-            "azure-container-instance",
-        )
 
-    try:
-        from cosmos.operators.aws_eks import (
-            DbtBuildAwsEksOperator,
-            DbtCloneAwsEksOperator,
-            DbtLSAwsEksOperator,
-            DbtRunAwsEksOperator,
-            DbtRunOperationAwsEksOperator,
-            DbtSeedAwsEksOperator,
-            DbtSnapshotAwsEksOperator,
-            DbtTestAwsEksOperator,
-        )
-    except ImportError:  # pragma: no cover
-        DbtBuildAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtBuildAwsEksOperator", "aws_eks"
-        )
-        DbtLSAwsEksOperator = MissingPackage("cosmos.operators.azure_container_instance.DbtLSAwsEksOperator", "aws_eks")
-        DbtRunAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtRunAwsEksOperator", "aws_eks"
-        )
-        DbtRunOperationAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtRunOperationAwsEksOperator",
-            "aws_eks",
-        )
-        DbtSeedAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtSeedAwsEksOperator", "aws_eks"
-        )
-        DbtSnapshotAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtSnapshotAwsEksOperator",
-            "aws_eks",
-        )
-        DbtTestAwsEksOperator = MissingPackage(
-            "cosmos.operators.azure_container_instance.DbtTestAwsEksOperator", "aws_eks"
-        )
-
-    try:
-        from cosmos.operators.aws_ecs import (
-            DbtBuildAwsEcsOperator,
-            DbtLSAwsEcsOperator,
-            DbtRunAwsEcsOperator,
-            DbtRunOperationAwsEcsOperator,
-            DbtSeedAwsEcsOperator,
-            DbtSnapshotAwsEcsOperator,
-            DbtSourceAwsEcsOperator,
-            DbtTestAwsEcsOperator,
-        )
-    except ImportError:  # pragma: no cover
-        DbtBuildAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtBuildAwsEcsOperator", "aws-ecs")
-        DbtLSAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtLSAwsEcsOperator", "aws-ecs")
-        DbtRunAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtRunAwsEcsOperator", "aws-ecs")
-        DbtRunOperationAwsEcsOperator = MissingPackage(
-            "cosmos.operators.aws_ecs.DbtRunOperationAwsEcsOperator",
-            "aws-ecs",
-        )
-        DbtSeedAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtSeedAwsEcsOperator", "aws-ecs")
-        DbtSnapshotAwsEcsOperator = MissingPackage(
-            "cosmos.operators.aws_ecs.DbtSnapshotAwsEcsOperator",
-            "aws-ecs",
-        )
-        DbtTestAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtTestAwsEcsOperator", "aws-ecs")
-        DbtSourceAwsEcsOperator = MissingPackage("cosmos.operators.aws_ecs.DbtSourceAwsEcsOperator", "aws-ecs")
-
-    try:
-        from cosmos.operators.gcp_cloud_run_job import (
-            DbtBuildGcpCloudRunJobOperator,
-            DbtCloneGcpCloudRunJobOperator,
-            DbtLSGcpCloudRunJobOperator,
-            DbtRunGcpCloudRunJobOperator,
-            DbtRunOperationGcpCloudRunJobOperator,
-            DbtSeedGcpCloudRunJobOperator,
-            DbtSnapshotGcpCloudRunJobOperator,
-            DbtTestGcpCloudRunJobOperator,
-        )
-    except (ImportError, AttributeError):
-        DbtBuildGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtBuildGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtLSGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtLSGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtRunGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtRunGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtRunOperationGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtRunOperationGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtSeedGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtSeedGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtSnapshotGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtSnapshotGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-        DbtTestGcpCloudRunJobOperator = MissingPackage(
-            "cosmos.operators.gcp_cloud_run_job.DbtTestGcpCloudRunJobOperator", "gcp-cloud-run-job"
-        )
-
-    __all__ = [
-        "ProjectConfig",
-        "ProfileConfig",
-        "ExecutionConfig",
-        "RenderConfig",
-        "DbtDag",
-        "DbtTaskGroup",
-        "ExecutionMode",
-        "LoadMode",
-        "TestBehavior",
-        "InvocationMode",
-        "TestIndirectSelection",
-        "SourceRenderingBehavior",
-        "DbtResourceType",
-        # Local Execution Mode
-        "DbtBuildLocalOperator",
-        "DbtCloneLocalOperator",
-        "DbtDepsLocalOperator",  # deprecated, to be delete in Cosmos 2.x
-        "DbtLSLocalOperator",
-        "DbtRunLocalOperator",
-        "DbtRunOperationLocalOperator",
-        "DbtSeedLocalOperator",
-        "DbtSnapshotLocalOperator",
-        "DbtTestLocalOperator",
-        # Docker Execution Mode
-        "DbtBuildDockerOperator",
-        "DbtCloneDockerOperator",
-        "DbtLSDockerOperator",
-        "DbtRunDockerOperator",
-        "DbtRunOperationDockerOperator",
-        "DbtSeedDockerOperator",
-        "DbtSnapshotDockerOperator",
-        "DbtTestDockerOperator",
-        # Kubernetes Execution Mode
-        "DbtBuildKubernetesOperator",
-        "DbtCloneKubernetesOperator",
-        "DbtLSKubernetesOperator",
-        "DbtRunKubernetesOperator",
-        "DbtRunOperationKubernetesOperator",
-        "DbtSeedKubernetesOperator",
-        "DbtSnapshotKubernetesOperator",
-        "DbtTestKubernetesOperator",
-        # Azure Container Instance Execution Mode
-        "DbtBuildAzureContainerInstanceOperator",
-        "DbtCloneAzureContainerInstanceOperator",
-        "DbtLSAzureContainerInstanceOperator",
-        "DbtRunAzureContainerInstanceOperator",
-        "DbtRunOperationAzureContainerInstanceOperator",
-        "DbtSeedAzureContainerInstanceOperator",
-        "DbtSnapshotAzureContainerInstanceOperator",
-        "DbtTestAzureContainerInstanceOperator",
-        # AWS EKS Execution Mode
-        "DbtBuildAwsEksOperator",
-        "DbtCloneAwsEksOperator",
-        "DbtLSAwsEksOperator",
-        "DbtRunAwsEksOperator",
-        "DbtRunOperationAwsEksOperator",
-        "DbtSeedAwsEksOperator",
-        "DbtSnapshotAwsEksOperator",
-        "DbtTestAwsEksOperator",
-        # AWS ECS Task Run Execution Mode
-        "DbtBuildAwsEcsOperator",
-        "DbtLSAwsEcsOperator",
-        "DbtRunAwsEcsOperator",
-        "DbtRunOperationAwsEcsOperator",
-        "DbtSeedAwsEcsOperator",
-        "DbtSnapshotAwsEcsOperator",
-        "DbtTestAwsEcsOperator",
-        "DbtSourceAwsEcsOperator",
-        # GCP Cloud Run Job Execution Mode
-        "DbtBuildGcpCloudRunJobOperator",
-        "DbtCloneGcpCloudRunJobOperator",
-        "DbtLSGcpCloudRunJobOperator",
-        "DbtRunGcpCloudRunJobOperator",
-        "DbtRunOperationGcpCloudRunJobOperator",
-        "DbtSeedGcpCloudRunJobOperator",
-        "DbtSnapshotGcpCloudRunJobOperator",
-        "DbtTestGcpCloudRunJobOperator",
-    ]
+__all__ = [
+    "__version__",
+    *_LAZY_IMPORTS,
+]

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -129,10 +129,13 @@ def __getattr__(name: str) -> object:
     # Submodule access (e.g. cosmos.settings)
     try:
         return importlib.import_module(f"{__name__}.{name}")
-    except ImportError:
-        pass
-
-    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    except ModuleNotFoundError as exc:
+        # Only convert to AttributeError when the *requested* submodule does not
+        # exist.  If the submodule exists but has an internal ImportError we must
+        # let it propagate so the real root cause is visible to the user.
+        if exc.name == f"{__name__}.{name}":
+            raise AttributeError(f"module {__name__!r} has no attribute {name!r}") from None
+        raise
 
 
 __all__ = [

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -7,42 +7,7 @@ When running dbt pipelines with Astronomer Cosmos, the framework executes dbt co
 
 Cosmos provides various configuration options and execution modes to optimize memory usage, reduce worker resource consumption, and prevent OOM issues. This document outlines these memory optimization strategies, from simple configuration changes to advanced execution modes that can dramatically reduce memory footprint while maintaining or improving pipeline performance.
 
-1. Enable Memory-Optimized Imports
-++++++++++++++++++++++++++++++++++
-
-**Impact**: High - Reduces memory footprint both at the DAG Processor and at Worker nodes.
-
-**Configuration**:
-
-.. code-block:: cfg
-
-   # In airflow.cfg
-   [cosmos]
-   enable_memory_optimised_imports = True
-
-.. code-block:: bash
-
-   # Or via environment variable
-   export AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS=True
-
-**What it does**: Disables eager imports in ``cosmos/__init__.py``, preventing unused modules and classes from being loaded into memory.
-
-**Note**: When enabled, you must use full module paths for importing classes, functions and objects from Cosmos:
-
-.. code-block:: python
-
-   # Instead of:
-   from cosmos import DbtDag, ProjectConfig, RenderConfig
-
-   # Use:
-   from cosmos.airflow.dag import DbtDag
-   from cosmos.config import ProjectConfig, RenderConfig
-
-**Default**: ``False`` (will become default in Cosmos 2.0.0)
-
------------------------------------------------------------------
-
-2. Use DBT_MANIFEST Load Mode
+1. Use DBT_MANIFEST Load Mode
 +++++++++++++++++++++++++++++
 
 **Impact**: High - Avoids running ``dbt ls`` subprocess which can consume significant CPU and memory. This reduces memory consumption when a cache miss occurs in the DBT LS method. It may not significantly reduce the memory footprint if there is a cache hit.
@@ -69,7 +34,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 ---------------------------------
 
-3. Use DBT_RUNNER Invocation Mode
+2. Use DBT_RUNNER Invocation Mode
 +++++++++++++++++++++++++++++++++
 
 * (default for ``ExecutionMode.LOCAL`` since 1.4.0, default for ``RenderConfig.DBT_LS`` since Cosmos 1.9.0)
@@ -101,7 +66,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 -------------------------------------------------------------------------------
 
-4. Use Partial Parse (Keep Enabled)
+3. Use Partial Parse (Keep Enabled)
 +++++++++++++++++++++++++++++++++++
 
 **Impact**: Low - Actually reduces memory by avoiding full project parsing.
@@ -128,7 +93,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 -------------------------------------------------------------------------------
 
-5. Use ExecutionMode.WATCHER
+4. Use ExecutionMode.WATCHER
 ++++++++++++++++++++++++++++
 
 **Impact**: Very High - Dramatically reduces Airflow worker slot usage and memory consumption.
@@ -140,7 +105,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 -------------------------------------------------------------------------------
 
-6. Control DAG-Level Concurrency with ``concurrency`` Parameter
+5. Control DAG-Level Concurrency with ``concurrency`` Parameter
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 
 **Impact**: High - Limits concurrent task execution per DAG based on available resources.
@@ -209,7 +174,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 -------------------------------------------------------------------------------
 
-7. Enable Task Profiling with Debug Mode
+6. Enable Task Profiling with Debug Mode
 ++++++++++++++++++++++++++++++++++++++++
 
 **Impact**: Low - Provides visibility into memory usage patterns to help identify optimization opportunities and prevent OOM issues.

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -295,30 +295,12 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 .. _enable_memory_optimised_imports:
 
 `enable_memory_optimised_imports`_:
-    (Introduced in Cosmos 1.10.1): Eager imports in cosmos/__init__.py expose all Cosmos classes at the top level,
-    which can significantly increase memory usage—even when Cosmos is just installed but not actively used. This option allows
-    disabling those eager imports to reduce memory footprint. When enabled, users must access Cosmos classes via their full
-    module paths, avoiding the overhead of importing unused modules and classes.
+    (Introduced in Cosmos 1.10.1): This setting is a no-op since Cosmos 1.14.0. All imports in ``cosmos/__init__.py``
+    are now lazy by default — modules are only loaded on first access. This provides the same memory optimization
+    automatically, without requiring users to change their import paths. The setting is still accepted but has no effect.
 
     - Default: ``False``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS``
-
-    .. note::
-        This option will become the default behavior in Cosmos 2.0.0, where all eager imports will be removed from ``cosmos/__init__.py``.
-
-    As an example, when this option is enabled, the following is an example of specifying the imports with full module paths:
-
-    .. literalinclude:: ../../../dev/dags/basic_cosmos_dag_full_module_path_imports.py
-        :language: python
-        :start-after: [START cosmos_explicit_imports]
-        :end-before: [END cosmos_explicit_imports]
-
-    as opposed to the following approach you might have when this option is disabled (default):
-
-    .. literalinclude:: ../../../dev/dags/basic_cosmos_dag.py
-        :language: python
-        :start-after: [START cosmos_init_imports]
-        :end-before: [END cosmos_init_imports]
 
 .. _enable_telemetry:
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import patch
+
+import pytest
+
+import cosmos
+
+
+class TestLazyImports:
+    """Tests for the lazy import dispatch in cosmos/__init__.py."""
+
+    def test_lazy_import_resolves_known_name(self):
+        """Known names in _LAZY_IMPORTS are resolved on attribute access."""
+        assert cosmos.DbtDag is not None
+        assert cosmos.ExecutionMode is not None
+
+    def test_optional_dependency_returns_missing_package(self):
+        """When an optional-dep module fails to import, a MissingPackage sentinel is returned."""
+        # Clear any cached value from a prior import
+        cosmos.__dict__.pop("DbtBuildDockerOperator", None)
+
+        with patch.dict(sys.modules, {"docker": None}):
+            with patch("importlib.import_module", side_effect=ImportError("No module named 'docker'")):
+                operator = cosmos.DbtBuildDockerOperator  # noqa: F841
+                # MissingPackage is a callable that raises RuntimeError when invoked
+                with pytest.raises(RuntimeError, match="optional dependencies"):
+                    operator()
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        """Accessing a non-existent attribute raises AttributeError."""
+        with pytest.raises(AttributeError, match="has no attribute"):
+            _ = cosmos.non_existent_attribute_xyz
+
+    def test_submodule_access(self):
+        """Submodule access via attribute (e.g. cosmos.settings) works."""
+        assert cosmos.settings is not None
+
+    def test_non_optional_import_error_propagates(self):
+        """ImportError for a non-optional module re-raises instead of returning MissingPackage."""
+        cosmos.__dict__.pop("DbtDag", None)
+
+        def fake_import(name, *args, **kwargs):
+            if name == "cosmos.airflow.dag":
+                raise ImportError("broken import")
+            return original_import(name, *args, **kwargs)
+
+        original_import = importlib.import_module
+        with patch("importlib.import_module", side_effect=fake_import):
+            with pytest.raises(ImportError, match="broken import"):
+                _ = cosmos.DbtDag
+
+    def test_submodule_internal_import_error_propagates(self):
+        """If an existing submodule has an internal ImportError, it must propagate."""
+
+        def fake_import(name, *args, **kwargs):
+            if name == "cosmos.settings":
+                raise ModuleNotFoundError("No module named 'some_internal_dep'", name="some_internal_dep")
+            return importlib.__import__(name, *args, **kwargs)
+
+        with patch("importlib.import_module", side_effect=fake_import):
+            # Clear cached submodule so __getattr__ is triggered
+            cosmos.__dict__.pop("settings", None)
+            with pytest.raises(ModuleNotFoundError, match="some_internal_dep"):
+                _ = cosmos.settings

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,6 +1,4 @@
 import os
-import subprocess
-import textwrap
 from importlib import reload
 from unittest.mock import patch
 
@@ -11,32 +9,6 @@ from cosmos import settings
 def test_enable_cache_env_var():
     reload(settings)
     assert settings.enable_cache is False
-
-
-def test_enable_memory_optimised_imports_true(monkeypatch):
-    script = textwrap.dedent("""
-            import os
-            os.environ["AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS"] = "True"
-            import cosmos
-            assert cosmos.settings.enable_memory_optimised_imports is True
-            assert not hasattr(cosmos, "DbtDag")
-        """)
-
-    result = subprocess.run(["python", "-c", script], capture_output=True, text=True)
-    assert result.returncode == 0, result.stderr
-
-
-def test_enable_memory_optimised_imports_false(monkeypatch):
-    script = textwrap.dedent("""
-            import os
-            os.environ["AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS"] = "False"
-            import cosmos
-            assert cosmos.settings.enable_memory_optimised_imports is False
-            assert hasattr(cosmos, "DbtDag")
-        """)
-
-    result = subprocess.run(["python", "-c", script], capture_output=True, text=True)
-    assert result.returncode == 0, result.stderr
 
 
 @patch.dict(os.environ, {"AIRFLOW__COSMOS__ENABLE_DEBUG_MODE": "True"}, clear=True)


### PR DESCRIPTION
Replace eager imports with lazy loading via module-level __getattr__. Imports are deferred until first access, reducing memory footprint by only loading modules that are actually used.

Optional dependency handling (docker, kubernetes, etc.) is preserved by catching ImportError in __getattr__ and returning MissingPackage sentinels, matching the previous behavior.

The enable_memory_optimised_imports setting is now a no-op since all imports are lazy by default. Remove the related tests and update documentation accordingly.

related: #2403 
related: #1769 