### PR TITLE
Update watcher test behavior docs for Cosmos 1.14.0

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -341,7 +341,16 @@ Test behavior
 
 By default, the watcher mode runs tests alongside models via the ``dbt build`` command being executed by the producer ``DbtProducerWatcherOperator`` operator.
 
-As a starting point, this execution mode does not support the ``TestBehavior.AFTER_EACH`` behavior, since the tests are not run as individual tasks. Since this is the default ``TestBehavior`` in Cosmos, we are injecting ``EmptyOperator`` as a starting point to ensure a seamless transition to the new mode.
+.. versionchanged:: 1.14.0
+
+Starting with Cosmos 1.14.0, ``TestBehavior.AFTER_EACH`` is fully supported in ``ExecutionMode.WATCHER``.
+Each test task is rendered as a ``DbtTestWatcherOperator`` (a ``DbtConsumerWatcherSensor`` subclass) that watches
+the aggregated test results published by the producer via XCom. This means test tasks now behave as real sensors
+rather than no-op placeholders.
+
+In Cosmos versions prior to 1.14.0, ``TestBehavior.AFTER_EACH`` was not supported by the watcher mode because tests
+were not run as individual tasks. Since ``TestBehavior.AFTER_EACH`` is the default ``TestBehavior`` in Cosmos,
+``EmptyOperator`` tasks were injected as placeholders to ensure a seamless transition to the new mode.
 
 The ``TestBehavior.BUILD`` behavior is embedded in the producer ``DbtProducerWatcherOperator`` operator.
 

--- a/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
@@ -165,7 +165,7 @@ The following limitations from ``ExecutionMode.WATCHER`` also apply to ``Executi
 
 * **Individual dbt Operators**: Only ``DbtSeedWatcherKubernetesOperator``, ``DbtSnapshotWatcherKubernetesOperator``, and ``DbtRunWatcherKubernetesOperator`` are implemented. The ``DbtTestWatcherKubernetesOperator`` is currently a placeholder.
 
-* **Test behavior**: The ``TestBehavior.AFTER_EACH`` is not supported. Tests are run as part of the ``dbt build`` command by the producer task.
+* **Test behavior**: Unlike ``ExecutionMode.WATCHER`` (which fully supports ``TestBehavior.AFTER_EACH`` since Cosmos 1.14.0), ``ExecutionMode.WATCHER_KUBERNETES`` does not yet support ``TestBehavior.AFTER_EACH``. Tests are run as part of the ``dbt build`` command by the producer task, and test tasks are rendered as ``EmptyOperator`` placeholders. This is tracked in `#1974 <https://github.com/astronomer/astronomer-cosmos/issues/1974>`_.
 
 * **Source freshness nodes**: The ``dbt build`` command does not run source freshness checks.
 


### PR DESCRIPTION
TestBehavior.AFTER_EACH is now fully supported in
ExecutionMode.WATCHER since 1.14.0 via DbtTestWatcherOperator. Update the docs to reflect this, preserve historical context about the EmptyOperator placeholders in prior versions, and clarify that WATCHER_KUBERNETES still uses placeholders.