### PR TITLE
Add aws and azure tarball upload options

### DIFF
--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -25,6 +25,7 @@ def upload_to_aws_s3(
     bucket_name: str,
     aws_conn_id: str | None = None,
     source_subpath: str = DEFAULT_TARGET_PATH,
+    use_tarball: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -34,6 +35,7 @@ def upload_to_aws_s3(
     :param bucket_name: Name of the S3 bucket to upload to.
     :param aws_conn_id: AWS connection ID to use when uploading files.
     :param source_subpath: Path of the source directory sub-path to upload files from.
+    :param use_tarball: If True, uploads a single tar.gz archive instead of individual files.
     """
     from airflow.providers.amazon.aws.hooks.s3 import S3Hook
 
@@ -45,22 +47,35 @@ def upload_to_aws_s3(
     # Airflow 3 and Airflow 2 compatibility, respectively:
     try_number = getattr(context["task_instance"], "try_number") or getattr(context["task_instance"], "_try_number")
 
-    # Iterate over the files in the target dir and upload them to S3
-    for dirpath, _, filenames in os.walk(target_dir):
-        for filename in filenames:
-            s3_key = (
-                f"{context['dag'].dag_id}"
-                f"/{context['run_id']}"
-                f"/{context['task_instance'].task_id}"
-                f"/{try_number}"
-                f"{dirpath.split(project_dir)[-1]}/{filename}"
-            )
-            hook.load_file(
-                filename=f"{dirpath}/{filename}",
-                bucket_name=bucket_name,
-                key=s3_key,
-                replace=True,
-            )
+    run_prefix = (
+        f"{context['dag'].dag_id}"
+        f"/{context['run_id']}"
+        f"/{context['task_instance'].task_id}"
+        f"/{try_number}"
+    )
+
+    if use_tarball:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            tar.add(target_dir, arcname=source_subpath)
+        buf.seek(0)
+        hook.load_bytes(
+            bytes_data=buf.read(),
+            bucket_name=bucket_name,
+            key=f"{run_prefix}/{source_subpath}.tar.gz",
+            replace=True,
+        )
+    else:
+        # Iterate over the files in the target dir and upload them to S3
+        for dirpath, _, filenames in os.walk(target_dir):
+            for filename in filenames:
+                s3_key = f"{run_prefix}{dirpath.split(project_dir)[-1]}/{filename}"
+                hook.load_file(
+                    filename=f"{dirpath}/{filename}",
+                    bucket_name=bucket_name,
+                    key=s3_key,
+                    replace=True,
+                )
 
 
 def upload_to_gcp_gs(
@@ -122,6 +137,7 @@ def upload_to_azure_wasb(
     container_name: str,
     azure_conn_id: str | None = None,
     source_subpath: str = DEFAULT_TARGET_PATH,
+    use_tarball: bool = False,
     **kwargs: Any,
 ) -> None:
     """
@@ -131,31 +147,47 @@ def upload_to_azure_wasb(
     :param container_name: Name of the Azure WASB container to upload files to.
     :param azure_conn_id: Azure connection ID to use when uploading files.
     :param source_subpath: Path of the source directory sub-path to upload files from.
+    :param use_tarball: If True, uploads a single tar.gz archive instead of individual files.
     """
     from airflow.providers.microsoft.azure.hooks.wasb import WasbHook
 
     target_dir = f"{project_dir}/{source_subpath}"
     azure_conn_id = azure_conn_id if azure_conn_id else WasbHook.default_conn_name
-    # container_name = kwargs["container_name"]
     hook = WasbHook(wasb_conn_id=azure_conn_id)
     context = kwargs["context"]
 
-    # Iterate over the files in the target dir and upload them to WASB container
-    for dirpath, _, filenames in os.walk(target_dir):
-        for filename in filenames:
-            blob_name = (
-                f"{context['dag'].dag_id}"
-                f"/{context['run_id']}"
-                f"/{context['task_instance'].task_id}"
-                f"/{context['task_instance']._try_number}"
-                f"{dirpath.split(project_dir)[-1]}/{filename}"
-            )
-            hook.load_file(
-                file_path=f"{dirpath}/{filename}",
-                container_name=container_name,
-                blob_name=blob_name,
-                overwrite=True,
-            )
+    # Airflow 3 and Airflow 2 compatibility, respectively:
+    try_number = getattr(context["task_instance"], "try_number") or getattr(context["task_instance"], "_try_number")
+
+    run_prefix = (
+        f"{context['dag'].dag_id}"
+        f"/{context['run_id']}"
+        f"/{context['task_instance'].task_id}"
+        f"/{try_number}"
+    )
+
+    if use_tarball:
+        buf = io.BytesIO()
+        with tarfile.open(fileobj=buf, mode="w:gz") as tar:
+            tar.add(target_dir, arcname=source_subpath)
+        buf.seek(0)
+        hook.upload(
+            container_name=container_name,
+            blob_name=f"{run_prefix}/{source_subpath}.tar.gz",
+            data=buf,
+            overwrite=True,
+        )
+    else:
+        # Iterate over the files in the target dir and upload them to WASB container
+        for dirpath, _, filenames in os.walk(target_dir):
+            for filename in filenames:
+                blob_name = f"{run_prefix}{dirpath.split(project_dir)[-1]}/{filename}"
+                hook.load_file(
+                    file_path=f"{dirpath}/{filename}",
+                    container_name=container_name,
+                    blob_name=blob_name,
+                    overwrite=True,
+                )
 
 
 def _configure_remote_target_path() -> tuple[Path | ObjectStoragePath, str] | tuple[None, None]:

--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -48,10 +48,7 @@ def upload_to_aws_s3(
     try_number = getattr(context["task_instance"], "try_number") or getattr(context["task_instance"], "_try_number")
 
     run_prefix = (
-        f"{context['dag'].dag_id}"
-        f"/{context['run_id']}"
-        f"/{context['task_instance'].task_id}"
-        f"/{try_number}"
+        f"{context['dag'].dag_id}" f"/{context['run_id']}" f"/{context['task_instance'].task_id}" f"/{try_number}"
     )
 
     if use_tarball:
@@ -160,10 +157,7 @@ def upload_to_azure_wasb(
     try_number = getattr(context["task_instance"], "try_number") or getattr(context["task_instance"], "_try_number")
 
     run_prefix = (
-        f"{context['dag'].dag_id}"
-        f"/{context['run_id']}"
-        f"/{context['task_instance'].task_id}"
-        f"/{try_number}"
+        f"{context['dag'].dag_id}" f"/{context['run_id']}" f"/{context['task_instance'].task_id}" f"/{try_number}"
     )
 
     if use_tarball:

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -30,16 +30,44 @@ def dummy_kwargs():
     }
 
 
-def test_upload_artifacts_to_aws_s3(dummy_kwargs):
-    """Test upload_artifacts_to_aws_s3."""
-    with patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook, patch("os.walk") as mock_walk:
-        mock_walk.return_value = [("/target", [], ["file1.txt", "file2.txt"])]
+def test_upload_artifacts_to_aws_s3_no_tarball(dummy_kwargs):
+    """Test upload_to_aws_s3 with use_tarball=False."""
+    with (
+        patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook,
+        patch("os.walk") as mock_walk,
+        patch("tarfile.open") as mock_tarfile_open,
+    ):
+        mock_walk.return_value = [("/project_dir/target", [], ["file1.txt", "file2.txt"])]
 
-        upload_to_aws_s3("/project_dir", **dummy_kwargs)
+        upload_to_aws_s3("/project_dir", use_tarball=False, **dummy_kwargs)
 
         mock_walk.assert_called_once_with("/project_dir/target")
+        mock_tarfile_open.assert_not_called()
         hook_instance = mock_hook.return_value
         assert hook_instance.load_file.call_count == 2
+        load_file_calls = hook_instance.load_file.call_args_list
+        assert load_file_calls[0].kwargs["key"] == "test_dag/test_run_id/test_task/1/target/file1.txt"
+        assert load_file_calls[1].kwargs["key"] == "test_dag/test_run_id/test_task/1/target/file2.txt"
+
+
+def test_upload_artifacts_to_aws_s3_tarball(dummy_kwargs):
+    """Test upload_to_aws_s3 with use_tarball=True."""
+    with (
+        patch("airflow.providers.amazon.aws.hooks.s3.S3Hook") as mock_hook,
+        patch("tarfile.open") as mock_tarfile_open,
+    ):
+        mock_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_tar
+
+        upload_to_aws_s3("/project_dir", use_tarball=True, **dummy_kwargs)
+
+        mock_tar.add.assert_called_once_with("/project_dir/target", arcname="target")
+        hook_instance = mock_hook.return_value
+        hook_instance.load_bytes.assert_called_once()
+        call_kwargs = hook_instance.load_bytes.call_args.kwargs
+        assert call_kwargs["key"] == "test_dag/test_run_id/test_task/1/target.tar.gz"
+        assert "bytes_data" in call_kwargs
+        hook_instance.load_file.assert_not_called()
 
 
 def test_upload_artifacts_to_gcp_gs_no_tarball(dummy_kwargs):
@@ -83,16 +111,44 @@ def test_upload_artifacts_to_gcp_gs_tarball(dummy_kwargs):
         assert "filename" not in call_kwargs
 
 
-def test_upload_artifacts_to_azure_wasb(dummy_kwargs):
-    """Test upload_artifacts_to_azure_wasb."""
-    with patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook") as mock_hook, patch("os.walk") as mock_walk:
-        mock_walk.return_value = [("/target", [], ["file1.txt", "file2.txt"])]
+def test_upload_artifacts_to_azure_wasb_no_tarball(dummy_kwargs):
+    """Test upload_to_azure_wasb with use_tarball=False."""
+    with (
+        patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook") as mock_hook,
+        patch("os.walk") as mock_walk,
+        patch("tarfile.open") as mock_tarfile_open,
+    ):
+        mock_walk.return_value = [("/project_dir/target", [], ["file1.txt", "file2.txt"])]
 
-        upload_to_azure_wasb("/project_dir", **dummy_kwargs)
+        upload_to_azure_wasb("/project_dir", use_tarball=False, **dummy_kwargs)
 
         mock_walk.assert_called_once_with("/project_dir/target")
+        mock_tarfile_open.assert_not_called()
         hook_instance = mock_hook.return_value
         assert hook_instance.load_file.call_count == 2
+        load_file_calls = hook_instance.load_file.call_args_list
+        assert load_file_calls[0].kwargs["blob_name"] == "test_dag/test_run_id/test_task/1/target/file1.txt"
+        assert load_file_calls[1].kwargs["blob_name"] == "test_dag/test_run_id/test_task/1/target/file2.txt"
+
+
+def test_upload_artifacts_to_azure_wasb_tarball(dummy_kwargs):
+    """Test upload_to_azure_wasb with use_tarball=True."""
+    with (
+        patch("airflow.providers.microsoft.azure.hooks.wasb.WasbHook") as mock_hook,
+        patch("tarfile.open") as mock_tarfile_open,
+    ):
+        mock_tar = MagicMock()
+        mock_tarfile_open.return_value.__enter__.return_value = mock_tar
+
+        upload_to_azure_wasb("/project_dir", use_tarball=True, **dummy_kwargs)
+
+        mock_tar.add.assert_called_once_with("/project_dir/target", arcname="target")
+        hook_instance = mock_hook.return_value
+        hook_instance.upload.assert_called_once()
+        call_kwargs = hook_instance.upload.call_args.kwargs
+        assert call_kwargs["blob_name"] == "test_dag/test_run_id/test_task/1/target.tar.gz"
+        assert "data" in call_kwargs
+        hook_instance.load_file.assert_not_called()
 
 
 @patch("cosmos.io.settings.remote_target_path", None)


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

Related to PR #2497, this extends the ability to add all artifacts to a tarball to the upload functions for both aws and azure.

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

No breaking changes anticipated. Should be silent for all present implementations, as the additional parameter is optional and the current behavior is preserved.

## Checklist

- [] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
