### PR TITLE
Fix incorrectly skipped source downstream tasks in the watcher

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -89,7 +89,7 @@ def _default_freshness_callback(
     # DFS from each stale source.  A dependent is added to the skip set only when every entry in
     # its depends_on is either a known-stale source or already in the skip set.  This preserves
     # nodes that have at least one clean upstream path: they may succeed and should not be
-    # pre-emptively excluded.  When a new node is added to visited its own dependents are queued
+    # preemptively excluded.  When a new node is added to visited its own dependents are queued
     # so they can be re-evaluated with the updated skip set.
     _excludable_resource_types = {DbtResourceType.MODEL, DbtResourceType.SEED, DbtResourceType.SNAPSHOT}
     visited: set[str] = set()

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -99,10 +99,10 @@ def _default_freshness_callback(
         for dependent_id in dependents.get(current, set()):
             if dependent_id in visited:
                 continue
-            node = nodes.get(dependent_id)
-            if node is None:
+            dependent_node = nodes.get(dependent_id)
+            if dependent_node is None:
                 continue
-            if all(dep in stale_source_ids or dep in visited for dep in node.depends_on):
+            if all(dep in stale_source_ids or dep in visited for dep in dependent_node.depends_on):
                 visited.add(dependent_id)
                 queue.append(dependent_id)
 

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -62,10 +62,16 @@ def _default_freshness_callback(
     nodes: dict[str, DbtNode] | None,
     sources_json: dict[str, Any] | None,
 ) -> tuple[list[str], str]:
-    """Return unique_ids of all nodes that transitively depend on a stale source, plus the status ``"skip"``.
+    """Return unique_ids of nodes that must be skipped due to stale sources, plus the status ``"skip"``.
 
     Stale sources are those with ``status`` of ``"error"`` or ``"warn"`` in ``sources_json["results"]``.
-    Traversal is DFS over the reverse-dependency graph built from ``nodes``.
+
+    A node is skipped only when **all** of its upstream dependencies are either stale sources or
+    already-skipped nodes.  If a node has at least one clean upstream path it may still execute
+    successfully — for example when a model depends on both a stale source and a clean model — so
+    it is excluded from the skip set and allowed to run.
+
+    Traversal is a DFS over the reverse-dependency graph built from ``nodes``.
     """
     if not nodes or not sources_json:
         return [], "skip"
@@ -80,14 +86,23 @@ def _default_freshness_callback(
         for dep_id in node.depends_on:
             dependents.setdefault(dep_id, set()).add(node_id)
 
-    # DFS from each stale source to collect all transitive dependents
+    # DFS from each stale source.  A dependent is added to the skip set only when every entry in
+    # its depends_on is either a known-stale source or already in the skip set.  This preserves
+    # nodes that have at least one clean upstream path: they may succeed and should not be
+    # pre-emptively excluded.  When a new node is added to visited its own dependents are queued
+    # so they can be re-evaluated with the updated skip set.
     _excludable_resource_types = {DbtResourceType.MODEL, DbtResourceType.SEED, DbtResourceType.SNAPSHOT}
     visited: set[str] = set()
     queue = list(stale_source_ids)
     while queue:
         current = queue.pop()
         for dependent_id in dependents.get(current, set()):
-            if dependent_id not in visited:
+            if dependent_id in visited:
+                continue
+            node = nodes.get(dependent_id)
+            if node is None:
+                continue
+            if all(dep in stale_source_ids or dep in visited for dep in node.depends_on):
                 visited.add(dependent_id)
                 queue.append(dependent_id)
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2169,6 +2169,92 @@ class TestDefaultFreshnessCallback:
         assert set(node_ids) == {"model.pkg.A", "model.pkg.B", "model.pkg.C", "model.pkg.D"}
         assert status == "skip"
 
+    def test_already_visited_dependent_not_processed_twice(self):
+        """A dependent reachable via two stale paths is only processed once.
+
+        Graph:  stale_src → A
+                stale_src → B
+                A, B → C
+
+        A and B are both direct dependents of stale_src.  C depends on both A and B.
+        When A is processed, C is added to visited.  When B is then processed, C is
+        already in visited → the ``if dependent_id in visited: continue`` branch fires.
+        All three (A, B, C) must still appear in the skip set.
+        """
+        from cosmos.constants import DbtResourceType
+        from cosmos.dbt.graph import DbtNode
+
+        nodes = {
+            "model.pkg.A": DbtNode(
+                unique_id="model.pkg.A",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/a.sql"),
+            ),
+            "model.pkg.B": DbtNode(
+                unique_id="model.pkg.B",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/b.sql"),
+            ),
+            "model.pkg.C": DbtNode(
+                unique_id="model.pkg.C",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["model.pkg.A", "model.pkg.B"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/c.sql"),
+            ),
+        }
+        sources_json = {"results": [{"unique_id": "source.pkg.stale_src", "status": "error"}]}
+        node_ids, status = _default_freshness_callback(
+            context=MagicMock(), dag=None, task_group=None, nodes=nodes, sources_json=sources_json
+        )
+        assert set(node_ids) == {"model.pkg.A", "model.pkg.B", "model.pkg.C"}
+        assert status == "skip"
+
+    def test_dependent_node_missing_from_nodes_is_skipped(self):
+        """A dependent_id whose node cannot be resolved via ``nodes.get`` is silently ignored.
+
+        This covers the ``if dependent_node is None: continue`` guard.  In normal operation the
+        dependents reverse-map is built from ``nodes.items()`` so every id is present; this test
+        simulates a lookup returning ``None`` (e.g. a corrupt or trimmed nodes dict) by using a
+        dict subclass that overrides ``get`` to return ``None`` for the nominated key.
+        """
+        from cosmos.constants import DbtResourceType
+        from cosmos.dbt.graph import DbtNode
+
+        class _NullOnGet(dict):  # type: ignore[type-arg]
+            """dict that returns None for keys listed in ``_null_keys``."""
+
+            def __init__(self, null_keys: set, *args, **kwargs):  # type: ignore[type-arg]
+                super().__init__(*args, **kwargs)
+                self._null_keys = null_keys
+
+            def get(self, key, default=None):  # type: ignore[override]
+                if key in self._null_keys:
+                    return None
+                return super().get(key, default)
+
+        raw_nodes = {
+            "model.pkg.A": DbtNode(
+                unique_id="model.pkg.A",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/a.sql"),
+            ),
+        }
+        # nodes.get("model.pkg.A") will return None → the node is silently skipped
+        nodes = _NullOnGet({"model.pkg.A"}, raw_nodes)
+        sources_json = {"results": [{"unique_id": "source.pkg.stale_src", "status": "error"}]}
+        node_ids, status = _default_freshness_callback(
+            context=MagicMock(), dag=None, task_group=None, nodes=nodes, sources_json=sources_json
+        )
+        assert node_ids == []
+        assert status == "skip"
+
 
 class TestProducerSourceFreshness:
     """Tests for source freshness methods on DbtProducerWatcherOperator."""

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2073,6 +2073,102 @@ class TestDefaultFreshnessCallback:
         assert node_ids == ["model.pkg.m1"]
         assert status == "skip"
 
+    def test_node_with_clean_upstream_not_skipped(self):
+        """A node that depends on both a stale source and a clean model should not be skipped.
+
+        Graph:  stale_src → A ← clean_model
+                              ↓
+                              C
+
+        A has a clean path via clean_model so A (and therefore C) should run.
+        """
+        from cosmos.constants import DbtResourceType
+        from cosmos.dbt.graph import DbtNode
+
+        nodes = {
+            "model.pkg.clean_model": DbtNode(
+                unique_id="model.pkg.clean_model",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=[],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/clean.sql"),
+            ),
+            "model.pkg.A": DbtNode(
+                unique_id="model.pkg.A",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src", "model.pkg.clean_model"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/a.sql"),
+            ),
+            "model.pkg.C": DbtNode(
+                unique_id="model.pkg.C",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["model.pkg.A"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/c.sql"),
+            ),
+        }
+        sources_json = {"results": [{"unique_id": "source.pkg.stale_src", "status": "warn"}]}
+        node_ids, status = _default_freshness_callback(
+            context=MagicMock(), dag=None, task_group=None, nodes=nodes, sources_json=sources_json
+        )
+        # A has a clean path via clean_model → neither A nor C should be skipped
+        assert node_ids == []
+        assert status == "skip"
+
+    def test_node_skipped_only_when_all_upstreams_stale(self):
+        """A node whose every upstream is stale or already skipped must be skipped.
+
+        Graph:  stale_src1 → A
+                stale_src2 → B
+                             A, B → C   (both parents stale → C must be skipped)
+                             A    → D   (only A stale, but A has no clean path → D skipped)
+        """
+        from cosmos.constants import DbtResourceType
+        from cosmos.dbt.graph import DbtNode
+
+        nodes = {
+            "model.pkg.A": DbtNode(
+                unique_id="model.pkg.A",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src1"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/a.sql"),
+            ),
+            "model.pkg.B": DbtNode(
+                unique_id="model.pkg.B",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["source.pkg.stale_src2"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/b.sql"),
+            ),
+            "model.pkg.C": DbtNode(
+                unique_id="model.pkg.C",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["model.pkg.A", "model.pkg.B"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/c.sql"),
+            ),
+            "model.pkg.D": DbtNode(
+                unique_id="model.pkg.D",
+                resource_type=DbtResourceType.MODEL,
+                depends_on=["model.pkg.A"],
+                path_base=Path("/tmp"),
+                original_file_path=Path("models/d.sql"),
+            ),
+        }
+        sources_json = {
+            "results": [
+                {"unique_id": "source.pkg.stale_src1", "status": "error"},
+                {"unique_id": "source.pkg.stale_src2", "status": "error"},
+            ]
+        }
+        node_ids, status = _default_freshness_callback(
+            context=MagicMock(), dag=None, task_group=None, nodes=nodes, sources_json=sources_json
+        )
+        assert set(node_ids) == {"model.pkg.A", "model.pkg.B", "model.pkg.C", "model.pkg.D"}
+        assert status == "skip"
+
 
 class TestProducerSourceFreshness:
     """Tests for source freshness methods on DbtProducerWatcherOperator."""


### PR DESCRIPTION
The DFS previously marked every transitive dependent of a stale source as skip, regardless of whether the node had additional clean upstream paths that would allow it to succeed.

For example, a model that depends on both a stale source and a clean upstream model was pre-emptively excluded even though dbt would have run it successfully (especially for warn-status sources where dbt continues execution normally).

A node is now added to the skip set only when all of its depends_on entries are either known-stale sources or already-skipped nodes. Nodes with at least one clean upstream path are left out of the skip set and allowed to run. The DFS still re-evaluates each candidate when a new node joins the skip set, so purely stale chains are handled correctly.

closes: https://github.com/astronomer/astronomer-cosmos/issues/2536