### PR TITLE
Fix duplicate logs in dbt build when source freshness is enabled

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -212,9 +212,21 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         When a callback is registered, dbt's stdout is redirected to a null buffer so that the
         raw ``--log-format json`` lines do not appear in Airflow task logs alongside the
         human-readable messages already emitted by ``_log_dbt_msg`` inside the callback.
+
+        The callback is intentionally **not** registered during the source freshness pre-check
+        (``context["_check_source_freshness"] is True``).  Registering it there would leave a
+        stale entry in ``_dbt_runner_callbacks`` that fires again for every event during the
+        subsequent ``dbt build``, producing duplicate log lines.  Freshness results are read from
+        ``target/sources.json`` after the run and do not need per-event XCom pushes.
         """
         context = kwargs.get("context")
         if context is not None:
+            # During the source freshness pre-check suppress raw JSON stdout, but do not register
+            # the XCom-pushing callback so it cannot accumulate and duplicate build logs later.
+            if context.get("_check_source_freshness"):
+                with contextlib.redirect_stdout(_NullWriter()):
+                    return super().run_dbt_runner(command, env, cwd, **kwargs)
+
             extra_kwargs: dict[str, Any] = {"project_dir": cwd, "context": context}
             parse = self._make_parse_callable()
             # Collect callback errors rather than raising inside the callback: dbt catches

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2133,3 +2133,25 @@ class TestProducerSourceFreshness:
         producer._skipped_node_token(context, [])
         ti.xcom_push.assert_not_called()
         assert producer.exclude is None
+
+    def test_run_dbt_runner_skips_callback_during_source_freshness(self):
+        """run_dbt_runner must not register the XCom-pushing callback during the source freshness
+        pre-check.  Registering it would leave a stale entry in _dbt_runner_callbacks that fires
+        again for every event during the subsequent dbt build, producing duplicate log lines.
+        """
+        producer = self._make_producer(_check_source_freshness=True)
+        producer._dbt_runner_callbacks = None
+
+        context = MagicMock()
+        context.get.side_effect = lambda key, default=None: True if key == "_check_source_freshness" else default
+
+        with patch.object(
+            type(producer).__bases__[1],  # DbtLocalBaseOperator
+            "run_dbt_runner",
+            return_value=MagicMock(),
+        ) as mock_super:
+            producer.run_dbt_runner(command=["dbt", "source", "freshness"], env={}, cwd="/tmp", context=context)
+
+        # The callback list must remain untouched — no watcher callback appended
+        assert producer._dbt_runner_callbacks is None
+        mock_super.assert_called_once()

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2145,8 +2145,10 @@ class TestProducerSourceFreshness:
         context = MagicMock()
         context.get.side_effect = lambda key, default=None: True if key == "_check_source_freshness" else default
 
+        from cosmos.operators.local import DbtLocalBaseOperator
+
         with patch.object(
-            type(producer).__bases__[1],  # DbtLocalBaseOperator
+            DbtLocalBaseOperator,
             "run_dbt_runner",
             return_value=MagicMock(),
         ) as mock_super:


### PR DESCRIPTION
In DBT_RUNNER mode, run_dbt_runner appended a new XCom-pushing callback to _dbt_runner_callbacks on every invocation. When source rendering is enabled the producer runs dbt source freshness first (via _run_source_freshness), registering a freshness callback, then runs dbt build which appended a second callback. Both callbacks fired for every event during the build, printing each log line twice.

Fix: skip callback registration when context["_check_source_freshness"] is True. The freshness run's results are captured from target/sources.json afterwards and do not need per-event XCom pushes. Raw JSON stdout is still suppressed via _NullWriter for both paths.

Logs Before changes
<img width="1713" height="968" alt="Screenshot 2026-04-16 at 4 18 00 PM" src="https://github.com/user-attachments/assets/ac24003d-97b6-4164-b659-177c01b779b1" />

Logs After changes
<img width="1680" height="1009" alt="Screenshot 2026-04-16 at 4 18 55 PM" src="https://github.com/user-attachments/assets/3b5fcb31-ff34-4059-93a8-674c5520c1bb" />


closes: https://github.com/astronomer/astronomer-cosmos/issues/2558