### PR TITLE
Remove Authorize gate from CI jobs that don't use secrets

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -740,7 +740,7 @@ jobs:
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
   Run-Kubernetes-Tests:
-    needs: Check-changed-files
+    needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -785,6 +785,7 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: test
 on:
   push: # Run on pushes to the default branch
     branches: [main]
-  # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
-  # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
-  # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.
+  # Also run on pull requests originating from forks. Jobs that require secrets (integration tests, code coverage)
+  # depend on the Authorize job, which requires manually approving the workflow run for external PRs. Jobs that do not
+  # use secrets (type-check, unit tests, performance, telemetry, kubernetes) run without approval.
   pull_request_target:
     branches: [main] # zizmor: ignore[dangerous-triggers]
 
@@ -29,7 +29,6 @@ jobs:
 
   # Skip unit/integration tests when only non-code files changed (Type-Check still runs).
   Check-changed-files:
-    needs: Authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -104,7 +103,6 @@ jobs:
           echo "code_changed=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
 
   Type-Check:
-    needs: Authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -123,7 +121,7 @@ jobs:
       - run: hatch run tests.py3.10-3.1-1.9:type-check
 
   Run-Unit-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -617,7 +615,7 @@ jobs:
 
 
   Run-Telemetry-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -666,7 +664,7 @@ jobs:
           include-hidden-files: true
 
   Run-Performance-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -742,7 +740,7 @@ jobs:
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
   Run-Kubernetes-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -787,9 +785,6 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
-          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
-          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
@@ -803,8 +798,6 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,10 @@ name: test
 on:
   push: # Run on pushes to the default branch
     branches: [main, security-approvals]
-  # Also run on pull requests originating from forks. Jobs that require secrets (integration tests, code coverage)
-  # depend on the Authorize job, which requires manually approving the workflow run for external PRs. Jobs that do not
-  # use secrets (type-check, unit tests, performance, telemetry, kubernetes) run without approval.
+  # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
+  # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
+  # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run
+  # without approval.
   pull_request_target:
     branches: [main] # zizmor: ignore[dangerous-triggers]
 
@@ -148,7 +149,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache@v5
+      - if: github.event_name == 'push'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - if: github.event_name != 'push'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -634,7 +644,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - if: github.event_name == 'push'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: telemetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - if: github.event_name != 'push'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -694,7 +713,16 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache@v5
+      - if: github.event_name == 'push'
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: perf-test-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - if: github.event_name != 'push'
+        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,9 +3,9 @@ name: test
 on:
   push: # Run on pushes to the default branch
     branches: [main]
-  # Also run on pull requests originating from forks. Although this is insecure by default, we need it to run
-  # integration tests on forked PRs. As a guardrail, we’ve added an Authorize step to each job, which requires manually
-  # approving the workflow run for each pushed commit. Approval only happens after a careful code review of the changes.
+  # Also run on pull requests originating from forks. Jobs that require secrets (integration tests, code coverage)
+  # depend on the Authorize job, which requires manually approving the workflow run for external PRs. Jobs that do not
+  # use secrets (type-check, unit tests, performance, telemetry, kubernetes) run without approval.
   pull_request_target:
     branches: [main] # zizmor: ignore[dangerous-triggers]
 
@@ -29,7 +29,6 @@ jobs:
 
   # Skip unit/integration tests when only non-code files changed (Type-Check still runs).
   Check-changed-files:
-    needs: Authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -103,7 +102,6 @@ jobs:
           echo "code_changed=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
 
   Type-Check:
-    needs: Authorize
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -122,7 +120,7 @@ jobs:
       - run: hatch run tests.py3.10-3.1-1.9:type-check
 
   Run-Unit-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -614,7 +612,7 @@ jobs:
 
 
   Run-Telemetry-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -663,7 +661,7 @@ jobs:
           include-hidden-files: true
 
   Run-Performance-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -739,7 +737,7 @@ jobs:
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
   Run-Kubernetes-Tests:
-    needs: [Authorize, Check-changed-files]
+    needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -784,9 +782,6 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
-          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
-          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
@@ -800,8 +795,6 @@ jobs:
           POSTGRES_DB: postgres
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
-          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
       - name: Upload coverage to Github
         uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -737,7 +737,7 @@ jobs:
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
 
   Run-Kubernetes-Tests:
-    needs: Check-changed-files
+    needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     permissions:
@@ -782,6 +782,7 @@ jobs:
         env:
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, security-approvals]
+    branches: [main]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -149,16 +149,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - if: github.event_name == 'push'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - if: github.event_name != 'push'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -644,16 +635,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - if: github.event_name == 'push'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: telemetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - if: github.event_name != 'push'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -713,16 +695,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - if: github.event_name == 'push'
-        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: perf-test-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - if: github.event_name != 'push'
-        uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, security-approvals]
   # Also run on pull requests originating from forks. Jobs that require secrets (integration tests, code coverage)
   # depend on the Authorize job, which requires manually approving the workflow run for external PRs. Jobs that do not
   # use secrets (type-check, unit tests, performance, telemetry, kubernetes) run without approval.


### PR DESCRIPTION
Jobs that don't reference cloud secrets (Check-changed-files, Type-Check, Unit Tests, Performance, Telemetry) no longer wait for manual approval on fork PRs. This lets external contributors get faster feedback while still gating integration tests that use AWS, GCP, Azure, and Snowflake credentials.

Also removes unused GCP/Azure connection secrets and remote target path config from the Kubernetes test job.

related: #1021 