### PR TITLE
Add allow-list of allowed operator names from dbt metadata

### DIFF
--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -22,6 +22,13 @@ from cosmos.log import get_logger
 logger = get_logger(__name__)
 
 
+ALLOWED_OPERATOR_MODULE_PREFIXES = (
+    "cosmos.operators.",
+    "airflow.operators.",
+    "airflow.providers.",
+)
+
+
 def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) -> BaseOperator:
     """
     Get the Airflow Operator class for a Task.
@@ -35,7 +42,14 @@ def get_airflow_task(task: Task, dag: DAG, task_group: TaskGroup | None = None) 
     """
     # first, import the operator class from the
     # fully qualified name defined in the task
-    module_name, class_name = task.operator_class.rsplit(".", 1)
+    try:
+        module_name, class_name = task.operator_class.rsplit(".", 1)
+    except ValueError as err:
+        raise ValueError(f"Invalid operator class path: {task.operator_class}") from err
+
+    if not module_name.startswith(ALLOWED_OPERATOR_MODULE_PREFIXES):
+        raise ValueError(f"Unsupported operator module: {module_name}")
+
     Operator = load_method_from_module(module_name, class_name)
 
     task_kwargs = task.arguments


### PR DESCRIPTION
## Summary

Security: Dynamic operator import from task metadata can enable arbitrary code execution

## Problem

**Severity**: `High` | **File**: `cosmos/core/airflow.py:L36`

The DAG builder dynamically imports and instantiates an operator class using `task.operator_class` (`module.class`) without enforcing an allowlist. If `task.operator_class` is influenced by untrusted dbt metadata/config, an attacker could cause import of unintended modules/classes and execute arbitrary code during DAG parsing/execution.

## Solution

Treat `task.operator_class` as untrusted input. Enforce a strict allowlist of permitted operator module prefixes/classes (e.g., known Cosmos/Airflow operators), reject anything else, and consider mapping symbolic task types to internal classes instead of importing arbitrary module paths.

## Changes

- `cosmos/core/airflow.py` (modified)