### PR TITLE
Warn and normalize when source_rendering_behavior=None is passed

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -118,6 +118,14 @@ class RenderConfig:
                 "RenderConfig.dbt_deps is deprecated since Cosmos 1.9 and will be removed in Cosmos 2.0. Use ProjectConfig.install_dbt_deps instead.",
                 DeprecationWarning,
             )
+        if self.source_rendering_behavior is None:
+            warnings.warn(
+                "Passing None for source_rendering_behavior is not supported. "
+                "Use SourceRenderingBehavior.NONE to disable source rendering. "
+                "Defaulting to SourceRenderingBehavior.NONE.",
+                UserWarning,
+            )
+            self.source_rendering_behavior = SourceRenderingBehavior.NONE
         self.project_path = Path(dbt_project_path) if dbt_project_path else None
         # allows us to initiate this attribute from Path objects and str
         self.dbt_ls_path = Path(self.dbt_ls_path) if self.dbt_ls_path else None

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -5,7 +5,7 @@ from unittest.mock import Mock, PropertyMock, call, patch
 import pytest
 
 from cosmos.config import CosmosConfigException, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import ExecutionMode, InvocationMode
+from cosmos.constants import ExecutionMode, InvocationMode, SourceRenderingBehavior
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.athena.access_key import AthenaAccessKeyProfileMapping
 from cosmos.profiles.postgres.user_pass import PostgresUserPasswordProfileMapping
@@ -269,6 +269,13 @@ def test_render_config_env_vars_deprecated():
     """RenderConfig.env_vars is deprecated since Cosmos 1.3, should warn user."""
     with pytest.deprecated_call():
         RenderConfig(env_vars={"VAR": "value"})
+
+
+def test_render_config_source_rendering_behavior_none_warns_and_normalizes():
+    """Passing None for source_rendering_behavior should warn and default to SourceRenderingBehavior.NONE."""
+    with pytest.warns(UserWarning, match="Passing None for source_rendering_behavior is not supported"):
+        config = RenderConfig(source_rendering_behavior=None)
+    assert config.source_rendering_behavior == SourceRenderingBehavior.NONE
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Python does not enforce type annotations at runtime, so passing None for source_rendering_behavior bypasses the SourceRenderingBehavior.NONE default, causing sources to be rendered incorrectly and an AttributeError in converter.py when .value is called on None.

Add a guard in RenderConfig.__post_init__ that issues a UserWarning and normalizes None to SourceRenderingBehavior.NONE, consistent with the existing deprecation warning pattern in __post_init__.

DAG
```python
example_watcher = DbtDag(
    # dbt/cosmos-specific parameters
    execution_config=ExecutionConfig(
        execution_mode=ExecutionMode.WATCHER,
    ),
    project_config=ProjectConfig(jaffle_shop_path),
    render_config=RenderConfig(source_rendering_behavior=None), 
    profile_config=default_profile,
    # normal dag parameters
    schedule="@daily",
    start_date=datetime(2023, 1, 1),
    catchup=False,
    dag_id="example_watcher",
    default_args={"retries": 0},
    operator_args={
        "dbt_cmd_flags": ["--log-level", "debug"],
    },
)
```

Before change DAG topology 
<img width="1689" height="992" alt="Screenshot 2026-04-17 at 1 42 49 AM" src="https://github.com/user-attachments/assets/0e828278-6aa6-4acd-8711-b926b72e13d7" />

After Change DAG topology 
<img width="1680" height="1001" alt="Screenshot 2026-04-17 at 1 41 10 AM" src="https://github.com/user-attachments/assets/7bff4615-5a90-48bc-94ed-a95129a1f322" />

closes: https://github.com/astronomer/astronomer-cosmos/issues/2568