### PR TITLE
Gracefully handle `Variable.set()` failures on Astro Remote Execution

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -566,21 +566,24 @@ class DbtGraph:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
             return
 
+        is_yaml_cache = "yaml" in cache_name.lower()
         disable_cache_env_var = (
             "AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS"
-            if "yaml" in cache_name.lower()
+            if is_yaml_cache
             else "AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS"
         )
+        cache_specific_workaround = "" if is_yaml_cache else ", using LoadMode.DBT_MANIFEST"
         try:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
         except AirflowRuntimeError as e:
             logger.warning(
                 "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
-                "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching, "
-                "using LoadMode.DBT_MANIFEST, or disabling the cache via %s.",
+                "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching%s, "
+                "or disabling the cache via %s.",
                 cache_name,
                 self.cache_key,
                 e,
+                cache_specific_workaround,
                 disable_cache_env_var,
             )
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -556,9 +556,9 @@ class DbtGraph:
     def _save_cache_to_variable(self, cache_dict: dict[str, Any], cache_name: str) -> None:
         """Write cache_dict to an Airflow Variable, warning on AirflowRuntimeError.
 
-        This failure is expected when running with Astro Remote Execution (where workers
-        do not have direct access to the Airflow metadata database), and is not expected
-        in other deployments such as Astro Executor.
+        This failure can be expected in DAG parsing environments where the scheduler or
+        DAG processor does not have direct access to a usable Airflow metadata database
+        (for example, when the ``variable`` table is unavailable).
         """
         try:
             from airflow.sdk.exceptions import AirflowRuntimeError
@@ -566,16 +566,22 @@ class DbtGraph:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
             return
 
+        disable_cache_env_var = (
+            "AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS"
+            if "yaml" in cache_name.lower()
+            else "AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS"
+        )
         try:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
         except AirflowRuntimeError as e:
             logger.warning(
                 "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
                 "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching, "
-                "using LoadMode.MANIFEST, or disabling the cache via AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS.",
+                "using LoadMode.DBT_MANIFEST, or disabling the cache via %s.",
                 cache_name,
                 self.cache_key,
                 e,
+                disable_cache_env_var,
             )
 
     def save_dbt_ls_cache(self, dbt_ls_output: str) -> None:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -553,6 +553,24 @@ class DbtGraph:
         logger.debug(f"Value of `dbt_yaml_selectors_cache_key` for <{self.cache_key}>: {cache_args}")
         return cache_args
 
+    def _save_cache_to_variable(self, cache_dict: dict[str, Any], cache_name: str) -> None:
+        """Write cache_dict to an Airflow Variable, warning on AirflowRuntimeError (Airflow 3 Task SDK only)."""
+        try:
+            from airflow.sdk.exceptions import AirflowRuntimeError
+        except ImportError:
+            Variable.set(self.cache_key, cache_dict, serialize_json=True)
+        else:
+            try:
+                Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            except AirflowRuntimeError as e:
+                logger.warning(
+                    "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
+                    "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
+                    cache_name,
+                    self.cache_key,
+                    e,
+                )
+
     def save_dbt_ls_cache(self, dbt_ls_output: str) -> None:
         """
         Store compressed dbt ls output into an Airflow Variable.
@@ -582,25 +600,7 @@ class DbtGraph:
             with remote_cache_key_path.open("w") as fp:
                 json.dump(cache_dict, fp)
         else:
-            variable_set_exceptions: list[type[BaseException]] = []
-            try:
-                from airflow.sdk.exceptions import AirflowRuntimeError
-
-                variable_set_exceptions.append(AirflowRuntimeError)
-            except ImportError:
-                pass
-            if variable_set_exceptions:
-                try:
-                    Variable.set(self.cache_key, cache_dict, serialize_json=True)
-                except tuple(variable_set_exceptions) as e:
-                    logger.warning(
-                        "Failed to save Cosmos dbt ls cache to Airflow Variable '%s': %s. "
-                        "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
-                        self.cache_key,
-                        e,
-                    )
-            else:
-                Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            self._save_cache_to_variable(cache_dict, "dbt ls")
 
     def _get_dbt_ls_remote_cache(self, remote_cache_dir: Path | ObjectStoragePath) -> dict[str, str]:
         """Loads the remote cache for dbt ls."""
@@ -1122,25 +1122,7 @@ class DbtGraph:
             with remote_cache_key_path.open("w") as fp:
                 json.dump(cache_dict, fp)
         else:
-            variable_set_exceptions: list[type[BaseException]] = []
-            try:
-                from airflow.sdk.exceptions import AirflowRuntimeError
-
-                variable_set_exceptions.append(AirflowRuntimeError)
-            except ImportError:
-                pass
-            if variable_set_exceptions:
-                try:
-                    Variable.set(self.cache_key, cache_dict, serialize_json=True)
-                except tuple(variable_set_exceptions) as e:
-                    logger.warning(
-                        "Failed to save Cosmos YAML selectors cache to Airflow Variable '%s': %s. "
-                        "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
-                        self.cache_key,
-                        e,
-                    )
-            else:
-                Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            self._save_cache_to_variable(cache_dict, "YAML selectors")
 
     def parse_yaml_selectors(self, selector_definitions: dict[str, Any]) -> YamlSelectors:
         """

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -582,7 +582,25 @@ class DbtGraph:
             with remote_cache_key_path.open("w") as fp:
                 json.dump(cache_dict, fp)
         else:
-            Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            variable_set_exceptions: list[type[BaseException]] = []
+            try:
+                from airflow.sdk.exceptions import AirflowRuntimeError
+
+                variable_set_exceptions.append(AirflowRuntimeError)
+            except ImportError:
+                pass
+            if variable_set_exceptions:
+                try:
+                    Variable.set(self.cache_key, cache_dict, serialize_json=True)
+                except tuple(variable_set_exceptions) as e:
+                    logger.warning(
+                        "Failed to save Cosmos dbt ls cache to Airflow Variable '%s': %s. "
+                        "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
+                        self.cache_key,
+                        e,
+                    )
+            else:
+                Variable.set(self.cache_key, cache_dict, serialize_json=True)
 
     def _get_dbt_ls_remote_cache(self, remote_cache_dir: Path | ObjectStoragePath) -> dict[str, str]:
         """Loads the remote cache for dbt ls."""
@@ -1104,7 +1122,25 @@ class DbtGraph:
             with remote_cache_key_path.open("w") as fp:
                 json.dump(cache_dict, fp)
         else:
-            Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            variable_set_exceptions: list[type[BaseException]] = []
+            try:
+                from airflow.sdk.exceptions import AirflowRuntimeError
+
+                variable_set_exceptions.append(AirflowRuntimeError)
+            except ImportError:
+                pass
+            if variable_set_exceptions:
+                try:
+                    Variable.set(self.cache_key, cache_dict, serialize_json=True)
+                except tuple(variable_set_exceptions) as e:
+                    logger.warning(
+                        "Failed to save Cosmos YAML selectors cache to Airflow Variable '%s': %s. "
+                        "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
+                        self.cache_key,
+                        e,
+                    )
+            else:
+                Variable.set(self.cache_key, cache_dict, serialize_json=True)
 
     def parse_yaml_selectors(self, selector_definitions: dict[str, Any]) -> YamlSelectors:
         """

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -554,22 +554,29 @@ class DbtGraph:
         return cache_args
 
     def _save_cache_to_variable(self, cache_dict: dict[str, Any], cache_name: str) -> None:
-        """Write cache_dict to an Airflow Variable, warning on AirflowRuntimeError (Airflow 3 Task SDK only)."""
+        """Write cache_dict to an Airflow Variable, warning on AirflowRuntimeError.
+
+        This failure is expected when running with Astro Remote Execution (where workers
+        do not have direct access to the Airflow metadata database), and is not expected
+        in other deployments such as Astro Executor.
+        """
         try:
             from airflow.sdk.exceptions import AirflowRuntimeError
         except ImportError:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
-        else:
-            try:
-                Variable.set(self.cache_key, cache_dict, serialize_json=True)
-            except AirflowRuntimeError as e:
-                logger.warning(
-                    "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
-                    "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching.",
-                    cache_name,
-                    self.cache_key,
-                    e,
-                )
+            return
+
+        try:
+            Variable.set(self.cache_key, cache_dict, serialize_json=True)
+        except AirflowRuntimeError as e:
+            logger.warning(
+                "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
+                "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching, "
+                "using LoadMode.MANIFEST, or disabling the cache via AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS.",
+                cache_name,
+                self.cache_key,
+                e,
+            )
 
     def save_dbt_ls_cache(self, dbt_ls_output: str) -> None:
         """

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2407,8 +2407,6 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
 @patch("cosmos.dbt.graph.Variable.set")
 def test_save_dbt_ls_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
-    from unittest.mock import MagicMock
-
     from airflow.sdk.exceptions import AirflowRuntimeError
 
     mock_variable_set.side_effect = AirflowRuntimeError(MagicMock())
@@ -2423,8 +2421,6 @@ def test_save_dbt_ls_cache_variable_set_failure(mock_variable_set, tmp_dbt_proje
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
 @patch("cosmos.dbt.graph.Variable.set")
 def test_save_yaml_selectors_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
-    from unittest.mock import MagicMock
-
     from airflow.sdk.exceptions import AirflowRuntimeError
 
     mock_variable_set.side_effect = AirflowRuntimeError(MagicMock())

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2404,6 +2404,38 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         assert hash_dir == "633a523f295ef0cd496525428815537b"
 
 
+@pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
+@patch("cosmos.dbt.graph.Variable.set")
+def test_save_dbt_ls_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from airflow.sdk.exceptions import AirflowRuntimeError
+
+    mock_variable_set.side_effect = AirflowRuntimeError("no such table: variable")
+    graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
+    with caplog.at_level(logging.WARNING, logger="cosmos.dbt.graph"):
+        graph.save_dbt_ls_cache("some output")
+    assert "Failed to save Cosmos dbt ls cache" in caplog.text
+    assert "cosmos_cache__something" in caplog.text
+    assert "AIRFLOW__COSMOS__REMOTE_CACHE_DIR" in caplog.text
+
+
+@pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
+@patch("cosmos.dbt.graph.Variable.set")
+def test_save_yaml_selectors_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from airflow.sdk.exceptions import AirflowRuntimeError
+
+    mock_variable_set.side_effect = AirflowRuntimeError("no such table: variable")
+    graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
+    selectors = YamlSelectors(
+        {"staging_orders": {"name": "staging_orders", "definition": {"method": "tag", "value": "tag_a"}}},
+        {"select": ["tag:tag_a"], "exclude": None},
+    )
+    with caplog.at_level(logging.WARNING, logger="cosmos.dbt.graph"):
+        graph.save_yaml_selectors_cache(selectors)
+    assert "Failed to save Cosmos YAML selectors cache" in caplog.text
+    assert "cosmos_cache__something" in caplog.text
+    assert "AIRFLOW__COSMOS__REMOTE_CACHE_DIR" in caplog.text
+
+
 @pytest.mark.integration
 def test_get_dbt_ls_cache_returns_empty_if_non_json_var(airflow_variable):
     graph = DbtGraph(project=ProjectConfig())

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2407,9 +2407,11 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
 @patch("cosmos.dbt.graph.Variable.set")
 def test_save_dbt_ls_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from unittest.mock import MagicMock
+
     from airflow.sdk.exceptions import AirflowRuntimeError
 
-    mock_variable_set.side_effect = AirflowRuntimeError("no such table: variable")
+    mock_variable_set.side_effect = AirflowRuntimeError(MagicMock())
     graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
     with caplog.at_level(logging.WARNING, logger="cosmos.dbt.graph"):
         graph.save_dbt_ls_cache("some output")
@@ -2421,9 +2423,11 @@ def test_save_dbt_ls_cache_variable_set_failure(mock_variable_set, tmp_dbt_proje
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")
 @patch("cosmos.dbt.graph.Variable.set")
 def test_save_yaml_selectors_cache_variable_set_failure(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from unittest.mock import MagicMock
+
     from airflow.sdk.exceptions import AirflowRuntimeError
 
-    mock_variable_set.side_effect = AirflowRuntimeError("no such table: variable")
+    mock_variable_set.side_effect = AirflowRuntimeError(MagicMock())
     graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
     selectors = YamlSelectors(
         {"staging_orders": {"name": "staging_orders", "definition": {"method": "tag", "value": "tag_a"}}},


### PR DESCRIPTION
## Summary

- Wraps `Variable.set()` in `save_dbt_ls_cache()` and `save_yaml_selectors_cache()` with a `try/except` that catches `AirflowRuntimeError` (Airflow 3 Task SDK only)
- On failure, logs a `WARNING` with the variable key and guidance to set `AIRFLOW__COSMOS__REMOTE_CACHE_DIR` instead of propagating the error
- On Airflow 2 the existing direct-DB path is unchanged (no exception expected)

## Related Issue(s)

closes #2551

## Breaking Change?

No.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)