### PR TITLE
[Bug] Maintain `outlets` passed to `DbtRunLocalOperator` when `enable_dataset_alias==True`

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -934,6 +934,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
                 and AIRFLOW_VERSION >= Version("2.10")
             ):
                 from airflow.datasets import DatasetAlias
+                from airflow.models.dataset import DatasetAliasModel
 
                 # ignoring the type because older versions of Airflow raise the follow error in mypy
                 # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
@@ -941,7 +942,18 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
                 task_group_id = kwargs.get("task_group")
 
                 # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
-                outlets: list = kwargs.get("outlets", [])
+                outlets: list = []
+
+                for outlet in kwargs.get("outlets", []):
+                    if isinstance(outlet, DatasetAlias):
+                        outlets.append(outlet)  # Keep as-is
+                    # Handle DatasetAliasModel, which is not JSON serializable in 2.10
+                    elif isinstance(outlet, DatasetAliasModel):
+                        dataset_alias_name = outlet.name
+                        outlets.append(DatasetAlias(name=dataset_alias_name))
+                    else:
+                        logger.warning(f"Unknown outlet type {outlet}")  # Otherwise, pass
+
                 operator_kwargs["outlets"] = outlets + [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
                 ]  # type: ignore

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -939,7 +939,10 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
                 # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
                 dag_id = kwargs.get("dag")
                 task_group_id = kwargs.get("task_group")
-                operator_kwargs["outlets"] = [
+
+                # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
+                outlets: list = kwargs.get("outlets", [])
+                operator_kwargs["outlets"] = outlets + [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
                 ]  # type: ignore
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -997,12 +997,24 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 and AIRFLOW_VERSION >= Version("2.10")
             ):
                 from airflow.datasets import DatasetAlias
+                from airflow.models.dataset import DatasetAliasModel
 
                 dag_id = kwargs.get("dag")
                 task_group_id = kwargs.get("task_group")
 
                 # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
-                outlets: list = kwargs.get("outlets", [])
+                outlets: list = []
+
+                for outlet in kwargs.get("outlets", []):
+                    if isinstance(outlet, DatasetAlias):
+                        outlets.append(outlet)  # Keep as-is
+                    # Handle DatasetAliasModel, which is not JSON serializable in 2.10
+                    elif isinstance(outlet, DatasetAliasModel):
+                        dataset_alias_name = outlet.name
+                        outlets.append(DatasetAlias(name=dataset_alias_name))
+                    else:
+                        logger.warning(f"Unknown outlet type {outlet}")  # Otherwise, pass
+
                 operator_kwargs["outlets"] = outlets + [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
                 ]

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1000,7 +1000,10 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
 
                 dag_id = kwargs.get("dag")
                 task_group_id = kwargs.get("task_group")
-                operator_kwargs["outlets"] = [
+
+                # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
+                outlets: list = kwargs.get("outlets", [])
+                operator_kwargs["outlets"] = outlets + [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
                 ]
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -956,7 +956,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
     template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
         # and eliminated the super().__init__() call. This change was made to resolve conflicts in parent class
         # initializations while adding support for ExecutionMode.AIRFLOW_ASYNC. Operators under this mode inherit
@@ -1003,7 +1003,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 task_group_id = kwargs.get("task_group")
 
                 # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
-                outlets: list = []
+                outlets: list[DatasetAlias] | list[DatasetAliasModel] = []
 
                 for outlet in kwargs.get("outlets", []):
                     if isinstance(outlet, DatasetAlias):

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1003,7 +1003,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 task_group_id = kwargs.get("task_group")
 
                 # issue-1591: Handle passed-in outlets when enable_dataset_alias is True
-                outlets: list[DatasetAlias] | list[DatasetAliasModel] = []
+                outlets: list[DatasetAlias] = []
 
                 for outlet in kwargs.get("outlets", []):
                     if isinstance(outlet, DatasetAlias):

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -863,9 +863,18 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
             if AIRFLOW_VERSION.major == 2:
                 logger.info("Assigning inlets/outlets with DatasetAlias in Airflow 2")
+                from airflow.datasets import DatasetAlias
 
-                for outlet in new_outlets:
-                    context["outlet_events"][dataset_alias_name].add(outlet)  # type: ignore[index]
+                alias_names = {dataset_alias_name} | {
+                    outlet.name
+                    for outlet in self.outlets  # type: ignore[attr-defined]
+                    if isinstance(outlet, DatasetAlias) and outlet.name != dataset_alias_name
+                }
+
+                for alias_name in alias_names:
+                    for outlet in new_outlets:
+                        context["outlet_events"][alias_name].add(outlet)  # type: ignore[index]
+
             else:  # AIRFLOW_VERSION.major == 3
                 logger.info("Assigning outlets with DatasetAlias in Airflow 3")
                 from airflow.sdk.definitions.asset import AssetAlias
@@ -956,7 +965,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
     template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields
 
-    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa
+    def __init__(self, *args: Any, **kwargs: Any) -> None:  # noqa: C901
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
         # and eliminated the super().__init__() call. This change was made to resolve conflicts in parent class
         # initializations while adding support for ExecutionMode.AIRFLOW_ASYNC. Operators under this mode inherit
@@ -996,7 +1005,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 and settings.enable_dataset_alias
                 and AIRFLOW_VERSION >= Version("2.10")
             ):
-                from airflow.datasets import DatasetAlias
+                from airflow.datasets import Dataset, DatasetAlias
                 from airflow.models.dataset import DatasetAliasModel
 
                 dag_id = kwargs.get("dag")
@@ -1008,10 +1017,17 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 for outlet in kwargs.get("outlets", []):
                     if isinstance(outlet, DatasetAlias):
                         outlets.append(outlet)  # Keep as-is
+
+                    # Handle Datasets
+                    elif isinstance(outlet, Dataset):
+                        dataset_alias_name = outlet.uri
+                        outlets.append(DatasetAlias(name=dataset_alias_name))
+
                     # Handle DatasetAliasModel, which is not JSON serializable in 2.10
                     elif isinstance(outlet, DatasetAliasModel):
                         dataset_alias_name = outlet.name
                         outlets.append(DatasetAlias(name=dataset_alias_name))
+
                     else:
                         logger.warning(f"Unknown outlet type {outlet}")  # Otherwise, pass
 

--- a/dev/dags/example_outlets.py
+++ b/dev/dags/example_outlets.py
@@ -9,6 +9,7 @@ try:  # Airflow 3
     from airflow.sdk.definitions.asset import AssetAlias as DatasetAlias
 except ImportError:  # Airflow 2
     from airflow.datasets import Dataset
+
     try:
         from airflow.datasets import DatasetAlias
     except ImportError:  # Airflow < 2.10

--- a/dev/dags/example_outlets.py
+++ b/dev/dags/example_outlets.py
@@ -6,12 +6,8 @@ from airflow import DAG
 from airflow.models.dataset import Dataset, DatasetAlias
 
 from cosmos import (
-    DbtBuildLocalOperator,
-    DbtCloneLocalOperator,
     DbtRunLocalOperator,
     DbtSeedLocalOperator,
-    DbtSnapshotLocalOperator,
-    DbtTestLocalOperator,
     ProfileConfig,
 )
 
@@ -46,7 +42,6 @@ with DAG("example_outlets", start_date=datetime(2024, 1, 1), catchup=False) as d
         install_deps=True,
     )
 
-
     run_operator__dataset = DbtRunLocalOperator(
         profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
@@ -55,7 +50,7 @@ with DAG("example_outlets", start_date=datetime(2024, 1, 1), catchup=False) as d
         install_deps=True,
         append_env=True,
         emit_datasets=True,
-        outlets=[Dataset("stg_customers__dataset")]
+        outlets=[Dataset("stg_customers__dataset")],
     )
 
     run_operator__dataset_alias = DbtRunLocalOperator(
@@ -66,7 +61,7 @@ with DAG("example_outlets", start_date=datetime(2024, 1, 1), catchup=False) as d
         install_deps=True,
         append_env=True,
         emit_datasets=True,
-        outlets=[DatasetAlias("stg_orders__dataset_alias")]
+        outlets=[DatasetAlias("stg_orders__dataset_alias")],
     )
 
     [seed_operator, seed_raw_orders] >> run_operator__dataset >> run_operator__dataset_alias

--- a/dev/dags/example_outlets.py
+++ b/dev/dags/example_outlets.py
@@ -3,7 +3,16 @@ from datetime import datetime
 from pathlib import Path
 
 from airflow import DAG
-from airflow.models.dataset import Dataset, DatasetAlias
+
+try:  # Airflow 3
+    from airflow.sdk.definitions.asset import Asset as Dataset
+    from airflow.sdk.definitions.asset import AssetAlias as DatasetAlias
+except ImportError:  # Airflow 2
+    from airflow.datasets import Dataset
+    try:
+        from airflow.datasets import DatasetAlias
+    except ImportError:  # Airflow < 2.10
+        DatasetAlias = None  # type: ignore[assignment]
 
 from cosmos import (
     DbtRunLocalOperator,
@@ -53,15 +62,18 @@ with DAG("example_outlets", start_date=datetime(2024, 1, 1), catchup=False) as d
         outlets=[Dataset("stg_customers__dataset")],
     )
 
-    run_operator__dataset_alias = DbtRunLocalOperator(
-        profile_config=profile_config,
-        project_dir=DBT_PROJ_DIR,
-        task_id="run__dataset_alias",
-        dbt_cmd_flags=["--select", "stg_orders"],
-        install_deps=True,
-        append_env=True,
-        emit_datasets=True,
-        outlets=[DatasetAlias("stg_orders__dataset_alias")],
-    )
+    if DatasetAlias is not None:
+        run_operator__dataset_alias = DbtRunLocalOperator(
+            profile_config=profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run__dataset_alias",
+            dbt_cmd_flags=["--select", "stg_orders"],
+            install_deps=True,
+            append_env=True,
+            emit_datasets=True,
+            outlets=[DatasetAlias("stg_orders__dataset_alias")],
+        )
 
-    [seed_operator, seed_raw_orders] >> run_operator__dataset >> run_operator__dataset_alias
+        [seed_operator, seed_raw_orders] >> run_operator__dataset >> run_operator__dataset_alias
+    else:
+        [seed_operator, seed_raw_orders] >> run_operator__dataset

--- a/dev/dags/example_outlets.py
+++ b/dev/dags/example_outlets.py
@@ -1,0 +1,72 @@
+import os
+from datetime import datetime
+from pathlib import Path
+
+from airflow import DAG
+from airflow.models.dataset import Dataset, DatasetAlias
+
+from cosmos import (
+    DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
+    DbtRunLocalOperator,
+    DbtSeedLocalOperator,
+    DbtSnapshotLocalOperator,
+    DbtTestLocalOperator,
+    ProfileConfig,
+)
+
+# Set contains to be used by local operators
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJ_DIR = DBT_ROOT_PATH / "jaffle_shop"
+DBT_PROFILE_PATH = DBT_PROJ_DIR / "profiles.yml"
+DBT_ARTIFACT = DBT_PROJ_DIR / "target"
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profiles_yml_filepath=DBT_PROFILE_PATH,
+)
+
+with DAG("example_outlets", start_date=datetime(2024, 1, 1), catchup=False) as dag:
+    seed_operator = DbtSeedLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="seed",
+        dbt_cmd_flags=["--select", "raw_customers"],
+        install_deps=True,
+        append_env=True,
+    )
+
+    seed_raw_orders = DbtSeedLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="seed_raw_orders",
+        dbt_cmd_flags=["--select", "raw_orders"],
+        install_deps=True,
+    )
+
+
+    run_operator__dataset = DbtRunLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="run__dataset",
+        dbt_cmd_flags=["--select", "stg_customers"],
+        install_deps=True,
+        append_env=True,
+        emit_datasets=True,
+        outlets=[Dataset("stg_customers__dataset")]
+    )
+
+    run_operator__dataset_alias = DbtRunLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="run__dataset_alias",
+        dbt_cmd_flags=["--select", "stg_orders"],
+        install_deps=True,
+        append_env=True,
+        emit_datasets=True,
+        outlets=[DatasetAlias("stg_orders__dataset_alias")]
+    )
+
+    [seed_operator, seed_raw_orders] >> run_operator__dataset >> run_operator__dataset_alias

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -544,6 +544,69 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
         # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
         # assert dataset_model == 1
 
+@pytest.mark.skipif(version.parse(airflow_version).major >= 3, reason="This test is specific for Airflow 2.10 and 2.11")
+@pytest.mark.skipif(
+    version.parse(airflow_version) < version.parse("2.10"),
+    reason="Outlets are only overridden in Airflow 2.10 and 2.11 in DbtLocalBaseOperator.",
+)
+@pytest.mark.integration
+def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
+    try:
+        from airflow.models.asset import AssetAliasModel
+    except ModuleNotFoundError:
+        from airflow.models.dataset import DatasetAliasModel as AssetAliasModel
+    from sqlalchemy.orm.exc import FlushError
+
+    with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
+        seed_operator = DbtSeedLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="seed",
+            dag=dag,
+            emit_datasets=False,
+            dbt_cmd_flags=["--select", "raw_customers"],
+            install_deps=True,
+            append_env=True,
+        )
+        run_operator = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+            outlets=[AssetAliasModel(name="manual_outlet__run")],
+        )
+        test_operator = DbtTestLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="test",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+        )
+        seed_operator >> run_operator >> test_operator
+
+    assert seed_operator.outlets == []  # because emit_datasets=False,
+    assert run_operator.outlets == [AssetAliasModel(name="manual_outlet__run"), AssetAliasModel(name="test_id_1__run")]
+    assert test_operator.outlets == [AssetAliasModel(name="test_id_1__test")]
+
+    with pytest.raises(FlushError):
+        run_test_dag(dag, custom_tester=True)
+        # This is a known limitation of Airflow 2.10.0 and 2.10.1
+        # https://github.com/apache/airflow/issues/42495
+
+        # When this is solved, we can uncomment the following:
+        # dag_run, session = run_test_dag(dag)
+
+        # Once this issue is solved, we should do some type of check on the actual datasets being emitted,
+        # so we guarantee Cosmos is backwards compatible via tests using something along the lines or an alternative,
+        # based on the resolution of the issue logged in Airflow:
+        # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
+        # assert dataset_model == 1
+
 
 @pytest.mark.skipif(
     version.parse(airflow_version) < version.Version("3.0.0"),

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -652,7 +652,10 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
         seed_operator >> run_operator >> test_operator
 
     assert seed_operator.outlets == []  # because emit_datasets=False,
-    assert run_operator.outlets == [DatasetAliasModel(name="manual_outlet__run"), DatasetAliasModel(name="test_id_1__run")]
+    assert run_operator.outlets == [
+        DatasetAliasModel(name="manual_outlet__run"),
+        DatasetAliasModel(name="test_id_1__run"),
+    ]
     assert test_operator.outlets == [DatasetAliasModel(name="test_id_1__test")]
 
     with pytest.raises(FlushError):

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -616,7 +616,8 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
 )
 @pytest.mark.integration
 def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
-    from airflow.models.dataset import DatasetAlias, DatasetAliasModel
+    from airflow.dataset import Dataset, DatasetAlias
+    from airflow.models.dataset import DatasetAliasModel
     from sqlalchemy.orm.exc import FlushError
 
     with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
@@ -630,6 +631,18 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             install_deps=True,
             append_env=True,
         )
+
+        run_operator_dataset = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run_operator_alias",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+            outlets=[Dataset(name="manual_outlet__run_dataset")],
+        )
+
         run_operator_alias = DbtRunLocalOperator(
             profile_config=real_profile_config,
             project_dir=DBT_PROJ_DIR,
@@ -640,6 +653,7 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             append_env=True,
             outlets=[DatasetAlias(name="manual_outlet__run_alias")],
         )
+
         run_operator_alias_model = DbtRunLocalOperator(
             profile_config=real_profile_config,
             project_dir=DBT_PROJ_DIR,
@@ -650,6 +664,7 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             append_env=True,
             outlets=[DatasetAliasModel(name="manual_outlet__run_alias_model")],
         )
+
         test_operator = DbtTestLocalOperator(
             profile_config=real_profile_config,
             project_dir=DBT_PROJ_DIR,
@@ -659,9 +674,17 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             install_deps=True,
             append_env=True,
         )
-        seed_operator >> [run_operator_alias, run_operator_alias_model] >> test_operator
+        seed_operator >> [run_operator_dataset, run_operator_alias, run_operator_alias_model] >> test_operator
 
     assert seed_operator.outlets == []  # because emit_datasets=False,
+
+    # Handling Dataset
+    assert run_operator_dataset.outlets == [
+        DatasetAlias(name="manual_outlet__run_dataset"),
+        DatasetAlias(name="test_id_1__run_operator_dataset"),
+    ]
+
+    assert all(isinstance(outlet, DatasetAlias) for outlet in run_operator_dataset.outlets)
 
     # Handling DatasetAlias
     assert run_operator_alias.outlets == [
@@ -669,11 +692,15 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
         DatasetAlias(name="test_id_1__run_operator_alias"),
     ]
 
+    assert all(isinstance(outlet, DatasetAlias) for outlet in run_operator_alias.outlets)
+
     # Handling DatasetAliasModel passed by user and the DatasetAlias outlet by the Operator
     assert run_operator_alias_model.outlets == [
-        DatasetAliasModel(name="manual_outlet__run_alias_model"),
+        DatasetAlias(name="manual_outlet__run_alias_model"),
         DatasetAlias(name="test_id_1__run_operator_alias_model"),
     ]
+
+    assert all(isinstance(outlet, DatasetAlias) for outlet in run_operator_alias_model.outlets)
 
     assert test_operator.outlets == [DatasetAlias(name="test_id_1__test")]
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -616,7 +616,7 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
 )
 @pytest.mark.integration
 def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
-    from airflow.dataset import Dataset, DatasetAlias
+    from airflow.datasets import Dataset, DatasetAlias
     from airflow.models.dataset import DatasetAliasModel
     from sqlalchemy.orm.exc import FlushError
 
@@ -635,7 +635,7 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
         run_operator_dataset = DbtRunLocalOperator(
             profile_config=real_profile_config,
             project_dir=DBT_PROJ_DIR,
-            task_id="run_operator_alias",
+            task_id="run_operator_dataset",
             dag=dag,
             dbt_cmd_flags=["--models", "stg_customers"],
             install_deps=True,

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -616,10 +616,7 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
 )
 @pytest.mark.integration
 def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
-    try:
-        from airflow.models.asset import AssetAliasModel
-    except ModuleNotFoundError:
-        from airflow.models.dataset import DatasetAliasModel as AssetAliasModel
+    from airflow.models.dataset import DatasetAliasModel
     from sqlalchemy.orm.exc import FlushError
 
     with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
@@ -641,7 +638,7 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             dbt_cmd_flags=["--models", "stg_customers"],
             install_deps=True,
             append_env=True,
-            outlets=[AssetAliasModel(name="manual_outlet__run")],
+            outlets=[DatasetAliasModel(name="manual_outlet__run")],
         )
         test_operator = DbtTestLocalOperator(
             profile_config=real_profile_config,
@@ -655,8 +652,8 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
         seed_operator >> run_operator >> test_operator
 
     assert seed_operator.outlets == []  # because emit_datasets=False,
-    assert run_operator.outlets == [AssetAliasModel(name="manual_outlet__run"), AssetAliasModel(name="test_id_1__run")]
-    assert test_operator.outlets == [AssetAliasModel(name="test_id_1__test")]
+    assert run_operator.outlets == [DatasetAliasModel(name="manual_outlet__run"), DatasetAliasModel(name="test_id_1__run")]
+    assert test_operator.outlets == [DatasetAliasModel(name="test_id_1__test")]
 
     with pytest.raises(FlushError):
         run_test_dag(dag, custom_tester=True)

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -616,7 +616,7 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
 )
 @pytest.mark.integration
 def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
-    from airflow.models.dataset import DatasetAliasModel
+    from airflow.models.dataset import DatasetAliasModel, DatasetAlias
     from sqlalchemy.orm.exc import FlushError
 
     with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
@@ -630,15 +630,25 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             install_deps=True,
             append_env=True,
         )
-        run_operator = DbtRunLocalOperator(
+        run_operator_alias = DbtRunLocalOperator(
             profile_config=real_profile_config,
             project_dir=DBT_PROJ_DIR,
-            task_id="run",
+            task_id="run_operator_alias",
             dag=dag,
             dbt_cmd_flags=["--models", "stg_customers"],
             install_deps=True,
             append_env=True,
-            outlets=[DatasetAliasModel(name="manual_outlet__run")],
+            outlets=[DatasetAlias(name="manual_outlet__run_alias")],
+        )
+        run_operator_alias_model = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run_operator_alias_model",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+            outlets=[DatasetAliasModel(name="manual_outlet__run_alias_model")],
         )
         test_operator = DbtTestLocalOperator(
             profile_config=real_profile_config,
@@ -649,14 +659,22 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             install_deps=True,
             append_env=True,
         )
-        seed_operator >> run_operator >> test_operator
+        seed_operator >> [run_operator_alias, run_operator_alias_model] >> test_operator
 
     assert seed_operator.outlets == []  # because emit_datasets=False,
-    assert run_operator.outlets == [
-        DatasetAliasModel(name="manual_outlet__run"),
-        DatasetAliasModel(name="test_id_1__run"),
+
+    # Handling DatasetAlias
+    assert run_operator_alias.outlets == [
+        DatasetAlias(name="manual_outlet__run_alias"), DatasetAlias(name="test_id_1__run_operator_alias")
     ]
-    assert test_operator.outlets == [DatasetAliasModel(name="test_id_1__test")]
+
+    # Handling DatasetAliasModel passed by user and the DatasetAlias outlet by the Operator
+    assert run_operator_alias_model.outlets == [
+        DatasetAliasModel(name="manual_outlet__run_alias_model"),
+        DatasetAlias(name="test_id_1__run_operator_alias_model")
+    ]
+
+    assert test_operator.outlets == [DatasetAlias(name="test_id_1__test")]
 
     with pytest.raises(FlushError):
         run_test_dag(dag, custom_tester=True)

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -608,6 +608,7 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
         # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
         # assert dataset_model == 1
 
+
 @pytest.mark.skipif(version.parse(airflow_version).major >= 3, reason="This test is specific for Airflow 2.10 and 2.11")
 @pytest.mark.skipif(
     version.parse(airflow_version) < version.parse("2.10"),

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -616,7 +616,7 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
 )
 @pytest.mark.integration
 def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
-    from airflow.models.dataset import DatasetAliasModel, DatasetAlias
+    from airflow.models.dataset import DatasetAlias, DatasetAliasModel
     from sqlalchemy.orm.exc import FlushError
 
     with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
@@ -665,13 +665,14 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
 
     # Handling DatasetAlias
     assert run_operator_alias.outlets == [
-        DatasetAlias(name="manual_outlet__run_alias"), DatasetAlias(name="test_id_1__run_operator_alias")
+        DatasetAlias(name="manual_outlet__run_alias"),
+        DatasetAlias(name="test_id_1__run_operator_alias"),
     ]
 
     # Handling DatasetAliasModel passed by user and the DatasetAlias outlet by the Operator
     assert run_operator_alias_model.outlets == [
         DatasetAliasModel(name="manual_outlet__run_alias_model"),
-        DatasetAlias(name="test_id_1__run_operator_alias_model")
+        DatasetAlias(name="test_id_1__run_operator_alias_model"),
     ]
 
     assert test_operator.outlets == [DatasetAlias(name="test_id_1__test")]

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -608,6 +608,69 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_210(caplog):
         # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
         # assert dataset_model == 1
 
+@pytest.mark.skipif(version.parse(airflow_version).major >= 3, reason="This test is specific for Airflow 2.10 and 2.11")
+@pytest.mark.skipif(
+    version.parse(airflow_version) < version.parse("2.10"),
+    reason="Outlets are only overridden in Airflow 2.10 and 2.11 in DbtLocalBaseOperator.",
+)
+@pytest.mark.integration
+def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
+    try:
+        from airflow.models.asset import AssetAliasModel
+    except ModuleNotFoundError:
+        from airflow.models.dataset import DatasetAliasModel as AssetAliasModel
+    from sqlalchemy.orm.exc import FlushError
+
+    with DAG("test_id_1", start_date=datetime(2022, 1, 1)) as dag:
+        seed_operator = DbtSeedLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="seed",
+            dag=dag,
+            emit_datasets=False,
+            dbt_cmd_flags=["--select", "raw_customers"],
+            install_deps=True,
+            append_env=True,
+        )
+        run_operator = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+            outlets=[AssetAliasModel(name="manual_outlet__run")],
+        )
+        test_operator = DbtTestLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="test",
+            dag=dag,
+            dbt_cmd_flags=["--models", "stg_customers"],
+            install_deps=True,
+            append_env=True,
+        )
+        seed_operator >> run_operator >> test_operator
+
+    assert seed_operator.outlets == []  # because emit_datasets=False,
+    assert run_operator.outlets == [AssetAliasModel(name="manual_outlet__run"), AssetAliasModel(name="test_id_1__run")]
+    assert test_operator.outlets == [AssetAliasModel(name="test_id_1__test")]
+
+    with pytest.raises(FlushError):
+        run_test_dag(dag, custom_tester=True)
+        # This is a known limitation of Airflow 2.10.0 and 2.10.1
+        # https://github.com/apache/airflow/issues/42495
+
+        # When this is solved, we can uncomment the following:
+        # dag_run, session = run_test_dag(dag)
+
+        # Once this issue is solved, we should do some type of check on the actual datasets being emitted,
+        # so we guarantee Cosmos is backwards compatible via tests using something along the lines or an alternative,
+        # based on the resolution of the issue logged in Airflow:
+        # dataset_model = session.scalars(select(DatasetModel).where(DatasetModel.uri == "<something>"))
+        # assert dataset_model == 1
+
 
 @pytest.mark.skipif(
     version.parse(airflow_version) < version.Version("3.0.0"),

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -640,7 +640,7 @@ def test_run_operator_dataset_manual_outlets_airflow_210(caplog):
             dbt_cmd_flags=["--models", "stg_customers"],
             install_deps=True,
             append_env=True,
-            outlets=[Dataset(name="manual_outlet__run_dataset")],
+            outlets=[Dataset(uri="manual_outlet__run_dataset")],
         )
 
         run_operator_alias = DbtRunLocalOperator(

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -56,6 +56,10 @@ def get_dag_bag() -> DagBag:
         if AIRFLOW_VERSION >= Version("3.0.0"):
             file.write("example_cosmos_cleanup_dag.py\n")
 
+        if AIRFLOW_VERSION < Version("2.10.0"):
+            # DatasetAlias was introduced in Airflow 2.10
+            file.write("example_outlets.py\n")
+
     print(".airflowignore contents: ")
     print(AIRFLOW_IGNORE_FILE.read_text())
     db = DagBag(EXAMPLE_DAGS_DIR, include_examples=False)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -67,6 +67,40 @@ def new_test_dag(dag: DAG, expected_dag_state: DagRunState = DagRunState.SUCCESS
         sync_bag_to_db(dagbag, bundle_name="test_bundle", bundle_version="1")
         dr = dag.test(logical_date=timezone.utcnow())
     elif AIRFLOW_VERSION >= version.Version("3.0"):
+        # In Airflow 3.0, dag.test() does not properly register Assets as active, must be registered manually
+        from airflow.models.asset import AssetActive, AssetModel
+        from airflow.utils.session import create_session
+
+        from sqlalchemy import select
+
+        with create_session() as session:
+            # Loop through each Task in the DAG, looking for outlets
+            for task in dag.tasks:
+                for outlet in getattr(task, "outlets", []):
+                    if not hasattr(outlet, "uri"):
+                        continue  # Skip the outlet
+
+                    name = getattr(outlet, "name", outlet.uri)
+                    uri = outlet.uri
+
+                    # Retrieve Assets from DB to validate if they exist
+                    asset_model = session.execute(
+                        select(AssetModel).where(AssetModel.name == name, AssetModel.uri == uri)
+                    ).scalar_one_or_none()
+
+                    if asset_model is None:
+                        # Add the Asset
+                        asset_model = AssetModel(name=name, uri=uri)
+                        session.add(asset_model)
+                        session.flush()
+
+                    if asset_model.active is None:
+                        # Set the Asset as "active"
+                        session.add(
+                            AssetActive.for_asset(asset_model)
+                        )
+                        session.flush()
+
         dr = dag.test(logical_date=timezone.utcnow())
     else:
         dr = dag.test()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -70,7 +70,6 @@ def new_test_dag(dag: DAG, expected_dag_state: DagRunState = DagRunState.SUCCESS
         # In Airflow 3.0, dag.test() does not properly register Assets as active, must be registered manually
         from airflow.models.asset import AssetActive, AssetModel
         from airflow.utils.session import create_session
-
         from sqlalchemy import select
 
         with create_session() as session:
@@ -96,9 +95,7 @@ def new_test_dag(dag: DAG, expected_dag_state: DagRunState = DagRunState.SUCCESS
 
                     if asset_model.active is None:
                         # Set the Asset as "active"
-                        session.add(
-                            AssetActive.for_asset(asset_model)
-                        )
+                        session.add(AssetActive.for_asset(asset_model))
                         session.flush()
 
         dr = dag.test(logical_date=timezone.utcnow())


### PR DESCRIPTION
## Description

According to #1591, when `outlets` were passed to the `DbtRunLocalOperator` (with `enable_dataset_alias==True`, those `DatasetAlias`'s were not being maintained. This was due to the following code snippet, which effectively overwrote all `outlets`.

```python
...

kwargs["outlets"] = [
    DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, task_id))
]  # type: ignore

...
```

This PR updates this functionality to allow for `outlets` to be passed by the user, and appended to list of Cosmos-generate `DatasetAlias`'s. 

## Related Issue(s)

closes: #1591 

## Breaking Change?

No, this is not a break change!

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
