### PR TITLE
`fix-issue-2393`: Support rendering of `DbtResourceType.EXPOSURE`

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -297,6 +297,7 @@ def create_dbt_resource_to_class(test_behavior: TestBehavior) -> dict[str, str]:
             DbtResourceType.SEED: "DbtBuild",
             DbtResourceType.TEST: "DbtTest",
             DbtResourceType.SOURCE: "DbtSource",
+            DbtResourceType.EXPOSURE: "DbtExposure"
         }
     else:
         dbt_resource_to_class = {
@@ -305,6 +306,7 @@ def create_dbt_resource_to_class(test_behavior: TestBehavior) -> dict[str, str]:
             DbtResourceType.SEED: "DbtSeed",
             DbtResourceType.TEST: "DbtTest",
             DbtResourceType.SOURCE: "DbtSource",
+            DbtResourceType.EXPOSURE: "DbtExposure"
         }
     return dbt_resource_to_class
 
@@ -413,6 +415,24 @@ def create_task_metadata(  # noqa: C901
                 else:
                     args = {}
                 return TaskMetadata(id=task_id, operator_class="airflow.operators.empty.EmptyOperator", arguments=args)
+
+        elif node.resource_type == DbtResourceType.EXPOSURE:
+            # Build the task_id and update args
+            task_id, args = _get_task_id_and_args(
+                node=node,
+                args=args,
+                use_task_group=use_task_group,
+                normalize_task_id=render_config.normalize_task_id,
+                normalize_task_display_name=render_config.normalize_task_display_name,
+                resource_suffix=r"exposure",
+                execution_mode=execution_mode,
+            )
+
+            # Strip down args to pass to EmptyOperator
+            args = {"task_display_name": args["task_display_name"]} if "task_display_name" in args else {}
+
+            return TaskMetadata(id=task_id, operator_class="airflow.operators.empty.EmptyOperator", arguments=args)
+
         else:  # DbtResourceType.MODEL, DbtResourceType.SEED and DbtResourceType.SNAPSHOT
             if node.fqn and len(node.fqn) > 0:
                 args[models_select_key] = f"fqn:{'.'.join(node.fqn)}"

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -706,6 +706,31 @@ def test_create_task_metadata_snapshot(caplog):
     assert metadata.arguments == {"select": "my_snapshot"}
 
 
+def test_create_task_metadata_exposure(caplog):
+    sample_node = DbtNode(
+        unique_id=f"{DbtResourceType.EXPOSURE.value}.my_folder.my_exposure",
+        resource_type=DbtResourceType.EXPOSURE,
+        depends_on=[],
+        path_base=Path("."),
+        original_file_path=Path("."),
+        tags=[],
+        config={},
+    )
+
+    metadata = create_task_metadata(
+        sample_node,
+        execution_mode=ExecutionMode.KUBERNETES,  # Can pick any ExecutionMode
+        args={
+            "task_display_name": "my_expose_display_name"
+        },
+        dbt_dag_task_group_identifier=""
+    )
+
+    assert metadata.id == "my_exposure_exposure"
+    assert metadata.operator_class == "airflow.operators.empty.EmptyOperator"
+    assert metadata.arguments == {"task_display_name": "my_expose_display_name"}
+
+
 def _normalize_task_id(node: DbtNode) -> str:
     """for test_create_task_metadata_normalize_task_id"""
     return f"new_task_id_{node.name}_{node.resource_type.value}"


### PR DESCRIPTION
## Description

Per issue #2393, `DbtResourceType.EXPOSURE` nodes defined in `render_config.node_converters` are silently ignored during DAG rendering, producing the following warning instead:

```
{graph.py:426} WARNING - Unavailable conversion function for <DbtResourceType.EXPOSURE>
(node <exposure.{project_name}.{node_name}>). Define a converter function using render_config.node_converters.
```

This PR ensures that exposures are properly rendered in the Airflow graph (as an `EmptyOperator`) with the appropriate metadata.

## Related Issue(s)

closes: #2393

## Breaking Change?

No, this is not a breaking change.

## Testing

These changes were tested via a unit-test (`test_create_task_metadata_exposure`) as well as E2E by running Airflow with Docker.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
