### PR TITLE
YAML selector parsing should skip malformed selectors instead of failing entirely

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -246,6 +246,7 @@ jobs:
           PYTEST_SPLIT_GROUP: ${{ matrix.split-group }}
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
+          AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
           AIRFLOW__CORE__DAG_FILE_PROCESSOR_TIMEOUT: 120
@@ -578,6 +579,7 @@ jobs:
         env:
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
+          AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0
           AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
           AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
           PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -1116,8 +1116,9 @@ class DbtGraph:
         Returns:
             YamlSelectors: A YamlSelectors instance
         """
-
-        yaml_selectors = YamlSelectors.parse(selector_definitions)
+        yaml_selectors = YamlSelectors.parse(
+            selector_definitions, lax_parsing_enabled=settings.enable_lax_selector_parsing
+        )
 
         if self.should_use_yaml_selectors_cache():
             self.save_yaml_selectors_cache(yaml_selectors)
@@ -1194,9 +1195,11 @@ class DbtGraph:
             yaml_selectors = self.load_parsed_selectors(selector_definitions)
             selections = yaml_selectors.get_parsed(self.render_config.selector)
             if not selections:
-                raise CosmosLoadDbtException(
-                    f"Selector `{self.render_config.selector}` not found in parsed YAML selectors `{selector_definitions}`"
-                )
+                error_message = f"Selector `{self.render_config.selector}` not found in parsed YAML selectors"
+                if settings.enable_lax_selector_parsing:
+                    error_message += ". Check logs - the selector may have parsing errors logged as warnings"
+                raise CosmosLoadDbtException(error_message)
+
             self.nodes = nodes
             self.filtered_nodes = select_nodes(
                 project_dir=project_dir,

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -1349,7 +1349,7 @@ class YamlSelectors:
         return (select, exclude, errors)
 
     @classmethod
-    def parse(cls, selectors: dict[str, dict[str, Any]]) -> YamlSelectors:
+    def parse(cls, selectors: dict[str, dict[str, Any]], lax_parsing_enabled: bool) -> YamlSelectors:
         """
         Parse selector definitions from a dbt manifest into a YamlSelectors instance.
 
@@ -1357,6 +1357,7 @@ class YamlSelectors:
         selector definitions from the manifest and converts them to Cosmos format.
 
         :param selectors: dict[str, dict[str, Any]] - Dictionary of selector definitions from the manifest, keyed by selector name
+        :param lax_parsing_enabled: bool - Flag to determine whether parser exceptions should be logged instead of raised
         :return: YamlSelectors - A YamlSelectors instance containing both raw and parsed selector definitions
 
         Example Input:
@@ -1386,12 +1387,24 @@ class YamlSelectors:
 
         for name, definition in selectors.items():
             if not isinstance(definition, dict):
-                raise CosmosValueError(
+                error_message = (
                     f"Invalid selector definition for '{name}'. Expected a dict, got {type(definition)}: {definition}"
                 )
+                if lax_parsing_enabled:
+                    logger.warning(error_message)
+                    continue
+                else:
+                    raise CosmosValueError(error_message)
 
             if not definition.get("name") or not definition.get("definition"):
-                raise CosmosValueError(f"Selector definition for '{name}' must contain 'name' and 'definition' keys.")
+                error_message = f"Selector definition for '{name}' must contain 'name' and 'definition' keys."
+                if lax_parsing_enabled:
+                    logger.warning(error_message)
+                    continue
+                else:
+                    raise CosmosValueError(
+                        f"Selector definition for '{name}' must contain 'name' and 'definition' keys."
+                    )
 
             selector_name = definition["name"]
             selector_definition = definition["definition"]

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -32,6 +32,7 @@ enable_cache_partial_parse = conf.getboolean("cosmos", "enable_cache_partial_par
 enable_cache_package_lockfile = conf.getboolean("cosmos", "enable_cache_package_lockfile", fallback=True)
 enable_cache_dbt_ls = conf.getboolean("cosmos", "enable_cache_dbt_ls", fallback=True)
 enable_cache_dbt_yaml_selectors = conf.getboolean("cosmos", "enable_cache_dbt_yaml_selectors", fallback=True)
+enable_lax_selector_parsing = conf.getboolean("cosmos", "enable_lax_selector_parsing", fallback=False)
 rich_logging = conf.getboolean("cosmos", "rich_logging", fallback=False)
 dbt_docs_dir = conf.get("cosmos", "dbt_docs_dir", fallback=None)
 dbt_docs_conn_id = conf.get("cosmos", "dbt_docs_conn_id", fallback=None)

--- a/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
+++ b/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
@@ -221,6 +221,8 @@ Cosmos distinguishes between two types of errors when parsing YAML selectors:
   - Missing required ``definition`` key
 
   These errors indicate malformed YAML structure and will raise a ``CosmosValueError`` immediately when calling ``YamlSelectors.parse()``.
+  You can modify this behavior to log instead of raising an exception by setting ``AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING=1``.
+  This allows DAGs referencing a manifest with one or more malformed selectors to render as long as the ``selector`` argument is valid.
 
 - **Selector Definition Errors** - These are isolated and surfaced when accessing the selector:
 

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -60,6 +60,15 @@ This page lists all available Airflow configurations that affect ``astronomer-co
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS``
 
+.. _enable_lax_selector_parsing:
+
+`enable_lax_selector_parsing`_:
+    Enable or disable lax parsing of YAML selectors when using ``LoadMode.DBT_MANIFEST`` with ``RenderConfig.selector``.
+    Lax parsing instructs the parser to log errors for selectors with malformed YAML structure instead of raising an exception.
+
+    - Default: ``False``
+    - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING``
+
 .. _enable_cache_partial_parse:
 
 `enable_cache_partial_parse`_:

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -569,7 +569,9 @@ def test_load_via_manifest_with_selectors_and_missing_definitions():
     assert err_info.value.args[0] == f"Selectors not found in manifest file `{project_config.manifest_path}`"
 
 
-def test_load_via_manifest_with_selectors_and_missing_selector():
+@pytest.mark.parametrize("enable_lax_selector_parsing", [True, False])
+def test_load_via_manifest_with_selectors_and_missing_selector(enable_lax_selector_parsing, monkeypatch):
+    monkeypatch.setattr("cosmos.settings.enable_lax_selector_parsing", enable_lax_selector_parsing)
     project_config = ProjectConfig(
         dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, manifest_path=SAMPLE_MANIFEST_SELECTORS
     )
@@ -593,7 +595,13 @@ def test_load_via_manifest_with_selectors_and_missing_selector():
     with pytest.raises(CosmosLoadDbtException) as err_info:
         dbt_graph.load_from_dbt_manifest()
 
-    assert "Selector `my_selector` not found in parsed YAML selectors" in err_info.value.args[0]
+    error_message = err_info.value.args[0]
+    assert "Selector `my_selector` not found in parsed YAML selectors" in error_message
+
+    if enable_lax_selector_parsing:
+        assert "Check logs" in error_message
+    else:
+        assert "Check logs" not in error_message
 
 
 def test_load_via_manifest_with_selectors():

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2393,7 +2393,7 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
     hash_dir, hash_selectors, hash_impl = version.split(",")
 
     assert hash_selectors == "43303af03e84e3b51fbfcf598261fae4"
-    assert hash_impl == "4c93048c66ca45356e1677511447c7ba"
+    assert hash_impl == "86424c8b70c2e9b6d1f595c7ec9a8291"
 
     if sys.platform == "darwin":
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1552,7 +1552,7 @@ def test_exposure_selector():
 )
 def test_valid_method_yaml_selectors(selector_name, selector_definition, parsed_selector):
     selectors = {selector_name: selector_definition}
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     result = yaml_selectors.get_parsed(selector_name)
 
@@ -1651,7 +1651,7 @@ def test_valid_method_yaml_selectors(selector_name, selector_definition, parsed_
 )
 def test_valid_graph_operator_yaml_selectors(selector_name, selector_definition, parsed_selector):
     selectors = {selector_name: selector_definition}
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     result = yaml_selectors.get_parsed(selector_name)
 
@@ -1736,7 +1736,7 @@ def test_valid_graph_operator_yaml_selectors(selector_name, selector_definition,
 )
 def test_invalid_cosmos_method_yaml_selectors(selector_name, selector_definition, exception_msg):
     selectors = {selector_name: selector_definition}
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     with pytest.raises(CosmosValueError) as err_info:
         _ = yaml_selectors.get_parsed(selector_name)
@@ -1962,7 +1962,7 @@ def test_invalid_cosmos_method_yaml_selectors(selector_name, selector_definition
 )
 def test_invalid_dbt_method_yaml_selectors(selector_name, selector_definition, exception_msg):
     selectors = {selector_name: selector_definition}
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     with pytest.raises(CosmosValueError) as err_info:
         _ = yaml_selectors.get_parsed(selector_name)
@@ -1992,14 +1992,20 @@ def test_invalid_dbt_method_yaml_selectors(selector_name, selector_definition, e
         ),
     ],
 )
-def test_invalid_yaml_structure_raises_immediately(selector_name, selector_definition, exception_msg):
-    """Test that structural YAML errors (missing name/definition) raise immediately from parse()."""
+@pytest.mark.parametrize("lax_parsing_enabled", [True, False])
+def test_invalid_yaml_structures(selector_name, selector_definition, exception_msg, lax_parsing_enabled, caplog):
     selectors = {selector_name: selector_definition}
 
-    with pytest.raises(CosmosValueError) as err_info:
-        _ = YamlSelectors.parse(selectors)
+    if lax_parsing_enabled:
+        yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=lax_parsing_enabled)
+        result = yaml_selectors.get_parsed(selector_name)
 
-    assert exception_msg in str(err_info.value)
+        assert result is None
+        assert exception_msg in caplog.text
+    else:
+        with pytest.raises(CosmosValueError) as err_info:
+            _ = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
+            assert exception_msg in str(err_info.value)
 
 
 @pytest.mark.parametrize(
@@ -2012,7 +2018,7 @@ def test_invalid_yaml_structure_raises_immediately(selector_name, selector_defin
 )
 def test_invalid_value_type_for_list_keys(selector_name, definition_key, invalid_value, expected_error_fragment):
     selectors = {selector_name: {"name": selector_name, "definition": {definition_key: invalid_value}}}
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     with pytest.raises(CosmosValueError) as err_info:
         _ = yaml_selectors.get_parsed(selector_name)
@@ -2039,7 +2045,7 @@ def test_invalid_items_in_selector_lists(selector_name, definition_key, invalid_
         }
     }
 
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     with pytest.raises(CosmosValueError) as err_info:
         _ = yaml_selectors.get_parsed(selector_name)
@@ -2068,7 +2074,7 @@ def test_non_string_keys_in_selector_dicts(selector_name, definition_key, non_st
         }
     }
 
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     with pytest.raises(CosmosValueError) as err_info:
         _ = yaml_selectors.get_parsed(selector_name)
@@ -2092,7 +2098,7 @@ def test_selector_reference_resolves_from_cache():
         },
     }
 
-    yaml_selectors = YamlSelectors.parse(selectors)
+    yaml_selectors = YamlSelectors.parse(selectors, lax_parsing_enabled=False)
 
     base_result = yaml_selectors.get_parsed("base_selector")
     reference_result = yaml_selectors.get_parsed("reference_selector")


### PR DESCRIPTION
## Description

Skip malformed selectors with a warning instead of raising an error, so that valid selectors in the same manifest still work.

I reproduced the bug outlined in the related issue and verified these changes will resolve the problem.

## Related Issue(s)

Closes #2565

## Breaking Change?
N/A

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
