### PR TITLE
Fix CI failures caused by docs build memory exhaustion

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,42 @@
+name: Build Sphinx documentation
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "cosmos/**"
+      - ".github/workflows/docs-build.yml"
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/**"
+      - "cosmos/**"
+      - ".github/workflows/docs-build.yml"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.11"
+
+      - name: Install documentation dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r docs/requirements.txt
+
+      - name: Build Sphinx documentation
+        run: sphinx-build -b html docs docs/_build --fail-on-warning --fresh-env

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,8 +1,10 @@
 name: Build Sphinx documentation
 
 on:
+  # TODO: remove `separate-out-docs-build` before merging; it is only here to
+  # validate the workflow end-to-end on this branch before the PR is opened.
   push:
-    branches: [main]
+    branches: [main, separate-out-docs-build]
     paths:
       - "docs/**"
       - "cosmos/**"

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,8 +1,7 @@
 name: Build Sphinx documentation
 
 on:
-  # TODO: remove `separate-out-docs-build` before merging; it is only here to
-  # validate the workflow end-to-end on this branch before the PR is opened.
+  # Run this workflow when documentation sources or this workflow definition change.
   push:
     branches: [main]
     paths:

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -4,7 +4,7 @@ on:
   # TODO: remove `separate-out-docs-build` before merging; it is only here to
   # validate the workflow end-to-end on this branch before the PR is opened.
   push:
-    branches: [main, separate-out-docs-build]
+    branches: [main]
     paths:
       - "docs/**"
       - "cosmos/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,7 @@ jobs:
               .github/ISSUE_TEMPLATE/*) ;;
               .github/dependabot.yml) ;;
               .github/workflows/docs.yml) ;;
+              .github/workflows/docs-build.yml) ;;
               .github/workflows/stale.yml) ;;
               .github/workflows/actionlint.yml) ;;
               .github/workflows/codeql.yml) ;;

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,27 +100,6 @@ repos:
       - id: blacken-docs
         alias: black
         additional_dependencies: [black>=26.3.1]
-  - repo: local
-    hooks:
-      - id: check-docs-build
-        name: Ensure the docs build without errors
-        entry: sphinx-build -b html docs docs/_build --fail-on-warning --fresh-env
-        language: python
-        additional_dependencies:
-          [
-            "aenum",
-            "deprecation",
-            "msgpack",
-            "apache-airflow",
-            "pydata-sphinx-theme>=0.16.0",
-            "sphinx",
-            "sphinx-autoapi",
-            "sphinx-autobuild",
-            "sphinx-reredirects",
-            "sphinxcontrib.mermaid",
-          ]
-        pass_filenames: false
-        files: ^docs/
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: "v1.20.0"
     hooks:


### PR DESCRIPTION
The Sphinx docs build had outgrown the memory available on
pre-commit.ci runners and was failing consistently on every pull
request, including ones that touched no documentation at all. The
result was a red pre-commit.ci check on unrelated PRs, blocked merges,
time lost to investigating failures that had nothing to do with the
change under review, and an erosion of trust in required checks.

Running the docs build on GitHub Actions restores that trust. PRs
that do not touch docs or library sources now pass cleanly. PRs that
do touch them get a reliable pass/fail signal with enough memory to
actually complete the build, so warnings surface where they belong
rather than being masked by OOM failures. pre-commit.ci is left to
focus on what it is good at, fast lint and format checks, and
reviewers and contributors get back the signal they rely on to ship
changes confidently.

related: https://github.com/astronomer/astronomer-cosmos/pull/2578
related: https://github.com/astronomer/astronomer-cosmos/pull/2579