### PR TITLE
Fix dbt Fusion broken integration tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,9 @@ actionlint
 # dbt_packages is a directory that gets created when you run dbt deps
 dev/dags/dbt/jaffle_shop/dbt_packages/
 
+# dbt package lockfile — removed so dbt resolves the version range in packages.yml at runtime
+dev/dags/dbt/jaffle_shop/package-lock.yml
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/dev/dags/dbt/jaffle_shop/dbt_project.yml
+++ b/dev/dags/dbt/jaffle_shop/dbt_project.yml
@@ -17,7 +17,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   jaffle_shop:

--- a/dev/dags/dbt/jaffle_shop/package-lock.yml
+++ b/dev/dags/dbt/jaffle_shop/package-lock.yml
@@ -1,4 +1,0 @@
-packages:
-  - package: dbt-labs/dbt_utils
-    version: 1.1.1
-sha1_hash: a158c48c59c2bb7d729d2a4e215aabe5bb4f3353

--- a/dev/dags/dbt/jaffle_shop/packages.yml
+++ b/dev/dags/dbt/jaffle_shop/packages.yml
@@ -1,3 +1,3 @@
 packages:
   - package: dbt-labs/dbt_utils
-    version: "1.1.1"
+    version: [">=1.1.1", "<1.4.0"]

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2357,9 +2357,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "8c11a931632283f4bb0af747a35ef0ab")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
     else:
-        assert hash_dir == "8c11a931632283f4bb0af747a35ef0ab"
+        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2399,9 +2399,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "8c11a931632283f4bb0af747a35ef0ab")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
     else:
-        assert hash_dir == "8c11a931632283f4bb0af747a35ef0ab"
+        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
 
 
 @pytest.mark.integration

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2357,9 +2357,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "d1fe27e97a66b046fc8bfd7b6bd0c9a6")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "8c11a931632283f4bb0af747a35ef0ab")
     else:
-        assert hash_dir == "d1fe27e97a66b046fc8bfd7b6bd0c9a6"
+        assert hash_dir == "8c11a931632283f4bb0af747a35ef0ab"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2399,9 +2399,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "d1fe27e97a66b046fc8bfd7b6bd0c9a6")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "8c11a931632283f4bb0af747a35ef0ab")
     else:
-        assert hash_dir == "d1fe27e97a66b046fc8bfd7b6bd0c9a6"
+        assert hash_dir == "8c11a931632283f4bb0af747a35ef0ab"
 
 
 @pytest.mark.integration

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2357,9 +2357,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "633a523f295ef0cd496525428815537b")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "d1fe27e97a66b046fc8bfd7b6bd0c9a6")
     else:
-        assert hash_dir == "633a523f295ef0cd496525428815537b"
+        assert hash_dir == "d1fe27e97a66b046fc8bfd7b6bd0c9a6"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2399,9 +2399,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "633a523f295ef0cd496525428815537b")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "d1fe27e97a66b046fc8bfd7b6bd0c9a6")
     else:
-        assert hash_dir == "633a523f295ef0cd496525428815537b"
+        assert hash_dir == "d1fe27e97a66b046fc8bfd7b6bd0c9a6"
 
 
 @pytest.mark.integration


### PR DESCRIPTION
Use a version range `[">=1.1.1", "<1.4.0"]` for `dbt_utils` in the jaffle_shop test project instead of pinning to `1.1.1` because `dbt_utils@1.1.1` is incompatible with dbt 2.0, causing dbt Fusion integration tests to fail with `dbt1080` warnings and exit code 1. The range allows dbt to resolve to `1.3.3` (which supports `>=1.3.0, <3.0.0`) for dbt 2.0 while still working with older dbt versions.