### PR TITLE
Avoid running tests when PRs from forks only change docs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,7 +50,10 @@ jobs:
             # Use GitHub API to list changed files — works reliably for fork PRs
             # where git diff may fail because the fork's commits aren't in local history.
             PR_NUMBER="${{ github.event.pull_request.number }}"
-            FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
+            if ! FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/dev/null); then
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           else
             BASE="${{ github.event.before }}"
             HEAD="${{ github.sha }}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,23 +43,27 @@ jobs:
           persist-credentials: false
 
       - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
           if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
-            BASE="${{ github.event.pull_request.base.sha }}"
-            HEAD="${{ github.event.pull_request.head.sha }}"
+            # Use GitHub API to list changed files — works reliably for fork PRs
+            # where git diff may fail because the fork's commits aren't in local history.
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename')
           else
             BASE="${{ github.event.before }}"
             HEAD="${{ github.sha }}"
-          fi
-          # Handle cases where BASE is missing or all zeros (e.g., first push, force push)
-          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
-            echo "code_changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-          # Compute changed files; if git diff fails, assume code changed to be safe
-          if ! FILES=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null); then
-            echo "code_changed=true" >> "$GITHUB_OUTPUT"
-            exit 0
+            # Handle cases where BASE is missing or all zeros (e.g., first push, force push)
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Compute changed files; if git diff fails, assume code changed to be safe
+            if ! FILES=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null); then
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
           fi
           CODE_CHANGED=false
           # If we can't determine changed files, run tests to be safe

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -51,7 +51,8 @@ jobs:
             # Use GitHub API to list changed files — works reliably for fork PRs
             # where git diff may fail because the fork's commits aren't in local history.
             PR_NUMBER="${{ github.event.pull_request.number }}"
-            if ! FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/dev/null); then
+            if ! FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/tmp/gh_api_err); then
+              echo "::warning::Failed to list PR changed files via GitHub API, falling back to running all tests. Error: $(cat /tmp/gh_api_err)"
               echo "code_changed=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
     outputs:
       code_changed: ${{ steps.check.outputs.code_changed }}
     steps:


### PR DESCRIPTION
I observed in #2575 that a docs-only PR from a fork triggered the full test suite after authorisation. The goal of this change is to run our tests only when needed.

- Fix `Check-changed-files` job to correctly skip tests for docs-only PRs from forks
- For `pull_request_target` events (fork PRs), use the GitHub API (`gh api repos/.../pulls/.../files`) instead of `git diff` to list changed files
- `git diff` fails silently for fork PRs because the fork's commits may not be in the local git history, causing the job to fall back to `code_changed=true` and run all tests unnecessarily
- Push events continue using `git diff` as before
