### PR TITLE
Add producer-internal dbt retry for ExecutionMode.WATCHER

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -25,6 +25,7 @@ from cosmos.operators._watcher.state import (
     _log_dbt_event,
     build_producer_state_fetcher,
     get_xcom_val,
+    is_dbt_node_status_failed,
     is_dbt_node_status_skipped,
     is_dbt_node_status_success,
     is_dbt_node_status_terminal,
@@ -237,6 +238,47 @@ def _ensure_subprocess_model_outlet_uris(
         model_outlet_uris[_MODEL_OUTLET_URIS_ATTEMPTED_KEY] = []  # type: ignore[assignment]
 
 
+def _push_or_defer_status(
+    task_instance: Any,
+    unique_id: str,
+    dbt_node_status: str,
+    status_value: dict[str, Any],
+    pending_failures: dict[str, dict[str, Any]] | None,
+) -> None:
+    """Push a node's status to XCom, or defer it into pending_failures for retry.
+
+    When ``pending_failures`` is provided:
+    - Failed/skipped nodes are stored in ``pending_failures`` instead of XCom,
+      because ``dbt retry`` re-runs both failed nodes and their skipped dependents.
+    - Nodes that were previously pending but now succeeded are removed from
+      ``pending_failures`` and pushed to XCom immediately.
+    """
+    should_defer = pending_failures is not None and (
+        is_dbt_node_status_failed(dbt_node_status) or is_dbt_node_status_skipped(dbt_node_status)
+    )
+    if should_defer:
+        assert pending_failures is not None  # narrowing for mypy
+        pending_failures[unique_id] = status_value
+        logger.info(
+            "Deferring XCom push for node '%s' (status='%s') — will retry",
+            unique_id,
+            dbt_node_status,
+        )
+    else:
+        if pending_failures is not None and unique_id in pending_failures:
+            del pending_failures[unique_id]
+            logger.info(
+                "Node '%s' succeeded on retry (status='%s') — pushing XCom now",
+                unique_id,
+                dbt_node_status,
+            )
+        safe_xcom_push(
+            task_instance=task_instance,
+            key=f"{unique_id.replace('.', '__')}_status",
+            value=status_value,
+        )
+
+
 def store_dbt_resource_status_from_log(
     line: str,
     extra_kwargs: Any,
@@ -245,6 +287,7 @@ def store_dbt_resource_status_from_log(
     test_results_per_model: dict[str, list[str]] | None = None,
     model_outlet_uris: dict[str, list[str]] | None = None,
     dataset_namespace: str | None = None,
+    pending_failures: dict[str, dict[str, Any]] | None = None,
 ) -> None:
     """
     Parses a single line from dbt JSON logs and stores node status to Airflow XCom.
@@ -265,6 +308,11 @@ def store_dbt_resource_status_from_log(
     :param model_outlet_uris: Mutable dict mapping unique_id to outlet URIs.
         Populated lazily from the manifest on first terminal status detection.
     :param dataset_namespace: The OL-compatible dataset namespace for URI construction.
+    :param pending_failures: When not None, failed model/seed/snapshot statuses are
+        stored in this dict instead of being pushed to XCom immediately. This allows
+        the producer to retry failed nodes via ``dbt retry`` before consumers see a
+        failure. Keyed by unique_id, values are the status dicts. Test results are
+        never deferred (they use a separate aggregation mechanism).
     """
     try:
         log_line = json.loads(line)
@@ -312,15 +360,11 @@ def store_dbt_resource_status_from_log(
                     _ensure_subprocess_model_outlet_uris(model_outlet_uris, dataset_namespace, project_dir)
                     outlet_uris = model_outlet_uris.get(unique_id, []) if model_outlet_uris else []
 
-                status_value: dict[str, Any] | str = {
+                status_value: dict[str, Any] = {
                     "status": dbt_node_status,
                     "outlet_uris": outlet_uris,
                 }
-                safe_xcom_push(
-                    task_instance=context["ti"],
-                    key=f"{unique_id.replace('.', '__')}_status",
-                    value=status_value,
-                )
+                _push_or_defer_status(context["ti"], unique_id, dbt_node_status, status_value, pending_failures)
 
             # Extract and push compiled_sql for models (centralised for both subprocess and node-event)
             # compiled_sql is available for both success and failed models - it's compiled before execution

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -43,6 +43,10 @@ except ImportError:  # pragma: no cover
 
 logger = get_logger(__name__)
 
+# Protects mutations of the ``pending_failures`` dict passed to
+# ``_push_or_defer_status`` from concurrent dbt runner callback threads.
+_pending_failures_lock = threading.Lock()
+
 # Subset of dbt event types that represent errors/failures.
 # Used (together with node status lifecycle events like NodeStart/NodeCompiling/
 # NodeExecuting/NodeFinished) to build _DBT_EVENT_ALLOWLIST, which controls which
@@ -252,26 +256,33 @@ def _push_or_defer_status(
       because ``dbt retry`` re-runs both failed nodes and their skipped dependents.
     - Nodes that were previously pending but now succeeded are removed from
       ``pending_failures`` and pushed to XCom immediately.
+
+    All mutations of ``pending_failures`` are performed under
+    ``_pending_failures_lock`` because dbt runner callbacks are invoked from
+    multiple threads.
     """
     should_defer = pending_failures is not None and (
         is_dbt_node_status_failed(dbt_node_status) or is_dbt_node_status_skipped(dbt_node_status)
     )
     if should_defer:
         assert pending_failures is not None  # narrowing for mypy
-        pending_failures[unique_id] = status_value
+        with _pending_failures_lock:
+            pending_failures[unique_id] = status_value
         logger.info(
             "Deferring XCom push for node '%s' (status='%s') — will retry",
             unique_id,
             dbt_node_status,
         )
     else:
-        if pending_failures is not None and unique_id in pending_failures:
-            del pending_failures[unique_id]
-            logger.info(
-                "Node '%s' succeeded on retry (status='%s') — pushing XCom now",
-                unique_id,
-                dbt_node_status,
-            )
+        if pending_failures is not None:
+            with _pending_failures_lock:
+                removed = pending_failures.pop(unique_id, None)
+            if removed is not None:
+                logger.info(
+                    "Node '%s' succeeded on retry (status='%s') — pushing XCom now",
+                    unique_id,
+                    dbt_node_status,
+                )
         safe_xcom_push(
             task_instance=task_instance,
             key=f"{unique_id.replace('.', '__')}_status",

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -636,6 +636,24 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             async_op_configurator(self, sql=sql)
             async_context["async_operator"].execute(self, context)
 
+    def _post_dbt_invoke(
+        self,
+        result: Any,
+        context: Context,
+        env: dict[str, str | bytes | os.PathLike[Any]],
+        tmp_project_dir: str,
+        profile_path: Path,
+    ) -> Any:
+        """Hook called after the main dbt command finishes, before post-processing and exception handling.
+
+        The temporary project directory is still available at this point. Subclasses
+        can override this to perform additional work (e.g. run ``dbt retry`` for
+        failed nodes in the watcher producer). The returned value replaces ``result``
+        for downstream exception handling — return a successful result to suppress
+        the original failure.
+        """
+        return result
+
     def run_command(  # noqa: C901
         self,
         cmd: list[str],
@@ -689,6 +707,9 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                     self._sources_json = _read_target_sources_json(tmp_dir_path)
                     self.handle_exception(result)
                     return result
+
+                result = self._post_dbt_invoke(result, context, env, tmp_project_dir, profile_path)
+
                 if is_openlineage_common_available:
                     self.calculate_openlineage_events_completes(env, tmp_dir_path, full_cmd)
                     if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import contextlib
 import functools
+import os
 from collections.abc import Callable
+from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException, AirflowSkipException
@@ -172,6 +174,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self.tests_per_model: dict[str, list[str]] = kwargs.pop("tests_per_model", {})
         self.test_results_per_model: dict[str, list[str]] = {}
         self._check_source_freshness: bool = kwargs.pop("_check_source_freshness", False)
+        self.dbt_retry_count: int = kwargs.pop("dbt_retry_count", 0)
         self._freshness_callback: Callable[
             [Context, Any, TaskGroup | None, dict[str, DbtNode] | None, dict[str, Any] | None],
             list[tuple[str, str]],
@@ -193,6 +196,11 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self._dataset_namespace: str | None = None
         self._model_outlet_uris: dict[str, list[str]] = {}
 
+        # Holds failed model statuses during the retry loop so that consumers
+        # don't see intermediate "failed" XCom values that will be retried.
+        # Maps unique_id -> {"status": ..., "outlet_uris": ...}
+        self._pending_failures: dict[str, dict[str, Any]] = {}
+
     def _handle_datasets(self, context: Context) -> None:
         """No-op override: consumer tasks handle their own dataset emission in WATCHER mode."""
 
@@ -204,6 +212,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             test_results_per_model=self.test_results_per_model,
             model_outlet_uris=self._model_outlet_uris,
             dataset_namespace=self._dataset_namespace,
+            pending_failures=self._pending_failures if self.dbt_retry_count > 0 else None,
         )
 
     def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str, **kwargs: Any) -> Any:
@@ -377,10 +386,121 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         freshness_results = self._freshness_callback(context, dag, task_group, nodes, self._sources_json)
         self._apply_node_state_tokens(context, freshness_results)
 
+    def _build_retry_command(self, tmp_project_dir: str, profile_path: Path) -> list[str]:
+        """Build a ``dbt retry`` command using the same project/profile flags as the original build."""
+        retry_cmd = [self.dbt_executable_path]
+        retry_cmd.extend(self.dbt_cmd_global_flags)
+        if not self.partial_parse:
+            retry_cmd.append("--no-partial-parse")
+        retry_cmd.append("retry")
+        retry_cmd.extend(self._generate_dbt_flags(tmp_project_dir, profile_path))
+        return retry_cmd
+
+    def _has_run_results(self, tmp_project_dir: str) -> bool:
+        """Check if run_results.json exists in the target directory."""
+        return (Path(tmp_project_dir) / "target" / "run_results.json").is_file()
+
+    def _run_dbt_retry_loop(
+        self,
+        context: Context,
+        env: dict[str, str | bytes | os.PathLike[Any]],
+        tmp_project_dir: str,
+        profile_path: Path,
+    ) -> Any:
+        """Run ``dbt retry`` up to ``dbt_retry_count`` times for any pending failures.
+
+        After each retry iteration the log-parsing callback updates
+        ``self._pending_failures``: nodes that now succeed are removed and their
+        XCom status is pushed immediately; nodes that still fail remain pending.
+
+        Returns the result of the last ``dbt retry`` invocation (or ``None`` if
+        no retry was executed), so the caller can decide whether to propagate the
+        original build failure.
+        """
+        last_result = None
+        for attempt in range(1, self.dbt_retry_count + 1):
+            if not self._pending_failures:
+                break
+
+            failed_nodes = list(self._pending_failures.keys())
+            logger.info(
+                "dbt retry attempt %d/%d — retrying %d failed node(s): %s",
+                attempt,
+                self.dbt_retry_count,
+                len(failed_nodes),
+                failed_nodes,
+            )
+
+            if not self._has_run_results(tmp_project_dir):
+                logger.warning(
+                    "run_results.json not found in %s/target/ — cannot run dbt retry. "
+                    "Flushing %d remaining failure(s) to XCom.",
+                    tmp_project_dir,
+                    len(self._pending_failures),
+                )
+                break
+
+            retry_cmd = self._build_retry_command(tmp_project_dir, profile_path)
+            try:
+                last_result = self.invoke_dbt(
+                    command=retry_cmd,
+                    env=env,
+                    cwd=tmp_project_dir,
+                    context=context,
+                )
+            except Exception:
+                logger.warning(
+                    "dbt retry attempt %d/%d raised an exception — %d failure(s) remain pending",
+                    attempt,
+                    self.dbt_retry_count,
+                    len(self._pending_failures),
+                    exc_info=True,
+                )
+        return last_result
+
+    def _flush_pending_failures(self, context: Context) -> None:
+        """Push all remaining pending failure statuses to XCom."""
+        if not self._pending_failures:
+            return
+        ti = context["ti"]
+        for unique_id, status_value in self._pending_failures.items():
+            logger.info("Pushing final failed status for node '%s' after exhausting retry budget", unique_id)
+            safe_xcom_push(
+                task_instance=ti,
+                key=f"{unique_id.replace('.', '__')}_status",
+                value=status_value,
+            )
+        self._pending_failures.clear()
+
+    def _post_dbt_invoke(
+        self,
+        result: Any,
+        context: Context,
+        env: dict[str, str | bytes | os.PathLike[Any]],
+        tmp_project_dir: str,
+        profile_path: Path,
+    ) -> Any:
+        """Run ``dbt retry`` for failed nodes, then flush any remaining failures to XCom.
+
+        If all retries succeed, returns the last retry result (which is successful)
+        so that ``handle_exception`` does not raise. Otherwise returns the original
+        failed build result.
+        """
+        if self.dbt_retry_count > 0 and self._pending_failures:
+            last_retry_result = self._run_dbt_retry_loop(context, env, tmp_project_dir, profile_path)
+            all_retries_succeeded = not self._pending_failures
+            self._flush_pending_failures(context)
+            # All retries succeeded — return the successful retry result so
+            # handle_exception does not raise for the original build failure.
+            if all_retries_succeeded and last_retry_result is not None:
+                return last_retry_result
+        return result
+
     def execute(self, context: Context, **kwargs: Any) -> Any:
         # Pre-compute the dataset namespace for per-model outlet URI generation.
         self._dataset_namespace = get_dataset_namespace(self.profile_config)
         self._model_outlet_uris.clear()
+        self._pending_failures.clear()
 
         task_instance = context.get("ti")
         if task_instance is None:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -386,14 +386,34 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         freshness_results = self._freshness_callback(context, dag, task_group, nodes, self._sources_json)
         self._apply_node_state_tokens(context, freshness_results)
 
-    def _build_retry_command(self, tmp_project_dir: str, profile_path: Path) -> list[str]:
-        """Build a ``dbt retry`` command with the same project/profile flags as the original build.
+    # Flags that ``dbt retry`` does not accept — it derives the node set from
+    # ``run_results.json`` and does not support selection or refresh overrides.
+    _RETRY_UNSUPPORTED_FLAGS = frozenset({"--select", "--exclude", "--selector", "--models", "--full-refresh"})
 
-        Includes ``--log-format json`` so the log parser can update
-        ``_pending_failures`` during retry. Build-specific flags like
-        ``--full-refresh``, ``--select``, ``--exclude`` are omitted because
-        ``dbt retry`` does not accept them — it derives the node set from
-        ``run_results.json``.
+    @classmethod
+    def _filter_retry_unsupported_flags(cls, flags: list[str]) -> list[str]:
+        """Remove flags that ``dbt retry`` does not accept from a flag list."""
+        filtered: list[str] = []
+        skip_next = False
+        for token in flags:
+            if skip_next:
+                # Skip the value that follows a flag-with-value like --select X
+                if not token.startswith("--"):
+                    continue
+                skip_next = False
+            if token in cls._RETRY_UNSUPPORTED_FLAGS:
+                skip_next = True
+                continue
+            filtered.append(token)
+        return filtered
+
+    def _build_retry_command(self, tmp_project_dir: str, profile_path: Path) -> list[str]:
+        """Build a ``dbt retry`` command with the same global/profile flags as the original build.
+
+        Uses ``add_global_flags()`` and ``add_cmd_flags()`` to include flags
+        like ``--vars``, ``--quiet``, ``--warn-error``, and ``--log-format json``,
+        then filters out flags that ``dbt retry`` does not accept (``--select``,
+        ``--exclude``, ``--selector``, ``--models``, ``--full-refresh``).
         """
         retry_cmd = [self.dbt_executable_path]
         retry_cmd.extend(self.dbt_cmd_global_flags)
@@ -401,8 +421,8 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             retry_cmd.append("--no-partial-parse")
         retry_cmd.append("retry")
         retry_cmd.extend(self._generate_dbt_flags(tmp_project_dir, profile_path))
-        if self.log_format:
-            retry_cmd.extend(["--log-format", self.log_format])
+        retry_cmd.extend(self._filter_retry_unsupported_flags(self.add_global_flags()))
+        retry_cmd.extend(self._filter_retry_unsupported_flags(self.add_cmd_flags()))
         return retry_cmd
 
     def _has_run_results(self, tmp_project_dir: str) -> bool:
@@ -487,6 +507,19 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             )
         self._pending_failures.clear()
 
+    @staticmethod
+    def _is_dbt_result_failure(result: Any) -> bool:
+        """Check if a dbt invocation result indicates failure.
+
+        Works for both ``dbtRunnerResult`` (has ``.success``) and
+        ``FullOutputSubprocessResult`` (has ``.exit_code``).
+        """
+        if hasattr(result, "success"):
+            return bool(not result.success)
+        if hasattr(result, "exit_code"):
+            return bool(result.exit_code != 0)
+        return False
+
     def _post_dbt_invoke(
         self,
         result: Any,
@@ -497,11 +530,17 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     ) -> Any:
         """Run ``dbt retry`` for failed nodes, then flush any remaining failures to XCom.
 
+        The retry loop fires when ``dbt_retry_count > 0`` and either:
+        - ``_pending_failures`` is non-empty (model/seed/snapshot failures), or
+        - the dbt result indicates failure (covers test-only failures that bypass
+          ``_pending_failures``).
+
         If all retries succeed, returns the last retry result (which is successful)
         so that ``handle_exception`` does not raise. Otherwise returns the original
         failed build result.
         """
-        if self.dbt_retry_count > 0 and self._pending_failures:
+        should_retry = self.dbt_retry_count > 0 and (self._pending_failures or self._is_dbt_result_failure(result))
+        if should_retry:
             last_retry_result = self._run_dbt_retry_loop(context, env, tmp_project_dir, profile_path)
             all_retries_succeeded = not self._pending_failures
             self._flush_pending_failures(context)

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -387,13 +387,22 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self._apply_node_state_tokens(context, freshness_results)
 
     def _build_retry_command(self, tmp_project_dir: str, profile_path: Path) -> list[str]:
-        """Build a ``dbt retry`` command using the same project/profile flags as the original build."""
+        """Build a ``dbt retry`` command with the same project/profile flags as the original build.
+
+        Includes ``--log-format json`` so the log parser can update
+        ``_pending_failures`` during retry. Build-specific flags like
+        ``--full-refresh``, ``--select``, ``--exclude`` are omitted because
+        ``dbt retry`` does not accept them — it derives the node set from
+        ``run_results.json``.
+        """
         retry_cmd = [self.dbt_executable_path]
         retry_cmd.extend(self.dbt_cmd_global_flags)
         if not self.partial_parse:
             retry_cmd.append("--no-partial-parse")
         retry_cmd.append("retry")
         retry_cmd.extend(self._generate_dbt_flags(tmp_project_dir, profile_path))
+        if self.log_format:
+            retry_cmd.extend(["--log-format", self.log_format])
         return retry_cmd
 
     def _has_run_results(self, tmp_project_dir: str) -> bool:
@@ -434,11 +443,17 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             if not self._has_run_results(tmp_project_dir):
                 logger.warning(
                     "run_results.json not found in %s/target/ — cannot run dbt retry. "
-                    "Flushing %d remaining failure(s) to XCom.",
+                    "%d failure(s) will be flushed to XCom after the retry loop.",
                     tmp_project_dir,
                     len(self._pending_failures),
                 )
                 break
+
+            # Reset the test results accumulator before each retry so that
+            # stale test failures from the previous attempt don't contaminate
+            # the aggregated result.  dbt retry re-runs failed tests, so
+            # the accumulator will be repopulated with fresh results.
+            self.test_results_per_model.clear()
 
             retry_cmd = self._build_retry_command(tmp_project_dir, profile_path)
             try:

--- a/dev/dags/dbt/jaffle_shop/models/flaky_model.sql
+++ b/dev/dags/dbt/jaffle_shop/models/flaky_model.sql
@@ -1,0 +1,29 @@
+{{
+  config(
+    tags=["flaky"],
+    materialized="table",
+    pre_hook=[
+      "CREATE TABLE IF NOT EXISTS {{ target.schema }}.retry_flag (attempt integer)",
+      "INSERT INTO {{ target.schema }}.retry_flag (attempt) SELECT 0 WHERE NOT EXISTS (SELECT 1 FROM {{ target.schema }}.retry_flag)",
+      "UPDATE {{ target.schema }}.retry_flag SET attempt = attempt + 1"
+    ]
+  )
+}}
+
+-- Simulates a transient failure for testing dbt retry.
+-- Fully self-contained: no manual DB setup required.
+--
+-- Pre-hooks run on every attempt (including dbt retry):
+--   1. Create flag table if not exists
+--   2. Seed with 0 if empty
+--   3. Increment attempt counter
+--
+-- First dbt build: pre-hooks set attempt=1, SELECT hits 1/0, model fails.
+-- dbt retry: pre-hooks set attempt=2, SELECT returns 1, model succeeds.
+
+SELECT
+    CASE
+        WHEN (SELECT attempt FROM {{ target.schema }}.retry_flag LIMIT 1) <= 1
+        THEN 1 / 0  -- Fail on first attempt
+        ELSE 1
+    END AS result

--- a/dev/dags/dbt/jaffle_shop/models/flaky_model.sql
+++ b/dev/dags/dbt/jaffle_shop/models/flaky_model.sql
@@ -1,6 +1,7 @@
 {{
   config(
     tags=["flaky"],
+    enabled=var("enable_flaky_models", false),
     materialized="table",
     pre_hook=[
       "CREATE TABLE IF NOT EXISTS {{ target.schema }}.retry_flag (attempt integer)",

--- a/dev/dags/dbt/jaffle_shop/models/flaky_model_cleanup.sql
+++ b/dev/dags/dbt/jaffle_shop/models/flaky_model_cleanup.sql
@@ -1,0 +1,14 @@
+{{
+  config(
+    tags=["flaky"],
+    materialized="table",
+    post_hook=[
+      "DELETE FROM {{ target.schema }}.retry_flag"
+    ]
+  )
+}}
+
+-- Depends on flaky_model so it runs after the retry succeeds.
+-- Post-hook resets the flag table so the next DAG run starts fresh.
+
+SELECT * FROM {{ ref('flaky_model') }}

--- a/dev/dags/dbt/jaffle_shop/models/flaky_model_cleanup.sql
+++ b/dev/dags/dbt/jaffle_shop/models/flaky_model_cleanup.sql
@@ -1,6 +1,7 @@
 {{
   config(
     tags=["flaky"],
+    enabled=var("enable_flaky_models", false),
     materialized="table",
     post_hook=[
       "DELETE FROM {{ target.schema }}.retry_flag"

--- a/dev/dags/example_watcher_retry.py
+++ b/dev/dags/example_watcher_retry.py
@@ -45,7 +45,10 @@ example_watcher_retry = DbtDag(
             "dbt_retry_count": 2,
         },
     ),
-    project_config=ProjectConfig(DBT_PROJECT_PATH),
+    project_config=ProjectConfig(
+        DBT_PROJECT_PATH,
+        dbt_vars={"enable_flaky_models": True},
+    ),
     profile_config=profile_config,
     render_config=RenderConfig(exclude=["raw_payments"]),
     operator_args=operator_args,

--- a/dev/dags/example_watcher_retry.py
+++ b/dev/dags/example_watcher_retry.py
@@ -1,0 +1,58 @@
+"""
+Example DAG that uses ExecutionMode.WATCHER with dbt_retry_count to demonstrate
+producer-internal dbt retry for transient failures.
+
+The jaffle_shop project includes a flaky_model that fails on its first attempt
+(division by zero) and succeeds on dbt retry (pre-hook increments a flag).
+The flaky_model_cleanup model depends on flaky_model and resets the flag so
+each DAG run starts fresh.
+"""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import ExecutionMode
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
+
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+        disable_event_tracking=True,
+    ),
+)
+
+operator_args = {
+    "install_deps": True,
+    "execution_timeout": timedelta(seconds=120),
+}
+
+# [START example_watcher_retry]
+example_watcher_retry = DbtDag(
+    execution_config=ExecutionConfig(
+        execution_mode=ExecutionMode.WATCHER,
+        setup_operator_args={
+            "dbt_retry_count": 2,
+        },
+    ),
+    project_config=ProjectConfig(DBT_PROJECT_PATH),
+    profile_config=profile_config,
+    render_config=RenderConfig(exclude=["raw_payments"]),
+    operator_args=operator_args,
+    schedule="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="example_watcher_retry",
+    default_args={"retries": 0},
+)
+# [END example_watcher_retry]

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2365,9 +2365,13 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in (
+            "835a0c9dd2d546fc98821b5dd4e783ee",
+            "9d95cbf6529e2ab51fadd6a3f0a3971f",
+            "5c1aed937708e585054c874ff8f33fd1",
+        )
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "835a0c9dd2d546fc98821b5dd4e783ee"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2407,9 +2411,13 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in (
+            "835a0c9dd2d546fc98821b5dd4e783ee",
+            "9d95cbf6529e2ab51fadd6a3f0a3971f",
+            "5c1aed937708e585054c874ff8f33fd1",
+        )
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "835a0c9dd2d546fc98821b5dd4e783ee"
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2366,12 +2366,12 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
         assert hash_dir in (
-            "835a0c9dd2d546fc98821b5dd4e783ee",
+            "0668e4412580793527a6a5a1fab88c3a",
             "9d95cbf6529e2ab51fadd6a3f0a3971f",
             "5c1aed937708e585054c874ff8f33fd1",
         )
     else:
-        assert hash_dir == "835a0c9dd2d546fc98821b5dd4e783ee"
+        assert hash_dir == "0668e4412580793527a6a5a1fab88c3a"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2412,12 +2412,12 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
         assert hash_dir in (
-            "835a0c9dd2d546fc98821b5dd4e783ee",
+            "0668e4412580793527a6a5a1fab88c3a",
             "9d95cbf6529e2ab51fadd6a3f0a3971f",
             "5c1aed937708e585054c874ff8f33fd1",
         )
     else:
-        assert hash_dir == "835a0c9dd2d546fc98821b5dd4e783ee"
+        assert hash_dir == "0668e4412580793527a6a5a1fab88c3a"
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2428,3 +2428,327 @@ class TestProducerSourceFreshness:
         # The callback list must remain untouched — no watcher callback appended
         assert producer._dbt_runner_callbacks is None
         mock_super.assert_called_once()
+
+
+class TestDbtProducerRetry:
+    """Tests for the producer-internal dbt retry mechanism."""
+
+    @staticmethod
+    def _make_producer(**kwargs):
+        defaults = dict(project_dir=".", profile_config=None)
+        defaults.update(kwargs)
+        return DbtProducerWatcherOperator(**defaults)
+
+    def test_dbt_retry_count_default_is_zero(self):
+        op = self._make_producer()
+        assert op.dbt_retry_count == 0
+
+    def test_dbt_retry_count_custom(self):
+        op = self._make_producer(dbt_retry_count=3)
+        assert op.dbt_retry_count == 3
+
+    def test_pending_failures_not_used_when_retry_count_zero(self):
+        """When dbt_retry_count=0, pending_failures should not be passed to the log parser."""
+        op = self._make_producer(dbt_retry_count=0)
+        op._dataset_namespace = "test"
+        parse_fn = op._make_parse_callable()
+        # Inspect the partial's keywords
+        assert parse_fn.keywords.get("pending_failures") is None
+
+    def test_pending_failures_used_when_retry_count_positive(self):
+        """When dbt_retry_count>0, pending_failures dict should be passed to the log parser."""
+        op = self._make_producer(dbt_retry_count=2)
+        op._dataset_namespace = "test"
+        parse_fn = op._make_parse_callable()
+        assert parse_fn.keywords.get("pending_failures") is op._pending_failures
+
+    def test_store_dbt_resource_status_defers_failed_model(self):
+        """Failed models should be stored in pending_failures instead of XCom when retries are configured."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+        pending = {}
+
+        log_line = json.dumps(
+            {
+                "data": {
+                    "node_info": {
+                        "node_status": "error",
+                        "unique_id": "model.pkg.failing_model",
+                        "node_path": "failing_model.sql",
+                        "resource_type": "model",
+                    }
+                }
+            }
+        )
+
+        store_dbt_resource_status_from_log(log_line, {"context": ctx, "project_dir": "/tmp"}, pending_failures=pending)
+
+        # Should NOT be in XCom
+        assert "model__pkg__failing_model_status" not in ti.store
+        # Should be in pending_failures
+        assert "model.pkg.failing_model" in pending
+        assert pending["model.pkg.failing_model"]["status"] == "error"
+
+    def test_store_dbt_resource_status_defers_skipped_model(self):
+        """Skipped models (e.g. due to upstream failure) should also be deferred when retries are configured,
+        because dbt retry re-runs both failed nodes and their skipped downstream dependents."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+        pending = {}
+
+        log_line = json.dumps(
+            {
+                "data": {
+                    "node_info": {
+                        "node_status": "skipped",
+                        "unique_id": "model.pkg.downstream_model",
+                        "node_path": "downstream_model.sql",
+                        "resource_type": "model",
+                    }
+                }
+            }
+        )
+
+        store_dbt_resource_status_from_log(log_line, {"context": ctx, "project_dir": "/tmp"}, pending_failures=pending)
+
+        # Should NOT be in XCom
+        assert "model__pkg__downstream_model_status" not in ti.store
+        # Should be in pending_failures
+        assert "model.pkg.downstream_model" in pending
+        assert pending["model.pkg.downstream_model"]["status"] == "skipped"
+
+    def test_store_dbt_resource_status_pushes_success_immediately_with_pending(self):
+        """Successful models should be pushed to XCom immediately even when pending_failures is provided."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+        pending = {}
+
+        log_line = json.dumps(
+            {
+                "data": {
+                    "node_info": {
+                        "node_status": "success",
+                        "unique_id": "model.pkg.good_model",
+                        "node_path": "good_model.sql",
+                        "resource_type": "model",
+                    }
+                }
+            }
+        )
+
+        store_dbt_resource_status_from_log(log_line, {"context": ctx, "project_dir": "/tmp"}, pending_failures=pending)
+
+        # Should be in XCom
+        assert ti.store.get("model__pkg__good_model_status") == {"status": "success", "outlet_uris": []}
+        # Should NOT be in pending
+        assert "model.pkg.good_model" not in pending
+
+    def test_store_dbt_resource_status_clears_pending_on_retry_success(self):
+        """When a previously failed model succeeds on retry, it should be removed from pending_failures and pushed to XCom."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+        pending = {"model.pkg.flaky_model": {"status": "error", "outlet_uris": []}}
+
+        log_line = json.dumps(
+            {
+                "data": {
+                    "node_info": {
+                        "node_status": "success",
+                        "unique_id": "model.pkg.flaky_model",
+                        "node_path": "flaky_model.sql",
+                        "resource_type": "model",
+                    }
+                }
+            }
+        )
+
+        store_dbt_resource_status_from_log(log_line, {"context": ctx, "project_dir": "/tmp"}, pending_failures=pending)
+
+        # Should now be in XCom with success
+        assert ti.store.get("model__pkg__flaky_model_status") == {"status": "success", "outlet_uris": []}
+        # Should be removed from pending
+        assert "model.pkg.flaky_model" not in pending
+
+    def test_flush_pending_failures_pushes_to_xcom(self):
+        """_flush_pending_failures should push all remaining failures to XCom and clear the dict."""
+        op = self._make_producer(dbt_retry_count=1)
+        op._pending_failures = {
+            "model.pkg.model_a": {"status": "error", "outlet_uris": []},
+            "model.pkg.model_b": {"status": "failed", "outlet_uris": []},
+        }
+        ti = _MockTI()
+        context = {"ti": ti}
+
+        op._flush_pending_failures(context)
+
+        assert ti.store["model__pkg__model_a_status"] == {"status": "error", "outlet_uris": []}
+        assert ti.store["model__pkg__model_b_status"] == {"status": "failed", "outlet_uris": []}
+        assert op._pending_failures == {}
+
+    def test_flush_pending_failures_noop_when_empty(self):
+        """_flush_pending_failures should do nothing when there are no pending failures."""
+        op = self._make_producer(dbt_retry_count=1)
+        ti = _MockTI()
+        context = {"ti": ti}
+
+        op._flush_pending_failures(context)
+
+        assert ti.store == {}
+
+    def test_has_run_results(self, tmp_path):
+        target = tmp_path / "target"
+        target.mkdir()
+
+        op = self._make_producer()
+
+        assert not op._has_run_results(str(tmp_path))
+
+        (target / "run_results.json").write_text("{}")
+        assert op._has_run_results(str(tmp_path))
+
+    def test_build_retry_command(self):
+        op = self._make_producer(profile_config=profile_config)
+        op.dbt_executable_path = "dbt"
+        op.dbt_cmd_global_flags = []
+        op.partial_parse = False
+
+        cmd = op._build_retry_command("/tmp/project", Path("/tmp/profiles/profiles.yml"))
+        assert "retry" in cmd
+        assert "--no-partial-parse" in cmd
+        assert "--project-dir" in cmd
+
+    def test_post_dbt_invoke_no_retries_configured(self):
+        """When dbt_retry_count=0, _post_dbt_invoke should return the original result unchanged."""
+        op = self._make_producer(dbt_retry_count=0)
+        original_result = MagicMock()
+        context = {"ti": _MockTI()}
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        assert result is original_result
+
+    def test_post_dbt_invoke_no_failures(self):
+        """When there are no pending failures, _post_dbt_invoke should return the original result."""
+        op = self._make_producer(dbt_retry_count=2)
+        op._pending_failures = {}
+        original_result = MagicMock()
+        context = {"ti": _MockTI()}
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        assert result is original_result
+
+    @patch.object(DbtProducerWatcherOperator, "_run_dbt_retry_loop")
+    def test_post_dbt_invoke_all_retries_succeed(self, mock_retry_loop):
+        """When retries resolve all failures, should return the retry result."""
+        op = self._make_producer(dbt_retry_count=2)
+        op._pending_failures = {"model.pkg.flaky": {"status": "error", "outlet_uris": []}}
+        original_result = MagicMock()
+        retry_result = MagicMock()
+
+        # Simulate retry loop clearing all failures
+        def side_effect(*args, **kwargs):
+            op._pending_failures.clear()
+            return retry_result
+
+        mock_retry_loop.side_effect = side_effect
+        context = {"ti": _MockTI()}
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        assert result is retry_result
+        mock_retry_loop.assert_called_once()
+
+    @patch.object(DbtProducerWatcherOperator, "_run_dbt_retry_loop")
+    def test_post_dbt_invoke_retries_exhausted_with_remaining_failures(self, mock_retry_loop):
+        """When retries don't resolve all failures, should flush them to XCom and return original result."""
+        op = self._make_producer(dbt_retry_count=1)
+        op._pending_failures = {"model.pkg.broken": {"status": "error", "outlet_uris": []}}
+        original_result = MagicMock()
+        ti = _MockTI()
+        context = {"ti": ti}
+
+        # Simulate retry loop NOT clearing failures
+        mock_retry_loop.return_value = MagicMock()
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        assert result is original_result
+        # Failures should have been flushed to XCom
+        assert ti.store["model__pkg__broken_status"] == {"status": "error", "outlet_uris": []}
+
+    @patch.object(DbtProducerWatcherOperator, "invoke_dbt")
+    def test_retry_loop_invokes_dbt_retry(self, mock_invoke, tmp_path):
+        """The retry loop should invoke dbt retry for each attempt while failures exist."""
+        op = self._make_producer(dbt_retry_count=2, profile_config=profile_config)
+        op.dbt_executable_path = "dbt"
+        op.dbt_cmd_global_flags = []
+        op.partial_parse = False
+        op._pending_failures = {"model.pkg.flaky": {"status": "error", "outlet_uris": []}}
+
+        # Create run_results.json so the loop doesn't abort
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "run_results.json").write_text("{}")
+
+        # Simulate first retry succeeding (clears pending)
+        def side_effect(*args, **kwargs):
+            op._pending_failures.clear()
+            return MagicMock()
+
+        mock_invoke.return_value = MagicMock()
+        mock_invoke.side_effect = side_effect
+
+        context = {"ti": _MockTI()}
+        op._run_dbt_retry_loop(context, {}, str(tmp_path), Path("/tmp/profiles"))
+
+        # Should only call once since failures were cleared
+        assert mock_invoke.call_count == 1
+        cmd_called = mock_invoke.call_args[1].get("command") or mock_invoke.call_args[0][0]
+        assert "retry" in cmd_called
+
+    @patch.object(DbtProducerWatcherOperator, "invoke_dbt")
+    def test_retry_loop_stops_when_run_results_missing(self, mock_invoke, tmp_path):
+        """If run_results.json is missing, the retry loop should break without invoking dbt."""
+        op = self._make_producer(dbt_retry_count=2)
+        op._pending_failures = {"model.pkg.broken": {"status": "error", "outlet_uris": []}}
+
+        # No run_results.json — target dir doesn't even exist
+        context = {"ti": _MockTI()}
+        op._run_dbt_retry_loop(context, {}, str(tmp_path), Path("/tmp/profiles"))
+
+        mock_invoke.assert_not_called()
+        # Failures should still be pending (not cleared by the loop)
+        assert "model.pkg.broken" in op._pending_failures
+
+    @patch.object(DbtProducerWatcherOperator, "invoke_dbt")
+    def test_retry_loop_handles_invoke_exception(self, mock_invoke, tmp_path):
+        """If dbt retry raises an exception, the loop should catch it and continue."""
+        op = self._make_producer(dbt_retry_count=2, profile_config=profile_config)
+        op.dbt_executable_path = "dbt"
+        op.dbt_cmd_global_flags = []
+        op.partial_parse = False
+        op._pending_failures = {"model.pkg.broken": {"status": "error", "outlet_uris": []}}
+
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "run_results.json").write_text("{}")
+
+        mock_invoke.side_effect = Exception("dbt retry failed")
+
+        context = {"ti": _MockTI()}
+        result = op._run_dbt_retry_loop(context, {}, str(tmp_path), Path("/tmp/profiles"))
+
+        # Should have tried dbt_retry_count times
+        assert mock_invoke.call_count == 2
+        assert result is None
+        # Failures should still be pending
+        assert "model.pkg.broken" in op._pending_failures
+
+    def test_execute_clears_pending_failures(self):
+        """execute() should clear _pending_failures at the start."""
+        op = self._make_producer(dbt_retry_count=1)
+        op._pending_failures = {"model.pkg.stale": {"status": "error", "outlet_uris": []}}
+        ti = _MockTI()
+        context = {"ti": ti}
+
+        with patch("cosmos.operators.local.DbtLocalBaseOperator.execute"):
+            op.execute(context=context)
+
+        assert op._pending_failures == {}

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2619,6 +2619,48 @@ class TestDbtProducerRetry:
         assert "--log-format" in cmd
         assert "json" in cmd
 
+    def test_filter_retry_unsupported_flags(self):
+        """_filter_retry_unsupported_flags should strip --select, --exclude, --full-refresh
+        and their values, while keeping other flags intact."""
+        flags = [
+            "--select",
+            "model_a model_b",
+            "--vars",
+            "{key: value}",
+            "--exclude",
+            "model_c",
+            "--full-refresh",
+            "--quiet",
+            "--models",
+            "model_d",
+            "--selector",
+            "my_selector",
+        ]
+        filtered = DbtProducerWatcherOperator._filter_retry_unsupported_flags(flags)
+        assert "--select" not in filtered
+        assert "model_a model_b" not in filtered
+        assert "--exclude" not in filtered
+        assert "--full-refresh" not in filtered
+        assert "--models" not in filtered
+        assert "--selector" not in filtered
+        assert "--vars" in filtered
+        assert "{key: value}" in filtered
+        assert "--quiet" in filtered
+
+    def test_is_dbt_result_failure_subprocess(self):
+        """_is_dbt_result_failure should detect subprocess failures via exit_code."""
+        result = MagicMock(spec=[])  # no .success attribute
+        result.exit_code = 1
+        assert DbtProducerWatcherOperator._is_dbt_result_failure(result) is True
+
+        result.exit_code = 0
+        assert DbtProducerWatcherOperator._is_dbt_result_failure(result) is False
+
+    def test_is_dbt_result_failure_unknown_result(self):
+        """_is_dbt_result_failure should return False for unknown result types."""
+        result = object()
+        assert DbtProducerWatcherOperator._is_dbt_result_failure(result) is False
+
     def test_post_dbt_invoke_no_retries_configured(self):
         """When dbt_retry_count=0, _post_dbt_invoke should return the original result unchanged."""
         op = self._make_producer(dbt_retry_count=0)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2746,7 +2746,7 @@ class TestDbtProducerRetry:
         op = self._make_producer(dbt_retry_count=1)
         op._pending_failures = {"model.pkg.stale": {"status": "error", "outlet_uris": []}}
         ti = _MockTI()
-        context = {"ti": ti}
+        context = {"ti": ti, "run_id": "test_run"}
 
         with patch("cosmos.operators.local.DbtLocalBaseOperator.execute"):
             op.execute(context=context)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2741,14 +2741,16 @@ class TestDbtProducerRetry:
         # Failures should still be pending
         assert "model.pkg.broken" in op._pending_failures
 
-    def test_execute_clears_pending_failures(self):
+    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom._persist_backup")
+    @patch("cosmos.operators.local.DbtLocalBaseOperator.execute")
+    def test_execute_clears_pending_failures(self, mock_execute, mock_persist, mock_variable):
         """execute() should clear _pending_failures at the start."""
         op = self._make_producer(dbt_retry_count=1)
         op._pending_failures = {"model.pkg.stale": {"status": "error", "outlet_uris": []}}
         ti = _MockTI()
         context = {"ti": ti, "run_id": "test_run"}
 
-        with patch("cosmos.operators.local.DbtLocalBaseOperator.execute"):
-            op.execute(context=context)
+        op.execute(context=context)
 
         assert op._pending_failures == {}

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2639,6 +2639,33 @@ class TestDbtProducerRetry:
         assert result is original_result
 
     @patch.object(DbtProducerWatcherOperator, "_run_dbt_retry_loop")
+    def test_post_dbt_invoke_triggers_retry_on_test_only_failure(self, mock_retry_loop):
+        """When dbt build fails only due to tests (no model failures), the retry loop should
+        still fire based on the dbt result, not just _pending_failures."""
+        op = self._make_producer(dbt_retry_count=1)
+        op._pending_failures = {}  # No model failures
+        original_result = MagicMock(success=False)  # dbt result indicates failure (tests failed)
+        retry_result = MagicMock(success=True)
+        mock_retry_loop.return_value = retry_result
+        context = {"ti": _MockTI()}
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        mock_retry_loop.assert_called_once()
+        assert result is retry_result
+
+    @patch.object(DbtProducerWatcherOperator, "_run_dbt_retry_loop")
+    def test_post_dbt_invoke_skips_retry_when_result_is_success(self, mock_retry_loop):
+        """When dbt build succeeds and _pending_failures is empty, no retry should fire."""
+        op = self._make_producer(dbt_retry_count=2)
+        op._pending_failures = {}
+        original_result = MagicMock(success=True)
+        context = {"ti": _MockTI()}
+
+        result = op._post_dbt_invoke(original_result, context, {}, "/tmp", Path("/tmp"))
+        mock_retry_loop.assert_not_called()
+        assert result is original_result
+
+    @patch.object(DbtProducerWatcherOperator, "_run_dbt_retry_loop")
     def test_post_dbt_invoke_all_retries_succeed(self, mock_retry_loop):
         """When retries resolve all failures, should return the retry result."""
         op = self._make_producer(dbt_retry_count=2)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2616,6 +2616,8 @@ class TestDbtProducerRetry:
         assert "retry" in cmd
         assert "--no-partial-parse" in cmd
         assert "--project-dir" in cmd
+        assert "--log-format" in cmd
+        assert "json" in cmd
 
     def test_post_dbt_invoke_no_retries_configured(self):
         """When dbt_retry_count=0, _post_dbt_invoke should return the original result unchanged."""
@@ -2740,6 +2742,37 @@ class TestDbtProducerRetry:
         assert result is None
         # Failures should still be pending
         assert "model.pkg.broken" in op._pending_failures
+
+    @patch.object(DbtProducerWatcherOperator, "invoke_dbt")
+    def test_retry_loop_resets_test_results_per_model(self, mock_invoke, tmp_path):
+        """test_results_per_model should be cleared before each retry so stale test
+        failures from the previous attempt don't contaminate the aggregated result."""
+        op = self._make_producer(dbt_retry_count=2, profile_config=profile_config)
+        op.dbt_executable_path = "dbt"
+        op.dbt_cmd_global_flags = []
+        op.partial_parse = False
+        op._pending_failures = {"model.pkg.flaky": {"status": "error", "outlet_uris": []}}
+        op.test_results_per_model = {"model.pkg.flaky": ["fail"]}
+
+        target = tmp_path / "target"
+        target.mkdir()
+        (target / "run_results.json").write_text("{}")
+
+        captured_test_results = []
+
+        def side_effect(*args, **kwargs):
+            # Capture the state of test_results_per_model at the time invoke_dbt is called
+            captured_test_results.append(dict(op.test_results_per_model))
+            op._pending_failures.clear()
+            return MagicMock()
+
+        mock_invoke.side_effect = side_effect
+
+        context = {"ti": _MockTI()}
+        op._run_dbt_retry_loop(context, {}, str(tmp_path), Path("/tmp/profiles"))
+
+        # test_results_per_model should have been empty when invoke_dbt was called
+        assert captured_test_results[0] == {}
 
     @patch("airflow.models.Variable")
     @patch("cosmos.operators._watcher.xcom._persist_backup")


### PR DESCRIPTION
When `dbt_retry_count > 0` is set on the producer via `setup_operator_args`, the `DbtProducerWatcherOperator` now runs `dbt retry` within the same temporary directory after a `dbt build` that has failures. This retries failed nodes using the existing `run_results.json` without requiring cross-attempt artefact persistence.

Key changes:
- Add `dbt_retry_count` parameter to `DbtProducerWatcherOperator`
- Add `_post_dbt_invoke` hook in `AbstractDbtLocalBase` so the producer can inject retry logic without duplicating `run_command`
- Defer XCom push for failed and skipped nodes when retries are configured, so consumers don't see intermediate states
- Add `flaky_model` test fixtures and example DAG for CI integration testing

closes: #1978 
closes: https://github.com/astronomer/oss-integrations-private/issues/374
