### PR TITLE
Expose `freshness_callback` in ExecutionConfig.setup_operator_args for WATCHER mode

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -691,6 +691,8 @@ def _add_watcher_producer_task(
         producer_task_args["tests_per_model"] = tests_per_model
     if render_config is not None and render_config.source_rendering_behavior != SourceRenderingBehavior.NONE:
         producer_task_args["_check_source_freshness"] = True
+        if render_config.freshness_callback is not None:
+            producer_task_args["freshness_callback"] = render_config.freshness_callback
 
     if render_config is not None:
         producer_task_args["select"] = _convert_list_to_str(render_config.select)

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -691,8 +691,6 @@ def _add_watcher_producer_task(
         producer_task_args["tests_per_model"] = tests_per_model
     if render_config is not None and render_config.source_rendering_behavior != SourceRenderingBehavior.NONE:
         producer_task_args["_check_source_freshness"] = True
-        if render_config.freshness_callback is not None:
-            producer_task_args["freshness_callback"] = render_config.freshness_callback
 
     if render_config is not None:
         producer_task_args["select"] = _convert_list_to_str(render_config.select)

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -79,6 +79,13 @@ class RenderConfig:
     :param normalize_task_display_name: A callable that takes a dbt node as input and returns the task display name. This allows users to assign a custom task display name separate from the node ID.
     :param should_detach_multiple_parents_tests: A boolean that allows users to decide whether to run tests with multiple parent dependencies in separate tasks.
     :param enable_owner_inheritance: A boolean that allows users to enable the owner inheritance from dbt models to airflow tasks. Defaults to True.
+    :param freshness_callback: **Experimental**. Only applicable when ``execution_mode`` is
+        ``ExecutionMode.WATCHER`` and ``source_rendering_behavior`` is not ``NONE``.
+        A callable invoked on the producer task after ``dbt source freshness`` completes. Receives
+        ``(context, dag, task_group, nodes, sources_json)`` and must return a list of
+        ``(unique_id, state)`` tuples for nodes to be marked before the main ``dbt build`` runs.
+        Defaults to the built-in skip-propagation logic when not set.
+        Support for ``ExecutionMode.WATCHER_KUBERNETES`` is not yet implemented.
     """
 
     emit_datasets: bool = True
@@ -106,6 +113,7 @@ class RenderConfig:
     normalize_task_display_name: Callable[..., Any] | None = None
     should_detach_multiple_parents_tests: bool = False
     enable_owner_inheritance: bool | None = True
+    freshness_callback: Callable[..., Any] | None = None
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         if self.env_vars:

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -79,13 +79,9 @@ class RenderConfig:
     :param normalize_task_display_name: A callable that takes a dbt node as input and returns the task display name. This allows users to assign a custom task display name separate from the node ID.
     :param should_detach_multiple_parents_tests: A boolean that allows users to decide whether to run tests with multiple parent dependencies in separate tasks.
     :param enable_owner_inheritance: A boolean that allows users to enable the owner inheritance from dbt models to airflow tasks. Defaults to True.
-    :param freshness_callback: **Experimental**. Only applicable when ``execution_mode`` is
-        ``ExecutionMode.WATCHER`` and ``source_rendering_behavior`` is not ``NONE``.
-        A callable invoked on the producer task after ``dbt source freshness`` completes. Receives
-        ``(context, dag, task_group, nodes, sources_json)`` and must return a list of
-        ``(unique_id, state)`` tuples for nodes to be marked before the main ``dbt build`` runs.
+    :param freshness_callback: **Experimental**. Only applicable when ``execution_mode`` is ``ExecutionMode.WATCHER`` and ``source_rendering_behavior`` is not ``NONE``. A callable invoked on the producer task after ``dbt source freshness`` completes. Receives
+        ``(context, dag, task_group, nodes, sources_json)`` and must return a list of ``(unique_id, state)`` tuples for nodes to be marked before the main ``dbt build`` runs.
         Defaults to the built-in skip-propagation logic when not set.
-        Support for ``ExecutionMode.WATCHER_KUBERNETES`` is not yet implemented.
     """
 
     emit_datasets: bool = True

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -426,7 +426,7 @@ class ExecutionConfig:
     :param async_py_requirements:  A list of Python packages to install when `ExecutionMode.AIRFLOW_ASYNC` is used. This parameter is required only if both `enable_setup_async_task` and `enable_teardown_async_task` are set to `True`.
     Example: `["dbt-postgres==1.5.0"]`
     :param setup_operator_args: A dictionary of producer operator parameters. These will override the values supplied in operator_args for producer operator.
-        Pass ``freshness_callback`` here to override the default skip-propagation logic when ``source_rendering_behavior`` is not ``NONE``. **Experimental**.
+        Pass ``freshness_callback`` here in `ExecutionMode.WATCHER` to override the default skip-propagation logic when ``source_rendering_behavior`` is not ``NONE``. **Experimental**.
         The callable receives ``(context, dag, task_group, nodes, sources_json)`` and must return a list of ``(unique_id, state)`` tuples.
     """
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -79,9 +79,6 @@ class RenderConfig:
     :param normalize_task_display_name: A callable that takes a dbt node as input and returns the task display name. This allows users to assign a custom task display name separate from the node ID.
     :param should_detach_multiple_parents_tests: A boolean that allows users to decide whether to run tests with multiple parent dependencies in separate tasks.
     :param enable_owner_inheritance: A boolean that allows users to enable the owner inheritance from dbt models to airflow tasks. Defaults to True.
-    :param freshness_callback: **Experimental**. Only applicable when ``execution_mode`` is ``ExecutionMode.WATCHER`` and ``source_rendering_behavior`` is not ``NONE``. A callable invoked on the producer task after ``dbt source freshness`` completes. Receives
-        ``(context, dag, task_group, nodes, sources_json)`` and must return a list of ``(unique_id, state)`` tuples for nodes to be marked before the main ``dbt build`` runs.
-        Defaults to the built-in skip-propagation logic when not set.
     """
 
     emit_datasets: bool = True
@@ -109,7 +106,6 @@ class RenderConfig:
     normalize_task_display_name: Callable[..., Any] | None = None
     should_detach_multiple_parents_tests: bool = False
     enable_owner_inheritance: bool | None = True
-    freshness_callback: Callable[..., Any] | None = None
 
     def __post_init__(self, dbt_project_path: str | Path | None) -> None:
         if self.env_vars:
@@ -429,7 +425,9 @@ class ExecutionConfig:
     should be used for execution when execution mode is set to `ExecutionMode.VIRTUALENV`
     :param async_py_requirements:  A list of Python packages to install when `ExecutionMode.AIRFLOW_ASYNC` is used. This parameter is required only if both `enable_setup_async_task` and `enable_teardown_async_task` are set to `True`.
     Example: `["dbt-postgres==1.5.0"]`
-    param setup_operator_args: A dictionary of producer operator parameters. These will override the values supplied in operator_args for producer operator.
+    :param setup_operator_args: A dictionary of producer operator parameters. These will override the values supplied in operator_args for producer operator.
+        Pass ``freshness_callback`` here to override the default skip-propagation logic when ``source_rendering_behavior`` is not ``NONE``. **Experimental**.
+        The callable receives ``(context, dag, task_group, nodes, sources_json)`` and must return a list of ``(unique_id, state)`` tuples.
     """
 
     execution_mode: ExecutionMode = ExecutionMode.LOCAL

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -160,9 +160,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     ``_add_watcher_producer_task`` when ``SourceRenderingBehavior`` is not ``NONE``), the
     producer first runs ``dbt source freshness``, identifies stale sources, marks all
     transitive dependents as ``"skipped"`` via XCom, and adds them to ``--exclude`` before
-    running the main ``dbt build``.  An optional ``freshness_callback`` kwarg
-    (exposed via ``RenderConfig.freshness_callback``) may be passed to override the default
-    skip-propagation logic.
+    running the main ``dbt build``
     """
 
     template_fields = DbtLocalBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -321,7 +321,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         ti = context["ti"]
 
         for unique_id, state in node_state_pairs:
-            logger.info("Marking resource '%s' as %s (stale upstream source)", unique_id, state)
+            logger.info("Pre-setting resource '%s' state to %s from source-freshness callback", unique_id, state)
             self._push_node_state_xcom(ti, unique_id, state)
 
         # Exclude any node whose pre-set state is non-success from the dbt build.

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -159,7 +159,9 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     ``_add_watcher_producer_task`` when ``SourceRenderingBehavior`` is not ``NONE``), the
     producer first runs ``dbt source freshness``, identifies stale sources, marks all
     transitive dependents as ``"skipped"`` via XCom, and adds them to ``--exclude`` before
-    running the main ``dbt build``.
+    running the main ``dbt build``.  An optional ``freshness_callback`` kwarg
+    (exposed via ``RenderConfig.freshness_callback``) may be passed to override the default
+    skip-propagation logic.
     """
 
     template_fields = DbtLocalBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]
@@ -175,7 +177,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self._freshness_callback: Callable[
             [Context, Any, TaskGroup | None, dict[str, DbtNode] | None, dict[str, Any] | None],
             list[tuple[str, str]],
-        ] = _default_freshness_callback
+        ] = kwargs.pop("freshness_callback", _default_freshness_callback)
         # Do not publish compiled_sql to the producer's rendered_template: it would contain SQL for
         # all models run by the producer, is often truncated in the UI due to size, and is of no use
         # there; individual sensor tasks show the corresponding rendered_template per model.
@@ -322,19 +324,23 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             logger.info("Marking resource '%s' as %s (stale upstream source)", unique_id, state)
             self._push_node_state_xcom(ti, unique_id, state)
 
-        # Only exclude nodes in the "skipped" state from future dbt runs.
+        # Exclude any node whose pre-set state is non-success from the dbt build.
+        # This covers both "skipped" (default) and failure states ("failed", "fail",
+        # "error") that a custom freshness_callback may return.  Without exclusion,
+        # dbt would run the model anyway and either overwrite the pre-set XCom status
+        # or trigger a race condition with the consumer sensor.
         # Use the same parsing as DbtNode.resource_name: unique_id.split(".", 2)[2]
         # This preserves version suffixes (e.g. model.pkg.my_model.v1 -> my_model.v1)
-        skipped_ids = [uid for uid, state in node_state_pairs if state == "skipped"]
-        if not skipped_ids:
+        from cosmos.operators._watcher.state import DBT_SUCCESS_STATUSES
+
+        excluded_ids = [uid for uid, state in node_state_pairs if state not in DBT_SUCCESS_STATUSES]
+        if not excluded_ids:
             return
-        model_names = sorted({uid.split(".", 2)[2] for uid in skipped_ids if len(uid.split(".", 2)) == 3})
+        model_names = sorted({uid.split(".", 2)[2] for uid in excluded_ids if len(uid.split(".", 2)) == 3})
         exclude_str = " ".join(model_names)
-        current_exclude = getattr(self, "exclude", None)
-        if current_exclude:
-            self.exclude = f"{current_exclude} {exclude_str}"
-        else:
-            self.exclude = exclude_str
+        if exclude_str:
+            current_exclude = getattr(self, "exclude", None)
+            self.exclude = f"{current_exclude} {exclude_str}" if current_exclude else exclude_str
 
     def _push_source_freshness_results(self, context: Context) -> None:
         """Push per-source freshness status to XCom so source consumer sensors can read it."""

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -160,7 +160,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     ``_add_watcher_producer_task`` when ``SourceRenderingBehavior`` is not ``NONE``), the
     producer first runs ``dbt source freshness``, identifies stale sources, marks all
     transitive dependents as ``"skipped"`` via XCom, and adds them to ``--exclude`` before
-    running the main ``dbt build``
+    running the main ``dbt build``.
     """
 
     template_fields = DbtLocalBaseOperator.template_fields + DbtBuildMixin.template_fields  # type: ignore[operator]

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -357,7 +357,18 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
 
     def _apply_source_freshness(self, context: Context) -> None:
         """Run source freshness, invoke the callback, and mark affected nodes as skipped."""
-        self._run_source_freshness(context)
+        try:
+            self._run_source_freshness(context)
+        except Exception as exc:
+            # dbt source freshness exits non-zero for WARN/ERROR freshness status, which is
+            # expected and handled by the callback. Re-raise only for genuine failures where
+            # sources.json was never written (e.g. connection error, bad project config).
+            if self._sources_json is None:
+                raise
+            logger.warning(
+                "dbt source freshness completed with non-zero exit code: %s. " "Proceeding with freshness results.",
+                exc,
+            )
 
         # Push per-source freshness results so source consumer sensors can read them
         self._push_source_freshness_results(context)

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -28,6 +28,7 @@ from cosmos.operators._watcher.base import (
     BaseConsumerSensor,
     store_dbt_resource_status_from_log,
 )
+from cosmos.operators._watcher.state import DBT_SUCCESS_STATUSES
 from cosmos.operators._watcher.xcom import (
     _backup_xcom_to_variable,
     _delete_xcom_backup_variable,
@@ -331,8 +332,6 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         # or trigger a race condition with the consumer sensor.
         # Use the same parsing as DbtNode.resource_name: unique_id.split(".", 2)[2]
         # This preserves version suffixes (e.g. model.pkg.my_model.v1 -> my_model.v1)
-        from cosmos.operators._watcher.state import DBT_SUCCESS_STATUSES
-
         excluded_ids = [uid for uid, state in node_state_pairs if state not in DBT_SUCCESS_STATUSES]
         if not excluded_ids:
             return

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -19,7 +19,7 @@ except ImportError:
     from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import ExecutionMode, SourceRenderingBehavior
+from cosmos.constants import ExecutionMode, InvocationMode, SourceRenderingBehavior
 from cosmos.dbt.graph import DbtNode
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
@@ -50,9 +50,6 @@ if os.getenv("CI"):
     operator_args["trigger_rule"] = "all_success"
 
 
-from cosmos.constants import InvocationMode
-
-
 def freshness_callback(
     context: Context,
     dag: Any,
@@ -60,7 +57,7 @@ def freshness_callback(
     nodes: dict[str, DbtNode] | None,
     sources_json: dict[str, Any] | None,
 ) -> list[tuple[str, str]]:
-    return [("model.jaffle_shop.stg_orders", "failed")]
+    return [("model.jaffle_shop.stg_orders", "skipped")]
 
 
 # [START example_watcher_with_freshness]

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -9,9 +9,14 @@ from typing import Any
 
 try:
     # Airflow 3.1 onwards
-    from airflow.sdk import TaskGroup
+    from airflow.sdk import TaskGroup, Context
 except ImportError:
     from airflow.utils.task_group import TaskGroup
+
+try:
+    from airflow.sdk.definitions.context import Context
+except ImportError:
+    from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import ExecutionMode, SourceRenderingBehavior

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -55,7 +55,7 @@ def freshness_callback(
     nodes: dict[str, DbtNode] | None,
     sources_json: dict[str, Any] | None,
 ) -> list[tuple[str, str]]:
-    return [("model.jaffle_shop.orders", "skipped")]
+    return [("model.altered_jaffle_shop.orders", "skipped")]
 
 
 # [START example_watcher_with_freshness]

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -60,7 +60,7 @@ example_watcher_with_freshness = DbtDag(
     schedule="@daily",
     start_date=datetime(2023, 1, 1),
     catchup=False,
-    dag_id="example_watcher",
+    dag_id="example_watcher_with_freshness",
     default_args={"retries": 0},
 )
 # [END example_watcher_with_freshness]

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -39,13 +39,19 @@ if os.getenv("CI"):
 
 from cosmos.constants import InvocationMode
 
+
 def freshness_callback() -> list[tuple[str, str]]:
     return [("model.jaffle_shop.stg_orders", "failed")]
+
 
 # [START example_watcher_with_freshness]
 example_watcher_with_freshness = DbtDag(
     # dbt/cosmos-specific parameters
-    execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER, invocation_mode=InvocationMode.DBT_RUNNER, setup_operator_args={"freshness_callback": freshness_callback}),
+    execution_config=ExecutionConfig(
+        execution_mode=ExecutionMode.WATCHER,
+        invocation_mode=InvocationMode.DBT_RUNNER,
+        setup_operator_args={"freshness_callback": freshness_callback},
+    ),
     render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
     project_config=ProjectConfig(DBT_PROJECT_PATH),
     profile_config=profile_config,

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -5,9 +5,17 @@ An example DAG that uses Cosmos to render a dbt project into an Airflow DAG.
 import os
 from datetime import datetime, timedelta
 from pathlib import Path
+from typing import Any
+
+try:
+    # Airflow 3.1 onwards
+    from airflow.sdk import TaskGroup
+except ImportError:
+    from airflow.utils.task_group import TaskGroup
 
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
 from cosmos.constants import ExecutionMode, SourceRenderingBehavior
+from cosmos.dbt.graph import DbtNode
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
@@ -40,7 +48,11 @@ if os.getenv("CI"):
 from cosmos.constants import InvocationMode
 
 
-def freshness_callback() -> list[tuple[str, str]]:
+def freshness_callback( context: Context,
+    dag: Any,
+    task_group: TaskGroup | None,
+    nodes: dict[str, DbtNode] | None,
+    sources_json: dict[str, Any] | None) -> list[tuple[str, str]]:
     return [("model.jaffle_shop.stg_orders", "failed")]
 
 

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -25,8 +25,6 @@ from cosmos.profiles import PostgresUserPasswordProfileMapping
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
 DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
-DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "altered_jaffle_shop")
-DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
 
 
 profile_config = ProfileConfig(
@@ -57,7 +55,7 @@ def freshness_callback(
     nodes: dict[str, DbtNode] | None,
     sources_json: dict[str, Any] | None,
 ) -> list[tuple[str, str]]:
-    return [("model.jaffle_shop.stg_orders", "skipped")]
+    return [("model.jaffle_shop.orders", "skipped")]
 
 
 # [START example_watcher_with_freshness]
@@ -69,7 +67,7 @@ example_watcher_with_freshness = DbtDag(
         setup_operator_args={"freshness_callback": freshness_callback},
     ),
     render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
-    project_config=ProjectConfig(DBT_PROJECT_PATH),
+    project_config=ProjectConfig(DBT_ROOT_PATH / "altered_jaffle_shop"),
     profile_config=profile_config,
     operator_args=operator_args,
     # normal dag parameters

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -9,7 +9,7 @@ from typing import Any
 
 try:
     # Airflow 3.1 onwards
-    from airflow.sdk import TaskGroup, Context
+    from airflow.sdk import Context, TaskGroup
 except ImportError:
     from airflow.utils.task_group import TaskGroup
 

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -48,11 +48,13 @@ if os.getenv("CI"):
 from cosmos.constants import InvocationMode
 
 
-def freshness_callback( context: Context,
+def freshness_callback(
+    context: Context,
     dag: Any,
     task_group: TaskGroup | None,
     nodes: dict[str, DbtNode] | None,
-    sources_json: dict[str, Any] | None) -> list[tuple[str, str]]:
+    sources_json: dict[str, Any] | None,
+) -> list[tuple[str, str]]:
     return [("model.jaffle_shop.stg_orders", "failed")]
 
 

--- a/dev/dags/watcher_with_freshness_check.py
+++ b/dev/dags/watcher_with_freshness_check.py
@@ -1,0 +1,60 @@
+"""
+An example DAG that uses Cosmos to render a dbt project into an Airflow DAG.
+"""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import ExecutionMode, SourceRenderingBehavior
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_NAME = os.getenv("DBT_PROJECT_NAME", "altered_jaffle_shop")
+DBT_PROJECT_PATH = DBT_ROOT_PATH / DBT_PROJECT_NAME
+
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+        disable_event_tracking=True,
+    ),
+)
+
+
+operator_args = {
+    "install_deps": True,  # install any necessary dependencies before running any dbt command
+    "execution_timeout": timedelta(seconds=120),
+}
+
+# Currently airflow dags test ignores priority_weight and  weight_rule, for this reason, we're setting the following in the CI only:
+if os.getenv("CI"):
+    operator_args["trigger_rule"] = "all_success"
+
+
+from cosmos.constants import InvocationMode
+
+def freshness_callback() -> list[tuple[str, str]]:
+    return [("model.jaffle_shop.stg_orders", "failed")]
+
+# [START example_watcher_with_freshness]
+example_watcher_with_freshness = DbtDag(
+    # dbt/cosmos-specific parameters
+    execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER, invocation_mode=InvocationMode.DBT_RUNNER, setup_operator_args={"freshness_callback": freshness_callback}),
+    render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
+    project_config=ProjectConfig(DBT_PROJECT_PATH),
+    profile_config=profile_config,
+    operator_args=operator_args,
+    # normal dag parameters
+    schedule="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    dag_id="example_watcher",
+    default_args={"retries": 0},
+)
+# [END example_watcher_with_freshness]

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2127,3 +2127,22 @@ def test_add_watcher_producer_task_sets_check_source_freshness_flag(source_rende
             assert task_metadata.arguments["_check_source_freshness"] is True
         else:
             assert "_check_source_freshness" not in task_metadata.arguments
+
+
+def test_add_watcher_producer_task_passes_freshness_callback_when_set():
+    """freshness_callback is forwarded to the producer when source_rendering_behavior is active."""
+    my_callback = MagicMock()
+    render_config = RenderConfig(
+        source_rendering_behavior=SourceRenderingBehavior.ALL,
+        freshness_callback=my_callback,
+    )
+    task_args = {"project_dir": "/tmp/sample_project", "profile_config": None}
+
+    with patch("cosmos.airflow.graph.create_airflow_task") as mock_create_task:
+        mock_create_task.return_value = MagicMock()
+        _add_watcher_producer_task(
+            dag=MagicMock(), task_group=None, tasks_map={}, render_config=render_config, task_args=task_args
+        )
+
+    task_metadata = mock_create_task.call_args[0][0]
+    assert task_metadata.arguments["freshness_callback"] is my_callback

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2129,14 +2129,12 @@ def test_add_watcher_producer_task_sets_check_source_freshness_flag(source_rende
             assert "_check_source_freshness" not in task_metadata.arguments
 
 
-def test_add_watcher_producer_task_passes_freshness_callback_when_set():
-    """freshness_callback is forwarded to the producer when source_rendering_behavior is active."""
+def test_add_watcher_producer_task_passes_freshness_callback_via_setup_operator_args():
+    """freshness_callback supplied via setup_operator_args (merged into task_args before the call) is forwarded to the producer."""
     my_callback = MagicMock()
-    render_config = RenderConfig(
-        source_rendering_behavior=SourceRenderingBehavior.ALL,
-        freshness_callback=my_callback,
-    )
-    task_args = {"project_dir": "/tmp/sample_project", "profile_config": None}
+    render_config = RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL)
+    # setup_operator_args is merged into task_args by the caller (generate_task_or_task_group)
+    task_args = {"project_dir": "/tmp/sample_project", "profile_config": None, "freshness_callback": my_callback}
 
     with patch("cosmos.airflow.graph.create_airflow_task") as mock_create_task:
         mock_create_task.return_value = MagicMock()

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2396,13 +2396,24 @@ class TestProducerSourceFreshness:
         ti.xcom_push.assert_not_called()
         assert producer.exclude is None
 
-    def test_apply_node_state_tokens_non_skipped_state_does_not_update_exclude(self):
+    def test_apply_node_state_tokens_failed_state_updates_exclude(self):
         producer = self._make_producer()
         producer.exclude = None
         ti = MagicMock()
         context = {"ti": ti}
         producer._apply_node_state_tokens(context, [("model.pkg.m1", "failed")])
         ti.xcom_push.assert_called_once_with(key="model__pkg__m1_status", value={"status": "failed", "outlet_uris": []})
+        assert "m1" in producer.exclude
+
+    def test_apply_node_state_tokens_success_state_does_not_update_exclude(self):
+        producer = self._make_producer()
+        producer.exclude = None
+        ti = MagicMock()
+        context = {"ti": ti}
+        producer._apply_node_state_tokens(context, [("model.pkg.m1", "success")])
+        ti.xcom_push.assert_called_once_with(
+            key="model__pkg__m1_status", value={"status": "success", "outlet_uris": []}
+        )
         assert producer.exclude is None
 
     def test_run_dbt_runner_skips_callback_during_source_freshness(self):

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1994,7 +1994,7 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
     dbt_error_message = """Database Error in model model_f (models/model_f.sql)\n  column "this_column_does_not_exist_at_all" does not exist\n  LINE 1"""
     assert dbt_error_message in caplog.text
 
- 
+
 @pytest.mark.skipif(
     AIRFLOW_VERSION < Version("2.10"),
     reason="dag.test() in Airflow 2.9 hangs when a task fails with retries configured",
@@ -2058,7 +2058,7 @@ def test_dbt_dag_with_watcher_freshness_callback_excludes_model():
     assert tis["customers_run"].state == "success"
     # source sensor for raw_orders (has freshness block) must also complete successfully
     assert tis["raw_orders_source"].state == "success"
-    
+
 
 @pytest.mark.skipif(
     AIRFLOW_VERSION < Version("2.10") or (Version("3.1.0") <= AIRFLOW_VERSION < Version("3.2.0")),

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -19,7 +19,12 @@ from packaging.version import Version
 
 from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig, TestBehavior
 from cosmos.config import InvocationMode
-from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT, ExecutionMode
+from cosmos.constants import (
+    _DBT_STARTUP_EVENTS_XCOM_KEY,
+    PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT,
+    ExecutionMode,
+    SourceRenderingBehavior,
+)
 from cosmos.operators._watcher.base import store_compiled_sql_for_model
 from cosmos.operators._watcher.triggerer import WatcherEventReason, WatcherTrigger
 from cosmos.operators.watcher import (
@@ -39,6 +44,7 @@ DBT_PROJECT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_sh
 DBT_PROFILES_YAML_FILEPATH = DBT_PROJECT_PATH / "profiles.yml"
 MULTI_FOLDER_DBT_PROJ_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt/multi_folder"
 DBT_WATCHER_FAILING_TESTS_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/watcher_failing_tests"
+ALTERED_JAFFLE_SHOP_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/altered_jaffle_shop"
 
 DBT_EXECUTABLE_PATH = Path(__file__).parent.parent.parent / "venv-subprocess/bin/dbt"
 DBT_PROJECT_WITH_EMPTY_MODEL_PATH = Path(__file__).parent.parent / "sample/dbt_project_with_empty_model"
@@ -1954,6 +1960,71 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
 
     dbt_error_message = """Database Error in model model_f (models/model_f.sql)\n  column "this_column_does_not_exist_at_all" does not exist\n  LINE 1"""
     assert dbt_error_message in caplog.text
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION < Version("2.10"),
+    reason="dag.test() in Airflow 2.9 hangs when a task fails with retries configured",
+)
+@pytest.mark.integration
+def test_dbt_dag_with_watcher_freshness_callback_excludes_model():
+    """
+    When freshness_callback returns a model with "skipped" state, the producer task:
+    - pre-sets a "skipped" XCom for that model
+    - adds it to dbt build's --exclude list so dbt never runs it
+
+    The consumer sensor for the excluded model reads the pre-set XCom and raises
+    AirflowSkipException. All other models run normally.
+
+    Pre-loads seeds via a local DbtDag first so that dbt source freshness can query
+    raw_orders (which has a freshness block in altered_jaffle_shop).
+    """
+    # Pre-load seeds and models so dbt source freshness has a table to check
+    preload_dag = DbtDag(
+        project_config=ProjectConfig(dbt_project_path=ALTERED_JAFFLE_SHOP_PATH),
+        profile_config=profile_config,
+        start_date=datetime(2023, 1, 1),
+        dag_id="altered_jaffle_shop_preload",
+        render_config=RenderConfig(
+            source_rendering_behavior=SourceRenderingBehavior.NONE,
+            test_behavior=TestBehavior.NONE,
+            emit_datasets=False,
+        ),
+        operator_args={"install_deps": True, "full_refresh": True, "execution_timeout": timedelta(seconds=180)},
+    )
+    new_test_dag(preload_dag)
+
+    def skip_orders(context, dag, task_group, nodes, sources_json):
+        return [("model.altered_jaffle_shop.orders", "skipped")]
+
+    watcher_dag = DbtDag(
+        project_config=ProjectConfig(dbt_project_path=ALTERED_JAFFLE_SHOP_PATH),
+        profile_config=profile_config,
+        start_date=datetime(2023, 1, 1),
+        dag_id="watcher_freshness_callback_exclude",
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.WATCHER,
+            invocation_mode=InvocationMode.DBT_RUNNER,
+            setup_operator_args={"freshness_callback": skip_orders},
+        ),
+        render_config=RenderConfig(
+            source_rendering_behavior=SourceRenderingBehavior.ALL,
+            test_behavior=TestBehavior.NONE,
+            emit_datasets=False,
+        ),
+        operator_args={"trigger_rule": "all_success", "execution_timeout": timedelta(seconds=120)},
+        default_args={"retries": 0},
+    )
+    outcome = new_test_dag(watcher_dag)
+    assert outcome.state == DagRunState.SUCCESS
+
+    tis = {ti.task_id: ti for ti in outcome.get_task_instances()}
+    # orders was returned by the callback → excluded from dbt build → sensor reads "skipped" XCom
+    assert tis["orders_run"].state == "skipped"
+    # other models are unaffected and succeed
+    assert tis["customers_run"].state == "success"
+    # source sensor for raw_orders (has freshness block) must also complete successfully
+    assert tis["raw_orders_source"].state == "success"
 
 
 def test_dbt_source_watcher_operator_template_fields():

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2057,7 +2057,8 @@ def test_dbt_dag_with_watcher_freshness_callback_excludes_model():
     # other models are unaffected and succeed
     assert tis["customers_run"].state == "success"
     # source sensor for raw_orders (has freshness block) must also complete successfully
-    assert tis["raw_orders_source"].state == "success"
+    # task ID derives from unique_id split: "postgres_db.raw_orders" → "postgres_db_raw_orders"
+    assert tis["postgres_db_raw_orders_source"].state == "success"
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
Add an experimental ``freshness_callback`` field to ``ExecutionConfig.setup_operator_args`` that lets users inject a custom callable to control what happens after ``dbt source freshness`` runs in WATCHER mode.

The callback receives ``(context, dag, task_group, nodes, sources_json)`` and returns a list of ``(unique_id, state)`` pairs.  Nodes whose state is not in ``DBT_SUCCESS_STATUSES`` are added to ``--exclude`` so dbt does not run them, avoiding both the previous skipped-only gap and a race condition where a pre-set "failed" XCom could be overwritten by the real dbt result.

When ``freshness_callback`` is not set the existing built-in skip-propagation logic is used unchanged.

closes: https://github.com/astronomer/astronomer-cosmos/issues/2053