### PR TITLE
[WIP] Fix warning when using Variable.get()

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -21,6 +21,18 @@ try:
 except ImportError:
     from airflow.models import Variable
 
+
+def _variable_get(key: str, default: str = "") -> str:
+    """Get an Airflow Variable, falling back to airflow.models.Variable when the SDK
+    raises ImportError or NameError (e.g. Airflow 3.0 without a running supervisor)."""
+    try:
+        return Variable.get(key, default)  # type: ignore[no-any-return]
+    except (ImportError, NameError):
+        from airflow.models import Variable as _ModelVariable
+
+        return _ModelVariable.get(key, default_var=default)  # type: ignore[no-any-return]
+
+
 if TYPE_CHECKING:
     try:
         # Airflow 3 onwards
@@ -528,7 +540,7 @@ class DbtGraph:
             cache_args.append(envvars_str)
         if self.render_config.airflow_vars_to_purge_dbt_ls_cache:
             for var_name in self.render_config.airflow_vars_to_purge_dbt_ls_cache:
-                airflow_vars = [var_name, Variable.get(var_name, "")]
+                airflow_vars = [var_name, _variable_get(var_name)]
                 cache_args.extend(airflow_vars)
 
         logger.debug(f"Value of `dbt_ls_cache_key_args` for <{self.cache_key}>: {cache_args}")
@@ -543,7 +555,7 @@ class DbtGraph:
         cache_args = []
         if self.render_config.airflow_vars_to_purge_dbt_yaml_selectors_cache:
             for var_name in self.render_config.airflow_vars_to_purge_dbt_yaml_selectors_cache:
-                airflow_vars = [var_name, Variable.get(var_name, "")]
+                airflow_vars = [var_name, _variable_get(var_name)]
                 cache_args.extend(airflow_vars)
         return cache_args
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -643,7 +643,9 @@ class DbtGraph:
         """
         cache_dict: dict[str, str] = {}
 
-        airflow_variable_exceptions: list[type[BaseException]] = [json.decoder.JSONDecodeError, KeyError]
+        # ImportError is included because airflow.sdk.Variable.get() raises it when called
+        # outside a task execution context (e.g. during DAG parsing in Airflow 3.0+).
+        airflow_variable_exceptions: list[type[BaseException]] = [json.decoder.JSONDecodeError, KeyError, ImportError]
         try:
             from airflow.sdk.exceptions import AirflowRuntimeError
         except ImportError:
@@ -1066,7 +1068,9 @@ class DbtGraph:
         """
         cache_dict: dict[str, Any] = {}
 
-        airflow_variable_exceptions: list[type[BaseException]] = [json.decoder.JSONDecodeError, KeyError]
+        # ImportError is included because airflow.sdk.Variable.get() raises it when called
+        # outside a task execution context (e.g. during DAG parsing in Airflow 3.0+).
+        airflow_variable_exceptions: list[type[BaseException]] = [json.decoder.JSONDecodeError, KeyError, ImportError]
         try:
             from airflow.sdk.exceptions import AirflowRuntimeError
         except ImportError:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -578,7 +578,7 @@ class DbtGraph:
         cache_specific_workaround = "" if is_yaml_cache else ", using LoadMode.DBT_MANIFEST"
         try:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
-        except AirflowRuntimeError as e:
+        except (AirflowRuntimeError, ImportError) as e:
             logger.warning(
                 "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "
                 "Consider setting AIRFLOW__COSMOS__REMOTE_CACHE_DIR to use object storage for caching%s, "

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -16,7 +16,10 @@ from pathlib import Path
 from subprocess import PIPE, Popen
 from typing import TYPE_CHECKING, Any
 
-from airflow.models import Variable
+try:
+    from airflow.sdk import Variable
+except ImportError:
+    from airflow.models import Variable
 
 if TYPE_CHECKING:
     try:

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -62,7 +62,11 @@ def _persist_backup(var_key: str, backup_buffer: dict[str, Any]) -> None:
         return
 
     compressed = base64.b64encode(zlib.compress(json.dumps(backup_buffer, default=str).encode("utf-8"))).decode("utf-8")
-    Variable.set(var_key, compressed)
+    try:
+        Variable.set(var_key, compressed)
+    except (ImportError, NameError) as exc:
+        logger.warning("Could not persist XCom backup to Variable '%s': %s", var_key, exc)
+        return
     logger.debug("Persisted %d XCom entries to Variable '%s'", len(backup_buffer), var_key)
 
 
@@ -92,7 +96,7 @@ def _delete_xcom_backup_variable(context: Any) -> None:
     try:
         Variable.delete(var_key)
         logger.debug("Deleted XCom backup Variable '%s'", var_key)
-    except KeyError:
+    except (KeyError, ImportError, NameError):
         pass
 
 
@@ -108,10 +112,13 @@ def _restore_xcom_from_variable(context: Any) -> bool:
 
     var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
     try:
-        compressed = Variable.get(var_key, default=None)
-    except TypeError:
-        # airflow.models.Variable.get() uses default_var instead of default
-        compressed = Variable.get(var_key, default_var=None)  # type: ignore[call-arg]
+        try:
+            compressed = Variable.get(var_key, default=None)
+        except TypeError:
+            compressed = Variable.get(var_key, default_var=None)  # type: ignore[call-arg]
+    except (ImportError, NameError) as exc:
+        logger.warning("Could not restore XCom backup from Variable '%s': %s", var_key, exc)
+        return False
     if compressed is None:
         logger.info("No XCom backup Variable found at '%s'", var_key)
         return False
@@ -124,6 +131,6 @@ def _restore_xcom_from_variable(context: Any) -> bool:
     try:
         Variable.delete(var_key)
         logger.debug("Deleted XCom backup Variable '%s' after restore", var_key)
-    except KeyError:
-        logger.debug("XCom backup Variable '%s' already deleted", var_key)
+    except (KeyError, ImportError, NameError):
+        logger.debug("XCom backup Variable '%s' already deleted or unavailable", var_key)
     return True

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -100,7 +100,10 @@ def _restore_xcom_from_variable(context: Any) -> bool:
 
     Returns True if the restore succeeded, False if no backup was found.
     """
-    from airflow.models import Variable
+    try:
+        from airflow.sdk import Variable
+    except ImportError:
+        from airflow.models import Variable
 
     ti = context["ti"]
     dag_id = ti.dag_id

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -56,7 +56,10 @@ def _persist_backup(var_key: str, backup_buffer: dict[str, Any]) -> None:
     if not backup_buffer:
         return
 
-    from airflow.models import Variable
+    try:
+        from airflow.sdk import Variable
+    except ImportError:
+        from airflow.models import Variable
 
     compressed = base64.b64encode(zlib.compress(json.dumps(backup_buffer, default=str).encode("utf-8"))).decode("utf-8")
     Variable.set(var_key, compressed)
@@ -87,7 +90,10 @@ def _delete_xcom_backup_variable(context: Any) -> None:
     if not isinstance(var_key, str):
         return
     try:
-        from airflow.models import Variable
+        try:
+            from airflow.sdk import Variable
+        except ImportError:
+            from airflow.models import Variable
 
         Variable.delete(var_key)
         logger.debug("Deleted XCom backup Variable '%s'", var_key)

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -13,6 +13,11 @@ import json
 import zlib
 from typing import Any
 
+try:
+    from airflow.sdk import Variable
+except ImportError:
+    from airflow.models import Variable  # type: ignore[no-redef]
+
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import safe_xcom_push
 
@@ -56,11 +61,6 @@ def _persist_backup(var_key: str, backup_buffer: dict[str, Any]) -> None:
     if not backup_buffer:
         return
 
-    try:
-        from airflow.sdk import Variable
-    except ImportError:
-        from airflow.models import Variable
-
     compressed = base64.b64encode(zlib.compress(json.dumps(backup_buffer, default=str).encode("utf-8"))).decode("utf-8")
     Variable.set(var_key, compressed)
     logger.debug("Persisted %d XCom entries to Variable '%s'", len(backup_buffer), var_key)
@@ -90,11 +90,6 @@ def _delete_xcom_backup_variable(context: Any) -> None:
     if not isinstance(var_key, str):
         return
     try:
-        try:
-            from airflow.sdk import Variable
-        except ImportError:
-            from airflow.models import Variable
-
         Variable.delete(var_key)
         logger.debug("Deleted XCom backup Variable '%s'", var_key)
     except KeyError:
@@ -106,18 +101,20 @@ def _restore_xcom_from_variable(context: Any) -> bool:
 
     Returns True if the restore succeeded, False if no backup was found.
     """
-    try:
-        from airflow.sdk import Variable
-    except ImportError:
-        from airflow.models import Variable
-
     ti = context["ti"]
     dag_id = ti.dag_id
     run_id = context["run_id"]
     task_group_id = _get_task_group_id(ti)
 
     var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
-    compressed = Variable.get(var_key, default_var=None)
+    try:
+        compressed = Variable.get(var_key, default_var=None)
+    except TypeError:
+        # airflow.sdk.Variable.get() does not support default_var
+        try:
+            compressed = Variable.get(var_key)
+        except Exception:
+            compressed = None
     if compressed is None:
         logger.info("No XCom backup Variable found at '%s'", var_key)
         return False

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -108,13 +108,10 @@ def _restore_xcom_from_variable(context: Any) -> bool:
 
     var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
     try:
-        compressed = Variable.get(var_key, default_var=None)
+        compressed = Variable.get(var_key, default=None)
     except TypeError:
-        # airflow.sdk.Variable.get() does not support default_var
-        try:
-            compressed = Variable.get(var_key)
-        except Exception:
-            compressed = None
+        # airflow.models.Variable.get() uses default_var instead of default
+        compressed = Variable.get(var_key, default_var=None)  # type: ignore[call-arg]
     if compressed is None:
         logger.info("No XCom backup Variable found at '%s'", var_key)
         return False

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -303,7 +303,7 @@ def test_dbt_runner_caching_and_callbacks(valid_dbt_project_dir):
 
             with (
                 patch("cosmos.operators._watcher.xcom._persist_backup"),
-                patch("airflow.models.Variable"),
+                patch("cosmos.operators._watcher.xcom.Variable"),
             ):
                 op2.execute(context=mock_context)
 

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -146,7 +146,7 @@ class TestInitXcomBackup:
 
 
 class TestPersistBackup:
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_writes_compressed_data_to_variable(self, mock_variable):
         _persist_backup("my_var_key", {"key1": "value1", "key2": "value2"})
 
@@ -156,7 +156,7 @@ class TestPersistBackup:
         data = json.loads(zlib.decompress(base64.b64decode(compressed.encode("utf-8"))).decode("utf-8"))
         assert data == {"key1": "value1", "key2": "value2"}
 
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_skips_empty_buffer(self, mock_variable):
         _persist_backup("my_var_key", {})
 
@@ -209,7 +209,7 @@ class TestBackupXcomToVariable:
 
 
 class TestDeleteXcomBackupVariable:
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_deletes_variable(self, mock_variable):
         ti = _MockTI()
         context = {"ti": ti, "run_id": "test_run"}
@@ -219,7 +219,7 @@ class TestDeleteXcomBackupVariable:
 
         mock_variable.delete.assert_called_once_with(ti._cosmos_xcom_backup_var_key)
 
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_noop_without_init(self, mock_variable):
         ti = _MockTI()
         context = {"ti": ti}
@@ -228,7 +228,7 @@ class TestDeleteXcomBackupVariable:
 
         mock_variable.delete.assert_not_called()
 
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_ignores_key_error(self, mock_variable):
         ti = _MockTI()
         context = {"ti": ti, "run_id": "test_run"}
@@ -240,7 +240,7 @@ class TestDeleteXcomBackupVariable:
 
 class TestRestoreXcomFromVariable:
     @patch("cosmos.operators._watcher.xcom._persist_backup")
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_restores_entries(self, mock_variable, mock_persist):
         ti = _MockTI()
         backup = {"key1": "val1", "key2": "val2"}
@@ -255,7 +255,7 @@ class TestRestoreXcomFromVariable:
         assert ti.store["key2"] == "val2"
         mock_variable.delete.assert_called_once()
 
-    @patch("airflow.models.Variable")
+    @patch("cosmos.operators._watcher.xcom.Variable")
     def test_returns_false_when_no_backup(self, mock_variable):
         ti = _MockTI()
         mock_variable.get.return_value = None

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -159,7 +159,7 @@ def test_dbt_producer_log_format_always_json():
     assert op.log_format == "json"
 
 
-@patch("airflow.models.Variable")
+@patch("cosmos.operators._watcher.xcom.Variable")
 @patch("cosmos.operators._watcher.xcom._persist_backup")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.execute")
 def test_dbt_producer_watcher_operator_pushes_completion_status_on_success(mock_execute, mock_persist, mock_variable):
@@ -174,7 +174,7 @@ def test_dbt_producer_watcher_operator_pushes_completion_status_on_success(mock_
     mock_execute.assert_called_once()
 
 
-@patch("airflow.models.Variable")
+@patch("cosmos.operators._watcher.xcom.Variable")
 @patch("cosmos.operators._watcher.xcom._persist_backup")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.execute")
 def test_dbt_producer_watcher_operator_pushes_completion_status_on_failure(mock_execute, mock_persist, mock_variable):


### PR DESCRIPTION
Fix warning when using variable.get() by using updated import path

```
[2026-04-22 09:21:24] WARNING - Using Variable.get from `airflow.models` is deprecated.Please use `get` on Variable from sdk(`airflow.sdk.Variable`) instead category=DeprecationWarning
```