### PR TITLE
Fix flaky cosmos_manifest_selectors_example DAG in CI

### DIFF
--- a/dev/dags/cosmos_manifest_selectors_example.py
+++ b/dev/dags/cosmos_manifest_selectors_example.py
@@ -58,7 +58,7 @@ with DAG(
         profile_config=profile_config,
         render_config=RenderConfig(
             load_method=LoadMode.DBT_MANIFEST,
-            select=["+customers", "raw_orders", "raw_payments"],
+            select=["+customers", "+orders", "raw_payments"],
             airflow_vars_to_purge_dbt_yaml_selectors_cache=["purge"],
         ),
         execution_config=execution_config,

--- a/dev/dags/cosmos_manifest_selectors_example.py
+++ b/dev/dags/cosmos_manifest_selectors_example.py
@@ -58,7 +58,7 @@ with DAG(
         profile_config=profile_config,
         render_config=RenderConfig(
             load_method=LoadMode.DBT_MANIFEST,
-            select=["+customers"],
+            select=["+customers", "raw_orders", "raw_payments"],
             airflow_vars_to_purge_dbt_yaml_selectors_cache=["purge"],
         ),
         execution_config=execution_config,

--- a/dev/dags/cosmos_manifest_selectors_example.py
+++ b/dev/dags/cosmos_manifest_selectors_example.py
@@ -58,7 +58,7 @@ with DAG(
         profile_config=profile_config,
         render_config=RenderConfig(
             load_method=LoadMode.DBT_MANIFEST,
-            select=["+customers", "+orders", "raw_payments"],
+            select=["+customers", "+orders", "raw_orders", "raw_payments"],
             airflow_vars_to_purge_dbt_yaml_selectors_cache=["purge"],
         ),
         execution_config=execution_config,


### PR DESCRIPTION
The `pre_condition` task group in `cosmos_manifest_selectors_example` used `select=["+customers"]`, which left the DAG dependent on state leaked from other tests. This made the integration test `test_example_dag[cosmos_manifest_selectors_example]` flaky; passing only when `pytest-split` happened to order another jaffle_shop DAG before it in the same split (which pre-populated the required tables in Postgres).

**Root cause**

Two gaps in the +customers selection:
1. Orphan seeds. In `altered_jaffle_shop`, `stg_orders` and `stg_payments` read their data via `source('postgres_db', 'raw_orders' | 'raw_payments')`. The corresponding seeds (`raw_orders`,
  `raw_payments`) are orphans in the manifest, nothing references them, so `+` traversal skips them, and they never get loaded. `raw_customers` is pulled in because each staging model has a `force_seed_dep CTE that does select * from {{ ref('raw_customers') }}`.
2. Missing `orders` model. The `relationships_orders_customer_id__customer_id__ref_customers_ test` is attached to both `customers` and `orders` and queries `public.orders`. `+customers` pulls the test in (it's a child of customers) but doesn't build the orders model, so `customers.test` fails with `relation public.orders" does not exist`. This also matters because the downstream `local_example` / `aws_s3_example` / `gcp_gs_example` / `azure_abfs_example` task groups all run the critical_path selector, which is the union of `customers` and `orders`, so pre_condition needs to leave both models present.

**Fix**

 Change the pre_condition selector to:

`select=["+customers", "+orders", "raw_orders", "raw_payments"]`

- `+customers` / `+orders` build both final models and their upstream `stg_*` models (and pull in `raw_customers` via `ref`)
- `raw_orders`, `raw_payments` explicitly seed the two orphan seeds so the `source()` reads in `stg_orders` / `stg_payments` resolve


related: #2562 
related: #2592 