### PR TITLE
Prevent watcher producer skip propagating to downstream tasks via gateway task

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -716,6 +716,20 @@ def _add_watcher_producer_task(
     )
     producer_airflow_task = create_airflow_task(producer_task_metadata, dag, task_group=task_group)
     tasks_map[PRODUCER_WATCHER_TASK_ID] = producer_airflow_task
+
+    # For DbtTaskGroup, add a gate task that absorbs the producer's skip state
+    # so it does not propagate to tasks downstream of the group.
+    # Not needed for DbtDag where producer >> consumers with trigger_rule="always" handles this.
+    if task_group is not None:
+        from cosmos.operators._watcher.base import create_producer_done_task
+
+        producer_done_task = create_producer_done_task(
+            dag=dag,
+            task_group=task_group,
+            task_id=f"{PRODUCER_WATCHER_TASK_ID}_done",
+        )
+        producer_airflow_task >> producer_done_task
+
     return producer_airflow_task
 
 
@@ -732,8 +746,8 @@ def _add_watcher_dependencies(
     - make the producer task to be the parent of the root dbt nodes, without blocking them from sensing XCom
     """
     for node_id, task_or_taskgroup in tasks_map.items():
-        # We do not want to set a dependency between the producer task and itself
-        if node_id == PRODUCER_WATCHER_TASK_ID:
+        # We do not want to set a dependency between the producer task (or its gate) and itself
+        if node_id in (PRODUCER_WATCHER_TASK_ID, f"{PRODUCER_WATCHER_TASK_ID}_done"):
             continue
 
         node_tasks = (

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -25,6 +25,7 @@ from cosmos.constants import (
     DBT_SETUP_ASYNC_TASK_ID,
     DBT_TEARDOWN_ASYNC_TASK_ID,
     DEFAULT_DBT_RESOURCES,
+    PRODUCER_WATCHER_DONE_TASK_ID,
     PRODUCER_WATCHER_TASK_ID,
     SUPPORTED_BUILD_RESOURCES,
     TESTABLE_DBT_RESOURCES,
@@ -726,7 +727,7 @@ def _add_watcher_producer_task(
         producer_done_task = create_producer_done_task(
             dag=dag,
             task_group=task_group,
-            task_id=f"{PRODUCER_WATCHER_TASK_ID}_done",
+            task_id=PRODUCER_WATCHER_DONE_TASK_ID,
         )
         producer_airflow_task >> producer_done_task
 
@@ -747,7 +748,7 @@ def _add_watcher_dependencies(
     """
     for node_id, task_or_taskgroup in tasks_map.items():
         # We do not want to set a dependency between the producer task (or its gate) and itself
-        if node_id in (PRODUCER_WATCHER_TASK_ID, f"{PRODUCER_WATCHER_TASK_ID}_done"):
+        if node_id in (PRODUCER_WATCHER_TASK_ID, PRODUCER_WATCHER_DONE_TASK_ID):
             continue
 
         node_tasks = (

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -185,6 +185,7 @@ WATCHER_TASK_WEIGHT_RULE = "absolute"
 CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT = 2
 PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT = 20
 PRODUCER_WATCHER_TASK_ID = "dbt_producer_watcher"
+PRODUCER_WATCHER_DONE_TASK_ID = f"{PRODUCER_WATCHER_TASK_ID}_done"
 
 # Historical telemetry endpoints retained for reference:
 # • v1 (Cosmos 1.8.0–1.10.x)

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -668,3 +668,29 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
             return True
         else:
             raise AirflowException(f"{self._resource_label} '{self.model_unique_id}' finished with status '{status}'")
+
+
+def create_producer_done_task(dag: Any, task_group: Any, task_id: str) -> Any:
+    """Create an EmptyOperator that absorbs the producer's skip state on retry.
+
+    This task sits downstream of the producer inside the DbtTaskGroup. When the producer
+    is skipped on retry, this task still succeeds (trigger_rule=NONE_FAILED), preventing
+    the skip from propagating to tasks downstream of the group.
+    """
+    try:
+        from airflow.providers.standard.operators.empty import EmptyOperator
+    except ImportError:
+        from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
+
+    from airflow.utils.trigger_rule import TriggerRule
+
+    return EmptyOperator(  # type: ignore[no-untyped-call]
+        task_id=task_id,
+        dag=dag,
+        task_group=task_group,
+        trigger_rule=TriggerRule.NONE_FAILED,
+        doc_md=(
+            "**Cosmos internal task.** Absorbs the producer's skip state on retry "
+            "so it does not propagate to tasks downstream of this DbtTaskGroup."
+        ),
+    )

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -682,7 +682,10 @@ def create_producer_done_task(dag: Any, task_group: Any, task_id: str) -> Any:
     except ImportError:
         from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
 
-    from airflow.utils.trigger_rule import TriggerRule
+    try:
+        from airflow.task.trigger_rule import TriggerRule
+    except ImportError:
+        from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef]
 
     return EmptyOperator(  # type: ignore[no-untyped-call]
         task_id=task_id,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -4,7 +4,7 @@ import json
 import logging
 import threading
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException, AirflowSkipException
 
@@ -39,6 +39,15 @@ try:
 except ImportError:  # pragma: no cover
     from airflow.sensors.base import BaseSensorOperator
     from airflow.utils.context import Context  # type: ignore[attr-defined]
+
+if TYPE_CHECKING:
+    from airflow.models.dag import DAG
+    from airflow.operators.empty import EmptyOperator
+
+    try:
+        from airflow.sdk import TaskGroup
+    except ImportError:
+        from airflow.utils.task_group import TaskGroup
 
 logger = get_logger(__name__)
 
@@ -670,7 +679,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
             raise AirflowException(f"{self._resource_label} '{self.model_unique_id}' finished with status '{status}'")
 
 
-def create_producer_done_task(dag: Any, task_group: Any, task_id: str) -> Any:
+def create_producer_done_task(dag: DAG, task_group: TaskGroup, task_id: str) -> EmptyOperator:
     """Create an EmptyOperator that absorbs the producer's skip state on retry.
 
     This task sits downstream of the producer inside the DbtTaskGroup. When the producer

--- a/dev/dags/dbt/watcher_downstream_not_skipped/dbt_project.yml
+++ b/dev/dags/dbt/watcher_downstream_not_skipped/dbt_project.yml
@@ -1,0 +1,26 @@
+name: 'watcher_downstream_not_skipped'
+
+config-version: 2
+version: '0.1'
+
+profile: 'default'
+
+model-paths: ["models"]
+seed-paths: ["seeds"]
+test-paths: ["tests"]
+macro-paths: ["macros"]
+
+target-path: "target"
+clean-targets:
+    - "target"
+    - "dbt_modules"
+    - "logs"
+
+require-dbt-version: [">=1.0.0", "<2.0.0"]
+
+on-run-start:
+  - "CREATE SEQUENCE IF NOT EXISTS {{ target.schema }}._cosmos_fail_once_seq"
+
+models:
+  watcher_downstream_not_skipped:
+      +materialized: table

--- a/dev/dags/dbt/watcher_downstream_not_skipped/models/model_a.sql
+++ b/dev/dags/dbt/watcher_downstream_not_skipped/models/model_a.sql
@@ -1,0 +1,5 @@
+select 1 as id, 'Alice' as first_name, 'Smith' as last_name, 'alice@example.com' as email
+union all
+select 2, 'Bob', 'Jones', 'bob@example.com'
+union all
+select 3, 'Charlie', 'Brown', 'charlie@example.com'

--- a/dev/dags/dbt/watcher_downstream_not_skipped/models/model_retry.sql
+++ b/dev/dags/dbt/watcher_downstream_not_skipped/models/model_retry.sql
@@ -1,0 +1,12 @@
+{{
+    config(
+        pre_hook=[
+            "DO $$ BEGIN IF nextval('{{ target.schema }}._cosmos_fail_once_seq') <= 1 THEN RAISE EXCEPTION 'fail_once: intentional first-run failure'; END IF; END $$"
+        ]
+    )
+}}
+
+select
+    id,
+    first_name
+from {{ ref('model_a') }}

--- a/dev/failed_dags/example_watcher_downstream_not_skipped.py
+++ b/dev/failed_dags/example_watcher_downstream_not_skipped.py
@@ -1,0 +1,93 @@
+"""
+Airflow DAG to verify watcher downstream-task behavior when a producer task is skipped on retry.
+
+In watcher mode, when a dbt model fails the producer retries and raises AirflowSkipException.
+Without the gateway task introduced in Cosmos, the skip would propagate to all tasks downstream
+of the TaskGroup (e.g. post_dbt), even though the consumer tasks inside the group succeeded.
+
+The gateway task (dbt_producer_watcher_done) sits downstream of the producer inside the group
+with trigger_rule="none_failed", absorbing the skip so it does not propagate outside.
+
+This DAG demonstrates that:
+- model_a succeeds in the producer and the consumer reads the result from XCom
+- model_retry fails on the first attempt (via a fail_once sequence pre-hook) but succeeds
+  on the consumer retry fallback
+- post_dbt (an EmptyOperator downstream of the group) runs successfully — it is NOT skipped
+
+A cleanup task drops the PostgreSQL sequence so the DAG can be re-triggered.
+"""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from airflow.models import DAG
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+try:
+    from airflow.providers.standard.operators.empty import EmptyOperator
+except ImportError:
+    from airflow.operators.empty import EmptyOperator
+
+from cosmos import DbtTaskGroup, ExecutionConfig, ProfileConfig, ProjectConfig
+from cosmos.constants import ExecutionMode
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent.parent / "dags/dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_PATH = DBT_ROOT_PATH / "watcher_downstream_not_skipped"
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+        disable_event_tracking=True,
+    ),
+)
+
+execution_config = ExecutionConfig(
+    execution_mode=ExecutionMode.WATCHER,
+)
+
+operator_args = {
+    "install_deps": True,
+    "execution_timeout": timedelta(seconds=120),
+}
+
+if os.getenv("CI"):
+    operator_args["trigger_rule"] = "all_success"
+
+default_args = {
+    "retries": 2,
+    "retry_delay": timedelta(seconds=0),
+    "depends_on_past": True,
+}
+
+with DAG(
+    dag_id="example_watcher_downstream_not_skipped",
+    schedule="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args=default_args,
+):
+    dbt_group = DbtTaskGroup(
+        group_id="watcher_downstream_not_skipped",
+        execution_config=execution_config,
+        project_config=ProjectConfig(DBT_PROJECT_PATH),
+        profile_config=profile_config,
+        operator_args=operator_args,
+    )
+
+    post_dbt = EmptyOperator(task_id="post_dbt")
+
+    cleanup = SQLExecuteQueryOperator(
+        task_id="drop_fail_once_marker",
+        conn_id="example_conn",
+        sql="DROP SEQUENCE IF EXISTS public._cosmos_fail_once_seq;",
+        trigger_rule="all_done",
+    )
+
+    dbt_group >> post_dbt
+    dbt_group >> cleanup

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -224,22 +224,65 @@ If a branch of the DAG fails, users can clear the status of a failed consumer ta
 
 **Producer retry behavior**
 
-.. versionadded:: 1.12.2
+.. versionchanged:: 1.14.1
 
-When the ``DbtProducerWatcherOperator`` is triggered for a retry (try_number > 1), it will not re-run the dbt build command and will succeed. In previous versions of Cosmos, the producer task would fail during retries.
-This behavior is designed to support TaskGroup-level retries, as reported in `#2282 <https://github.com/astronomer/astronomer-cosmos/issues/2282>`_.
+When the ``DbtProducerWatcherOperator`` is triggered for a retry (``try_number > 1``), it raises
+``AirflowSkipException`` instead of re-running the ``dbt build`` command. Before skipping, it restores
+XCom values from a backup so that consumer sensors can still read model statuses from the first attempt.
 
-**Why this matters:**
+**XCom backup and restore:**
 
-- In earlier versions, attempting to retry the producer task would raise an ``AirflowException``, causing the retry to fail immediately.
-- Now, the producer gracefully skips execution on retries, logging an informational message explaining that the retry was skipped to avoid running a second ``dbt build``.
-- This allows users to retry entire TaskGroups and/or DAGs without the producer task blocking the retry flow.
+During execution, each XCom push is incrementally backed up to an Airflow Variable. This ensures that
+when the producer fails and Airflow clears XCom entries before the retry, the backed-up values can be
+restored. On a successful run, the backup Variable is automatically deleted to avoid stale data
+accumulating over time.
+
+**How consumer retries work:**
+
+1. The producer runs ``dbt build`` — some models succeed, some fail.
+2. The producer task fails, and XCom values are backed up to a Variable.
+3. On retry, the producer restores XCom from the Variable and raises ``AirflowSkipException``.
+4. Consumer sensors read model statuses from the restored XCom.
+5. Consumers for successful models complete immediately.
+6. Consumers for failed models detect the error status and raise ``AirflowException``.
+7. On their own retry, failed consumers fall back to running dbt individually for their model
+   (via ``_fallback_to_non_watcher_run``), behaving like ``ExecutionMode.LOCAL``.
 
 **Important considerations:**
 
-- Retries are no longer forced to ``0`` by Cosmos, since 1.14.0. Users may configure ``retries`` freely on the producer task. On any retry attempt (``try_number > 1``), the producer gracefully skips execution and returns success — it will not re-run the ``dbt build`` command. This means retrying the producer (or clearing an entire TaskGroup) is safe and will not cause duplicate dbt builds. During the retry of the sensor tasks, they will effectively run the corresponding dbt commands.
+- Users may configure ``retries`` freely on the producer task. On any retry attempt (``try_number > 1``),
+  the producer gracefully skips execution — it will not re-run the ``dbt build`` command.
+- Retrying the producer (or clearing an entire TaskGroup) is safe and will not cause duplicate dbt builds.
+- During the retry of the sensor tasks, they will effectively run the corresponding dbt commands.
 
 The overall retry behavior will be further improved once `#1978 <https://github.com/astronomer/astronomer-cosmos/issues/1978>`_ is implemented.
+
+Producer done gateway task (DbtTaskGroup only)
+...............................................
+
+.. versionadded:: 1.14.1
+
+When using ``DbtTaskGroup`` in watcher mode, the producer task may be skipped on retry
+(via ``AirflowSkipException``). Because the producer is a leaf task inside the ``TaskGroup``,
+Airflow's default ``trigger_rule="all_success"`` would cause any tasks downstream of the group
+to be skipped as well — even when all consumer tasks succeeded. **This makes
+``ExecutionMode.WATCHER`` behave differently from ``ExecutionMode.LOCAL``** when used with
+``DbtTaskGroup``.
+
+To prevent this, Cosmos automatically adds an internal gateway task called
+``dbt_producer_watcher_done`` inside the ``DbtTaskGroup``. This task:
+
+- Sits directly downstream of the producer (``producer >> dbt_producer_watcher_done``)
+- Uses ``trigger_rule="none_failed"`` so it succeeds even when the producer is skipped
+- Absorbs the producer's skip state, preventing it from propagating to tasks downstream of the group
+
+This gateway is only added for ``DbtTaskGroup`` — ``DbtDag`` does not need it because it handles
+the producer-to-consumer dependency differently (``producer >> consumers`` with
+``trigger_rule="always"``).
+
+.. note::
+   The ``dbt_producer_watcher_done`` task is visible in the Airflow UI. Click on it to see a
+   description of its purpose in the "Doc" tab.
 
 Watcher dbt Execution Queue
 ...........................

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -269,7 +269,8 @@ to be skipped as well — even when all consumer tasks succeeded. **This makes
 ``ExecutionMode.WATCHER`` behave differently from ``ExecutionMode.LOCAL``** when used with
 ``DbtTaskGroup``.
 
-To prevent this, Cosmos automatically adds an internal gateway task called
+To prevent this (`#2594 <https://github.com/astronomer/astronomer-cosmos/issues/2594>`_),
+Cosmos automatically adds an internal gateway task called
 ``dbt_producer_watcher_done`` inside the ``DbtTaskGroup``. This task:
 
 - Sits directly downstream of the producer (``producer >> dbt_producer_watcher_done``)

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1972,10 +1972,10 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
 
 
 @pytest.mark.skipif(
-    AIRFLOW_VERSION < Version("2.10") or AIRFLOW_VERSION == Version("3.1.0"),
+    AIRFLOW_VERSION < Version("2.10") or (Version("3.1.0") <= AIRFLOW_VERSION < Version("3.2.0")),
     reason=(
         "dag.test() in Airflow 2.9 hangs when a task fails with retries configured. "
-        "Airflow 3.1.0 crashes during task finalization (SetRenderedFields) when retrying "
+        "Airflow 3.1.x crashes during task finalization (SetRenderedFields) when retrying "
         "tasks inside a DbtTaskGroup via dag.test()."
     ),
 )

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1756,7 +1756,10 @@ def test_dbt_task_group_with_watcher():
 
     done_task = dag_dbt_task_group_watcher.task_dict["dbt_task_group.dbt_producer_watcher_done"]
     assert done_task.__class__.__name__ == "EmptyOperator"
-    from airflow.utils.trigger_rule import TriggerRule
+    try:
+        from airflow.task.trigger_rule import TriggerRule
+    except ImportError:
+        from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef]
 
     assert done_task.trigger_rule == TriggerRule.NONE_FAILED
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1747,7 +1747,9 @@ def test_dbt_task_group_with_watcher():
     assert isinstance(dag_dbt_task_group_watcher.task_dict["dbt_task_group.customers_run"], DbtRunWatcherOperator)
     assert isinstance(dag_dbt_task_group_watcher.task_dict["dbt_task_group.orders_run"], DbtRunWatcherOperator)
 
-    assert dag_dbt_task_group_watcher.task_dict["dbt_task_group.dbt_producer_watcher"].downstream_task_ids == set()
+    assert dag_dbt_task_group_watcher.task_dict["dbt_task_group.dbt_producer_watcher"].downstream_task_ids == {
+        "dbt_task_group.dbt_producer_watcher_done",
+    }
 
 
 @pytest.mark.integration

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -39,6 +39,9 @@ DBT_PROJECT_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/jaffle_sh
 DBT_PROFILES_YAML_FILEPATH = DBT_PROJECT_PATH / "profiles.yml"
 MULTI_FOLDER_DBT_PROJ_DIR = Path(__file__).parent.parent.parent / "dev/dags/dbt/multi_folder"
 DBT_WATCHER_FAILING_TESTS_PATH = Path(__file__).parent.parent.parent / "dev/dags/dbt/watcher_failing_tests"
+DBT_WATCHER_DOWNSTREAM_NOT_SKIPPED_PATH = (
+    Path(__file__).parent.parent.parent / "dev/dags/dbt/watcher_downstream_not_skipped"
+)
 
 DBT_EXECUTABLE_PATH = Path(__file__).parent.parent.parent / "venv-subprocess/bin/dbt"
 DBT_PROJECT_WITH_EMPTY_MODEL_PATH = Path(__file__).parent.parent / "sample/dbt_project_with_empty_model"
@@ -1751,6 +1754,10 @@ def test_dbt_task_group_with_watcher():
         "dbt_task_group.dbt_producer_watcher_done",
     }
 
+    done_task = dag_dbt_task_group_watcher.task_dict["dbt_task_group.dbt_producer_watcher_done"]
+    assert done_task.__class__.__name__ == "EmptyOperator"
+    assert str(done_task.trigger_rule) == "none_failed"
+
 
 @pytest.mark.integration
 def test_dbt_task_group_with_watcher_has_correct_dbt_cmd():
@@ -1957,6 +1964,83 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
 
     dbt_error_message = """Database Error in model model_f (models/model_f.sql)\n  column "this_column_does_not_exist_at_all" does not exist\n  LINE 1"""
     assert dbt_error_message in caplog.text
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION < Version("2.10") or AIRFLOW_VERSION == Version("3.1.0"),
+    reason=(
+        "dag.test() in Airflow 2.9 hangs when a task fails with retries configured. "
+        "Airflow 3.1.0 crashes during task finalization (SetRenderedFields) when retrying "
+        "tasks inside a DbtTaskGroup via dag.test()."
+    ),
+)
+@pytest.mark.integration
+def test_dbt_task_group_watcher_gateway_prevents_downstream_skip(caplog):
+    """
+    Verify that the dbt_producer_watcher_done gateway task prevents the producer's skip
+    from propagating to tasks downstream of the DbtTaskGroup.
+    """
+    import psycopg2
+    from airflow import DAG
+    from airflow.hooks.base import BaseHook
+
+    from cosmos import DbtTaskGroup
+
+    try:
+        from airflow.providers.standard.operators.empty import EmptyOperator
+    except ImportError:
+        from airflow.operators.empty import EmptyOperator
+
+    # Reset the fail_once sequence using credentials from the same Airflow connection
+    airflow_conn = BaseHook.get_connection("example_conn")
+    with psycopg2.connect(
+        host=airflow_conn.host,
+        port=airflow_conn.port or 5432,
+        dbname=airflow_conn.schema or "postgres",
+        user=airflow_conn.login,
+        password=airflow_conn.password,
+    ) as conn:
+        conn.autocommit = True
+        with conn.cursor() as cur:
+            cur.execute("DROP SEQUENCE IF EXISTS public._cosmos_fail_once_seq")
+
+    caplog.set_level(logging.DEBUG, logger="cosmos.operators._watcher.base")
+
+    with DAG(
+        dag_id="watcher_taskgroup_gateway_test",
+        start_date=datetime(2023, 1, 1),
+        default_args={"retries": 2, "retry_delay": timedelta(seconds=0)},
+        dagrun_timeout=timedelta(seconds=120),
+    ) as dag:
+        dbt_group = DbtTaskGroup(
+            group_id="watcher_downstream_not_skipped",
+            execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER),
+            project_config=ProjectConfig(dbt_project_path=DBT_WATCHER_DOWNSTREAM_NOT_SKIPPED_PATH),
+            profile_config=profile_config,
+            render_config=RenderConfig(emit_datasets=False, test_behavior=TestBehavior.NONE),
+            operator_args={"trigger_rule": "none_failed", "execution_timeout": timedelta(seconds=120)},
+        )
+
+        # Force gateway >> root consumers so dag.test() respects execution order.
+        # Using the gateway (not the producer) as upstream ensures consumers see a
+        # successful upstream even when the producer is skipped.
+        # This workaround is only needed for dag.test() — the real scheduler uses priority_weight.
+        # See https://github.com/apache/airflow/issues/56723
+        gateway = dag.task_dict["watcher_downstream_not_skipped.dbt_producer_watcher_done"]
+        for root_task in dbt_group.get_roots():
+            if root_task.task_id.endswith("_done") or root_task.task_id.endswith("dbt_producer_watcher"):
+                continue
+            gateway >> root_task
+
+        post_dbt = EmptyOperator(task_id="post_dbt")
+        dbt_group >> post_dbt
+
+    outcome = new_test_dag(dag, expected_dag_state=DagRunState.SUCCESS)
+
+    tis = {ti.task_id: ti for ti in outcome.get_task_instances()}
+    # The gateway task absorbs the producer skip — post_dbt runs successfully
+    assert tis["post_dbt"].state == "success"
+    assert tis["watcher_downstream_not_skipped.dbt_producer_watcher_done"].state == "success"
 
 
 def test_dbt_source_watcher_operator_template_fields():

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1756,7 +1756,9 @@ def test_dbt_task_group_with_watcher():
 
     done_task = dag_dbt_task_group_watcher.task_dict["dbt_task_group.dbt_producer_watcher_done"]
     assert done_task.__class__.__name__ == "EmptyOperator"
-    assert str(done_task.trigger_rule) == "none_failed"
+    from airflow.utils.trigger_rule import TriggerRule
+
+    assert done_task.trigger_rule == TriggerRule.NONE_FAILED
 
 
 @pytest.mark.integration

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1717,12 +1717,13 @@ def test_dbt_task_group_with_watcher():
     # assert outcome.state == DagRunState.SUCCESS
     # Fortunately, when we trigger the DAG run manually, the weight is being respected and the producer task is being picked up in advance.
 
-    assert len(dag_dbt_task_group_watcher.task_dict) == 10
+    assert len(dag_dbt_task_group_watcher.task_dict) == 11
     tasks_names = [task.task_id for task in dag_dbt_task_group_watcher.topological_sort()]
 
     expected_task_names = [
         "pre_dbt",
         "dbt_task_group.dbt_producer_watcher",
+        "dbt_task_group.dbt_producer_watcher_done",
         "dbt_task_group.raw_customers_seed",
         "dbt_task_group.raw_orders_seed",
         "dbt_task_group.raw_payments_seed",


### PR DESCRIPTION
When using `ExecutionMode.WATCHER` with `DbtTaskGroup`, the producer task may be skipped on retry (via `AirflowSkipException`) since https://github.com/astronomer/astronomer-cosmos/pull/2559. Because the producer is a leaf task inside the `TaskGroup`, Airflow's default `trigger_rule="all_success"` causes any tasks downstream of the group to be skipped as well - even when all consumer tasks succeeded. **This makes `ExecutionMode.WATCHER` behave differently from `ExecutionMode.LOCAL`** when used with `DbtTaskGroup`. This issue does not happen in `DbtDag`.

This PR introduces a downstream gateway task (`dbt_producer_watcher_done`) for the producer when in watcher mode. This ensures the producer's skip state does not propagate outside the task group, since the gateway task has `trigger_rule=none_failed`.

This solution was originally proposed by @johnhoran in https://github.com/astronomer/astronomer-cosmos/pull/2430. The code has changed significantly since, so we're opening a new PR and adding him as a co-author. It is an alternative approach to https://github.com/astronomer/astronomer-cosmos/pull/2591.

Co-authored-by: John Horan <jhoran@zendesk.com>

**Behaviour before and after**

The newly introduced DAG `example_watcher_downstream_not_skipped` illustrates the problematic behaviour this PR aims to address.

Video before this change:

https://github.com/user-attachments/assets/3cd03975-3c97-44c5-bf6f-8f56796815a9

Video after this change:

https://github.com/user-attachments/assets/3a50b882-9ed0-4d16-b5ae-662bec76b4e3

**Alternative approaches**

- Cosmos changing the `trigger_rule` of the downstream tasks as implemented in https://github.com/astronomer/astronomer-cosmos/pull/2591
- Accept that `ExecutionMode.LOCAL` and `ExecutionMode.WATCHER` are not fully compatible and document that users should set `trigger_rule="none_failed_min_one_success"` manually

**Implications**

- The DAG topology is changed to include a new `EmptyOperator` task (`dbt_producer_watcher_done`)

**Unsolved problem: `depends_on_past`**

This PR does not solve the problem: https://github.com/astronomer/astronomer-cosmos/issues/2596.

PR #2430 also doesn't solve the `depends_on_past` race condition. The PR fixes the retry/skip mechanism (backup XCom, restore on retry, skip producer on second attempt), but it doesn't prevent Run 2's producer from starting while Run 1's consumers are still running their fallback dbt commands.

Closes #2594