### PR TITLE
Add docs related to `ExecutionMode.WATCHER` and `depends_on_past` limitation

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -379,6 +379,15 @@ This use case is not currently supported by the ``ExecutionMode.WATCHER``, since
 
 We have a follow-up ticket to `further investigate this use case <https://github.com/astronomer/astronomer-cosmos/issues/2053>`_.
 
+Concurrent DAG runs with ``depends_on_past``
+''''''''''''''''''''''''''''''''''''''''''''
+
+When ``depends_on_past=True`` is used together with concurrent DAG runs, a race can occur between consecutive runs where the next run's producer starts while the previous run's consumer fallback is still executing, causing two dbt processes to write to the same models concurrently.
+
+As a workaround, set ``max_active_runs=1`` on the DAG.
+
+For details, see `#2596 <https://github.com/astronomer/astronomer-cosmos/issues/2596>`_.
+
 
 Advanced config
 +++++++++++++++


### PR DESCRIPTION
Document the limitation detailed in the ticket https://github.com/astronomer/astronomer-cosmos/issues/2596, while we don't implement a solution for this.