### PR TITLE
Add  'release-*' branches for pull_request_target to run CI on release branches

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
     paths: [".github/workflows/**"]
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths: [".github/workflows/**"]
 
 jobs:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -15,7 +15,7 @@ on:
   push:
     branches: [ "main" ]
   pull_request:
-    branches: [ "main" ]
+    branches: [ "main", 'release-*' ]
   schedule:
     - cron: '30 9 * * 4'
 

--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -9,7 +9,7 @@ on:
       - "cosmos/**"
       - ".github/workflows/docs-build.yml"
   pull_request:
-    branches: [main]
+    branches: [main, 'release-*']
     paths:
       - "docs/**"
       - "cosmos/**"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ on:
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run
   # without approval.
   pull_request_target:
-    branches: [main] # zizmor: ignore[dangerous-triggers]
+    branches: [main, 'release-*'] # zizmor: ignore[dangerous-triggers]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}


### PR DESCRIPTION
It appears we're missing running tests when creating release PRs for micro releases.

Observed in 1.13.1 PR https://github.com/astronomer/astronomer-cosmos/pull/2388
and 1.14.1 PR https://github.com/astronomer/astronomer-cosmos/pull/2601

This is an attempt to check if we can run tests there.