### PR TITLE
Restore memory-optimised imports docs for Cosmos < 1.14.0

### DIFF
--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -179,7 +179,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Applies to**: Cosmos versions **earlier than 1.14.0**. Since Cosmos 1.14.0, ``cosmos/__init__.py`` uses lazy imports by default and this setting is a no-op. If you are on 1.14.0 or newer, skip this section.
 
-**Impact**: High - Reduces memory footprint both at the DAG Processor and at Worker nodes.
+**Impact**: High - Reduces memory footprint both at the DAG processor and at worker nodes.
 
 **Configuration**:
 

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -174,7 +174,44 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 -------------------------------------------------------------------------------
 
-6. Enable Task Profiling with Debug Mode
+6. Enable Memory-Optimized Imports (Cosmos < 1.14.0 only)
++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+
+**Applies to**: Cosmos versions **earlier than 1.14.0**. Since Cosmos 1.14.0, ``cosmos/__init__.py`` uses lazy imports by default and this setting is a no-op. If you are on 1.14.0 or newer, skip this section.
+
+**Impact**: High - Reduces memory footprint both at the DAG Processor and at Worker nodes.
+
+**Configuration**:
+
+.. code-block:: cfg
+
+   # In airflow.cfg
+   [cosmos]
+   enable_memory_optimised_imports = True
+
+.. code-block:: bash
+
+   # Or via environment variable
+   export AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS=True
+
+**What it does**: Disables eager imports in ``cosmos/__init__.py``, preventing unused modules and classes from being loaded into memory.
+
+**Note**: When enabled, you must use full module paths for importing classes, functions and objects from Cosmos:
+
+.. code-block:: python
+
+   # Instead of:
+   from cosmos import DbtDag, ProjectConfig, RenderConfig
+
+   # Use:
+   from cosmos.airflow.dag import DbtDag
+   from cosmos.config import ProjectConfig, RenderConfig
+
+**Default**: ``False``
+
+-----------------------------------------------------------------
+
+7. Enable Task Profiling with Debug Mode
 ++++++++++++++++++++++++++++++++++++++++
 
 **Impact**: Low - Provides visibility into memory usage patterns to help identify optimization opportunities and prevent OOM issues.

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -209,7 +209,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Default**: ``False``
 
------------------------------------------------------------------
+-------------------------------------------------------------------------------
 
 7. Enable Task Profiling with Debug Mode
 ++++++++++++++++++++++++++++++++++++++++

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -319,7 +319,7 @@ This page lists all available Airflow configurations that affect ``astronomer-co
         import paths. On 1.14.0 and newer, this setting is accepted but has no effect. The guidance below is relevant
         only for users on Cosmos versions earlier than 1.14.0.
 
-    As an example, when this option is enabled, the following is an example of specifying the imports with full module paths:
+    When enabled, import Cosmos classes via their full module paths:
 
     .. literalinclude:: ../../../dev/dags/basic_cosmos_dag_full_module_path_imports.py
         :language: python

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -304,12 +304,34 @@ This page lists all available Airflow configurations that affect ``astronomer-co
 .. _enable_memory_optimised_imports:
 
 `enable_memory_optimised_imports`_:
-    (Introduced in Cosmos 1.10.1): This setting is a no-op since Cosmos 1.14.0. All imports in ``cosmos/__init__.py``
-    are now lazy by default — modules are only loaded on first access. This provides the same memory optimization
-    automatically, without requiring users to change their import paths. The setting is still accepted but has no effect.
+    (Introduced in Cosmos 1.10.1): On Cosmos versions earlier than 1.14.0, eager imports in ``cosmos/__init__.py``
+    exposed all Cosmos classes at the top level, which could significantly increase memory usage—even when Cosmos was
+    just installed but not actively used. This option allowed disabling those eager imports to reduce memory footprint.
+    When enabled, users had to access Cosmos classes via their full module paths, avoiding the overhead of importing
+    unused modules and classes.
 
     - Default: ``False``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_MEMORY_OPTIMISED_IMPORTS``
+
+    .. note::
+        Since Cosmos 1.14.0, all imports in ``cosmos/__init__.py`` are lazy by default — modules are only loaded on
+        first access. This provides the same memory optimization automatically, without requiring users to change their
+        import paths. On 1.14.0 and newer, this setting is accepted but has no effect. The guidance below is relevant
+        only for users on Cosmos versions earlier than 1.14.0.
+
+    As an example, when this option is enabled, the following is an example of specifying the imports with full module paths:
+
+    .. literalinclude:: ../../../dev/dags/basic_cosmos_dag_full_module_path_imports.py
+        :language: python
+        :start-after: [START cosmos_explicit_imports]
+        :end-before: [END cosmos_explicit_imports]
+
+    as opposed to the following approach you might have when this option is disabled (default):
+
+    .. literalinclude:: ../../../dev/dags/basic_cosmos_dag.py
+        :language: python
+        :start-after: [START cosmos_init_imports]
+        :end-before: [END cosmos_init_imports]
 
 .. _enable_telemetry:
 


### PR DESCRIPTION
PR #2531 removed the "Enable Memory-Optimized Imports" section from the memory optimization guide and the detailed explanation/examples from the cosmos-conf reference, because the switch to lazy imports in cosmos/__init__.py made enable_memory_optimised_imports a no-op.

However, that change only shipped in Cosmos 1.14.0. Users on earlier versions still need the flag (and the full-module-path import pattern it requires) to reduce the DAG processor and worker memory footprint, and removing the docs left them with no guidance.

Bring the content back, clearly scoped to Cosmos < 1.14.0:

- Add it to memory_optimization.rst as section 6 (just before the debug-mode profiling section), with an "Applies to" preamble so readers on 1.14.0+ know to skip it.
- Restore the long-form explanation and both literalinclude example blocks in cosmos-conf.rst, with a note that the setting is a no-op on 1.14.0 and newer.

related: #2531 