### PR TITLE
Add Changelog and version bump for Release 1.14.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -26,6 +26,7 @@ Docs
 
 Others
 
+* Speed up Airflow 3.1+ integration tests by caching InProcessExecutionAPI by @pankajkoti in #2547
 * Improve stability of cache hash unit tests by @tatiana in #2539
 * Fix mypy 1.20.0 type check failures by @pankajkoti in #2546
 * Fix CI failures caused by docs build memory exhaustion by @pankajkoti in #2580

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,16 +1,39 @@
 Changelog
 =========
 
-1.14.1a2 (2026-04-21)
+1.14.1 (2026-04-23)
 -------------------
 
 Bug Fixes
 
-* Fix watcher producer retries behaviour by @tatiana in #2559
-+ K8s watcher fix
+* Fix ``ExecutionMode.WATCHER`` producer retry behaviour by @tatiana in #2559
+* Prevent watcher producer skip propagating to downstream tasks via gateway task by @johnhoran and @tatiana in #2597
+* Keep watcher sensor polling when producer is still running by @pankajkoti in #2592
+* Fix circular import error in Cosmos plugin discovery under Astro Runtime by @tatiana in #2538
+* Fix ``CosmosRichLogger`` crash on ``None`` log message by @tatiana in #2540
+* Enable inlets and outlets using dbt Fusion on Airflow 3 by @ichirotakami in #2561
+* Fix incorrectly skipped source downstream tasks in ``ExecutionMode.WATCHER`` by @pankajastro in #2563
+* Fix duplicate logs in ``dbt build`` when source freshness is enabled by @pankajastro in #2564
+* Warn and normalize when ``source_rendering_behavior=None`` is passed by @pankajastro in #2570
+* Gracefully handle ``Variable.set()`` failures on Astro Remote Execution by @hkc-8010 in #2573
+* Skip malformed YAML selectors instead of failing entirely by @YourRoyalLinus in #2577
 
-(and others)
+Docs
 
+* Update watcher test behavior docs for Cosmos 1.14.0 by @tatiana in #2549
+* Add redirect for moved partial-parsing docs page by @tatiana in #2550
+* Document ``ExecutionMode.WATCHER`` and ``depends_on_past`` limitation by @tatiana in #2602
+* Restore memory-optimised imports docs for Cosmos < 1.14.0 by @pankajkoti in #2604
+
+Others
+
+* Improve stability of cache hash unit tests by @tatiana in #2539
+* Fix mypy 1.20.0 type check failures by @pankajkoti in #2546
+* Fix CI failures caused by docs build memory exhaustion by @pankajkoti in #2580
+* Fix dbt Fusion broken integration tests by @tatiana in #2581
+* Fix flaky ``cosmos_manifest_selectors_example`` DAG in CI by @pankajkoti in #2593
+* Reduce pre-commit autoupdate frequency PRs by @tatiana in #2544
+* Bump ``reviewdog/action-actionlint`` from 1.71.0 to 1.72.0 by @dependabot in #2542
 
 1.14.0 (2026-04-07)
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,7 @@ Bug Fixes
 
 * Fix ``ExecutionMode.WATCHER`` producer retry behaviour by @tatiana in #2559
 * Prevent watcher producer skip propagating to downstream tasks via gateway task by @johnhoran and @tatiana in #2597
+* Keep watcher sensor polling when producer is still running by @pankajkoti in #2592
 * Fix circular import error in Cosmos plugin discovery under Astro Runtime by @tatiana in #2538
 * Fix ``CosmosRichLogger`` crash on ``None`` log message by @tatiana in #2540
 * Enable inlets and outlets using dbt Fusion on Airflow 3 by @ichirotakami in #2561
@@ -34,6 +35,7 @@ Others
 * Fix flaky ``cosmos_manifest_selectors_example`` DAG in CI by @pankajkoti in #2593
 * Reduce pre-commit autoupdate frequency PRs by @tatiana in #2544
 * Bump ``reviewdog/action-actionlint`` from 1.71.0 to 1.72.0 by @dependabot in #2542
+* Skip watcher gateway test on Airflow 3.0 by @tatiana in #2607
 
 1.14.0 (2026-04-07)
 ---------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,7 +8,6 @@ Bug Fixes
 
 * Fix ``ExecutionMode.WATCHER`` producer retry behaviour by @tatiana in #2559
 * Prevent watcher producer skip propagating to downstream tasks via gateway task by @johnhoran and @tatiana in #2597
-* Keep watcher sensor polling when producer is still running by @pankajkoti in #2592
 * Fix circular import error in Cosmos plugin discovery under Astro Runtime by @tatiana in #2538
 * Fix ``CosmosRichLogger`` crash on ``None`` log message by @tatiana in #2540
 * Enable inlets and outlets using dbt Fusion on Airflow 3 by @ichirotakami in #2561

--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import importlib
 
-__version__ = "1.14.1a2"
+__version__ = "1.14.1"
 
 
 # Mapping of public names to their module paths for lazy loading via __getattr__.


### PR DESCRIPTION
Adds Changelogs and version bump for Cosmos 1.14.1 to the main branch.

related: https://github.com/astronomer/oss-integrations-private/issues/381
related: #2601 