### PR TITLE
Pin pre-commit hooks to commit SHAs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
         types: [file]
         pass_filenames: false
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v6.0.0
+    rev: 3e8a8703264a2f4a69428a0aa4dcb512790b2c8c  # v6.0.0
     hooks:
       - id: check-added-large-files
         exclude: ^dev/dags/dbt/cross_project/downstream/target/manifest.json$
@@ -55,7 +55,7 @@ repos:
       - id: detect-aws-credentials
         args: ["--allow-missing-credentials"]
   - repo: https://github.com/codespell-project/codespell
-    rev: v2.4.2
+    rev: 2ccb47ff45ad361a21071a7eedda4c37e6ae8c5a  # v2.4.2
     hooks:
       - id: codespell
         name: Run codespell to check for common misspellings in files
@@ -67,41 +67,41 @@ repos:
           - -L connexion,aci
           - --ignore-words=.codespell-ignore-words
   - repo: https://github.com/pre-commit/pygrep-hooks
-    rev: v1.10.0
+    rev: 3a6eb0fadf60b3cccfd80bad9dbb6fae7e47b316  # v1.10.0
     hooks:
       - id: rst-backticks
       - id: python-check-mock-methods
   - repo: https://github.com/Lucas-C/pre-commit-hooks
-    rev: v1.5.6
+    rev: ad1b27d73581aa16cca06fc4a0761fc563ffe8e8  # v1.5.6
     hooks:
       - id: remove-crlf
       - id: remove-tabs
         exclude: ^docs/make.bat$|^docs/Makefile$|^dev/dags/dbt/jaffle_shop/seeds/raw_orders.csv$
   - repo: https://github.com/asottile/pyupgrade
-    rev: v3.21.2
+    rev: 75992aaa40730136014f34227e0135f63fc951b4  # v3.21.2
     hooks:
       - id: pyupgrade
         args:
           - --py310-plus
           - --keep-runtime-typing
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.15.11
+    rev: d1b833175a5d08a925900115526febd8fe71c98e  # v0.15.11
     hooks:
       - id: ruff-check
         args: [ --fix ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: 26.3.1
+    rev: fa505ab9c3e0fedafe1709fd7ac2b5f8996c670d  # 26.3.1
     hooks:
       - id: black
         args: ["--config", "./pyproject.toml"]
   - repo: https://github.com/asottile/blacken-docs
-    rev: 1.20.0
+    rev: fda77690955e9b63c6687d8806bafd56a526e45f  # 1.20.0
     hooks:
       - id: blacken-docs
         alias: black
         additional_dependencies: [black>=26.3.1]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: "v1.20.1"
+    rev: 0f369d245750787ce34997d464ed9605391a5283  # v1.20.1
     hooks:
       - id: mypy
         name: mypy-python


### PR DESCRIPTION
Replace tag-based `rev` values with their commit SHAs and keep the original tag as a trailing comment. Pinning to SHAs removes the implicit trust that an upstream tag still points at the same commit we reviewed, and protects against a maintainer (or attacker with push access) moving a tag to malicious code.

Dependabot's pre-commit ecosystem entry already tracks these hooks and will continue to propose upgrades, updating both the SHA and the adjacent version comment.