### PR TITLE
Pin actions/stale to commit SHA in stale.yml

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -9,7 +9,7 @@ jobs:
       issues: write
       pull-requests: write
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@b5d41d4e1d5dceea10e7104786b73624c18a190f # v10.2.0
         with:
           days-before-issue-stale: 30
           days-before-issue-close: -1  # Never closes issues, more information in https://github.com/actions/stale/


### PR DESCRIPTION
Replace the floating `actions/stale@v10` reference with the commit SHA for `v10.2.0` (`b5d41d4e1d5dceea10e7104786b73624c18a190f`). Pinning to SHAs avoids the implicit trust that an upstream tag still points at the code we reviewed, and Dependabot's `github-actions` entry will keep both the SHA and the version comment up to date on upgrades.