### PR TITLE
Fix `example_cosmos_sources` to use a dbt project with sources

### DIFF
--- a/dev/dags/example_cosmos_sources.py
+++ b/dev/dags/example_cosmos_sources.py
@@ -69,7 +69,7 @@ render_config = RenderConfig(
 )
 
 project_config = ProjectConfig(
-    DBT_ROOT_PATH / "jaffle_shop",
+    DBT_ROOT_PATH / "altered_jaffle_shop",
     dbt_vars={"animation_alias": "top_5_animated_movies"},
 )
 


### PR DESCRIPTION
## Description

The `example_cosmos_sources` DAG in the `dev/dags/example_cosmos_sources.py` file was improperly mapped to the `jaffle_shop` project, rather than the `altered_jaffle_shop` project. The `ProfileConfig` in the DAG pointed to `altered_jaffle_shop`, and the `jaffle_shop` had no dbt Sources to render. Thus, it seemed as if this change was needed.

The work done in #2608 will ensure that these dbt Sources are properly rendered using the `node_converters` supplied in the DAG itself.

## Testing

These changes were tested E2E by spinning up Airflow and testing the DAG.

## Related Issue(s)

No related issues.

## Breaking Change?

No!

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
