### PR TITLE
Docs: capitalize Docker as a product name in prose

### DIFF
--- a/docs/guides/run_dbt/container/azure-container-instance.rst
+++ b/docs/guides/run_dbt/container/azure-container-instance.rst
@@ -74,7 +74,7 @@ In order to run a container in Azure Container Instance, it needs access to the 
 
 **Build the dbt Docker image**
 
-For the Docker operators to work, you need to create a docker image that will be supplied as image parameter to the dbt docker operators used in the DAG.
+For the Docker operators to work, you need to create a Docker image that will be supplied as image parameter to the dbt Docker operators used in the DAG.
 
 Clone the `cosmos-example <https://github.com/astronomer/cosmos-example.git>`_ repo
 
@@ -83,7 +83,7 @@ Clone the `cosmos-example <https://github.com/astronomer/cosmos-example.git>`_ r
     git clone https://github.com/astronomer/cosmos-example.git
     cd cosmos-example
 
-Create a docker image containing the dbt project files and dbt profile by using the `Dockerfile <https://github.com/astronomer/cosmos-example/blob/main/Dockerfile.azure_container_instance>`_, which will be supplied to the Docker operators.
+Create a Docker image containing the dbt project files and dbt profile by using the `Dockerfile <https://github.com/astronomer/cosmos-example/blob/main/Dockerfile.azure_container_instance>`_, which will be supplied to the Docker operators.
 
 .. code-block:: bash
 
@@ -96,14 +96,14 @@ After this, the image needs to be pushed to the registry of your choice. Note th
 
 .. note::
 
-    You may need to ensure docker knows to use the right credentials. If using Azure Container Registry, this can be done by running the following command:
+    You may need to ensure Docker knows to use the right credentials. If using Azure Container Registry, this can be done by running the following command:
     .. code-block:: bash
 
         az acr login
 
 .. note::
 
-    If running on M1, you may need to set the following envvars for running the docker build command in case it fails
+    If running on M1, you may need to set the following envvars for running the ``docker build`` command in case it fails
 
     .. code-block:: bash
 
@@ -142,7 +142,7 @@ Run Airflow
 
 .. note::
 
-    You might need to run airflow standalone with ``sudo`` if your Airflow user is not able to access the docker socket URL or pull the images in the Kind cluster.
+    You might need to run airflow standalone with ``sudo`` if your Airflow user is not able to access the Docker socket URL or pull the images in the Kind cluster.
 
 Log in to Airflow through a web browser ``http://localhost:8080/``, using the user ``airflow`` and the password described in the ``standalone_admin_password.txt`` file.
 

--- a/docs/guides/run_dbt/container/gcp-cloud-run-job.rst
+++ b/docs/guides/run_dbt/container/gcp-cloud-run-job.rst
@@ -238,7 +238,7 @@ Run Airflow:
 
 .. note::
 
-    You might need to run airflow standalone with ``sudo`` if your Airflow user is not able to access the docker socket URL or pull the images in the Kind cluster.
+    You might need to run airflow standalone with ``sudo`` if your Airflow user is not able to access the Docker socket URL or pull the images in the Kind cluster.
 
 Log in to Airflow through a web browser ``http://localhost:8080/``, using the user ``airflow`` and the password described in the ``standalone_admin_password.txt`` file.
 

--- a/docs/reference/configs/execution-config.rst
+++ b/docs/reference/configs/execution-config.rst
@@ -12,7 +12,7 @@ The ``ExecutionConfig`` class takes the following arguments:
 - ``invocation_mode`` (new in v1.4): The way dbt is invoked within the execution mode. This is only configurable for ``ExecutionMode.LOCAL``. For more information, see :ref:`invocation-mode`.
 - ``test_indirect_selection``: The mode to configure the test behavior when performing indirect selection.
 - ``dbt_executable_path``: The path to the dbt executable for dag generation. Defaults to dbt if available on the path.
-- ``dbt_project_path``: Configures the dbt project location accessible at runtime for dag execution. This is the project path in a docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.
+- ``dbt_project_path``: Configures the dbt project location accessible at runtime for dag execution. This is the project path in a Docker container for ``ExecutionMode.DOCKER`` or ``ExecutionMode.KUBERNETES``. Mutually exclusive with ``ProjectConfig.dbt_project_path``.
 - ``virtualenv_dir`` (new in v1.6): Directory path to locate the (cached) virtual env that should be used for execution when execution mode is set to ``ExecutionMode.VIRTUALENV``.
 - ``async_py_requirements`` (new in v1.9): A list of Python packages to install when ``ExecutionMode.AIRFLOW_ASYNC`` is used. This parameter is required only when ``enable_setup_async_task`` and ``enable_teardown_async_task`` are set to ``True``. Example value: ``["dbt-postgres==1.9.0"]``.
 - ``setup_operator_args`` (new in v1.12): A dictionary of Airflow operator arguments to be passed to DbtProducerWatcherOperator when using ExecutionMode.WATCHER. These values override any arguments provided through operator_args for the producer task.


### PR DESCRIPTION
## Description

Per the lightweight style guide proposed in #2460, capitalize `Docker` when it
refers to the product (Docker image, Docker daemon, Docker container, Docker
socket, Docker operators) in docs prose. Literal CLI invocations such as
`docker build` are wrapped in double backticks and kept lowercase.

This re-applies the `docker → Docker` portion of #2462 against current `main` as
a focused, standalone change.

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works