### PR TITLE
Enhanced ProjectConfig to support multiple model paths

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -163,7 +163,8 @@ class ProjectConfig:
     :param dbt_project_path: The path to the dbt project directory. Example: /path/to/dbt/project. Defaults to None
     :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True.
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
-    :param models_relative_path: The relative path to the dbt models directory within the project. Defaults to models
+    :param models_relative_path: The relative path(s) to the dbt models directory within the project. Accepts a single
+        path or a list of paths, mirroring dbt's ``model-paths`` configuration. Defaults to models
     :param seeds_relative_path: The relative path to the dbt seeds directory within the project. Defaults to seeds
     :param snapshots_relative_path: The relative path to the dbt snapshots directory within the project. Defaults to
     snapshots
@@ -186,16 +187,18 @@ class ProjectConfig:
     copy_dbt_packages: bool = settings.default_copy_dbt_packages
     manifest_path: Path | ObjectStoragePath | None = None
     models_path: Path | None = None
+    models_paths: list[Path] | None = None
     seeds_path: Path | None = None
     snapshots_path: Path | None = None
     project_name: str
+    model_relative_paths: list[str | Path] | None = None
 
     def __init__(
         self,
         dbt_project_path: str | Path | None = None,
         install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
-        models_relative_path: str | Path = "models",
+        models_relative_path: str | Path | list[str | Path] = "models",
         seeds_relative_path: str | Path = "seeds",
         snapshots_relative_path: str | Path = "snapshots",
         manifest_path: str | Path | None = None,
@@ -216,9 +219,16 @@ class ProjectConfig:
         if project_name:
             self.project_name = project_name
 
+        if isinstance(models_relative_path, list):
+            normalized_model_paths = models_relative_path
+        else:
+            normalized_model_paths = [models_relative_path]
+        self.model_relative_paths = normalized_model_paths
+
         if dbt_project_path:
             self.dbt_project_path = Path(dbt_project_path)
-            self.models_path = self.dbt_project_path / Path(models_relative_path)
+            self.models_paths = [self.dbt_project_path / Path(p) for p in normalized_model_paths]
+            self.models_path = self.models_paths[0]
             self.seeds_path = self.dbt_project_path / Path(seeds_relative_path)
             self.snapshots_path = self.dbt_project_path / Path(snapshots_relative_path)
             if not project_name:
@@ -268,12 +278,13 @@ class ProjectConfig:
         # map works correctly for all paths, thereby validating the project.
         if self.dbt_project_path:
             project_yml_path = self.dbt_project_path / "dbt_project.yml"
-            mandatory_paths.update(
-                {
-                    "dbt_project.yml": Path(project_yml_path) if project_yml_path else None,
-                    "models directory ": Path(self.models_path) if self.models_path else None,
-                }
-            )
+            mandatory_paths["dbt_project.yml"] = Path(project_yml_path) if project_yml_path else None
+            if self.models_paths:
+                for i, models_path in enumerate(self.models_paths):
+                    label = "models directory" if i == 0 else f"models directory ({models_path.name})"
+                    mandatory_paths[label] = Path(models_path) if models_path else None
+            elif self.models_path:
+                mandatory_paths["models directory"] = Path(self.models_path)
         if self.manifest_path:
             mandatory_paths["manifest"] = self.manifest_path
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -312,6 +312,7 @@ class DbtToAirflowConverter:
             "vars": dbt_vars,
             "cache_dir": cache_dir,
             "manifest_filepath": project_config.manifest_path,
+            "model_relative_paths": project_config.model_relative_paths,
         }
 
         validate_arguments(

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -683,7 +683,7 @@ class DbtGraph:
         self._add_vars_arg(deps_command)
         run_command(deps_command, dbt_project_path, env, self.render_config.invocation_mode, self.log_dir)
 
-    def _copy_or_create_symbolic_links(self, source_dir_path: Path, dest_dir_path: Path) -> None:
+    def _copy_or_create_symbolic_links(self, source_dir_path: Path, dest_dir_path: Path) -> Path:
         """
         This method handles creating symbolic links and/or copying files from the original file to a destination folder.
 
@@ -710,6 +710,8 @@ class DbtGraph:
 
         The current settings make sense for Cosmos 1.x and allow users to set things in different ways, while being backwards
         compatible. We should review this for Cosmos 2.x.
+
+        :returns: The effective project directory inside dest_dir_path (may differ when external model paths are used).
         """
 
         should_not_create_dbt_deps_symbolic_link = self.should_install_dbt_deps or self.project.copy_dbt_packages
@@ -731,10 +733,17 @@ class DbtGraph:
         # C. (Non-practical) Middle performance and deps may become outdated: Users manage `dbt deps` outside of Cosmos and give pre-generated dbt packages. Dependencies may become outdated. More expensive than A, similar behaviour.
         # D. Middle performance and up-to-date deps: Users run `dbt deps` outside of Cosmos and give pre-generated dbt packages. Cosmos runs dbt deps taking into account those user-generated files.
 
-        create_symlinks(source_dir_path, dest_dir_path, ignore_dbt_packages=should_not_create_dbt_deps_symbolic_link)
+        effective_dir = create_symlinks(
+            source_dir_path,
+            dest_dir_path,
+            ignore_dbt_packages=should_not_create_dbt_deps_symbolic_link,
+            model_relative_paths=self.project.model_relative_paths,
+        )
 
         if self.project.copy_dbt_packages:
-            copy_dbt_packages(source_dir_path, dest_dir_path)
+            copy_dbt_packages(source_dir_path, effective_dir)
+
+        return effective_dir
 
     def load_via_dbt_ls_without_cache(self) -> None:
         """
@@ -759,7 +768,7 @@ class DbtGraph:
             logger.debug(f"Content of the dbt project dir {project_path}: `{os.listdir(project_path)}`")
             tmpdir_path = Path(tmpdir)
 
-            self._copy_or_create_symbolic_links(project_path, tmpdir_path)
+            effective_dir = self._copy_or_create_symbolic_links(project_path, tmpdir_path)
 
             latest_partial_parse = None
             if self.project.partial_parse:
@@ -770,7 +779,7 @@ class DbtGraph:
 
             if latest_partial_parse is not None and latest_partial_parse.exists():
                 logger.info("Partial parse is enabled and the latest partial parse file is %s", latest_partial_parse)
-                cache._copy_partial_parse_to_project(latest_partial_parse, tmpdir_path)
+                cache._copy_partial_parse_to_project(latest_partial_parse, effective_dir)
 
             with (
                 self.profile_config.ensure_profile(
@@ -784,7 +793,7 @@ class DbtGraph:
 
                 self.local_flags = [
                     "--project-dir",
-                    str(tmpdir),
+                    str(effective_dir),
                     "--profiles-dir",
                     str(profile_path.parent),
                     "--profile",
@@ -793,25 +802,25 @@ class DbtGraph:
                     self.profile_config.target_name,
                 ]
 
-                self.target_dir = Path(env.get(DBT_TARGET_PATH_ENVVAR) or tmpdir_path / DBT_TARGET_DIR_NAME)
+                self.target_dir = Path(env.get(DBT_TARGET_PATH_ENVVAR) or effective_dir / DBT_TARGET_DIR_NAME)
                 env[DBT_TARGET_PATH_ENVVAR] = str(self.target_dir)
 
-                self.log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or tmpdir_path / DBT_LOG_DIR_NAME)
+                self.log_dir = Path(env.get(DBT_LOG_PATH_ENVVAR) or effective_dir / DBT_LOG_DIR_NAME)
                 env[DBT_LOG_PATH_ENVVAR] = str(self.log_dir)
 
                 if self.should_install_dbt_deps and has_non_empty_dependencies_file(self.project_path):
                     if is_cache_package_lockfile_enabled(project_path):
                         latest_package_lockfile = _get_latest_cached_package_lockfile(project_path)
                         if latest_package_lockfile:
-                            _copy_cached_package_lockfile_to_project(latest_package_lockfile, tmpdir_path)
-                    self.run_dbt_deps(dbt_cmd, tmpdir_path, env)
+                            _copy_cached_package_lockfile_to_project(latest_package_lockfile, effective_dir)
+                    self.run_dbt_deps(dbt_cmd, effective_dir, env)
 
-                nodes = self.run_dbt_ls(dbt_cmd, self.project_path, tmpdir_path, env)
+                nodes = self.run_dbt_ls(dbt_cmd, self.project_path, effective_dir, env)
                 self.nodes = nodes
                 self.filtered_nodes = nodes
 
             if self.should_use_partial_parse_cache():
-                partial_parse_file = get_partial_parse_path(tmpdir_path)
+                partial_parse_file = get_partial_parse_path(effective_dir)
                 if partial_parse_file.exists() and self.cache_dir:
                     cache._update_partial_parse_cache(partial_parse_file, self.cache_dir)
 

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -110,16 +110,65 @@ def copy_manifest_file_if_exists(source_manifest: str | Path, dbt_project_folder
         shutil.copy(source_manifest, tmp_manifest_filepath)
 
 
-def create_symlinks(project_path: Path, tmp_dir: Path, ignore_dbt_packages: bool) -> None:
-    """Helper function to create symlinks to the dbt project files."""
+def _get_external_model_paths(
+    project_path: Path, model_relative_paths: list[str | Path] | None
+) -> list[str | Path]:
+    """Return model relative paths that resolve to locations outside the project root."""
+    if not model_relative_paths:
+        return []
+    resolved_project = project_path.resolve()
+    external = []
+    for rel_path in model_relative_paths:
+        resolved = (project_path / rel_path).resolve()
+        try:
+            resolved.relative_to(resolved_project)
+        except ValueError:
+            external.append(rel_path)
+    return external
+
+
+def create_symlinks(
+    project_path: Path,
+    tmp_dir: Path,
+    ignore_dbt_packages: bool,
+    model_relative_paths: list[str | Path] | None = None,
+) -> Path:
+    """Helper function to create symlinks to the dbt project files.
+
+    When ``model_relative_paths`` contains paths that resolve outside the project root
+    (e.g. ``../shared_sources``), the project is nested inside ``tmp_dir`` so that
+    external symlinks remain within the temporary workspace for automatic cleanup.
+
+    :param project_path: The path to the real dbt project.
+    :param tmp_dir: The temporary directory to create symlinks in.
+    :param ignore_dbt_packages: Whether to skip symlinking the dbt_packages directory.
+    :param model_relative_paths: List of model-relative paths as configured in ProjectConfig.
+    :returns: The effective project directory inside ``tmp_dir``.
+    """
+    external_model_paths = _get_external_model_paths(project_path, model_relative_paths)
+
+    if external_model_paths:
+        effective_dir = tmp_dir / project_path.name
+        effective_dir.mkdir(exist_ok=True)
+    else:
+        effective_dir = tmp_dir
+
     ignore_paths = [DBT_LOG_DIR_NAME, DBT_TARGET_DIR_NAME, PACKAGE_LOCKFILE_YML, "profiles.yml"]
     if ignore_dbt_packages:
         dbt_packages_subpath = get_dbt_packages_subpath(project_path)
-        # this is linked to dbt deps so if dbt deps is true then ignore existing dbt_packages folder
         ignore_paths.append(dbt_packages_subpath)
     for child_name in os.listdir(project_path):
         if child_name not in ignore_paths:
-            os.symlink(project_path / child_name, tmp_dir / child_name)
+            os.symlink(project_path / child_name, effective_dir / child_name)
+
+    for rel_path in external_model_paths:
+        source = (project_path / rel_path).resolve()
+        target = (effective_dir / Path(rel_path)).resolve()
+        if source.exists() and not target.exists():
+            target.parent.mkdir(parents=True, exist_ok=True)
+            os.symlink(source, target)
+
+    return effective_dir
 
 
 def get_partial_parse_path(project_dir_path: Path) -> Path:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -196,6 +196,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         should_upload_compiled_sql: bool = False,
         append_env: bool = True,
         dbt_runner_callbacks: list[Callable] | None = None,  # type: ignore[type-arg]
+        model_relative_paths: list[str | Path] | None = None,
         **kwargs: Any,
     ) -> None:
         self.task_id = task_id
@@ -210,6 +211,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         self.invocation_mode = invocation_mode
         self._dbt_runner: dbtRunner | None = None
         self._dbt_runner_callbacks = dbt_runner_callbacks
+        self.model_relative_paths = model_relative_paths
 
         super().__init__(task_id=task_id, **kwargs)
 
@@ -495,22 +497,26 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             sql_content: str = sql_file.read()
         return sql_content
 
-    def _clone_project(self, tmp_dir_path: Path) -> None:
+    def _clone_project(self, tmp_dir_path: Path) -> Path:
         logger.info(
             "Cloning project to writable temp directory %s from %s",
             tmp_dir_path,
             self.project_dir,
         )
         should_not_create_dbt_deps_symbolic_link = self.install_deps or self.copy_dbt_packages
-        create_symlinks(
-            Path(self.project_dir), tmp_dir_path, ignore_dbt_packages=should_not_create_dbt_deps_symbolic_link
+        effective_dir = create_symlinks(
+            Path(self.project_dir),
+            tmp_dir_path,
+            ignore_dbt_packages=should_not_create_dbt_deps_symbolic_link,
+            model_relative_paths=self.model_relative_paths,
         )
         if self.copy_dbt_packages:
             logger.info("Copying dbt packages to temporary folder.")
-            copy_dbt_packages(Path(self.project_dir), tmp_dir_path)
+            copy_dbt_packages(Path(self.project_dir), effective_dir)
             logger.info("Completed copying dbt packages to temporary folder.")
 
-        copy_manifest_file_if_exists(self.manifest_filepath, Path(tmp_dir_path))
+        copy_manifest_file_if_exists(self.manifest_filepath, Path(effective_dir))
+        return effective_dir
 
     def _handle_partial_parse(self, tmp_dir_path: Path) -> None:
         if self.cache_dir is None:
@@ -659,21 +665,22 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             tmp_dir_path = Path(tmp_project_dir)
             env = {k: str(v) for k, v in env.items()}
 
-            self._clone_project(tmp_dir_path)
+            effective_dir = self._clone_project(tmp_dir_path)
+            effective_dir_str = str(effective_dir)
 
             if self.partial_parse:
-                self._handle_partial_parse(tmp_dir_path)
+                self._handle_partial_parse(effective_dir)
 
             with self.profile_config.ensure_profile() as profile_values:
                 (profile_path, env_vars) = profile_values
                 env.update(env_vars)
                 logger.debug("Using environment variables keys: %s", env.keys())
 
-                flags = self._generate_dbt_flags(tmp_project_dir, profile_path)
+                flags = self._generate_dbt_flags(effective_dir_str, profile_path)
 
                 if self.install_deps:
                     self._install_dependencies(
-                        tmp_dir_path, flags + self._process_global_flag("--vars", self.vars), env
+                        effective_dir, flags + self._process_global_flag("--vars", self.vars), env
                     )
 
                 if run_as_async and not settings.enable_setup_async_task:
@@ -683,10 +690,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 result = self.invoke_dbt(
                     command=full_cmd,
                     env=env,
-                    cwd=tmp_project_dir,
+                    cwd=effective_dir_str,
                 )
                 if is_openlineage_common_available:
-                    self.calculate_openlineage_events_completes(env, tmp_dir_path)
+                    self.calculate_openlineage_events_completes(env, effective_dir)
                     if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION:
                         # Airflow 3 does not support associating 'openlineage_events_completes' with task_instance,
                         # in that case we're storing as self.openlineage_events_completes
@@ -696,13 +703,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                     self._handle_datasets(context)
 
                 if self.partial_parse:
-                    self._update_partial_parse_cache(tmp_dir_path)
+                    self._update_partial_parse_cache(effective_dir)
 
-                self._handle_post_execution(tmp_project_dir, context, push_run_results_to_xcom)
+                self._handle_post_execution(effective_dir_str, context, push_run_results_to_xcom)
                 self.handle_exception(result)
 
                 if run_as_async and async_context:
-                    self._handle_async_execution(tmp_project_dir, context, async_context)
+                    self._handle_async_execution(effective_dir_str, context, async_context)
 
                 return result
 

--- a/docs/configuration/project-config.rst
+++ b/docs/configuration/project-config.rst
@@ -5,8 +5,9 @@ The ``cosmos.config.ProjectConfig`` allows you to specify information about wher
 variables that should be used for rendering and execution. It takes the following arguments:
 
 - ``dbt_project_path``: The full path to your dbt project. This directory should have a ``dbt_project.yml`` file
-- ``models_relative_path``: The path to your models directory, relative to the ``dbt_project_path``. This defaults to
-  ``models/``
+- ``models_relative_path``: The path to your models directory, relative to the ``dbt_project_path``. Accepts a single
+  path or a list of paths, mirroring dbt's ``model-paths`` configuration. When a list is provided, all paths are
+  validated and symlinked during DAG parsing and task execution. This defaults to ``models/``
 - ``seeds_relative_path``: The path to your seeds directory, relative to the ``dbt_project_path``. This defaults to
   ``data/``
 - ``snapshots_relative_path``: The path to your snapshots directory, relative to the ``dbt_project_path``. This defaults
@@ -49,4 +50,10 @@ Project Config Example
             "start_time": "{{ data_interval_start.strftime('%Y%m%d%H%M%S') }}",
             "end_time": "{{ data_interval_end.strftime('%Y%m%d%H%M%S') }}",
         },
+    )
+
+    # Multiple model paths (mirrors dbt's model-paths configuration)
+    config_with_multiple_model_paths = ProjectConfig(
+        dbt_project_path="/path/to/dbt/project",
+        models_relative_path=["models", "../shared_sources"],
     )

--- a/tests/dbt/test_project.py
+++ b/tests/dbt/test_project.py
@@ -7,6 +7,7 @@ import yaml
 
 from cosmos.constants import DBT_DEFAULT_PACKAGES_FOLDER, DBT_PROJECT_FILENAME, PACKAGE_LOCKFILE_YML
 from cosmos.dbt.project import (
+    _get_external_model_paths,
     change_working_directory,
     copy_dbt_packages,
     copy_manifest_file_if_exists,
@@ -83,10 +84,71 @@ def test_create_symlinks(tmp_path):
     tmp_dir = tmp_path / "dbt-project"
     tmp_dir.mkdir()
 
-    create_symlinks(DBT_PROJECTS_ROOT_DIR / "altered_jaffle_shop", tmp_dir, False)
+    effective_dir = create_symlinks(DBT_PROJECTS_ROOT_DIR / "altered_jaffle_shop", tmp_dir, False)
+    assert effective_dir == tmp_dir
     for child in tmp_dir.iterdir():
         assert child.is_symlink()
         assert child.name not in ("logs", "target", "profiles.yml", "dbt_packages")
+
+
+def test_create_symlinks_with_internal_model_paths(tmp_path):
+    """When all model paths are inside the project root, behavior is unchanged."""
+    tmp_dir = tmp_path / "dbt-project"
+    tmp_dir.mkdir()
+
+    effective_dir = create_symlinks(
+        DBT_PROJECTS_ROOT_DIR / "altered_jaffle_shop",
+        tmp_dir,
+        False,
+        model_relative_paths=["models"],
+    )
+    assert effective_dir == tmp_dir
+
+
+def test_create_symlinks_with_external_model_paths(tmp_path):
+    """When model paths point outside the project root, symlinks are created for them."""
+    project_dir = tmp_path / "workspace" / "my_project"
+    project_dir.mkdir(parents=True)
+    (project_dir / "models").mkdir()
+    (project_dir / "dbt_project.yml").write_text("name: test")
+
+    external_sources = tmp_path / "workspace" / "shared_sources"
+    external_sources.mkdir()
+    (external_sources / "source_file.yml").write_text("version: 2")
+
+    tmp_dir = tmp_path / "tmpdir"
+    tmp_dir.mkdir()
+
+    effective_dir = create_symlinks(
+        project_dir,
+        tmp_dir,
+        ignore_dbt_packages=False,
+        model_relative_paths=["models", "../shared_sources"],
+    )
+
+    assert effective_dir == tmp_dir / "my_project"
+    assert effective_dir.exists()
+    assert (effective_dir / "models").is_symlink()
+    assert (effective_dir / "dbt_project.yml").is_symlink()
+
+    external_symlink = (effective_dir / ".." / "shared_sources").resolve()
+    assert external_symlink.exists()
+    assert external_symlink.is_dir()
+
+
+def test_get_external_model_paths(tmp_path):
+    """_get_external_model_paths correctly identifies paths outside the project root."""
+    project_dir = tmp_path / "project"
+    project_dir.mkdir()
+
+    result = _get_external_model_paths(project_dir, ["models", "../shared", "subdir/models"])
+    assert result == ["../shared"]
+
+
+def test_get_external_model_paths_none():
+    """_get_external_model_paths returns empty list for None input."""
+    result = _get_external_model_paths(Path("/some/path"), None)
+    assert result == []
 
 
 @patch.dict(os.environ, {"VAR1": "value1", "VAR2": "value2"})

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1783,8 +1783,10 @@ def test_test_clone_project(create_symlinks_mock, copy_dbt_packages_mock, caplog
     )
     operator._clone_project(tmp_dir_path)
 
-    create_symlinks_mock.assert_called_once_with(project_dir, tmp_dir_path, ignore_dbt_packages=True)
-    copy_dbt_packages_mock.assert_called_once_with(project_dir, tmp_dir_path)
+    create_symlinks_mock.assert_called_once_with(
+        project_dir, tmp_dir_path, ignore_dbt_packages=True, model_relative_paths=None
+    )
+    copy_dbt_packages_mock.assert_called_once_with(project_dir, create_symlinks_mock.return_value)
 
     assert f"Cloning project to writable temp directory {tmp_dir_path} from {project_dir}" in caplog.text
     assert "Copying dbt packages to temporary folder." in caplog.text

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -24,11 +24,39 @@ def test_init_with_project_path_only():
     project_config = ProjectConfig(dbt_project_path="path/to/dbt/project")
     assert project_config.dbt_project_path == Path("path/to/dbt/project")
     assert project_config.models_path == Path("path/to/dbt/project/models")
+    assert project_config.models_paths == [Path("path/to/dbt/project/models")]
     assert project_config.seeds_path == Path("path/to/dbt/project/seeds")
     assert project_config.snapshots_path == Path("path/to/dbt/project/snapshots")
     assert project_config.project_name == "project"
     assert project_config.manifest_path is None
     assert project_config.install_dbt_deps is True
+
+
+def test_init_with_multiple_model_paths():
+    """
+    Passing a list of model-relative paths should set models_path to the first entry
+    and models_paths to all resolved entries.
+    """
+    project_config = ProjectConfig(
+        dbt_project_path="path/to/dbt/project",
+        models_relative_path=["models", "../shared_sources"],
+    )
+    assert project_config.models_path == Path("path/to/dbt/project/models")
+    assert project_config.models_paths == [
+        Path("path/to/dbt/project/models"),
+        Path("path/to/dbt/project/../shared_sources"),
+    ]
+    assert project_config.model_relative_paths == ["models", "../shared_sources"]
+
+
+def test_init_with_single_model_path_normalizes_to_list():
+    """
+    Passing a single string for models_relative_path should normalize model_relative_paths to a single-element list.
+    """
+    project_config = ProjectConfig(dbt_project_path="path/to/dbt/project", models_relative_path="custom_models")
+    assert project_config.models_path == Path("path/to/dbt/project/custom_models")
+    assert project_config.models_paths == [Path("path/to/dbt/project/custom_models")]
+    assert project_config.model_relative_paths == ["custom_models"]
 
 
 def test_init_with_project_path_and_install_dbt_deps_succeeds():


### PR DESCRIPTION
## Description

Enhanced ProjectConfig to support multiple model paths

Updated the ProjectConfig class to accept a list of model-relative paths, aligning with dbt's model-paths configuration. Adjusted related methods to handle the new structure, ensuring proper normalization and symlink creation for both internal and external model paths. Updated documentation and tests to reflect these changes.

## Related Issue(s)

closes #1357

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation
- [x] I have added tests that prove my fix is effective or that my feature works
