### PR TITLE
Sanitize disallowed chars from xcom backup variable key

### DIFF
--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 
 import base64
 import json
+import re
 import zlib
 from typing import Any
 
@@ -20,14 +21,35 @@ logger = get_logger(__name__)
 
 XCOM_BACKUP_VARIABLE_PREFIX = "cosmos_xcom_backup"
 
+# Characters that secrets backends commonly reject in Variable keys. AWS
+# Secrets Manager allows alphanumerics + ``-/_+=.@!``; GCP Secret Manager is
+# stricter at ``[A-Za-z0-9_-]``. Run IDs routinely contain ``:`` and ``+``
+# (timestamps and timezone offsets, e.g. ``scheduled__2026-05-04T10:15:00+00:00``)
+# and dag/task-group IDs can contain ``.``. Sanitize all components down to
+# ``[A-Za-z0-9_-]`` so the resulting key is portable across backends and does
+# not log a ``ValidationException`` on every ``Variable.set`` call when an
+# external secrets backend is configured (Airflow walks the backend chain on
+# set as well as get).
+_DISALLOWED_VARIABLE_KEY_CHAR_RE = re.compile(r"[^A-Za-z0-9_-]")
+
 
 def _xcom_backup_variable_key(dag_id: str, task_group_id: str | None, run_id: str) -> str:
-    """Build a unique Airflow Variable key for the XCom backup of a watcher producer run."""
-    parts = [XCOM_BACKUP_VARIABLE_PREFIX, dag_id.replace(".", "___")]
+    """Build a unique Airflow Variable key for the XCom backup of a watcher producer run.
+
+    The component-specific period-replacement counts (3 underscores for dag_id,
+    2 for task_group_id, 1 for run_id) are preserved so keys remain visually
+    parseable, then any remaining disallowed character is normalized to ``_``.
+    """
+    parts = [XCOM_BACKUP_VARIABLE_PREFIX, _sanitize_key_component(dag_id.replace(".", "___"))]
     if task_group_id:
-        parts.append(task_group_id.replace(".", "__"))
-    parts.append(run_id.replace(".", "_"))
+        parts.append(_sanitize_key_component(task_group_id.replace(".", "__")))
+    parts.append(_sanitize_key_component(run_id.replace(".", "_")))
     return "__".join(parts)
+
+
+def _sanitize_key_component(value: str) -> str:
+    """Replace characters that secrets backends reject in Variable keys with ``_``."""
+    return _DISALLOWED_VARIABLE_KEY_CHAR_RE.sub("_", value)
 
 
 def _get_task_group_id(ti: Any) -> str | None:

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -25,6 +25,7 @@ from cosmos.operators._watcher.xcom import (
     _init_xcom_backup,
     _persist_backup,
     _restore_xcom_from_variable,
+    _xcom_backup_variable_key,
 )
 
 
@@ -122,6 +123,40 @@ class _MockTI:
 
     def xcom_push(self, key, value, **_):
         self.store[key] = value
+
+
+class TestXcomBackupVariableKey:
+    """Tests for ``_xcom_backup_variable_key`` covering secrets-backend
+    compatibility (AWS Secrets Manager and similar reject ``:``, ``+`` etc.)."""
+
+    AWS_ALLOWED = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789-_"
+
+    def test_period_replacement_preserved(self):
+        key = _xcom_backup_variable_key("a.b", "g.h", "r.s")
+        assert key == "cosmos_xcom_backup__a___b__g__h__r_s"
+
+    def test_run_id_with_colon_and_plus_is_sanitized(self):
+        key = _xcom_backup_variable_key(
+            dag_id="dbt_daily",
+            task_group_id=None,
+            run_id="scheduled__2026-05-04T10:15:00+00:00",
+        )
+        assert key == "cosmos_xcom_backup__dbt_daily__scheduled__2026-05-04T10_15_00_00_00"
+        assert ":" not in key and "+" not in key
+
+    @pytest.mark.parametrize(
+        "dag_id,task_group_id,run_id",
+        [
+            ("dbt_daily", None, "scheduled__2026-05-04T10:15:00+00:00"),
+            ("dag.with.dots", "group.id", "manual__2026-01-01T00:00:00+00:00"),
+            ("dag with spaces", None, "manual__2026-01-01"),
+            ("dag(parens)", None, "run/with/slashes"),
+            ("dag*star", "group:colon", "run+plus"),
+        ],
+    )
+    def test_result_contains_only_safe_characters(self, dag_id, task_group_id, run_id):
+        key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
+        assert all(c in self.AWS_ALLOWED for c in key), key
 
 
 class TestInitXcomBackup:


### PR DESCRIPTION
## Summary

Cosmos's `WATCHER_KUBERNETES` execution mode persists XCom backups under Airflow Variables keyed `cosmos_xcom_backup__<dag>__<run_id>` ([cosmos/operators/_watcher/xcom.py#L24-L30](https://github.com/astronomer/astronomer-cosmos/blob/main/cosmos/operators/_watcher/xcom.py#L24-L30)). The existing key generator only replaces `.` with underscores. Airflow run IDs routinely contain `:` (timestamps) and `+` (timezone offsets) — e.g. `scheduled__2026-05-04T10:15:00+00:00` — which AWS Secrets Manager rejects with:

```
ClientError: An error occurred (ValidationException) when calling the GetSecretValue operation:
Invalid name. Must be a valid name containing alphanumeric characters,
or any of the following: -/_+=.@!
```

(GCP Secret Manager is even stricter — `[A-Za-z0-9_-]` only.)

When an external secrets backend is configured, Airflow's SDK walks the backend chain on `Variable.set` as well as `Variable.get` (`airflow.sdk.execution_time.context._set_variable` invokes `get_variable` on each backend). So every `safe_xcom_push` triggered from `_persist_backup` emits a `ValidationException` from the secrets backend. The Variable does ultimately get persisted via the metadata DB backend, but the noise spams task logs once per dbt model state transition. For a large model run that's hundreds of false-positive `ERROR Unable to retrieve variable from secrets backend (SecretsManagerBackend)` lines, which obscures real failures.

## Fix

Normalize all key components to `[A-Za-z0-9_-]` — the most restrictive common subset across the secrets backends Airflow ships with — so the resulting key round-trips through any backend without raising. A small `_sanitize_key_component` helper applies a `re.sub(r"[^A-Za-z0-9_-]", "_", ...)` on top of the existing component-specific period-replacement counts (3/2/1 underscores), preserving the prior visual format for keys that didn't contain disallowed chars.

## Reproducer

```python
from cosmos.operators._watcher.xcom import _xcom_backup_variable_key

# Before:
_xcom_backup_variable_key("dbt_daily", None, "scheduled__2026-05-04T10:15:00+00:00")
# 'cosmos_xcom_backup__dbt_daily__scheduled__2026-05-04T10:15:00+00:00'  ← AWS rejects

# After:
# 'cosmos_xcom_backup__dbt_daily__scheduled__2026-05-04T10_15_00_00_00'  ← accepted
```

## Tests

- New `TestXcomBackupVariableKey` class in `tests/operators/_watcher/test_state.py` with three cases:
  - `:` and `+` from a typical scheduled run_id are removed.
  - The existing `.` → `___`/`__`/`_` replacement is preserved (backwards-compat).
  - Parametrized check that the produced key contains only AWS-Secrets-Manager-safe characters across a range of dag_id / task_group_id / run_id combinations.
- Full file passes locally: `pytest tests/operators/_watcher/test_state.py` → 77 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Closes: https://github.com/astronomer/astronomer-cosmos/issues/2619