### PR TITLE
Docs: drop decorative separator lines

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -11,7 +11,6 @@ Early benchmarks show that ``ExecutionMode.WATCHER`` can cut total DAG runtime *
 - The topology of the dbt pipeline
 - The ``poke_interval`` and ``timeout`` settings of the ``DbtConsumerWatcherSensor`` operator, which determine the frequency and duration of the sensor's polling.
 
--------------------------------------------------------------------------------
 
 Background: The Problem with the Local Execution Mode in Cosmos
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -32,7 +31,6 @@ Consider the `google/fhir-dbt-analytics <https://github.com/google/fhir-dbt-anal
 
 This difference motivated a rethinking of how Cosmos interacts with dbt.
 
--------------------------------------------------------------------------------
 
 Concept: ``ExecutionMode.WATCHER``
 ++++++++++++++++++++++++++++++++++
@@ -53,7 +51,6 @@ Together, these operators let you:
 * Retain model-level observability (for clarity)
 * Retry specific models (for resilience)
 
--------------------------------------------------------------------------------
 
 Performance Gains
 +++++++++++++++++
@@ -130,7 +127,6 @@ If you prefer to manage threads through Cosmos profile mappings instead of editi
    )
 
 
--------------------------------------------------------------------------------
 
 Example Usage of ``ExecutionMode.WATCHER``
 ++++++++++++++++++++++++++++++++++++++++++
@@ -208,7 +204,6 @@ If your Airflow DAG includes multiple stages or integrations (e.g., data ingesti
     :alt: Cosmos DbtDag with `ExecutionMode.WATCHER`
     :align: center
 
--------------------------------------------------------------------------------
 
 Additional details
 ++++++++++++++++++
@@ -345,7 +340,6 @@ Starting with Cosmos 1.12.0, the ``DbtConsumerWatcherSensor`` supports
 `deferrable (asynchronous) execution <https://airflow.apache.org/docs/apache-airflow/stable/authoring-and-scheduling/deferring.html>`_. Deferrable execution frees up the Airflow worker slot, while task status monitoring is handled by the Airflow triggerer component,
 which increases overall task throughput. By default, the sensor now runs in deferrable mode.
 
--------------------------------------------------------------------------------
 
 Known Limitations
 +++++++++++++++++
@@ -497,7 +491,6 @@ To override the default logic, pass a ``freshness_callback`` via ``setup_operato
 * ``dbt source freshness`` is always re-executed at runtime; ``LoadMode.DBT_MANIFEST`` freshness data is not consulted.
 * Not supported for ``ExecutionMode.WATCHER_KUBERNETES``.
 
--------------------------------------------------------------------------------
 
 Overriding ``operator_args``
 ''''''''''''''''''''''''''''
@@ -565,7 +558,6 @@ To disable asynchronous execution, set the ``deferrable`` flag to ``False`` in t
    :start-after: [START example_watcher_synchronous]
    :end-before: [END example_watcher_synchronous]
 
--------------------------------------------------------------------------------
 
 Troubleshooting
 +++++++++++++++

--- a/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
@@ -14,7 +14,6 @@ This execution mode is ideal for users who:
 * Need to run dbt in isolated Kubernetes pods
 * Prefer not to install dbt in their `Apache Airflow® <https://airflow.apache.org/>`_ deployment
 
--------------------------------------------------------------------------------
 
 Background
 ++++++++++
@@ -25,7 +24,6 @@ However, the original ``ExecutionMode.WATCHER`` requires dbt to be installed alo
 
 For more details on the watcher concept and how it works, please refer to the :ref:`watcher-execution-mode` documentation.
 
--------------------------------------------------------------------------------
 
 How to Use
 ++++++++++
@@ -62,7 +60,6 @@ The following example shows how to configure a ``DbtDag`` with ``ExecutionMode.W
 
 For the complete setup including Kubernetes secrets, Docker image configuration, and profile setup, refer to the :ref:`kubernetes` documentation.
 
--------------------------------------------------------------------------------
 
 Performance Gains
 +++++++++++++++++
@@ -85,7 +82,6 @@ The performance improvement comes from:
 * Leveraging dbt's native threading capabilities
 * Eliminating repeated dbt initialization for each model
 
--------------------------------------------------------------------------------
 
 Known Limitations
 +++++++++++++++++
@@ -173,7 +169,6 @@ For more details on these limitations, refer to the :ref:`watcher-execution-mode
 
 Additionally, the limitations from ``ExecutionMode.KUBERNETES`` also apply to ``ExecutionMode.WATCHER_KUBERNETES``. For details, refer to the :ref:`kubernetes-known-limitations` documentation.
 
--------------------------------------------------------------------------------
 
 Example DAG
 +++++++++++
@@ -183,7 +178,6 @@ Below is a complete example of a DAG using ``ExecutionMode.WATCHER_KUBERNETES``:
 .. literalinclude:: ../../../../dev/dags/jaffle_shop_watcher_kubernetes.py
     :language: python
 
--------------------------------------------------------------------------------
 
 Prerequisites
 +++++++++++++
@@ -196,7 +190,6 @@ Before using ``ExecutionMode.WATCHER_KUBERNETES``, ensure you have:
 
 For detailed setup instructions, refer to the :ref:`kubernetes` documentation.
 
--------------------------------------------------------------------------------
 
 Summary
 +++++++

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -32,7 +32,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Requirements**: You need a ``manifest.json`` file (can be generated with ``dbt compile`` or ``dbt run``).
 
----------------------------------
 
 2. Use DBT_RUNNER Invocation Mode
 +++++++++++++++++++++++++++++++++
@@ -64,7 +63,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Default**: default behaviour for ``ExecutionMode.LOCAL`` since 1.4.0, default behaviour for ``RenderConfig.DBT_LS`` since Cosmos 1.9.0
 
--------------------------------------------------------------------------------
 
 3. Use Partial Parse (Keep Enabled)
 +++++++++++++++++++++++++++++++++++
@@ -91,7 +89,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Default**: ``True`` since Cosmos 1.4.0
 
--------------------------------------------------------------------------------
 
 4. Use ExecutionMode.WATCHER
 ++++++++++++++++++++++++++++
@@ -103,7 +100,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 - `Getting Started with ExecutionMode.WATCHER <https://astronomer.github.io/astronomer-cosmos/guides/run_dbt/airflow-worker/watcher-execution-mode.html>`_
 - `Configure a Custom Queue for Producer and Watcher Tasks in ExecutionMode.WATCHER <https://astronomer.github.io/astronomer-cosmos/guides/run_dbt/airflow-worker/watcher-execution-mode.html#watcher-dbt-execution-queue>`_
 
--------------------------------------------------------------------------------
 
 5. Control DAG-Level Concurrency with ``concurrency`` Parameter
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -172,7 +168,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Reference**: `Airflow Scaling Workers Documentation <https://www.astronomer.io/docs/learn/airflow-scaling-workers>`_
 
--------------------------------------------------------------------------------
 
 6. Enable Memory-Optimized Imports (Cosmos < 1.14.0 only)
 +++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -209,7 +204,6 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **Default**: ``False``
 
--------------------------------------------------------------------------------
 
 7. Enable Task Profiling with Debug Mode
 ++++++++++++++++++++++++++++++++++++++++


### PR DESCRIPTION
## Description

Per the lightweight style guide proposed in #2460, drop standalone
horizontal-rule separator lines (long sequences of `-` characters surrounded
by blank lines on both sides) used as visual section dividers. Heading
hierarchy is enough — the dividers add visual noise without conveying
structure that the heading levels don't already.

Heading underlines and any separator immediately adjacent to text are left
untouched. The script removes only separators surrounded by blank lines.

This re-applies the separator-removal slice of the header commit in #2462
against current `main` as a focused, standalone change. 3 files / 21 lines
removed.

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works