### PR TITLE
Document docs build and serve commands in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,6 +34,16 @@ hatch run tests.py3.10-2.10-1.9:type-check
 
 Other available matrix versions: Python `3.10`, `3.11`, `3.12`, `3.13` × Airflow `2.9`, `2.10`, `2.11`, `3.0`, `3.1` × dbt `1.5`–`2.0`.
 
+### Building and Serving Docs
+
+```bash
+hatch run docs:build              # build HTML into docs/_build
+hatch run docs:serve              # sphinx-autobuild with live reload
+hatch run docs:serve-no-reload    # static build served on http://127.0.0.1:8000
+```
+
+Always run `hatch run docs:build` before committing any change that touches `docs/`, and verify the build succeeds without warnings or errors.
+
 ### Linting and Formatting
 
 Pre-commit runs the configured linters/formatters (e.g., Black (formatter), Ruff (linter), mypy, codespell). See `.pre-commit-config.yaml` for the full list:


### PR DESCRIPTION
## Summary
- Add a "Building and Serving Docs" section to `CLAUDE.md` listing the `hatch run docs:{build,serve,serve-no-reload}` scripts already defined in `pyproject.toml`.
- Note that `hatch run docs:build` must succeed (no warnings/errors) before committing any change under `docs/`.

## Test plan
- [x] Confirm the new section renders correctly in `CLAUDE.md`.
- [x] Sanity-check that `hatch run docs:build`, `hatch run docs:serve`, and `hatch run docs:serve-no-reload` work as documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)