### PR TITLE
Make local `hatch run docs:build` fail on Sphinx warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -224,7 +224,7 @@ dependencies = [
 ]
 
 [tool.hatch.envs.docs.scripts]
-build = "sphinx-build -b html docs docs/_build"
+build = "sphinx-build -b html docs docs/_build --fail-on-warning"
 serve = "sphinx-autobuild docs docs/_build"
 # Serve without auto-reload: build once, then serve static files on port 8000
 serve-no-reload = "sphinx-build -b html docs docs/_build && python -m http.server 8000 --bind 127.0.0.1 --directory docs/_build"


### PR DESCRIPTION
## Summary
- Add `--fail-on-warning` to `[tool.hatch.envs.docs.scripts] build` so `hatch run docs:build` match the CI's warning gate(https://github.com/astronomer/astronomer-cosmos/blob/d33115b69da5573b33123c310a5a7b6fbc02a364/.github/workflows/docs-build.yml#L43).
- Caught while reviewing #2637 — CLAUDE.md instructs contributors to verify the local build "succeeds without warnings", but the script previously didn't enforce that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)