### PR TITLE
Fix dbt docs iframe src missing deployment path prefix

### DIFF
--- a/cosmos/__init__.py
+++ b/cosmos/__init__.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import importlib
 
-__version__ = "1.14.1"
+__version__ = "1.14.2a1"
 
 
 # Mapping of public names to their module paths for lazy loading via __getattr__.

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -142,7 +142,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
             cfg_local = projects.get(slug_alias, {})
             if not cfg_local.get("dir"):
                 return "<div>dbt Docs are not configured.</div>"
-            iframe_src = f"/cosmos/{slug_alias}/dbt_docs_index.html"
+            iframe_src = f"{API_BASE_PATH}/cosmos/{slug_alias}/dbt_docs_index.html"
             safe_iframe_src = html.escape(iframe_src, quote=True)
             return (
                 '<div style="height:100%;display:flex;flex-direction:column;">'

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -131,6 +131,25 @@ def test_manifest_and_catalog_error_500(tmp_path: Path):
 
 
 @skip_pre_airflow_31
+def test_dbt_docs_view_iframe_src_uses_api_base_path(tmp_path: Path):
+    # Regression: iframe src must include the deployment path prefix (e.g. Astronomer /de3jzcwo)
+    # so browsers don't strip it and hit the wrong URL.
+    docs_dir = tmp_path / "target"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "index.html").write_text("<head></head><body>dbt</body>")
+
+    af3 = _reload_af3_module(api_base="https://host/de3jzcwo")
+    projects = {"core": {"dir": str(docs_dir), "index": "index.html"}}
+    with patch("cosmos.plugin.airflow3._load_projects_from_conf", return_value=projects):
+        app = af3.create_cosmos_fastapi_app()
+
+    client = TestClient(app)
+    r = client.get("/core/dbt_docs")
+    assert r.status_code == 200
+    assert "/de3jzcwo/cosmos/core/dbt_docs_index.html" in r.text
+
+
+@skip_pre_airflow_31
 def test_external_view_href_uses_api_base_path():
     # Ensure base path is respected (e.g., Astronomer deployment prefix)
     _reload_af3_module(api_base="https://host/prefix/")


### PR DESCRIPTION
The dbt_docs_view endpoint built the iframe src with a hardcoded /cosmos/... path, ignoring AIRFLOW__API__BASE_URL.

/cosmos/<slug>/dbt_docs_index.html instead of
/****/cosmos/<slug>/dbt_docs_index.html, hitting 403/404.

Use API_BASE_PATH (already used correctly for external_views hrefs) when constructing the iframe src. When no base path is configured API_BASE_PATH is "" so the behaviour is unchanged for standard Airflow.

using directly in browser https://**.**.astronomer.run/**/cosmos/core/dbt_docs

**Before PR**
<img width="1644" height="374" alt="Screenshot 2026-05-06 at 7 09 04 PM" src="https://github.com/user-attachments/assets/5ea262d3-6300-44ea-a127-cdcbe848a8ce" />

**After PR**
<img width="1717" height="472" alt="Screenshot 2026-05-06 at 7 15 51 PM" src="https://github.com/user-attachments/assets/91370545-d523-4cf3-a08e-a465a0118447" />



