### PR TITLE
Document incremental model limitation for AIRFLOW_ASYNC mode

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/async-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/async-execution-mode.rst
@@ -247,4 +247,6 @@ Limitations
 
 8. **TeardownAsyncOperator limitation**: When using a remote object location, in addition to the ``SetupAsyncOperator``, a ``TeardownAsyncOperator`` is also added to the DAG. This task will delete the SQL files from the remote location by the end of the DAG Run. This is can lead to a limitation from a retry perspective, as described in the issue `#2066 <https://github.com/astronomer/astronomer-cosmos/issues/2066>`_. This can be avoided by setting the ``enable_teardown_async_task`` configuration to ``False``, as described in the :ref:`enable_teardown_async_task` section.
 
+9. **Incremental models not supported**: Incremental models using the ``merge`` or ``insert_overwrite`` strategy are not supported. Use ``ExecutionMode.LOCAL`` for incremental models.
+
 For a comparison between different Cosmos execution modes, please, check the :ref:`execution-modes-comparison` section.


### PR DESCRIPTION
Restore the Incremental models limitation for ExecutionMode.AIRFLOW_ASYNC

Incremental models using merge or insert_overwrite strategy fail because async mode only submits the final MERGE SQL without first creating the required __dbt_tmp staging table.

closes: https://github.com/astronomer/astronomer-cosmos/issues/2351