### PR TITLE
Add docs for Run, Test, Snapshot and Build local operators

### DIFF
--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -143,11 +143,12 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
     # [END seed_local_example]
 
     (
-        [seed_operator, seed_raw_orders]
+        seed_operator
+        >> seed_raw_orders
         >> run_operator
         >> test_operator
         >> snapshot_operator
         >> build_operator
         >> clone_operator
     )
-    [seed_operator, seed_raw_orders] >> check_file_uploaded_task
+    seed_raw_orders >> check_file_uploaded_task

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -126,7 +126,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="clone",
-        dbt_cmd_flags=["--models", "stg_customers", "--state", DBT_ARTIFACT],
+        dbt_cmd_flags=["--select", "stg_customers", "--state", DBT_ARTIFACT],
         install_deps=True,
         append_env=True,
     )

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -10,7 +10,15 @@ try:
 except ImportError:
     from airflow.operators.python import PythonOperator
 
-from cosmos import DbtCloneLocalOperator, DbtRunLocalOperator, DbtSeedLocalOperator, ProfileConfig
+from cosmos import (
+    DbtBuildLocalOperator,
+    DbtCloneLocalOperator,
+    DbtRunLocalOperator,
+    DbtSeedLocalOperator,
+    DbtSnapshotLocalOperator,
+    DbtTestLocalOperator,
+    ProfileConfig,
+)
 from cosmos.io import upload_to_aws_s3
 
 DEFAULT_DBT_ROOT_PATH = Path(__file__).parent / "dbt"
@@ -71,6 +79,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         },
     )
 
+    # [START run_local_example]
     run_operator = DbtRunLocalOperator(
         profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
@@ -79,6 +88,38 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         install_deps=True,
         append_env=True,
     )
+    # [END run_local_example]
+
+    # [START test_local_example]
+    test_operator = DbtTestLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="test",
+        dbt_cmd_flags=["--models", "stg_customers"],
+        install_deps=True,
+        append_env=True,
+    )
+    # [END test_local_example]
+
+    # [START snapshot_local_example]
+    snapshot_operator = DbtSnapshotLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="snapshot",
+        install_deps=True,
+        append_env=True,
+    )
+    # [END snapshot_local_example]
+
+    # [START build_local_example]
+    build_operator = DbtBuildLocalOperator(
+        profile_config=profile_config,
+        project_dir=DBT_PROJ_DIR,
+        task_id="build",
+        install_deps=True,
+        append_env=True,
+    )
+    # [END build_local_example]
 
     # [START clone_example]
     clone_operator = DbtCloneLocalOperator(

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -84,7 +84,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="run",
-        dbt_cmd_flags=["--models", "stg_customers"],
+        dbt_cmd_flags=["--select", "stg_customers"],
         install_deps=True,
         append_env=True,
     )
@@ -95,7 +95,7 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
         profile_config=profile_config,
         project_dir=DBT_PROJ_DIR,
         task_id="test",
-        dbt_cmd_flags=["--models", "stg_customers"],
+        dbt_cmd_flags=["--select", "stg_customers"],
         install_deps=True,
         append_env=True,
     )

--- a/dev/dags/example_operators.py
+++ b/dev/dags/example_operators.py
@@ -142,5 +142,12 @@ with DAG("example_operators", start_date=datetime(2024, 1, 1), catchup=False) as
     )
     # [END seed_local_example]
 
-    [seed_operator, seed_raw_orders] >> run_operator >> clone_operator
+    (
+        [seed_operator, seed_raw_orders]
+        >> run_operator
+        >> test_operator
+        >> snapshot_operator
+        >> build_operator
+        >> clone_operator
+    )
     [seed_operator, seed_raw_orders] >> check_file_uploaded_task

--- a/docs/guides/run_dbt/operators/operators.rst
+++ b/docs/guides/run_dbt/operators/operators.rst
@@ -11,6 +11,8 @@ You can see the full example DAG in the `dev/dags directory <https://github.com/
 Run
 +++
 
+Requires Cosmos >= 0.6.0.
+
 The ``DbtRunLocalOperator`` implements the `dbt run <https://docs.getdbt.com/reference/commands/run>`_ command.
 
 .. literalinclude:: ../../../../dev/dags/example_operators.py
@@ -21,6 +23,8 @@ The ``DbtRunLocalOperator`` implements the `dbt run <https://docs.getdbt.com/ref
 
 Test
 ++++
+
+Requires Cosmos >= 0.6.0.
 
 The ``DbtTestLocalOperator`` implements the `dbt test <https://docs.getdbt.com/reference/commands/test>`_ command.
 
@@ -33,6 +37,8 @@ The ``DbtTestLocalOperator`` implements the `dbt test <https://docs.getdbt.com/r
 Snapshot
 ++++++++
 
+Requires Cosmos >= 0.6.0.
+
 The ``DbtSnapshotLocalOperator`` implements the `dbt snapshot <https://docs.getdbt.com/reference/commands/snapshot>`_ command.
 
 .. literalinclude:: ../../../../dev/dags/example_operators.py
@@ -43,6 +49,8 @@ The ``DbtSnapshotLocalOperator`` implements the `dbt snapshot <https://docs.getd
 
 Build
 +++++
+
+Requires Cosmos >= 1.4.0.
 
 The ``DbtBuildLocalOperator`` implements the `dbt build <https://docs.getdbt.com/reference/commands/build>`_ command.
 
@@ -55,6 +63,8 @@ The ``DbtBuildLocalOperator`` implements the `dbt build <https://docs.getdbt.com
 Seed
 ++++
 
+Requires Cosmos >= 0.6.0.
+
 The ``DbtSeedLocalOperator`` implements the `dbt seed <https://docs.getdbt.com/reference/commands/seed>`_ command.
 
 .. literalinclude:: ../../../../dev/dags/example_operators.py
@@ -65,6 +75,8 @@ The ``DbtSeedLocalOperator`` implements the `dbt seed <https://docs.getdbt.com/r
 
 Clone
 +++++
+
+Requires Cosmos >= 1.8.0.
 
 The ``DbtCloneLocalOperator`` implements the `dbt clone <https://docs.getdbt.com/reference/commands/clone>`_ command.
 

--- a/docs/guides/run_dbt/operators/operators.rst
+++ b/docs/guides/run_dbt/operators/operators.rst
@@ -6,24 +6,50 @@ dbt command operators
 Cosmos exposes individual operators that correspond to specific dbt commands, which can be used just like traditional
 `Apache Airflow® <https://airflow.apache.org/>`_ operators. Cosmos names these operators using the format ``Dbt<dbt-command><execution-mode>Operator``.
 
-The following examples show ``DbtCloneLocalOperator`` and ``DbtSeedLocalOperator``. You can see the full ``example_operator`` Dag in the `dev/dags directory <https://github.com/astronomer/astronomer-cosmos/blob/main/dev/dags/example_operators.py>`_.
+You can see the full example DAG in the `dev/dags directory <https://github.com/astronomer/astronomer-cosmos/blob/main/dev/dags/example_operators.py>`_.
 
-Clone
-+++++
+Run
++++
 
-Requirement
-
-- Cosmos >= 1.8.0
-- dbt-core >= 1.6.0
-
-The ``DbtCloneLocalOperator`` implement `dbt clone <https://docs.getdbt.com/reference/commands/clone>`_ command.
-
-Example of how to use
+The ``DbtRunLocalOperator`` implements the `dbt run <https://docs.getdbt.com/reference/commands/run>`_ command.
 
 .. literalinclude:: ../../../../dev/dags/example_operators.py
     :language: python
-    :start-after: [START clone_example]
-    :end-before: [END clone_example]
+    :start-after: [START run_local_example]
+    :end-before: [END run_local_example]
+
+
+Test
+++++
+
+The ``DbtTestLocalOperator`` implements the `dbt test <https://docs.getdbt.com/reference/commands/test>`_ command.
+
+.. literalinclude:: ../../../../dev/dags/example_operators.py
+    :language: python
+    :start-after: [START test_local_example]
+    :end-before: [END test_local_example]
+
+
+Snapshot
+++++++++
+
+The ``DbtSnapshotLocalOperator`` implements the `dbt snapshot <https://docs.getdbt.com/reference/commands/snapshot>`_ command.
+
+.. literalinclude:: ../../../../dev/dags/example_operators.py
+    :language: python
+    :start-after: [START snapshot_local_example]
+    :end-before: [END snapshot_local_example]
+
+
+Build
++++++
+
+The ``DbtBuildLocalOperator`` implements the `dbt build <https://docs.getdbt.com/reference/commands/build>`_ command.
+
+.. literalinclude:: ../../../../dev/dags/example_operators.py
+    :language: python
+    :start-after: [START build_local_example]
+    :end-before: [END build_local_example]
 
 
 Seed
@@ -31,9 +57,18 @@ Seed
 
 The ``DbtSeedLocalOperator`` implements the `dbt seed <https://docs.getdbt.com/reference/commands/seed>`_ command.
 
-In this example, we're using the ``DbtSeedLocalOperator`` to seed ``raw_orders``.
-
 .. literalinclude:: ../../../../dev/dags/example_operators.py
     :language: python
     :start-after: [START seed_local_example]
     :end-before: [END seed_local_example]
+
+
+Clone
++++++
+
+The ``DbtCloneLocalOperator`` implements the `dbt clone <https://docs.getdbt.com/reference/commands/clone>`_ command.
+
+.. literalinclude:: ../../../../dev/dags/example_operators.py
+    :language: python
+    :start-after: [START clone_example]
+    :end-before: [END clone_example]


### PR DESCRIPTION
The operators.rst page only documented Clone and Seed. Users had no way to discover DbtRunLocalOperator, DbtTestLocalOperator, DbtSnapshotLocalOperator and DbtBuildLocalOperator without reading source code, leading them to implement custom operators unnecessarily.

Add a code example for each operator in example_operators.py and a corresponding section in operators.rst with consistent formatting across all entries.

closes: https://github.com/astronomer/astronomer-cosmos/issues/1926