### PR TITLE
Import DAG from airflow.sdk to silence deprecation warning

### DIFF
--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -6,10 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-try:
-    from airflow.sdk import DAG  # type: ignore[assignment]
-except ImportError:
-    from airflow.models.dag import DAG  # type: ignore[assignment]
+from airflow.models.dag import DAG  # type: ignore[assignment]
 
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 

--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from airflow.models.dag import DAG  # type: ignore[assignment]
+try:
+    from airflow.sdk import DAG  # type: ignore[assignment]
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -11,7 +11,11 @@ except ImportError:  # Airflow 2
     from airflow.models import BaseOperator
 
 from airflow.models.base import ID_LEN as AIRFLOW_MAX_ID_LENGTH
-from airflow.models.dag import DAG
+
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 
 try:
     # Airflow 3.1 onwards

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -15,7 +15,11 @@ from typing import TYPE_CHECKING, Any
 import msgpack
 import yaml
 from airflow.models import DagRun, Variable
-from airflow.models.dag import DAG
+
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 from airflow.utils.session import provide_session
 from sqlalchemy import select
 from sqlalchemy.orm import Session

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -16,7 +16,11 @@ try:
     from airflow.sdk.exceptions import ParamValidationError
 except ImportError:
     from airflow.exceptions import ParamValidationError
-from airflow.models.dag import DAG
+
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 
 try:
     # Airflow 3.0 onwards

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -13,7 +13,11 @@ from typing import Any
 from warnings import warn
 
 from airflow.exceptions import ParamValidationError
-from airflow.models.dag import DAG
+
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG
 
 try:
     # Airflow 3.0 onwards

--- a/cosmos/core/airflow.py
+++ b/cosmos/core/airflow.py
@@ -8,7 +8,10 @@ try:  # Airflow 3
     from airflow.sdk.bases.operator import BaseOperator
 except ImportError:  # Airflow 2
     from airflow.models import BaseOperator
-from airflow.models.dag import DAG
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 
 try:
     # Airflow 3.1 onwards

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -9,7 +9,10 @@ from typing import TYPE_CHECKING, Any
 from airflow.listeners import hookimpl
 
 if TYPE_CHECKING:
-    from airflow.models.dag import DAG
+    try:
+        from airflow.sdk import DAG
+    except ImportError:
+        from airflow.models.dag import DAG  # type: ignore[assignment]
     from airflow.models.dagrun import DagRun
 
 from cosmos import telemetry

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -42,7 +42,10 @@ except ImportError:  # pragma: no cover
     from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 if TYPE_CHECKING:
-    from airflow.models.dag import DAG
+    try:
+        from airflow.sdk import DAG
+    except ImportError:
+        from airflow.models.dag import DAG  # type: ignore[assignment]
     from airflow.operators.empty import EmptyOperator
 
     try:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -788,7 +788,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         with DatasetAlias:
         https://github.com/apache/airflow/issues/42495
         """
-        from airflow import DAG
+        try:
+            from airflow.sdk import DAG
+        except ImportError:
+            from airflow.models.dag import DAG  # type: ignore[assignment]
 
         if AIRFLOW_VERSION.major >= 3 and not settings.enable_dataset_alias:
             logger.error("To emit datasets with Airflow 3, the setting `enable_dataset_alias` must be True (default).")


### PR DESCRIPTION
Airflow 3.2 deprecated importing DAG from airflow.models.dag. Replace all occurrences with a try/except that prefers airflow.sdk and falls back to airflow.models.dag for Airflow 2.

closes: https://github.com/astronomer/astronomer-cosmos/issues/2638
