### PR TITLE
Import ParamValidationError from airflow.sdk to silence deprecation warning

### DIFF
--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -12,7 +12,10 @@ from collections.abc import Callable
 from typing import Any
 from warnings import warn
 
-from airflow.exceptions import ParamValidationError
+try:
+    from airflow.sdk.exceptions import ParamValidationError
+except ImportError:
+    from airflow.exceptions import ParamValidationError
 from airflow.models.dag import DAG
 
 try:


### PR DESCRIPTION
Airflow 3.2 deprecated importing ParamValidationError from airflow.exceptions. Replace with a try/except that prefers airflow.sdk.exceptions and falls back to airflow.exceptions for Airflow 2.

Related-to: https://github.com/astronomer/astronomer-cosmos/issues/2638
