### PR TITLE
Import DAG from airflow.sdk in cosmos/airflow/dag.py

### DIFF
--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -6,7 +6,10 @@ from __future__ import annotations
 
 from typing import Any
 
-from airflow.models.dag import DAG  # type: ignore[assignment]
+try:
+    from airflow.sdk import DAG
+except ImportError:
+    from airflow.models.dag import DAG  # type: ignore[assignment]
 
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 


### PR DESCRIPTION
Follow-up to #2644. That PR converted the DAG import in seven cosmos modules to prefer `airflow.sdk` and fall back to `airflow.models.dag`, but the module defining `DbtDag` (`cosmos/airflow/dag.py`) was missed and still triggers the Airflow 3.2 deprecation warning at import time.

This applies the same try/except pattern there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)