### PR TITLE
Map Snowflake query_tag from connection extras to dbt profile

### DIFF
--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
@@ -44,6 +44,7 @@ class SnowflakeEncryptedPrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping)
         "role": "extra.role",
         "private_key": "extra.private_key_content",
         "private_key_passphrase": "password",
+        "query_tag": "extra.query_tag",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
@@ -43,6 +43,7 @@ class SnowflakeEncryptedPrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapp
         "role": "extra.role",
         "private_key_passphrase": "password",
         "private_key_path": "extra.private_key_file",
+        "query_tag": "extra.query_tag",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_pass.py
+++ b/cosmos/profiles/snowflake/user_pass.py
@@ -42,6 +42,7 @@ class SnowflakeUserPasswordProfileMapping(SnowflakeBaseProfileMapping):
         "role": "extra.role",
         "host": "extra.host",
         "port": "extra.port",
+        "query_tag": "extra.query_tag",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -41,6 +41,7 @@ class SnowflakePrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping):
         "schema": "schema",
         "role": "extra.role",
         "private_key": "extra.private_key_content",
+        "query_tag": "extra.query_tag",
     }
 
     @property

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -246,6 +246,44 @@ def test_profile_env_vars_with_base64(
     }
 
 
+def test_query_tag() -> None:
+    """
+    Tests that query_tag from connection extras is mapped to the dbt profile.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_connection",
+        conn_type="snowflake",
+        login="my_user",
+        schema="my_schema",
+        password="secret",
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
+                "query_tag": "my_query_tag",
+            }
+        ),
+    )
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakeEncryptedPrivateKeyPemProfileMapping(conn)
+        assert profile_mapping.profile["query_tag"] == "my_query_tag"
+
+
+def test_query_tag_absent_when_not_set(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that query_tag is omitted from the profile when not set on the connection.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+    )
+    assert "query_tag" not in profile_mapping.profile
+
+
 def test_old_snowflake_format() -> None:
     """
     Tests that the old format still works.

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_file.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_file.py
@@ -184,6 +184,44 @@ def test_profile_env_vars(
     }
 
 
+def test_query_tag() -> None:
+    """
+    Tests that query_tag from connection extras is mapped to the dbt profile.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_connection",
+        conn_type="snowflake",
+        login="my_user",
+        schema="my_schema",
+        password="secret",
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_file": "path/to/private_key.p8",
+                "query_tag": "my_query_tag",
+            }
+        ),
+    )
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakeEncryptedPrivateKeyFilePemProfileMapping(conn)
+        assert profile_mapping.profile["query_tag"] == "my_query_tag"
+
+
+def test_query_tag_absent_when_not_set(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that query_tag is omitted from the profile when not set on the connection.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+    )
+    assert "query_tag" not in profile_mapping.profile
+
+
 def test_old_snowflake_format() -> None:
     """
     Tests that the old format still works.

--- a/tests/profiles/snowflake/test_snowflake_user_pass.py
+++ b/tests/profiles/snowflake/test_snowflake_user_pass.py
@@ -260,6 +260,43 @@ def test_appends_region() -> None:
         }
 
 
+def test_query_tag() -> None:
+    """
+    Tests that query_tag from connection extras is mapped to the dbt profile.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_connection",
+        conn_type="snowflake",
+        login="my_user",
+        password="my_password",
+        schema="my_schema",
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "query_tag": "my_query_tag",
+            }
+        ),
+    )
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakeUserPasswordProfileMapping(conn)
+        assert profile_mapping.profile["query_tag"] == "my_query_tag"
+
+
+def test_query_tag_absent_when_not_set(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that query_tag is omitted from the profile when not set on the connection.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+    )
+    assert "query_tag" not in profile_mapping.profile
+
+
 def test_appends_host_and_port() -> None:
     """
     Tests that host/port extras are appended to the connection settings.

--- a/tests/profiles/snowflake/test_snowflake_user_privatekey.py
+++ b/tests/profiles/snowflake/test_snowflake_user_privatekey.py
@@ -275,6 +275,43 @@ def test_old_snowflake_format() -> None:
         }
 
 
+def test_query_tag() -> None:
+    """
+    Tests that query_tag from connection extras is mapped to the dbt profile.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_connection",
+        conn_type="snowflake",
+        login="my_user",
+        schema="my_schema",
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
+                "query_tag": "my_query_tag",
+            }
+        ),
+    )
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakePrivateKeyPemProfileMapping(conn)
+        assert profile_mapping.profile["query_tag"] == "my_query_tag"
+
+
+def test_query_tag_absent_when_not_set(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that query_tag is omitted from the profile when not set on the connection.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+    )
+    assert "query_tag" not in profile_mapping.profile
+
+
 def test_appends_region() -> None:
     """
     Tests that region is appended to account if it doesn't already exist.


### PR DESCRIPTION
dbt-snowflake supports a profile-level query_tag that Snowflake records in QUERY_HISTORY for cost attribution, debugging, and auditing. Until now, Cosmos users had to set it via profile_args or hard-code it in profiles.yml.

Reading query_tag from extra.query_tag on the Airflow Snowflake connection lets users tag all queries from a given connection without touching dbt config. Applies to all four Snowflake profile mappings (user/password, private key, encrypted private key env, encrypted private key file).

Closes #1722
