### PR TITLE
Add Airflow 3.2 to supported versions in compatibility policy

### DIFF
--- a/docs/policy/compatibility-policy.rst
+++ b/docs/policy/compatibility-policy.rst
@@ -42,7 +42,7 @@ New minor or major releases of Cosmos may drop support for Apache Airflow versio
 In some cases, Cosmos may continue to support older Airflow versions, depending on the Cosmos release cycle.
 
 - **Minimum required version**: Apache Airflow 2.9.0
-- **Supported versions**: 2.9, 2.10, 2.11, 3.0, 3.1
+- **Supported versions**: 2.9, 2.10, 2.11, 3.0, 3.1, 3.2
 
 dbt Core
 ''''''''


### PR DESCRIPTION
The compatibility policy doc still listed 2.9, 2.10, 2.11, 3.0, 3.1 as the supported Airflow versions, but the test matrix in pyproject.toml already includes 3.2. Update the doc so users referencing the policy see the actual supported set.