### PR TITLE
Refresh dbt/Airflow conflicts table to match compatibility policy

### DIFF
--- a/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
+++ b/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
@@ -44,7 +44,7 @@ Examples of errors
 
 .. code-block:: bash
 
-  ERROR: Cannot install apache-airflow and dbt-core==1.10.0 because these package versions have conflicting dependencies.
+  ERROR: Cannot install apache-airflow==3.0 and dbt-core==1.10.0 because these package versions have conflicting dependencies.
 
   The conflict is caused by:
       dbt-core 1.10.0 depends on pydantic<2

--- a/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
+++ b/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
@@ -15,86 +15,40 @@ The page, :ref:`execution-modes` describes many other methods that support isola
 
 In the following table, ``x`` represents combinations that lead to conflicts (vanilla ``apache-airflow`` and ``dbt-core`` packages):
 
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| Airflow / DBT | 1.0 | 1.1 | 1.2 | 1.3 | 1.4 | 1.5 | 1.6 | 1.7 | 1.8 | 1.9 | 1.10 |
-+===============+=====+=====+=====+=====+=====+=====+=====+=====+=====+=====+======+
-| 2.2           |     |     |     | x   | x   | x   | x   | x   | x   | x   |  x   |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.3           | x   | x   |     | x   | x   | x   | x   | x   | x   | x   |  x   |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.4           | x   | x   | x   |     |     |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.5           | x   | x   | x   |     |     |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.6           | x   | x   | x   | x   | x   |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.7           | x   | x   | x   | x   | x   |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.8           | x   | x   | x   | x   | x   |     |  x  |     |     |     |  x   |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.9           | x   | x   | x   | x   | x   |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.10          | x   | x   | x   | x   | x   |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 2.11          | x   | x   | x   | x   | x   |     |     |     |     |     |      |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
-| 3.0           | x   | x   | x   | x   | x   | x   | x   | x   |     |     |  x   |
-+---------------+-----+-----+-----+-----+-----+-----+-----+-----+-----+-----+------+
++---------------+-----+-----+-----+-----+-----+------+------+
+| Airflow / DBT | 1.5 | 1.6 | 1.7 | 1.8 | 1.9 | 1.10 | 1.11 |
++===============+=====+=====+=====+=====+=====+======+======+
+| 2.9           |     |     |     |     |     |      |      |
++---------------+-----+-----+-----+-----+-----+------+------+
+| 2.10          |     |     |     |     |     |      |      |
++---------------+-----+-----+-----+-----+-----+------+------+
+| 2.11          |     |     |     |     |     |      |      |
++---------------+-----+-----+-----+-----+-----+------+------+
+| 3.0           | x   | x   | x   |     |     |  x   |      |
++---------------+-----+-----+-----+-----+-----+------+------+
+| 3.1           | x   | x   | x   | x   |     |  x   |      |
++---------------+-----+-----+-----+-----+-----+------+------+
+| 3.2           | x   | x   | x   | x   |     |  x   |      |
++---------------+-----+-----+-----+-----+-----+------+------+
 
 Examples of errors
 ++++++++++++++++++
 
 .. code-block:: bash
 
+  ERROR: Cannot install apache-airflow==3.1 and dbt-core==1.5 because these package versions have conflicting dependencies.
+
   The conflict is caused by:
-    apache-airflow 2.8.0 depends on pydantic>=2.3.0
-    dbt-semantic-interfaces 0.4.2 depends on pydantic~=1.10
-    apache-airflow 2.8.0 depends on pydantic>=2.3.0
-    dbt-semantic-interfaces 0.4.2.dev0 depends on pydantic~=1.10
-    apache-airflow 2.8.0 depends on pydantic>=2.3.0
-    dbt-semantic-interfaces 0.4.1 depends on pydantic~=1.10
-    apache-airflow 2.8.0 depends on pydantic>=2.3.0
-    dbt-semantic-interfaces 0.4.0 depends on pydantic~=1.10
-
+      dbt-core 1.5.0 depends on Jinja2==3.1.2
+      apache-airflow-core 3.1.0 depends on jinja2>=3.1.5
 
 .. code-block:: bash
 
-  ERROR: Cannot install apache-airflow==2.2.4 and dbt-core==1.5.0 because these package versions have conflicting dependencies.
+  ERROR: Cannot install apache-airflow and dbt-core==1.10.0 because these package versions have conflicting dependencies.
+
   The conflict is caused by:
-    apache-airflow 2.2.4 depends on jinja2<3.1 and >=2.10.1
-    dbt-core 1.5.0 depends on Jinja2==3.1.2
-
-.. code-block:: bash
-
-  ERROR: Cannot install apache-airflow==2.6.0 and dbt-core because these package versions have conflicting dependencies.
-  The conflict is caused by:
-    apache-airflow 2.6.0 depends on importlib-metadata<5.0.0 and >=1.7; python_version < "3.9"
-    dbt-semantic-interfaces 0.1.0.dev7 depends on importlib-metadata==6.6.0
-
-.. code-block:: bash
-
-    ERROR: Cannot install apache-airflow, apache-airflow==2.7.0 and dbt-core==1.4.0 because these package versions have conflicting dependencies.
-
-    The conflict is caused by:
-        dbt-core 1.4.0 depends on pyyaml>=6.0
-        connexion 2.12.0 depends on PyYAML<6 and >=5.1
-        dbt-core 1.4.0 depends on pyyaml>=6.0
-        connexion 2.11.2 depends on PyYAML<6 and >=5.1
-        dbt-core 1.4.0 depends on pyyaml>=6.0
-        connexion 2.11.1 depends on PyYAML<6 and >=5.1
-        dbt-core 1.4.0 depends on pyyaml>=6.0
-        connexion 2.11.0 depends on PyYAML<6 and >=5.1
-        apache-airflow 2.7.0 depends on jsonschema>=4.18.0
-        flask-appbuilder 4.3.3 depends on jsonschema<5 and >=3
-        connexion 2.10.0 depends on jsonschema<4 and >=2.5.1
-
-.. code-block:: bash
-
-ERROR: Cannot install apache-airflow and dbt-core==1.10.0 because these package versions have conflicting dependencies.
-
-The conflict is caused by:
-    dbt-core 1.10.0 depends on pydantic<2
-    apache-airflow-core 3.0.0 depends on pydantic>=2.11.0
+      dbt-core 1.10.0 depends on pydantic<2
+      apache-airflow-core 3.0.0 depends on pydantic>=2.11.0
 
 
 
@@ -114,11 +68,11 @@ The table was created by running  `nox <https://nox.thea.codes/en/stable/>`__ wi
     @nox.session(python=["3.10"])
     @nox.parametrize(
         "dbt_version",
-        ["1.0", "1.1", "1.2", "1.3", "1.4", "1.5", "1.6", "1.7", "1.8", "1.9", "1.10"],
+        ["1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11"],
     )
     @nox.parametrize(
         "airflow_version",
-        ["2.2.4", "2.3", "2.4", "2.5", "2.6", "2.7", "2.8", "2.9", "2.10", "2.11", "3.0"],
+        ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"],
     )
     def compatibility(session: nox.Session, airflow_version, dbt_version) -> None:
         """Run both unit and integration tests."""


### PR DESCRIPTION
Trim the local-execution conflicts table and noxfile snippet to the versions actually supported per docs/policy/compatibility-policy.rst: Airflow >= 2.9 and dbt-core >= 1.5. Add the new dbt-core 1.11 column and rows for Airflow 3.1 and 3.2, with cells populated from fresh pip dry-run resolves in a Python 3.10 venv. Drop the four error examples that referenced unsupported Airflow versions, and add a Jinja2 conflict example (Airflow 3.1 + dbt-core 1.5) to complement the existing pydantic example.

