### PR TITLE
Normalize heading underlines in optimize_performance docs

### DIFF
--- a/docs/optimize_performance/caching.rst
+++ b/docs/optimize_performance/caching.rst
@@ -1,7 +1,7 @@
 .. _caching:
 
 Caching
--------
+=======
 
 This page explains the caching strategies in ``astronomer-cosmos`` Astronomer Cosmos behavior.
 
@@ -20,7 +20,7 @@ It is possible to turn off any cache in Cosmos by exporting the environment vari
 Disabling individual types of cache in Cosmos is also possible, as explained below.
 
 Caching the dbt ls output
-+++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (Introduced in Cosmos 1.5)
 
@@ -111,7 +111,7 @@ The cache values contain a few properties:
 - ``cosmos_type`` is either ``DbtDag`` or ``DbtTaskGroup``
 
 Caching the YAML selectors
-++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (Introduced in Cosmos 1.13)
 
@@ -198,7 +198,7 @@ When using Airflow variables as the backend to store cached cosmos artifacts, bo
 to have both artifacts occupy the cache at the same time due to their distinct `RenderConfig.load_mode <./render-config.html>`_ and switching from using one cache to the other will invalidate the cache on the next version check.
 
 Caching the partial parse file
-++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 (Introduced in Cosmos 1.4)
 
@@ -217,7 +217,7 @@ For more information, read the `Cosmos partial parsing documentation <./partial-
 
 
 Caching the profiles
-++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~
 
 (Introduced in Cosmos 1.5)
 

--- a/docs/optimize_performance/index.rst
+++ b/docs/optimize_performance/index.rst
@@ -1,7 +1,7 @@
 .. _optimize-performance:
 
 Optimize Performance
---------------------
+====================
 
 Cosmos performance can be tuned across two dimensions: how fast DAGs are parsed (affecting how quickly they appear
 and update in `Apache Airflow® <https://airflow.apache.org/>`_) and how fast tasks execute (affecting DAG run duration).

--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -1,7 +1,7 @@
 .. _invocation-mode:
 
 Invocation modes
-----------------
+================
 .. versionadded:: 1.4
 
 For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes for running dbt:

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -1,14 +1,14 @@
 .. _memory-optimization:
 
 Memory optimization options for Astronomer Cosmos
---------------------------------------------------
+==================================================
 
 When running dbt pipelines with Astronomer Cosmos, the framework executes dbt commands that can consume significant memory resources. In high-memory scenarios, tasks may reach a zombie state or workers may be killed due to Out of Memory (OOM) errors, leading to pipeline failures and reduced reliability.
 
 Cosmos provides various configuration options and execution modes to optimize memory usage, reduce worker resource consumption, and prevent OOM issues. This document outlines these memory optimization strategies, from simple configuration changes to advanced execution modes that can dramatically reduce memory footprint while maintaining or improving pipeline performance.
 
 1. Use DBT_MANIFEST load mode
-+++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Impact**: High - Avoids running ``dbt ls`` subprocess which can consume significant CPU and memory. This reduces memory consumption when a cache miss occurs in the DBT LS method. It may not significantly reduce the memory footprint if there is a cache hit.
 
@@ -34,7 +34,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 2. Use DBT_RUNNER invocation mode
-+++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 - (default for ``ExecutionMode.LOCAL`` since 1.4.0, default for ``RenderConfig.DBT_LS`` since Cosmos 1.9.0)
 
@@ -65,7 +65,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 3. Use partial parse (keep enabled)
-+++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Impact**: Low - Actually reduces memory by avoiding full project parsing.
 
@@ -91,7 +91,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 4. Use ExecutionMode.WATCHER
-++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Impact**: Very High - Dramatically reduces `Apache Airflow® <https://airflow.apache.org/>`_ worker slot usage and memory consumption.
 
@@ -102,7 +102,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 5. Control DAG-level concurrency with ``concurrency`` parameter
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Impact**: High - Limits concurrent task execution per DAG based on available resources.
 
@@ -170,7 +170,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 6. Enable memory-optimized imports (Cosmos < 1.14.0 only)
-+++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Applies to**: Cosmos versions **earlier than 1.14.0**. Since Cosmos 1.14.0, ``cosmos/__init__.py`` uses lazy imports by default and this setting is a no-op. If you are on 1.14.0 or newer, skip this section.
 
@@ -206,7 +206,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 
 7. Enable task profiling with debug mode
-++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 **Impact**: Low - Provides visibility into memory usage patterns to help identify optimization opportunities and prevent OOM issues.
 

--- a/docs/optimize_performance/optimize_execution.rst
+++ b/docs/optimize_performance/optimize_execution.rst
@@ -1,7 +1,7 @@
 .. _optimize-execution:
 
 Optimize Task Execution
------------------------
+=======================
 
 Once your DAG is parsed, performance depends on how quickly tasks execute. Each Cosmos task runs one or more dbt
 commands, and the overhead of those invocations adds up across a DAG run. This page covers the most impactful ways
@@ -9,7 +9,7 @@ to reduce DAG run time.
 
 
 1. Use an efficient execution mode
-+++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The execution mode determines how Cosmos runs dbt commands at task execution time. Choosing the right mode is the
 single most impactful change for DAG run performance.
@@ -63,7 +63,7 @@ the same Python environment; otherwise Cosmos falls back to ``InvocationMode.SUB
 
 
 2. Install dbt in the same Python environment as Airflow
-++++++++++++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 When dbt is installed alongside Airflow, Cosmos uses dbt's programmatic API (``dbtRunner``) instead of spawning
 subprocesses. This eliminates process creation overhead and reduces both CPU and memory usage during task execution
@@ -75,7 +75,7 @@ For more details, see :ref:`invocation-mode`.
 
 
 3. Pre-install dbt dependencies
-+++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 By default, Cosmos runs ``dbt deps`` during both DAG parsing and task execution to ensure packages are available.
 For large projects with many packages, this adds significant overhead to every task.
@@ -101,7 +101,7 @@ For large projects with many packages, this adds significant overhead to every t
 
 
 4. Use profiles.yml instead of profile mapping
-+++++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cosmos can generate dbt profiles at runtime from Airflow connections using profile mapping classes. While convenient,
 this adds overhead to each task invocation because Cosmos must read the Airflow connection and construct the profile.
@@ -114,7 +114,7 @@ For how to configure this, see
 
 
 5. Worker node sizing
-+++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~
 
 The adequate resources needed to run Cosmos tasks depend on your dbt project and the Cosmos configuration chosen.
 Airflow workers configured for IO-intensive workloads (the default on Astro, which uses a ratio of 5 concurrent
@@ -149,7 +149,7 @@ to route the producer task and sensor retries to a worker queue with more resour
 
 
 6. Profile memory usage with debug mode
-++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To right-size your workers, enable Cosmos debug mode to measure actual memory consumption per task:
 

--- a/docs/optimize_performance/optimize_rendering.rst
+++ b/docs/optimize_performance/optimize_rendering.rst
@@ -1,7 +1,7 @@
 .. _optimize-rendering:
 
 Optimize DAG Parsing
---------------------
+====================
 
 Every time `Apache Airflow® <https://airflow.apache.org/>`_ parses a DAG file that contains a ``DbtDag`` or ``DbtTaskGroup``, Cosmos must load and process the
 dbt project to build the corresponding Airflow task graph. The time this takes directly affects how quickly your DAGs
@@ -19,7 +19,7 @@ appear and update in Airflow. This page covers the most impactful ways to reduce
 
 
 1. Choose the right LoadMode
-++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The ``LoadMode`` controls how Cosmos reads your dbt project. It is the single most impactful setting for parse-time
 performance.
@@ -76,7 +76,7 @@ Use ``LoadMode.DBT_LS`` with the following optimizations to minimize parse-time 
 
 
 2. Reduce DAG granularity
-+++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Fewer nodes in the Airflow DAG means faster parsing. There are two ways to reduce the number of nodes Cosmos generates.
 
@@ -112,7 +112,7 @@ increase the number of tasks in the DAG. Consider these alternatives:
 
 
 3. Skip stale sources
-+++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~
 
 If your DAG includes multiple data sources and some may not have fresh data, you can avoid running unnecessary
 branches by rendering source nodes with freshness checks. When a source is not fresh, the downstream branch can be

--- a/docs/optimize_performance/troubleshooting.rst
+++ b/docs/optimize_performance/troubleshooting.rst
@@ -1,13 +1,13 @@
 .. _perf-troubleshooting:
 
 Troubleshooting Performance
----------------------------
+===========================
 
 This page helps you diagnose common performance issues when running Cosmos.
 
 
 Measuring DAG parse time
-+++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Cosmos logs the time it takes to parse each dbt project at the ``INFO`` level. Search your `Apache Airflow® <https://airflow.apache.org/>`_ scheduler or
 DAG processor logs for messages like:
@@ -27,7 +27,7 @@ If the parse time is high, see :ref:`optimize-rendering` for strategies to reduc
 
 
 Apache Airflow® DAG processor configuration
-++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The Airflow DAG processor controls how often and how quickly DAG files are parsed. Understanding these settings helps
 you diagnose issues where DAGs are slow to appear or update.
@@ -69,7 +69,7 @@ you diagnose issues where DAGs are slow to appear or update.
 
 
 DAGs not appearing
-++++++++++++++++++
+~~~~~~~~~~~~~~~~~~
 
 If your ``DbtDag`` or ``DbtTaskGroup`` does not appear in Airflow, the most likely cause is that DAG parsing exceeds
 the ``dagbag_import_timeout``.
@@ -98,7 +98,7 @@ the ``dagbag_import_timeout``.
 
 
 OOM errors during task execution
-++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 If tasks are being killed by the OS or reaching a zombie state, they are likely running out of memory.
 


### PR DESCRIPTION
## Description

Per the lightweight style guide proposed in #2460, RST heading underlines
should follow the canonical hierarchy:

- Page title: `=`
- H1: `~`
- H2: `+`
- H3: `^`

The pages under `docs/optimize_performance/` used a mix of `-`/`+` for the
title and H1 levels. Remap them positionally per file (first level encountered
becomes `=`, second becomes `~`, etc.) so the rendered hierarchy matches the
convention. Underline lengths and heading text are unchanged; only the
underline character is swapped.

Continues the underline-normalization work from #2641 (covered
`getting_started/`).

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works