### PR TITLE
Normalize heading underlines in policy docs

### DIFF
--- a/docs/policy/airflow3-compatibility.rst
+++ b/docs/policy/airflow3-compatibility.rst
@@ -1,13 +1,13 @@
 .. _airflow3-compatibility:
 
 Apache Airflow® 3 compatibility (first iteration)
---------------------------------------------------
+==================================================
 
 The Cosmos 1.10.0 release marks the **first iteration** of adding compatibility for `Apache Airflow® 3 <https://airflow.apache.org/>`_
 This is an important milestone as we work towards ensuring that Cosmos seamlessly integrates with the latest advancements in the Airflow ecosystem.
 
 Breaking changes
-++++++++++++++++
+~~~~~~~~~~~~~~~~
 
 Airflow Asset (Dataset) URIs validation rules changed in Airflow 3.0.0 and OpenLineage URIs (standard used by Cosmos) are no longer valid in Airflow 3.
 
@@ -33,7 +33,7 @@ If you want to use the Airflow 3 URI standard while still using Airflow 2, pleas
 
 
 What works
-++++++++++
+~~~~~~~~~~
 
 With the changes contributed in Cosmos 1.10.0 to bring in compatibility with Airflow 3, we have validated Cosmos’
 functionality with Airflow 3 by extending our CI infrastructure:
@@ -49,7 +49,7 @@ These additions ensure that all core functionality, workflows, and integrations 
 reliably under Airflow 3.
 
 Multiple dbt docs in Apache Airflow® 3 UI
-++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 There have been significant changes to how plugins work in Airflow 3.x. Cosmos now supports Airflow 3 FastAPI plugins for UI integration and hosting dbt docs via external views.
 
@@ -88,7 +88,7 @@ You can set the same mapping via the Airflow config environment variable ``AIRFL
 Docs are available at ``/cosmos/<slug>/dbt_docs_index.html``. Static assets are served directly for local directories or proxied for remote storage (S3/GCS/Azure/HTTP).
 
 Validation in progress
-++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~
 
 We are actively validating the combined support for `Assets <https://airflow.apache.org/docs/apache-airflow/3.0.0/authoring-and-scheduling/assets.html>`_
 and `OpenLineage <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/guides/user.html>`_ with Airflow 3.
@@ -97,13 +97,13 @@ We encourage users to try it out and provide feedback, but note that certain edg
 investigation.
 
 Known limitations
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 Airflow 3 DatasetAlias no longer support ASCII characters. This issue has been reported to the `Airflow community <https://github.com/apache/airflow/issues/51566>`_
 and we are also tracking it in the `Cosmos repository <https://github.com/astronomer/astronomer-cosmos/issues/1802>`_.
 
 What's next
-+++++++++++
+~~~~~~~~~~~
 
 We are actively tracking open issues and enhancements related to **Airflow 3 compatibility** in Cosmos.
 You can view the full list of currently open issues on GitHub here:

--- a/docs/policy/compatibility-policy.rst
+++ b/docs/policy/compatibility-policy.rst
@@ -1,7 +1,7 @@
 .. _compatibility-policy:
 
 Compatibility policy
---------------------
+====================
 
 This document outlines Astronomer Cosmos's compatibility policy for Python,
 Apache Airflow, and dbt Core versions. This policy provides transparency and
@@ -9,7 +9,7 @@ predictability for users and contributors regarding version support and removal
 criteria.
 
 Overview
-++++++++
+~~~~~~~~
 
 Astronomer Cosmos is committed to maintaining compatibility with a range of
 Python, Apache Airflow, and dbt Core versions to support diverse user
@@ -24,18 +24,18 @@ This policy establishes:
 - Contributor guidance for proposing version changes
 
 Currently supported versions
-++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following versions are currently tested and supported.
 
 Python
-''''''
+++++++
 
 - **Minimum required**: Python 3.10
 - **Supported versions**: 3.10, 3.11, 3.12, 3.13
 
 Apache Airflow
-''''''''''''''
+++++++++++++++
 
 New minor or major releases of Cosmos may drop support for Apache Airflow versions that have reached **End of Basic Support**, as defined in the `Astro Runtime Lifecycle schedule <https://www.astronomer.io/docs/runtime/runtime-version-lifecycle-policy#astro-runtime-lifecycle-schedule>`_.
 
@@ -45,7 +45,7 @@ In some cases, Cosmos may continue to support older Airflow versions, depending 
 - **Supported versions**: 2.9, 2.10, 2.11, 3.0, 3.1, 3.2
 
 dbt Core
-''''''''
+++++++++
 
 - **Supported versions**: 1.5, 1.6, 1.7, 1.8, 1.9, 1.10, 1.11, 2.0 (dbt Fusion)
 
@@ -56,14 +56,14 @@ dbt Core
    for adapter-specific version compatibility.
 
 Version removal policy
-++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~
 
 Cosmos removes support for versions based on clear and objective criteria.
 There is no deprecation period—versions are removed when they meet the removal
 criteria.
 
 Python version removal criteria
-'''''''''''''''''''''''''''''''
++++++++++++++++++++++++++++++++
 
 Python versions are removed from support when **any** of the following
 conditions are met:
@@ -76,7 +76,7 @@ conditions are met:
   the Python version
 
 Apache Airflow version removal criteria
-'''''''''''''''''''''''''''''''''''''''
++++++++++++++++++++++++++++++++++++++++
 
 Apache Airflow versions are removed from support when **both** of the
 following conditions are met:
@@ -89,7 +89,7 @@ following conditions are met:
   `Astronomer Runtime lifecycle policy <https://www.astronomer.io/docs/runtime/runtime-version-lifecycle-policy>`_
 
 dbt Core version removal criteria
-'''''''''''''''''''''''''''''''''
++++++++++++++++++++++++++++++++++
 
 dbt Core versions are removed from support when:
 
@@ -97,7 +97,7 @@ dbt Core versions are removed from support when:
   `dbt Labs support policy <https://docs.getdbt.com/docs/dbt-versions/core>`_
 
 Version removal process
-+++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~
 
 When a version meets the removal criteria:
 
@@ -110,10 +110,10 @@ When a version meets the removal criteria:
    the next release
 
 User guidance
-+++++++++++++
+~~~~~~~~~~~~~
 
 Checking compatibility
-''''''''''''''''''''''
+++++++++++++++++++++++
 
 Before upgrading Cosmos or its dependencies:
 
@@ -125,7 +125,7 @@ Before upgrading Cosmos or its dependencies:
    or migration guides
 
 Planning upgrades
-'''''''''''''''''
++++++++++++++++++
 
 To minimize disruption:
 
@@ -138,7 +138,7 @@ To minimize disruption:
 - **Use CI/CD**: Test compatibility in your CI/CD pipeline before deploying
 
 Reporting compatibility issues
-''''''''''''''''''''''''''''''
+++++++++++++++++++++++++++++++
 
 If you encounter compatibility issues:
 
@@ -151,10 +151,10 @@ If you encounter compatibility issues:
    in your report
 
 Contributor guidance
-++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~
 
 Proposing version changes
-'''''''''''''''''''''''''
++++++++++++++++++++++++++
 
 When proposing to add or remove version support:
 
@@ -173,7 +173,7 @@ When proposing to add or remove version support:
    this policy
 
 Updating test matrix
-''''''''''''''''''''
+++++++++++++++++++++
 
 When adding or removing versions:
 
@@ -185,7 +185,7 @@ When adding or removing versions:
 4. **Update CHANGELOG.rst**: Document the change in the changelog
 
 Testing requirements
-''''''''''''''''''''
+++++++++++++++++++++
 
 All supported version combinations should:
 
@@ -195,7 +195,7 @@ All supported version combinations should:
 - Have example DAGs validated (where applicable)
 
 How do I know when a version will be removed?
-'''''''''''''''''''''''''''''''''''''''''''''
++++++++++++++++++++++++++++++++++++++++++++++
 
 - **Monitor EOL dates**: Check the official EOL dates for Python, Apache Airflow,
   and dbt Core
@@ -206,7 +206,7 @@ How do I know when a version will be removed?
   version removals
 
 Related documentation
-'''''''''''''''''''''
++++++++++++++++++++++
 
 - `CHANGELOG.rst <https://github.com/astronomer/astronomer-cosmos/blob/main/CHANGELOG.rst>`_
   – Release notes and version removal notices

--- a/docs/policy/contributing.rst
+++ b/docs/policy/contributing.rst
@@ -1,7 +1,7 @@
 .. _contributing:
 
 Cosmos Contributing Guide
--------------------------
+=========================
 
 All contributions, bug reports, bug fixes, documentation improvements and enhancements are welcome.
 
@@ -11,7 +11,7 @@ As contributors and maintainers to this project, you are expected to abide by th
 Learn more about the contributors' roles in :ref:`contributors-roles`.
 
 Overview
-++++++++
+~~~~~~~~
 
 To contribute to the Cosmos project:
 
@@ -25,10 +25,10 @@ To contribute to the Cosmos project:
 .. _setting-up-cosmos-dev-env:
 
 Setting up the Cosmos development environment
-+++++++++++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Set up local development on the host machine
-''''''''''''''''''''''''''''''''''''''''''''
+++++++++++++++++++++++++++++++++++++++++++++
 
 This guide will set up Astronomer development on the host machine, first clone the ``astronomer-cosmos`` repo and enter the repo directory:
 
@@ -65,7 +65,7 @@ Once Airflow is up, you can access the Airflow UI at ``http://localhost:8080``.
     Note: whenever you want to start the development server, you need to activate the ``virtualenv`` and set the ``environment variables``.
 
 Using Docker Compose for local development
-''''''''''''''''''''''''''''''''''''''''''
+++++++++++++++++++++++++++++++++++++++++++
 
 It is also possible to just build the development environment using Docker Compose.
 
@@ -94,7 +94,7 @@ Once the sandbox is up, you can access the Airflow UI at ``http://localhost:8080
 .. _setting-up-hatch:
 
 Working with Hatch
-''''''''''''''''''
+++++++++++++++++++
 
 `Hatch <https://hatch.pypa.io/latest/>`_ is a unified command-line tool for managing Python dependencies and environment isolation. In Cosmos, we use it for building, distributing, running tests, and building documentation.
 
@@ -193,7 +193,7 @@ Hatch will automatically update the version for you. Then, create a new release 
     You can update the version in a few different ways. Check out the `Hatch docs <https://hatch.pypa.io/latest/version/#updating>`_ to learn more.
 
 pre-commit
-''''''''''
+++++++++++
 
 We use pre-commit to run a number of checks on the code before committing. To install pre-commit, run:
 
@@ -208,7 +208,7 @@ To run the checks manually, run:
     pre-commit run --all-files
 
 Writing docs
-++++++++++++
+~~~~~~~~~~~~
 
 `Hatch <https://hatch.pypa.io/latest/>`_ is a unified command-line tool for managing dependencies and environment isolation for Python developers. In Cosmos, we use a Hatch to declare the dependencies required for the project itself, as well as for tests and documentation builds.
 
@@ -228,7 +228,7 @@ You can run the docs locally by running the following:
 
 
 Building
-++++++++
+~~~~~~~~
 
 We use ``hatch`` to build the project. To build the project, run:
 
@@ -238,7 +238,7 @@ We use ``hatch`` to build the project. To build the project, run:
 
 
 Releasing
-+++++++++
+~~~~~~~~~
 
 We use GitHub actions to create and deploy new releases. To create a new release, first create a new version using:
 

--- a/docs/policy/contributing.rst
+++ b/docs/policy/contributing.rst
@@ -107,7 +107,7 @@ If you don't already have Hatch installed, `install it <https://hatch.pypa.io/la
 The `pyproject.toml <https://github.com/astronomer/astronomer-cosmos/blob/main/pyproject.toml>`_ file defines a matrix of supported versions of Python, Airflow and dbt-core for which a user can run the tests against.
 
 Testing the application with Hatch
-..................................
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 After following the steps described in :ref:`setting-up-hatch`, you are ready to run Cosmos tests locally.
 For instance, to run the tests using Python 3.11, `Apache Airflow® <https://airflow.apache.org/>`_ 2.10 and `dbt-core <https://github.com/dbt-labs/dbt-core/>`_ 1.9, use the following:
@@ -154,7 +154,7 @@ If testing for the same Airflow and Python version, next runs of the integration
     hatch run tests.py3.11-2.10-1.9:test-integration
 
 Writing Docs
-............
+^^^^^^^^^^^^
 
 After following the steps described in :ref:`setting-up-hatch`, you are ready to build and serve the documentation locally.
 
@@ -165,7 +165,7 @@ You can run the docs locally by running the following:
     hatch run docs:serve
 
 Building
-........
+^^^^^^^^
 
 After following the steps described in :ref:`setting-up-hatch`, you are ready to build the project.
 
@@ -176,7 +176,7 @@ To build the project, run:
     hatch build
 
 Releasing
-.........
+^^^^^^^^^
 
 .. note::
     This section is intended for Cosmos maintainers only.
@@ -210,7 +210,7 @@ To run the checks manually, run:
 Writing docs
 ~~~~~~~~~~~~
 
-`Hatch <https://hatch.pypa.io/latest/>`_ is a unified command-line tool for managing dependencies and environment isolation for Python developers. In Cosmos, we use a Hatch to declare the dependencies required for the project itself, as well as for tests and documentation builds.
+`Hatch <https://hatch.pypa.io/latest/>`_ is a unified command-line tool for managing dependencies and environment isolation for Python developers. In Cosmos, we use Hatch to declare the dependencies required for the project itself, as well as for tests and documentation builds.
 
 If you don’t already have Hatch installed, please `install it <https://hatch.pypa.io/latest/install/>`_ before proceeding. As an example, on macOS, you can do so with:
 
@@ -240,7 +240,7 @@ We use ``hatch`` to build the project. To build the project, run:
 Releasing
 ~~~~~~~~~
 
-We use GitHub actions to create and deploy new releases. To create a new release, first create a new version using:
+We use GitHub Actions to create and deploy new releases. To create a new release, first create a new version using:
 
 .. code-block:: bash
 

--- a/docs/policy/contributors-roles.rst
+++ b/docs/policy/contributors-roles.rst
@@ -1,7 +1,7 @@
 .. _contributors-roles:
 
 Contributor roles
------------------
+=================
 
 Contributors are welcome and are greatly appreciated! Every little bit helps, and we give credit to them.
 
@@ -10,7 +10,7 @@ For more information, check :ref:`contributing` and :ref:`contributors`.
 
 
 Contributors
-++++++++++++
+~~~~~~~~~~~~
 
 A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the Astronomer Cosmos project.
 
@@ -27,7 +27,7 @@ Contributors are responsible for:
 
 
 Committers
-++++++++++
+~~~~~~~~~~
 
 Committers are community members with write access to the `Astronomer Cosmos Github repository <https://github.com/astronomer/astronomer-cosmos>`_.
 They can modify the code and the documentation and accept others' contributions to the repo.
@@ -44,7 +44,7 @@ Emeritus committers will no longer have write access to the repo.
 As merit earned never expires, once an emeritus committer becomes active again, they can simply email another maintainer from Astronomer and ask to be reinstated.
 
 Pre-requisites to becoming a committer
-''''''''''''''''''''''''''''''''''''''
+++++++++++++++++++++++++++++++++++++++
 
 General prerequisites that we look for in all candidates:
 

--- a/docs/policy/contributors-roles.rst
+++ b/docs/policy/contributors-roles.rst
@@ -29,7 +29,7 @@ Contributors are responsible for:
 Committers
 ~~~~~~~~~~
 
-Committers are community members with write access to the `Astronomer Cosmos Github repository <https://github.com/astronomer/astronomer-cosmos>`_.
+Committers are community members with write access to the `Astronomer Cosmos GitHub repository <https://github.com/astronomer/astronomer-cosmos>`_.
 They can modify the code and the documentation and accept others' contributions to the repo.
 
 Check :ref:`contributors` for the official list of Astronomer Cosmos committers.

--- a/docs/policy/contributors.rst
+++ b/docs/policy/contributors.rst
@@ -4,7 +4,7 @@ Contributors
 ============
 
 There are different ways people can contribute to Astronomer Cosmos.
-Learn more about the project contributors roles in :ref:`contributors-roles`.
+Learn more about the project contributors' roles in :ref:`contributors-roles`.
 
 Committers
 ~~~~~~~~~~
@@ -28,4 +28,4 @@ Contributors
 ~~~~~~~~~~~~
 
 Many people are improving Astronomer Cosmos each day.
-Find more contributors `in our Github page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ Slack channel.
+Find more contributors `in our GitHub page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ Slack channel.

--- a/docs/policy/contributors.rst
+++ b/docs/policy/contributors.rst
@@ -1,13 +1,13 @@
 .. _contributors:
 
 Contributors
-------------
+============
 
 There are different ways people can contribute to Astronomer Cosmos.
 Learn more about the project contributors roles in :ref:`contributors-roles`.
 
 Committers
-++++++++++
+~~~~~~~~~~
 
 - Daniel Reeves (`@dwreeves <https://github.com/dwreeves>`_)
 - Giovanni Corsetti Silva (`@corsettigyg <https://github.com/corsettigyg>`_)
@@ -19,13 +19,13 @@ Committers
 
 
 Emeritus committers
-+++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~
 
 - Chris Hronek (`@chrishronek <https://github.com/chrishronek>`_)
 
 
 Contributors
-++++++++++++
+~~~~~~~~~~~~
 
 Many people are improving Astronomer Cosmos each day.
 Find more contributors `in our Github page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ Slack channel.

--- a/docs/policy/index.rst
+++ b/docs/policy/index.rst
@@ -1,7 +1,7 @@
 .. _policy:
 
 Cosmos project policies and compatibility
------------------------------------------
+=========================================
 
 
 .. toctree::

--- a/docs/policy/policies.rst
+++ b/docs/policy/policies.rst
@@ -1,8 +1,8 @@
 Cosmos project policies
------------------------
+=======================
 
 Project repositories and subprojects
-++++++++++++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The following repositories constitute the codebases for the Astronomer Cosmos project for compliance purposes (OSPS-QA-04.01):
 
@@ -17,14 +17,14 @@ The following repositories constitute the codebases for the Astronomer Cosmos pr
 Note: There are no additional subproject codebases beyond the repositories listed above for OSPS-QA-04.01 compliance purposes.
 
 Versioning policy
-+++++++++++++++++
+~~~~~~~~~~~~~~~~~
 
 We follow `Semantic Versioning <https://semver.org/>`_ for releases.
 
 Refer to `CHANGELOG.rst <https://github.com/astronomer/astronomer-cosmos/blob/main/CHANGELOG.rst>`_ for the latest changes.
 
 Privacy notice
-++++++++++++++
+~~~~~~~~~~~~~~
 
 The application and this website collect telemetry to support the project's development. These can be disabled by the end-users.
 

--- a/docs/policy/security.rst
+++ b/docs/policy/security.rst
@@ -1,15 +1,15 @@
 Cosmos security
----------------
+===============
 
 Security policy
-+++++++++++++++
+~~~~~~~~~~~~~~~
 
 Check the project's `Security Policy <https://github.com/astronomer/astronomer-cosmos/blob/main/SECURITY.rst>`_ to learn
 how to report security vulnerabilities in Astronomer Cosmos and how security issues reported to the Astronomer Cosmos
 security team are handled.
 
 Dependency update cooldown
-++++++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 To mitigate the risk of supply chain attacks from newly released versions, Cosmos enforces a **7-day cooldown period**
 before merging automated dependency update pull requests. This cooldown gives time for the broader community to discover


### PR DESCRIPTION
## Description

Per the lightweight style guide proposed in #2460, RST heading underlines
should follow the canonical hierarchy:

- Page title: `=`
- H1: `~`
- H2: `+`
- H3: `^`

The pages under `docs/policy/` used a mix of `-`/`+`/`'` for those levels.
Remap them positionally per file (first level encountered becomes `=`, second
becomes `~`, etc.) so the rendered hierarchy matches the convention. Underline
lengths and heading text are unchanged; only the underline character is
swapped.

Continues the underline-normalization work from #2641 (`getting_started/`)
and #2655 (`optimize_performance/`).

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works