### PR TITLE
Fix test sensor retry in ExecutionMode.WATCHER

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -417,15 +417,9 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         Reconstructs the dbt command by cloning the project and re-running the model
         with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
 
-        For test sensors, re-execution is not supported in watcher mode; retries are skipped.
+        Subclasses may override to issue a different dbt subcommand (e.g. ``dbt test``
+        for test sensors or ``dbt source freshness`` for source sensors).
         """
-        if self.is_test_sensor:
-            raise AirflowException(
-                f"Test re-execution is not yet supported in watcher mode. "
-                f"{self._resource_label} '{self.model_unique_id}' cannot be retried. "
-                f"A future release will add fallback to local test execution."
-            )
-
         if try_number > 1:
             logger.info(
                 f"Retry attempt #%s – Running model '%s' from project '%s' using {self.__class__.__name__}",

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -608,8 +608,8 @@ class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
                 self.project_dir,
             )
 
-        model_selector = self.model_unique_id.split(".")[-1]
+        model_selector = self.model_unique_id.split(".", 2)[2]
         cmd_flags = ["--select", model_selector]
         self.build_and_run_cmd(context, cmd_flags=cmd_flags)
-        logger.info("dbt test completed successfully on retry for model '%s'", self.model_unique_id)
+        logger.info("dbt test completed successfully for model '%s'", self.model_unique_id)
         return True

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -571,10 +571,45 @@ class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
 
     Deferral is fully supported: the ``WatcherTrigger`` receives
     ``is_test_sensor=True`` and polls the correct aggregated key.
+
+    On manual clear from the Airflow UI or Airflow-level retry, the sensor falls
+    back to running ``dbt test --select <model>`` locally for this specific model.
     """
 
     template_fields: tuple[str, ...] = DbtConsumerWatcherSensor.template_fields  # type: ignore[operator]
 
+    # Override DbtRunMixin.base_cmd so build_and_run_cmd issues `dbt test` in the
+    # fallback path. The normal sensor poll path does not shell out, so this is
+    # only consulted when _fallback_to_non_watcher_run runs.
+    base_cmd = ["test"]
+
     @property
     def is_test_sensor(self) -> bool:
+        return True
+
+    def _fallback_to_non_watcher_run(self, try_number: int, context: Context) -> bool:
+        """Run ``dbt test --select <model>`` locally to retry tests for this model.
+
+        Used when the test sensor is manually cleared from the Airflow UI or when
+        Airflow-level retries fire. Producer flags are intentionally not forwarded
+        because some of them (e.g. ``--full-refresh``) are not valid for ``dbt test``.
+        """
+        if try_number > 1:
+            logger.info(
+                "Retry attempt #%s – Running tests for model '%s' from project '%s'",
+                try_number - 1,
+                self.model_unique_id,
+                self.project_dir,
+            )
+        else:
+            logger.info(
+                "Falling back to running tests for model '%s' from project '%s'",
+                self.model_unique_id,
+                self.project_dir,
+            )
+
+        model_selector = self.model_unique_id.split(".")[-1]
+        cmd_flags = ["--select", model_selector]
+        self.build_and_run_cmd(context, cmd_flags=cmd_flags)
+        logger.info("dbt test completed successfully on retry for model '%s'", self.model_unique_id)
         return True

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -578,8 +578,13 @@ class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
 
     template_fields: tuple[str, ...] = DbtConsumerWatcherSensor.template_fields  # type: ignore[operator]
 
-    # Override DbtRunMixin.base_cmd so build_and_run_cmd issues `dbt test` in the
-    # fallback path. The normal sensor poll path does not shell out, so this is
+    # Hardcode base_cmd = ["test"] (overriding DbtRunMixin inherited via
+    # DbtConsumerWatcherSensor) rather than inheriting from DbtTestMixin: due
+    # to the multiple class inheritance and incompatible arguments,
+    # DbtTestMixin.__init__ forwards select/exclude/selector kwargs to super(),
+    # which the sensor side of our MRO (BaseSensorOperator) rejects. Setting
+    # the attribute here is simpler than overriding __init__ to bypass the
+    # mixin's chain. The normal sensor poll path does not shell out; this is
     # only consulted when _fallback_to_non_watcher_run runs.
     base_cmd = ["test"]
 
@@ -594,19 +599,12 @@ class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
         Airflow-level retries fire. Producer flags are intentionally not forwarded
         because some of them (e.g. ``--full-refresh``) are not valid for ``dbt test``.
         """
-        if try_number > 1:
-            logger.info(
-                "Retry attempt #%s – Running tests for model '%s' from project '%s'",
-                try_number - 1,
-                self.model_unique_id,
-                self.project_dir,
-            )
-        else:
-            logger.info(
-                "Falling back to running tests for model '%s' from project '%s'",
-                self.model_unique_id,
-                self.project_dir,
-            )
+        logger.info(
+            "Running tests for model '%s' from project '%s' (try %s)",
+            self.model_unique_id,
+            self.project_dir,
+            try_number,
+        )
 
         model_selector = self.model_unique_id.split(".", 2)[2]
         cmd_flags = ["--select", model_selector]

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2235,12 +2235,15 @@ class TestDbtTestWatcherOperator:
         assert self.TESTS_STATUS_XCOM_KEY in xcom_keys_used
 
     def test_fallback_runs_dbt_test_on_retry(self):
-        """On retry (try_number > 1) with a terminated producer, the test sensor should
-        fall back to running ``dbt test --select <model>`` locally for this model.
+        """On retry (try_number > 1) with a terminated producer, ``poke`` should
+        invoke ``_fallback_to_non_watcher_run``, which runs ``dbt test --select <model>``
+        locally for this model.
         """
         sensor = self.make_sensor()
         sensor._get_producer_task_status.return_value = "success"
         sensor.build_and_run_cmd = MagicMock()
+        mock_fallback_to_non_watcher_run = MagicMock(side_effect=sensor._fallback_to_non_watcher_run)
+        sensor._fallback_to_non_watcher_run = mock_fallback_to_non_watcher_run
         ti = MagicMock()
         ti.try_number = 2
         context = self.make_context(ti)
@@ -2248,48 +2251,36 @@ class TestDbtTestWatcherOperator:
         result = sensor.poke(context)
 
         assert result is True
+        mock_fallback_to_non_watcher_run.assert_called_once()
         sensor.build_and_run_cmd.assert_called_once()
         _, kwargs = sensor.build_and_run_cmd.call_args
         assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".", 2)[2]]
 
-    def test_fallback_to_non_watcher_run_invokes_dbt_test(self):
-        """``_fallback_to_non_watcher_run`` should call ``build_and_run_cmd`` with only
-        a ``--select <model>`` selector and rely on ``base_cmd = ["test"]`` to issue dbt test.
-        Producer flags must not be forwarded since some (e.g. ``--full-refresh``) are
-        invalid for ``dbt test``.
+    def test_fallback_via_poke_does_not_forward_producer_flags(self):
+        """Driving through ``poke`` on retry, the fallback should issue ``dbt test`` with
+        a ``--select <model>`` selector only. Producer flags must not be forwarded since
+        some (e.g. ``--full-refresh``) are invalid for ``dbt test``.
         """
         sensor = self.make_sensor()
+        sensor._get_producer_task_status.return_value = "success"
         sensor.build_and_run_cmd = MagicMock()
+        mock_fallback_to_non_watcher_run = MagicMock(side_effect=sensor._fallback_to_non_watcher_run)
+        sensor._fallback_to_non_watcher_run = mock_fallback_to_non_watcher_run
         ti = MagicMock()
+        ti.try_number = 2
         # If producer flags were forwarded, this would leak into cmd_flags.
         ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--full-refresh"]
         context = self.make_context(ti)
 
-        result = sensor._fallback_to_non_watcher_run(try_number=2, context=context)
+        assert sensor.poke(context) is True
 
-        assert result is True
+        mock_fallback_to_non_watcher_run.assert_called_once()
         _, kwargs = sensor.build_and_run_cmd.call_args
         assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".", 2)[2]]
         assert "--full-refresh" not in kwargs["cmd_flags"]
         assert sensor.base_cmd == ["test"]
 
-    def test_fallback_on_first_attempt_logs_fallback_message(self, caplog):
-        """When the fallback runs at ``try_number == 1`` (e.g. producer skipped/failed),
-        it should log the "Falling back" message rather than the "Retry attempt" one.
-        """
-        sensor = self.make_sensor()
-        sensor.build_and_run_cmd = MagicMock()
-        ti = MagicMock()
-        context = self.make_context(ti)
-
-        with caplog.at_level("INFO"):
-            result = sensor._fallback_to_non_watcher_run(try_number=1, context=context)
-
-        assert result is True
-        assert any("Falling back to running tests for model" in r.message for r in caplog.records)
-        assert not any("Retry attempt" in r.message for r in caplog.records)
-
-    def test_fallback_selector_preserves_version_suffix(self):
+    def test_fallback_via_poke_preserves_version_suffix(self):
         """Versioned dbt models (e.g. ``model.pkg.my_model.v1``) must select the full
         ``my_model.v1`` resource name, not just the trailing ``v1`` segment.
         """
@@ -2302,13 +2293,17 @@ class TestDbtTestWatcherOperator:
             deferrable=True,
             extra_context=extra_context,
         )
+        sensor._get_producer_task_status = MagicMock(return_value="success")
         sensor.build_and_run_cmd = MagicMock()
+        mock_fallback_to_non_watcher_run = MagicMock(side_effect=sensor._fallback_to_non_watcher_run)
+        sensor._fallback_to_non_watcher_run = mock_fallback_to_non_watcher_run
         ti = MagicMock()
+        ti.try_number = 2
         context = self.make_context(ti)
 
-        result = sensor._fallback_to_non_watcher_run(try_number=2, context=context)
+        assert sensor.poke(context) is True
 
-        assert result is True
+        mock_fallback_to_non_watcher_run.assert_called_once()
         _, kwargs = sensor.build_and_run_cmd.call_args
         assert kwargs["cmd_flags"] == ["--select", "stg_orders.v1"]
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2250,7 +2250,7 @@ class TestDbtTestWatcherOperator:
         assert result is True
         sensor.build_and_run_cmd.assert_called_once()
         _, kwargs = sensor.build_and_run_cmd.call_args
-        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".")[-1]]
+        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".", 2)[2]]
 
     def test_fallback_to_non_watcher_run_invokes_dbt_test(self):
         """``_fallback_to_non_watcher_run`` should call ``build_and_run_cmd`` with only
@@ -2269,9 +2269,32 @@ class TestDbtTestWatcherOperator:
 
         assert result is True
         _, kwargs = sensor.build_and_run_cmd.call_args
-        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".")[-1]]
+        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".", 2)[2]]
         assert "--full-refresh" not in kwargs["cmd_flags"]
         assert sensor.base_cmd == ["test"]
+
+    def test_fallback_selector_preserves_version_suffix(self):
+        """Versioned dbt models (e.g. ``model.pkg.my_model.v1``) must select the full
+        ``my_model.v1`` resource name, not just the trailing ``v1`` segment.
+        """
+        versioned_uid = "model.jaffle_shop.stg_orders.v1"
+        extra_context = {"dbt_node_config": {"unique_id": versioned_uid}}
+        sensor = DbtTestWatcherOperator(
+            task_id="stg_orders_v1.test",
+            project_dir="/tmp/project",
+            profile_config=None,
+            deferrable=True,
+            extra_context=extra_context,
+        )
+        sensor.build_and_run_cmd = MagicMock()
+        ti = MagicMock()
+        context = self.make_context(ti)
+
+        result = sensor._fallback_to_non_watcher_run(try_number=2, context=context)
+
+        assert result is True
+        _, kwargs = sensor.build_and_run_cmd.call_args
+        assert kwargs["cmd_flags"] == ["--select", "stg_orders.v1"]
 
     def test_retry_keeps_polling_when_producer_still_running(self):
         """On retry, if the producer is still running, the test sensor should keep polling instead of raising."""

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2273,6 +2273,22 @@ class TestDbtTestWatcherOperator:
         assert "--full-refresh" not in kwargs["cmd_flags"]
         assert sensor.base_cmd == ["test"]
 
+    def test_fallback_on_first_attempt_logs_fallback_message(self, caplog):
+        """When the fallback runs at ``try_number == 1`` (e.g. producer skipped/failed),
+        it should log the "Falling back" message rather than the "Retry attempt" one.
+        """
+        sensor = self.make_sensor()
+        sensor.build_and_run_cmd = MagicMock()
+        ti = MagicMock()
+        context = self.make_context(ti)
+
+        with caplog.at_level("INFO"):
+            result = sensor._fallback_to_non_watcher_run(try_number=1, context=context)
+
+        assert result is True
+        assert any("Falling back to running tests for model" in r.message for r in caplog.records)
+        assert not any("Retry attempt" in r.message for r in caplog.records)
+
     def test_fallback_selector_preserves_version_suffix(self):
         """Versioned dbt models (e.g. ``model.pkg.my_model.v1``) must select the full
         ``my_model.v1`` resource name, not just the trailing ``v1`` segment.

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2234,16 +2234,44 @@ class TestDbtTestWatcherOperator:
         xcom_keys_used = [call.kwargs.get("key") or call[1].get("key") for call in calls]
         assert self.TESTS_STATUS_XCOM_KEY in xcom_keys_used
 
-    def test_fallback_raises_on_retry(self):
-        """On retry (try_number > 1) with a terminated producer, the test sensor should raise since test re-execution is not yet supported."""
+    def test_fallback_runs_dbt_test_on_retry(self):
+        """On retry (try_number > 1) with a terminated producer, the test sensor should
+        fall back to running ``dbt test --select <model>`` locally for this model.
+        """
         sensor = self.make_sensor()
         sensor._get_producer_task_status.return_value = "success"
+        sensor.build_and_run_cmd = MagicMock()
         ti = MagicMock()
         ti.try_number = 2
         context = self.make_context(ti)
 
-        with pytest.raises(AirflowException, match="Test re-execution is not yet supported"):
-            sensor.poke(context)
+        result = sensor.poke(context)
+
+        assert result is True
+        sensor.build_and_run_cmd.assert_called_once()
+        _, kwargs = sensor.build_and_run_cmd.call_args
+        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".")[-1]]
+
+    def test_fallback_to_non_watcher_run_invokes_dbt_test(self):
+        """``_fallback_to_non_watcher_run`` should call ``build_and_run_cmd`` with only
+        a ``--select <model>`` selector and rely on ``base_cmd = ["test"]`` to issue dbt test.
+        Producer flags must not be forwarded since some (e.g. ``--full-refresh``) are
+        invalid for ``dbt test``.
+        """
+        sensor = self.make_sensor()
+        sensor.build_and_run_cmd = MagicMock()
+        ti = MagicMock()
+        # If producer flags were forwarded, this would leak into cmd_flags.
+        ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--full-refresh"]
+        context = self.make_context(ti)
+
+        result = sensor._fallback_to_non_watcher_run(try_number=2, context=context)
+
+        assert result is True
+        _, kwargs = sensor.build_and_run_cmd.call_args
+        assert kwargs["cmd_flags"] == ["--select", self.MODEL_UID.split(".")[-1]]
+        assert "--full-refresh" not in kwargs["cmd_flags"]
+        assert sensor.base_cmd == ["test"]
 
     def test_retry_keeps_polling_when_producer_still_running(self):
         """On retry, if the producer is still running, the test sensor should keep polling instead of raising."""


### PR DESCRIPTION
## Summary

- Removes the `AirflowException` guard in `BaseConsumerSensor._fallback_to_non_watcher_run` that blocked manual clears and Airflow-level retries on `DbtTestWatcherOperator`.
- Adds a test-sensor fallback that runs `dbt test --select <model>` locally for the watched model: `DbtTestWatcherOperator` now sets `base_cmd = ["test"]` and overrides `_fallback_to_non_watcher_run`.

Addresses part 1 of #2598. The producer-internal test-retry race condition (part 2) is unchanged and remains tracked there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)