### PR TITLE
Fix watcher fallback selector for versioned dbt models

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -447,7 +447,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
             raw_flags = upstream_task.add_cmd_flags()
             extra_flags = self._filter_flags(raw_flags)
 
-        model_selector = self.model_unique_id.split(".")[-1]
+        model_selector = self.model_unique_id.split(".", 2)[2]
         cmd_flags = extra_flags + ["--select", model_selector]
 
         self.build_and_run_cmd(context, cmd_flags=cmd_flags)  # type: ignore[attr-defined]

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1118,7 +1118,21 @@ class TestDbtConsumerWatcherSensor:
         sensor.build_and_run_cmd.assert_called_once()
         args, kwargs = sensor.build_and_run_cmd.call_args
         assert "--select" in kwargs["cmd_flags"]
-        assert MODEL_UNIQUE_ID.split(".")[-1] in kwargs["cmd_flags"]
+        assert MODEL_UNIQUE_ID.split(".", 2)[2] in kwargs["cmd_flags"]
+
+    def test_fallback_selector_preserves_version_suffix(self):
+        """For versioned dbt models (e.g. ``model.pkg.my_model.v1``) the selector must keep the version suffix."""
+        sensor = self.make_sensor()
+        sensor.model_unique_id = "model.jaffle_shop.stg_orders.v1"
+        ti = MagicMock()
+        ti.task.dag.get_task.return_value.add_cmd_flags.return_value = []
+        context = self.make_context(ti)
+        sensor.build_and_run_cmd = MagicMock()
+
+        sensor._fallback_to_non_watcher_run(2, context)
+
+        kwargs = sensor.build_and_run_cmd.call_args.kwargs
+        assert kwargs["cmd_flags"] == ["--select", "stg_orders.v1"]
 
     def test_filter_flags(self):
         flags = ["--select", "model", "--exclude", "other", "--threads", "2"]


### PR DESCRIPTION
## Summary

- `BaseConsumerSensor._fallback_to_non_watcher_run` used `model_unique_id.split(".")[-1]` to build the dbt `--select` value, which strips the version segment for versioned models (e.g. `model.pkg.my_model.v1` became `v1`).
- Switched to `split(".", 2)[2]`, matching `DbtNode.resource_name` in `cosmos/dbt/graph.py` — the canonical parsing used throughout Cosmos for dbt unique_ids (per the [dbt manifest spec](https://docs.getdbt.com/reference/artifacts/manifest-json#resource-details), `resource_type` and `package` cannot contain dots, so everything after the second dot is the full resource name including any version suffix).
- Added a regression test (`test_fallback_selector_preserves_version_suffix`) covering a versioned `unique_id`.

Surfaced by Copilot review on #2658.

🤖 Generated with [Claude Code](https://claude.com/claude-code)