### PR TITLE
Defer TaskInstance import in cluster policy to fix sentry init crash

### DIFF
--- a/cosmos/plugin/cluster_policy.py
+++ b/cosmos/plugin/cluster_policy.py
@@ -1,10 +1,15 @@
-from logging import getLogger
+from __future__ import annotations
 
-from airflow.models.taskinstance import TaskInstance
+from logging import getLogger
+from typing import TYPE_CHECKING
+
 from airflow.policies import hookimpl
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION
+
+if TYPE_CHECKING:
+    from airflow.models.taskinstance import TaskInstance
 
 log = getLogger(__name__)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -167,6 +167,10 @@ dependencies = [
     "types-python-dateutil",
     "Werkzeug<3.0.0",
     "pytest-asyncio",
+    # Needed by the regression test for issue #2620: the test exercises
+    # airflow.sentry's module-level ConfiguredSentry() path, which only
+    # runs when sentry_sdk is importable.
+    "sentry-sdk",
 ]
 pre-install-commands = ["sh scripts/test/pre-install-airflow.sh {matrix:airflow} {matrix:python}"]
 

--- a/tests/plugin/test_cluster_policy.py
+++ b/tests/plugin/test_cluster_policy.py
@@ -1,3 +1,6 @@
+import os
+import subprocess
+import sys
 from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
@@ -243,3 +246,59 @@ class TestTaskInstanceMutationHook:
         task_instance_mutation_hook(task_instance)
 
         assert task_instance.queue == "retry_queue"
+
+
+def test_cluster_policy_load_does_not_break_airflow_sentry_init(tmp_path):
+    """Regression test for issue #2620.
+
+    Reproduces the user-reported failure: when Airflow is configured with
+    ``[sentry] sentry_on = True`` and ``[sentry] before_send`` pointing at a
+    module that lives in the user's DAGs folder (i.e., not on ``sys.path``
+    yet when Airflow's ``settings.initialize()`` loads policy entry points),
+    the ``cosmos.plugin.cluster_policy`` entry point load triggers
+    ``AirflowConfigException: ... key "before_send" in "sentry" section.``
+    and the ``airflow`` CLI dies on startup.
+
+    The chain is::
+
+        airflow.settings.initialize()
+          -> load_policy_plugins("airflow.policy")
+            -> ep.load() -> cosmos.plugin.cluster_policy
+              -> from airflow.models.taskinstance import TaskInstance
+                -> from airflow.sentry import Sentry
+                  -> Sentry = ConfiguredSentry()
+                    -> conf.getimport("sentry", "before_send")
+                      -> importlib.import_module(<user-dags-module>) FAILS
+
+    The fix is to keep ``TaskInstance`` as a type-only import in
+    ``cosmos/plugin/cluster_policy.py`` (under ``if TYPE_CHECKING``) so the
+    above chain never runs at plugin-load time.
+
+    Runs in a fresh subprocess with the user's exact ``[sentry]`` config
+    supplied via env vars; expects ``import cosmos.plugin.cluster_policy``
+    to succeed.
+    """
+    code = "import cosmos.plugin.cluster_policy  # noqa: F401\n" "print('OK')\n"
+    env = {
+        **os.environ,
+        "AIRFLOW_HOME": str(tmp_path),
+        # User's scenario: sentry is on and before_send points at a module
+        # that is not importable at plugin-load time.
+        "AIRFLOW__SENTRY__SENTRY_ON": "True",
+        "AIRFLOW__SENTRY__BEFORE_SEND": "cosmos_2620_dags_folder_module.before_send",
+    }
+    result = subprocess.run(
+        [sys.executable, "-c", code],
+        capture_output=True,
+        text=True,
+        env=env,
+    )
+    assert result.returncode == 0 and "OK" in result.stdout, (
+        "Issue #2620 reproduced: importing cosmos.plugin.cluster_policy with "
+        "[sentry] before_send pointing at a not-yet-importable module "
+        "transitively loaded airflow.sentry and raised AirflowConfigException "
+        "at plugin-load time.\n"
+        f"returncode: {result.returncode}\n"
+        f"stdout: {result.stdout}\n"
+        f"stderr: {result.stderr}"
+    )

--- a/tests/plugin/test_cluster_policy.py
+++ b/tests/plugin/test_cluster_policy.py
@@ -249,34 +249,10 @@ class TestTaskInstanceMutationHook:
 
 
 def test_cluster_policy_load_does_not_break_airflow_sentry_init(tmp_path):
-    """Regression test for issue #2620.
-
-    Reproduces the user-reported failure: when Airflow is configured with
-    ``[sentry] sentry_on = True`` and ``[sentry] before_send`` pointing at a
-    module that lives in the user's DAGs folder (i.e., not on ``sys.path``
-    yet when Airflow's ``settings.initialize()`` loads policy entry points),
-    the ``cosmos.plugin.cluster_policy`` entry point load triggers
-    ``AirflowConfigException: ... key "before_send" in "sentry" section.``
-    and the ``airflow`` CLI dies on startup.
-
-    The chain is::
-
-        airflow.settings.initialize()
-          -> load_policy_plugins("airflow.policy")
-            -> ep.load() -> cosmos.plugin.cluster_policy
-              -> from airflow.models.taskinstance import TaskInstance
-                -> from airflow.sentry import Sentry
-                  -> Sentry = ConfiguredSentry()
-                    -> conf.getimport("sentry", "before_send")
-                      -> importlib.import_module(<user-dags-module>) FAILS
-
-    The fix is to keep ``TaskInstance`` as a type-only import in
-    ``cosmos/plugin/cluster_policy.py`` (under ``if TYPE_CHECKING``) so the
-    above chain never runs at plugin-load time.
-
-    Runs in a fresh subprocess with the user's exact ``[sentry]`` config
-    supplied via env vars; expects ``import cosmos.plugin.cluster_policy``
-    to succeed.
+    """Regression for #2620: importing cosmos.plugin.cluster_policy must not
+    transitively load airflow.sentry. If it does, [sentry] before_send is
+    evaluated before the DAGs folder is on sys.path and Airflow startup
+    fails with AirflowConfigException.
     """
     code = "import cosmos.plugin.cluster_policy  # noqa: F401\n" "print('OK')\n"
     env = {


### PR DESCRIPTION
## Summary

Cosmos 1.14 registers `cosmos.plugin.cluster_policy` as an `airflow.policy` entry point. Airflow loads policy entry points from `airflow.settings.initialize()` — very early in startup, *before* the DAGs folder is on `sys.path`. The module currently does a top-level `from airflow.models.taskinstance import TaskInstance` purely for type annotations. That import transitively pulls in `airflow.sentry`, whose module body runs `ConfiguredSentry()` and evaluates `[sentry] before_send` via `importlib.import_module`. Users whose `before_send` lives in their DAGs folder (the standard pattern) crash on `airflow` CLI startup with:

```
airflow.exceptions.AirflowConfigException: The object could not be loaded.
Please check "before_send" key in "sentry" section.
Current value: "sentry.before_send".
```

Move the `TaskInstance` import under `TYPE_CHECKING` and add `from __future__ import annotations` so the existing `task_instance: TaskInstance` annotations continue to type-check while the import chain no longer runs at plugin-load time.

The chain that triggers the bug:
```
airflow.settings.initialize()
  -> load_policy_plugins("airflow.policy")
    -> ep.load() -> cosmos.plugin.cluster_policy
      -> from airflow.models.taskinstance import TaskInstance
        -> from airflow.sentry import Sentry
          -> Sentry = ConfiguredSentry()
            -> conf.getimport("sentry", "before_send")  # FAILS
```

Closes #2620
Related: #2293 (added the cluster policy)

## Test plan

- [x] Added subprocess-based regression test `test_cluster_policy_load_does_not_break_airflow_sentry_init` that reproduces the user's exact `AirflowConfigException` verbatim on pre-fix code, by setting `AIRFLOW__SENTRY__SENTRY_ON=True` and `AIRFLOW__SENTRY__BEFORE_SEND=<not-yet-importable.path>` and importing `cosmos.plugin.cluster_policy`.
- [x] Verified the test **fails** on current main with the exact `AirflowConfigException: ... key "before_send" in "sentry" section.` from issue #2620 (same traceback chain).
- [x] Verified the test **passes** after the fix.
- [x] All 27 tests in `tests/plugin/test_cluster_policy.py` pass (1 new + 26 existing).
- [x] Added `sentry-sdk` to the hatch `tests` env dependencies — `airflow.sentry`'s `ConfiguredSentry()` only runs when `sentry_sdk` is importable, so the regression test needs it (mirrors the user's environment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)