### PR TITLE
Normalize heading underlines in docs/reference/

### DIFF
--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -1,7 +1,7 @@
 .. _cosmos-config:
 
 Cosmos Config
--------------
+=============
 
 This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ configurations that affect Astronomer Cosmos behavior. They can be set in the ``airflow.cfg`` file or using environment variables.
 
@@ -14,7 +14,7 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 - [openlineage]
 
 [cosmos]
-++++++++
+~~~~~~~~
 
 .. _cache_dir:
 
@@ -378,7 +378,7 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
     - Environment Variable: ``AIRFLOW__COSMOS__WATCHER_DBT_EXECUTION_QUEUE``
 
 [openlineage]
-+++++++++++++
+~~~~~~~~~~~~~
 
 .. _namespace:
 
@@ -392,7 +392,7 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
     For more information, see `OpenLineage Configuration Options <https://airflow.apache.org/docs/apache-airflow-providers-openlineage/stable/guides/user.html>`_.
 
 Environment Variables
-+++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~
 
 .. _LINEAGE_NAMESPACE:
 

--- a/docs/reference/configs/execution-config.rst
+++ b/docs/reference/configs/execution-config.rst
@@ -1,7 +1,7 @@
 .. _execution-config:
 
 Execution Config
-----------------
+================
 
 Cosmos aims to give you control over how your dbt project is executed when running in airflow.
 It does this by exposing a ``cosmos.config.ExecutionConfig`` class that you can use to configure how your DAGs are executed.

--- a/docs/reference/configs/profile-config.rst
+++ b/docs/reference/configs/profile-config.rst
@@ -1,7 +1,7 @@
 .. _profile-config:
 
 Profile Config
---------------
+==============
 
 Cosmos supports two methods of authenticating with your database:
 

--- a/docs/reference/configs/project-config.rst
+++ b/docs/reference/configs/project-config.rst
@@ -1,7 +1,7 @@
 .. _project-config:
 
 Project config
---------------
+==============
 
 The ``cosmos.config.ProjectConfig`` allows you to specify information about where your dbt project is located and project
 variables that should be used for rendering and execution. It takes the following arguments:
@@ -29,7 +29,7 @@ variables that should be used for rendering and execution. It takes the followin
   execution modes. Due to the way that dbt `partial parsing works <https://docs.getdbt.com/reference/parsing#known-limitations>`_, it does not work with Cosmos profile mapping classes. To benefit from this feature, users have to set the ``profiles_yml_filepath`` argument in ``ProfileConfig``.
 
 Project config example
-++++++++++++++++++++++
+~~~~~~~~~~~~~~~~~~~~~~
 
 .. code-block:: python
 

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -40,7 +40,7 @@ There are different configurations and profiles that you can use to configure ho
 - `ProjectConfig <configs/project-config.html>`_: The ``ProjectConfig`` contains information about which dbt project a Cosmos Dag or task group is going to execute, as well as configurations that apply to both rendering and execution.
 - `ExecutionConfig <configs/execution-config.html>`_: The ``ExecutionConfig`` determines where and how the dbt commands are run within Cosmos.
 - `CosmosConfig <configs/cosmos-conf.html>`_: This page lists available `Apache Airflow® <https://airflow.apache.org/>`_ configurations that affect ``astronomer-cosmos`` behavior. You can set them in the ``airflow.cfg`` file or using environment variables.
-- `ProfileConfig <configs/profiles-config.html>`_: The ``ProfileConfig`` class determines which data warehouse Cosmos connects to when it executes the dbt SQL. These docs include reference documentation for connecting to popular data warehouses you might use in your dbt code.
+- `ProfileConfig <configs/profile-config.html>`_: The ``ProfileConfig`` class determines which data warehouse Cosmos connects to when it executes the dbt SQL. These docs include reference documentation for connecting to popular data warehouses you might use in your dbt code.
 
 Profiles
 ~~~~~~~~

--- a/docs/reference/index.rst
+++ b/docs/reference/index.rst
@@ -1,5 +1,5 @@
 Reference
----------
+=========
 
 .. toctree::
    :maxdepth: 0
@@ -33,7 +33,7 @@ Reference
 
 
 Configurations
-++++++++++++++
+~~~~~~~~~~~~~~
 
 There are different configurations and profiles that you can use to configure how Cosmos works.
 
@@ -43,7 +43,7 @@ There are different configurations and profiles that you can use to configure ho
 - `ProfileConfig <configs/profiles-config.html>`_: The ``ProfileConfig`` class determines which data warehouse Cosmos connects to when it executes the dbt SQL. These docs include reference documentation for connecting to popular data warehouses you might use in your dbt code.
 
 Profiles
-++++++++
+~~~~~~~~
 
 The **Profiles** reference provides information about the different kinds of profile mappings available in Cosmos. These profile mappings are Airflow operators that map Airflow connections to dbt profiles, allowing you to work with resources in your data warehouses.
 

--- a/docs/reference/templates/profile_mapping.rst.jinja2
+++ b/docs/reference/templates/profile_mapping.rst.jinja2
@@ -57,7 +57,7 @@ Some notes about the table above:
 {% if profile_defaults %}
 
 Default values
---------------
+~~~~~~~~~~~~~~
 
 This profile mapping sets the following default values. These can be overridden by passing
 them in ``profile_args``.


### PR DESCRIPTION
## Description

Per the lightweight style guide proposed in #2460, RST heading underlines
should follow the canonical hierarchy:

- Page title: `=`
- H1: `~`
- H2: `+`
- H3: `^`

The pages under `docs/reference/` used a mix of `-`/`+` for those levels.
Remap them positionally per file (first level encountered becomes `=`,
second becomes `~`, etc.) so the rendered hierarchy matches the convention.
Underline lengths and heading text are unchanged; only the underline
character is swapped.

Scope of this PR:

- `docs/reference/configs/` — `cosmos-conf.rst`, `execution-config.rst`,
  `profile-config.rst`, `project-config.rst`.
- `docs/reference/index.rst` — page title and the two H1 sections.
- `docs/reference/templates/profile_mapping.rst.jinja2` — the "Default
  values" subheading, so the generated profile pages (Snowflake variants,
  etc.) emit the canonical H1 underline. `docs/reference/profiles/*.rst`
  is gitignored and regenerated from this template at docs build time.

`docs/reference/glossary.rst` and the "Profile mapping reference" title
in `templates/index.rst.jinja2` already use `=`, so they are unchanged.

Continues the underline-normalization work from #2641 (`getting_started/`),
#2655 (`optimize_performance/`), and #2656 (`policy/`).

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation only.