### PR TITLE
Document the docs style guide in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ Always run `hatch run docs:build` before committing any change that touches `doc
 
 When writing or editing files under `docs/`, follow the Cosmos lightweight style rules in this section:
 
-- **Heading underlines** use this canonical hierarchy per file: page title `=`, H1 `~`, H2 `+`, H3 `^`. The remap is positional per file (first level encountered becomes `=`, second `~`, etc.). Underline length must match the title's character length (UTF-8 byte length matters for non-ASCII titles).
+- **Heading underlines** use this canonical hierarchy per file: page title `=`, H1 `~`, H2 `+`, H3 `^`. The remap is positional per file (first level encountered becomes `=`, second `~`, etc.). Underline length must be at least the title's UTF-8 byte length.
 - **Headings** use sentence case (e.g., "Choose an execution mode"), not Title Case.
 - **Bullet points** use `-`, not `*` or `+`.
 - **Decorative separator lines** (e.g., `-----` or `=====` not attached to a heading) should not be added.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,19 @@ hatch run docs:serve-no-reload    # static build served on http://127.0.0.1:8000
 
 Always run `hatch run docs:build` before committing any change that touches `docs/`, and verify the build succeeds without warnings or errors.
 
+### Documentation Style
+
+When writing or editing files under `docs/`, follow the Cosmos lightweight style guide (proposed in #2460):
+
+- **Heading underlines** use this canonical hierarchy per file: page title `=`, H1 `~`, H2 `+`, H3 `^`. The remap is positional per file (first level encountered becomes `=`, second `~`, etc.). Underline length must match the title's character length (UTF-8 byte length matters for non-ASCII titles).
+- **Headings** use sentence case (e.g., "Choose an execution mode"), not Title Case.
+- **Bullet points** use `-`, not `*` or `+`.
+- **Decorative separator lines** (e.g., `-----` or `=====` not attached to a heading) should not be added.
+- **Apache Airflow trademark**: linked full form on the first prominent prose mention per page (`` `Apache Airflow® <https://airflow.apache.org/>`_ ``); plain `Apache Airflow®` in headings; subsequent prose mentions are bare "Airflow".
+- **DAG identifier** stays uppercase in code identifiers (`DAG` class, `DAG_FOLDER`, `AIRFLOW__DAG_*`) and in log-line samples that must match the code output (e.g., `cosmos/converter.py:334` emits "for DAG using ...").
+- A subset of these rules is enforced by `scripts/check_docs_style.py` in pre-commit.
+- Per-profile pages under `docs/reference/profiles/` are auto-generated from `docs/reference/templates/profile_mapping.rst.jinja2` by `docs/generate_mappings.py` at Sphinx build time. The generated `.rst` files are gitignored. Edit the template, not the generated files.
+
 ### Linting and Formatting
 
 Pre-commit runs the configured linters/formatters (e.g., Black (formatter), Ruff (linter), mypy, codespell). See `.pre-commit-config.yaml` for the full list:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,7 +53,7 @@ When writing or editing files under `docs/`, follow the Cosmos lightweight style
 - **Bullet points** use `-`, not `*` or `+`.
 - **Decorative separator lines** (e.g., `-----` or `=====` not attached to a heading) should not be added.
 - **Apache Airflow trademark**: linked full form on the first prominent prose mention per page (`` `Apache Airflow® <https://airflow.apache.org/>`_ ``); plain `Apache Airflow®` in headings; subsequent prose mentions are bare "Airflow".
-- **DAG identifier** stays uppercase in code identifiers (`DAG` class, `DAG_FOLDER`, `AIRFLOW__DAG_*`) and in log-line samples that must match the code output (e.g., `cosmos/converter.py:334` emits "for DAG using ...").
+- **DAG identifier** stays uppercase in code identifiers (`DAG` class, `DAG_FOLDER`, `AIRFLOW__DAG_*`) and in log-line samples that must match the code output (e.g., the `cosmos/converter.py` log message "for DAG using ...").
 - A subset of these rules is enforced by `scripts/check_docs_style.py` in pre-commit.
 - Per-profile pages under `docs/reference/profiles/` are auto-generated from `docs/reference/templates/profile_mapping.rst.jinja2` by `docs/generate_mappings.py` at Sphinx build time. The generated `.rst` files are gitignored. Edit the template, not the generated files.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,7 @@ Always run `hatch run docs:build` before committing any change that touches `doc
 
 ### Documentation Style
 
-When writing or editing files under `docs/`, follow the Cosmos lightweight style guide (proposed in #2460):
+When writing or editing files under `docs/`, follow the Cosmos lightweight style rules in this section:
 
 - **Heading underlines** use this canonical hierarchy per file: page title `=`, H1 `~`, H2 `+`, H3 `^`. The remap is positional per file (first level encountered becomes `=`, second `~`, etc.). Underline length must match the title's character length (UTF-8 byte length matters for non-ASCII titles).
 - **Headings** use sentence case (e.g., "Choose an execution mode"), not Title Case.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,7 +52,6 @@ When writing or editing files under `docs/`, follow the Cosmos lightweight style
 - **Headings** use sentence case (e.g., "Choose an execution mode"), not Title Case.
 - **Bullet points** use `-`, not `*` or `+`.
 - **Decorative separator lines** (e.g., `-----` or `=====` not attached to a heading) should not be added.
-- **Apache Airflow trademark**: linked full form on the first prominent prose mention per page (`` `Apache Airflow® <https://airflow.apache.org/>`_ ``); plain `Apache Airflow®` in headings; subsequent prose mentions are bare "Airflow".
 - **DAG identifier** stays uppercase in code identifiers (`DAG` class, `DAG_FOLDER`, `AIRFLOW__DAG_*`) and in log-line samples that must match the code output (e.g., the `cosmos/converter.py` log message "for DAG using ...").
 - A subset of these rules is enforced by `scripts/check_docs_style.py` in pre-commit.
 - Per-profile pages under `docs/reference/profiles/` are auto-generated from `docs/reference/templates/profile_mapping.rst.jinja2` by `docs/generate_mappings.py` at Sphinx build time. The generated `.rst` files are gitignored. Edit the template, not the generated files.


### PR DESCRIPTION
## Description

Add a `Documentation Style` subsection to `CLAUDE.md` so future
contributors (and Claude Code sessions), writing or editing docs follow
the same lightweight style guide that the recent underline-character,
bullet, separator-line, sentence-case, and trademark passes have been
applying.

The rules captured:

- Heading underline canonical hierarchy (`=`, `~`, `+`, `^`) and the
  positional per-file remap rule.
- Sentence-case section headings.
- Bullet character is `-`.
- No decorative separator lines.
- `DAG` identifier casing.
- Pointer to `scripts/check_docs_style.py` for the pre-commit subset.
- Note that `docs/reference/profiles/*.rst` is auto-generated from
  `docs/reference/templates/profile_mapping.rst.jinja2` and gitignored,
  so the template (not the generated files) is the edit target.

## Related Issue(s)

Refs #2460

## Breaking Change?

No. Documentation/CLAUDE.md only.