### PR TITLE
Export Clickhouse and encrypted Snowflake mappings from cosmos.profiles

### DIFF
--- a/cosmos/profiles/__init__.py
+++ b/cosmos/profiles/__init__.py
@@ -83,6 +83,7 @@ def get_automatic_profile_mapping(
 __all__ = [
     "AthenaAccessKeyProfileMapping",
     "BaseProfileMapping",
+    "ClickhouseUserPasswordProfileMapping",
     "GoogleCloudServiceAccountFileProfileMapping",
     "GoogleCloudServiceAccountDictProfileMapping",
     "GoogleCloudOauthProfileMapping",
@@ -98,6 +99,7 @@ __all__ = [
     "SnowflakePrivateKeyPemProfileMapping",
     "SnowflakePrivateKeyFilePemProfileMapping",
     "SnowflakeEncryptedPrivateKeyFilePemProfileMapping",
+    "SnowflakeEncryptedPrivateKeyPemProfileMapping",
     "StarrocksUserPasswordProfileMapping",
     "SparkThriftProfileMapping",
     "ExasolUserPasswordProfileMapping",


### PR DESCRIPTION
ClickhouseUserPasswordProfileMapping and SnowflakeEncryptedPrivateKeyPemProfileMapping were imported at the module level and registered in profile_mappings, but missing from` __all__.` As a result, "from cosmos.profiles import *" did not pick them up