### PR TITLE
Use `cosmos.log.get_logger` consistently

### DIFF
--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 import re
 from typing import TYPE_CHECKING
 
@@ -11,6 +10,9 @@ if TYPE_CHECKING:
 
 from cosmos import __version__ as cosmos_version  # type: ignore[attr-defined]
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
+from cosmos.log import get_logger
+
+logger = get_logger(__name__)
 
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"
@@ -37,7 +39,7 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
         try:
             num = int(output.split(f"{DBT_WARN_MSG}=")[1].split()[0])
         except ValueError:
-            logging.error(
+            logger.error(
                 f"Could not parse number of {DBT_WARN_MSG}s. Check your dbt/airflow version or if --quiet is not being used"
             )
     return num

--- a/cosmos/operators/_asynchronous/base.py
+++ b/cosmos/operators/_asynchronous/base.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import logging
 from typing import Any
 
 from cosmos._utils.importer import load_method_from_module
@@ -8,8 +7,6 @@ from cosmos.airflow.graph import _snake_case_to_camelcase
 from cosmos.config import ProfileConfig
 from cosmos.constants import ExecutionMode
 from cosmos.operators.local import DbtRunLocalOperator
-
-log = logging.getLogger(__name__)
 
 
 def _create_async_operator_class(profile_type: str, dbt_class: str) -> Any:

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import html
 import json
-import logging
 import os
 import os.path as op
 from collections.abc import Generator
@@ -26,8 +25,11 @@ from packaging.version import Version
 from cosmos import telemetry
 from cosmos.constants import AIRFLOW_OBJECT_STORAGE_PATH_URL_SCHEMES
 from cosmos.listeners import dag_run_listener, task_instance_listener
+from cosmos.log import get_logger
 from cosmos.plugin.snippets import IFRAME_SCRIPT
 from cosmos.plugin.storage import get_storage_type_from_path
+
+logger = get_logger(__name__)
 
 # Airflow version gating: External views feature for the plugins used here (CosmosAF3Plugin) exist only in >= 3.1
 # Note: We compute AIRFLOW_VERSION locally here (not from constants) so that tests can patch airflow.__version__ and reload this module
@@ -111,7 +113,7 @@ def _load_projects_from_conf() -> dict[str, dict[str, str | None]]:
         try:
             parsed = json.loads(projects_raw)
         except json.JSONDecodeError:
-            logging.exception("Invalid JSON in [cosmos] dbt_docs_projects: %s", projects_raw)
+            logger.exception("Invalid JSON in [cosmos] dbt_docs_projects: %s", projects_raw)
             raise
 
         if isinstance(parsed, dict):
@@ -193,7 +195,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                     status_code=404,
                 )
             except (OSError, ValueError, RuntimeError, TimeoutError, PermissionError):
-                logging.exception(
+                logger.exception(
                     f"Cosmos dbt docs error: index read failed for slug={slug_alias}, path={op.join(docs_dir_local, index_local)}, conn_id={conn_id_local}"
                 )
                 return HTMLResponse(
@@ -226,7 +228,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                     status_code=404,
                 )
             except (OSError, ValueError, RuntimeError, TimeoutError, PermissionError) as e:
-                logging.exception(
+                logger.exception(
                     f"Error reading manifest for slug '{slug_alias}', path '{op.join(docs_dir_local, 'manifest.json')}', conn_id '{conn_id_local}': {e}"
                 )
                 return JSONResponse(
@@ -260,7 +262,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
                     status_code=404,
                 )
             except (OSError, ValueError, RuntimeError, TimeoutError, PermissionError) as e:
-                logging.exception(
+                logger.exception(
                     f"Error reading catalog for slug '{slug_alias}', path '{op.join(docs_dir_local, 'catalog.json')}', conn_id '{conn_id_local}': {e}"
                 )
                 return JSONResponse(

--- a/cosmos/profiles/snowflake/user_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_privatekey_file.py
@@ -2,12 +2,12 @@
 
 from __future__ import annotations
 
-import logging
 from typing import Any
 
+from cosmos.log import get_logger
 from cosmos.profiles.snowflake.base import SnowflakeBaseProfileMapping
 
-logger = logging.getLogger(__name__)
+logger = get_logger(__name__)
 
 
 class SnowflakePrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapping):


### PR DESCRIPTION
The rest of the codebase (31 modules) instantiates loggers via cosmos.log.get_logger so messages carry the (astronomer-cosmos) prefix when rich_logging is enabled. A few outliers still used the stdlib logger directly, breaking that branding and bypassing scoped log-level configuration:

- cosmos/operators/_asynchronous/base.py: dropped an unused `log = logging.getLogger(__name__)` (no callers in-module or via imports).
- cosmos/profiles/snowflake/user_privatekey_file.py: switched `logger` to get_logger; it is used for the passphrase warning.
- cosmos/dbt/parser/output.py: replaced a module-level `logging.error(...)` call (which hit the root logger) with a proper `logger.error(...)` via a module-level get_logger instance.
- cosmos/plugin/airflow3.py: replaced four module-level `logging.exception(...)` root-logger calls similarly.

closes: https://github.com/astronomer/astronomer-cosmos/issues/1157
