### PR TITLE
Promote inline watcher status collections to named constants

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -178,6 +178,8 @@ SUPPORTED_BUILD_RESOURCES = [
 # https://docs.getdbt.com/reference/commands/test
 TESTABLE_DBT_RESOURCES = {DbtResourceType.MODEL, DbtResourceType.SOURCE, DbtResourceType.SNAPSHOT, DbtResourceType.SEED}
 
+_DATASET_EMITTING_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
+
 DBT_SETUP_ASYNC_TASK_ID = "dbt_setup_async"
 DBT_TEARDOWN_ASYNC_TASK_ID = "dbt_teardown_async"
 

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -9,7 +9,7 @@ import yaml
 from packaging.version import Version
 
 from cosmos import settings
-from cosmos.constants import AIRFLOW_VERSION
+from cosmos.constants import _DATASET_EMITTING_RESOURCE_TYPES, AIRFLOW_VERSION
 from cosmos.log import get_logger
 
 if TYPE_CHECKING:
@@ -244,8 +244,6 @@ def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict
     :param namespace: The OL-compatible dataset namespace (e.g. ``postgres://host:5432``).
     :returns: Mapping of ``{unique_id: [uri]}`` for model, seed, and snapshot nodes.
     """
-    _RESOURCE_TYPES_WITH_DATASETS = {"model", "seed", "snapshot"}
-
     # The manifest may not exist if dbt failed before completing compilation,
     # or if the temp project directory was cleaned up before this function ran.
     # In those cases we gracefully return an empty dict — consumers simply
@@ -264,7 +262,7 @@ def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict
     result: dict[str, list[str]] = {}
     for unique_id, node in manifest.get("nodes", {}).items():
         resource_type = node.get("resource_type", "")
-        if resource_type not in _RESOURCE_TYPES_WITH_DATASETS:
+        if resource_type not in _DATASET_EMITTING_RESOURCE_TYPES:
             continue
 
         database = node.get("database", "")

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -21,6 +21,7 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
 from cosmos.operators._watcher.state import (
+    DATASET_EMITTING_RESOURCE_TYPES,
     _iso_to_string,
     _log_dbt_event,
     build_producer_state_fetcher,
@@ -320,7 +321,7 @@ def store_dbt_resource_status_from_log(
                 # Lazily populate per-model outlet URIs from the manifest, but only for
                 # resource types that can emit datasets (models/seeds/snapshots).
                 outlet_uris: list[str] = []
-                if dbt_node_resource_type in {"model", "seed", "snapshot"}:
+                if dbt_node_resource_type in DATASET_EMITTING_RESOURCE_TYPES:
                     project_dir = extra_kwargs.get("project_dir")
                     _ensure_subprocess_model_outlet_uris(model_outlet_uris, dataset_namespace, project_dir)
                     outlet_uris = model_outlet_uris.get(unique_id, []) if model_outlet_uris else []

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -11,6 +11,7 @@ from airflow.exceptions import AirflowException, AirflowSkipException
 from cosmos import settings
 from cosmos.config import ProfileConfig
 from cosmos.constants import (
+    _DATASET_EMITTING_RESOURCE_TYPES,
     _DBT_STARTUP_EVENTS_XCOM_KEY,
     AIRFLOW_VERSION,
     CONSUMER_WATCHER_DEFAULT_PRIORITY_WEIGHT,
@@ -21,7 +22,6 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
 from cosmos.operators._watcher.state import (
-    DATASET_EMITTING_RESOURCE_TYPES,
     _iso_to_string,
     _log_dbt_event,
     build_producer_state_fetcher,
@@ -321,7 +321,7 @@ def store_dbt_resource_status_from_log(
                 # Lazily populate per-model outlet URIs from the manifest, but only for
                 # resource types that can emit datasets (models/seeds/snapshots).
                 outlet_uris: list[str] = []
-                if dbt_node_resource_type in DATASET_EMITTING_RESOURCE_TYPES:
+                if dbt_node_resource_type in _DATASET_EMITTING_RESOURCE_TYPES:
                     project_dir = extra_kwargs.get("project_dir")
                     _ensure_subprocess_model_outlet_uris(model_outlet_uris, dataset_namespace, project_dir)
                     outlet_uris = model_outlet_uris.get(unique_id, []) if model_outlet_uris else []

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -25,9 +25,19 @@ DBT_SUCCESS_STATUSES = frozenset({"success", "pass", "warn"})
 DBT_FAILED_STATUSES = frozenset({"failed", "fail", "error", "runtime error"})
 DBT_SKIPPED_STATUSES = frozenset({"skipped"})
 
+# dbt source freshness statuses that mark a source as stale and propagate skips downstream.
+DBT_SOURCE_FRESHNESS_STALE_STATUSES = frozenset({"error", "warn"})
+
+# dbt resource types whose nodes can emit datasets (i.e. produce outputs with outlet URIs).
+DATASET_EMITTING_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
+
 # Airflow task states that indicate the producer has finished and will not deliver any more XCom updates.
 # Used to decide whether a sensor retry should fall back to a non-watcher run or keep polling.
 PRODUCER_TERMINAL_STATES = frozenset({"success", "failed", "skipped", "upstream_failed", "removed"})
+
+# Airflow task states checked by the watcher trigger to know the producer task has reached its
+# final outcome and the trigger can exit early. Subset of PRODUCER_TERMINAL_STATES.
+PRODUCER_FINAL_STATES = frozenset({"failed", "success", "skipped"})
 
 
 class DbtTestStatus(str, Enum):

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -28,9 +28,6 @@ DBT_SKIPPED_STATUSES = frozenset({"skipped"})
 # dbt source freshness statuses that mark a source as stale and propagate skips downstream.
 DBT_SOURCE_FRESHNESS_STALE_STATUSES = frozenset({"error", "warn"})
 
-# dbt resource types whose nodes can emit datasets (i.e. produce outputs with outlet URIs).
-DATASET_EMITTING_RESOURCE_TYPES = frozenset({"model", "seed", "snapshot"})
-
 # Airflow task states that indicate the producer has finished and will not deliver any more XCom updates.
 # Used to decide whether a sensor retry should fall back to a non-watcher run or keep polling.
 PRODUCER_TERMINAL_STATES = frozenset({"success", "failed", "skipped", "upstream_failed", "removed"})

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -13,6 +13,7 @@ from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, AIRFLOW_VERSION
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import (
+    PRODUCER_FINAL_STATES,
     _log_dbt_event,
     build_producer_state_fetcher,
     is_dbt_node_status_failed,
@@ -202,7 +203,7 @@ class WatcherTrigger(BaseTrigger):
             # logging the full list. Also ensures we exit if producer finishes before
             # ever pushing _DBT_STARTUP_EVENTS_XCOM_KEY.
             producer_task_state = await self._get_producer_task_status()
-            if producer_task_state in ("failed", "success", "skipped"):
+            if producer_task_state in PRODUCER_FINAL_STATES:
                 return
 
             # Return if dbt node is in terminal state

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -28,7 +28,7 @@ from cosmos.operators._watcher.base import (
     BaseConsumerSensor,
     store_dbt_resource_status_from_log,
 )
-from cosmos.operators._watcher.state import DBT_SUCCESS_STATUSES
+from cosmos.operators._watcher.state import DBT_SOURCE_FRESHNESS_STALE_STATUSES, DBT_SUCCESS_STATUSES
 from cosmos.operators._watcher.xcom import (
     _backup_xcom_to_variable,
     _delete_xcom_backup_variable,
@@ -83,7 +83,11 @@ def _default_freshness_callback(
     if not nodes or not sources_json:
         return []
 
-    stale_source_ids = {r["unique_id"] for r in sources_json.get("results", []) if r.get("status") in ("error", "warn")}
+    stale_source_ids = {
+        r["unique_id"]
+        for r in sources_json.get("results", [])
+        if r.get("status") in DBT_SOURCE_FRESHNESS_STALE_STATUSES
+    }
     if not stale_source_ids:
         return []
 


### PR DESCRIPTION
Watcher mode already defines frozenset constants for dbt and Airflow state classifications (DBT_SUCCESS_STATUSES, DBT_FAILED_STATUSES, PRODUCER_TERMINAL_STATES, etc.) but a few hot paths still inlined tuples or set literals for the same idea, making the membership checks visually inconsistent and harder to reuse.

Add three named frozensets in cosmos/operators/_watcher/state.py and replace the inline literals at the three call sites:

- DBT_SOURCE_FRESHNESS_STALE_STATUSES = {"error", "warn"} Replaces the tuple at cosmos/operators/watcher.py:86 used to detect stale dbt sources for downstream skip propagation.

- DATASET_EMITTING_RESOURCE_TYPES = {"model", "seed", "snapshot"} Replaces the bare-string set at cosmos/operators/_watcher/base.py where the watcher decides whether to look up outlet URIs from the manifest for a node.

- PRODUCER_FINAL_STATES = {"failed", "success", "skipped"} Replaces the tuple in cosmos/operators/_watcher/triggerer.py used to early-exit the async poll loop when the producer task has finished. Kept as a proper subset of PRODUCER_TERMINAL_STATES to preserve existing behaviour (this commit does not change which states the trigger exits on).

