### PR TITLE
Add dbt 1.10 integration smoke coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -200,6 +200,12 @@ jobs:
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
         dbt-version: [ "1.11" ]
         split-group: [1, 2, 3]
+        include:
+          - python-version: "3.11"
+            airflow-version: "3.0"
+            dbt-version: "1.10"
+            split-group: 1
+            smoke-test: "true"
         exclude:
           # Apache Airflow versions prior to 3.1.0 have not been tested with Python 3.13.
           - python-version: "3.13"
@@ -249,7 +255,11 @@ jobs:
       - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }} (split ${{ matrix.split-group }}/3)
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-setup
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration
+          if [ "${{ matrix.smoke-test }}" = "true" ]; then
+            hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-smoke
+          else
+            hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration
+          fi
         env:
           PYTEST_SPLITS: 3
           PYTEST_SPLIT_GROUP: ${{ matrix.split-group }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -192,6 +192,7 @@ test = 'sh scripts/test/unit.sh'
 test-cov = 'sh scripts/test/unit-cov.sh'
 test-integration-setup = 'sh scripts/test/integration-setup.sh {matrix:dbt}'
 test-integration = 'sh scripts/test/integration.sh'
+test-integration-smoke = 'sh scripts/test/integration-smoke.sh'
 test-kubernetes = "sh scripts/test/integration-kubernetes.sh"
 test-kubernetes-setup = "sh scripts/test/kubernetes-setup.sh {matrix:dbt}"
 test-integration-dbtf-setup = 'sh scripts/test/integration-dbtf-setup.sh'

--- a/scripts/test/integration-smoke.sh
+++ b/scripts/test/integration-smoke.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -x
+set -e
+
+export SOURCE_RENDERING_BEHAVIOR=all
+
+pip freeze | grep airflow
+echo $AIRFLOW_HOME
+ls $AIRFLOW_HOME
+
+airflow db check
+
+pytest -vv \
+    tests/dbt/test_runner.py::test_run_command \
+    -m 'integration and not dbtfusion'


### PR DESCRIPTION
This adds a lightweight dbt 1.10 integration smoke job alongside the existing dbt 1.11 integration matrix. The smoke path reuses the normal setup but runs a single dbt runner integration test, which gives coverage for another supported dbt version without multiplying the full Python, Airflow, and split-group matrix.
