### PR TITLE
Add store-failures to after-all tests

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -217,6 +217,11 @@ def create_test_task_metadata(
         task_args["selector"] = render_config.selector
         task_args["exclude"] = _convert_list_to_str(render_config.exclude)
 
+        dbt_cmd_flags = list(task_args.get("dbt_cmd_flags") or [])
+        if render_config.test_behavior == TestBehavior.AFTER_ALL and "--store-failures" not in dbt_cmd_flags:
+            dbt_cmd_flags.append("--store-failures")
+            task_args["dbt_cmd_flags"] = dbt_cmd_flags
+
     if node:
         exclude_detached_tests_if_needed(node, task_args, detached_from_parent)
         _override_profile_if_needed(task_args, node.profile_config_to_override)

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2181,6 +2181,38 @@ class TestSelectExcludeAsStringsInOperators:
         assert metadata.arguments["exclude"] is None
         assert metadata.arguments["selector"] is None
 
+    def test_create_test_task_metadata_after_all_adds_store_failures(self):
+        """AFTER_ALL test tasks should pass --store-failures to dbt test."""
+        render_config = RenderConfig(
+            test_behavior=TestBehavior.AFTER_ALL,
+        )
+        metadata = create_test_task_metadata(
+            test_task_name="test_all",
+            execution_mode=ExecutionMode.LOCAL,
+            test_indirect_selection=TestIndirectSelection.EAGER,
+            task_args={"project_dir": SAMPLE_PROJ_PATH},
+            render_config=render_config,
+        )
+
+        assert metadata.arguments["dbt_cmd_flags"] == ["--store-failures"]
+
+    def test_create_test_task_metadata_after_all_preserves_existing_dbt_cmd_flags(self):
+        """AFTER_ALL should append --store-failures without dropping caller-supplied dbt flags."""
+        render_config = RenderConfig(
+            test_behavior=TestBehavior.AFTER_ALL,
+        )
+        existing_flags = ["--full-refresh"]
+        metadata = create_test_task_metadata(
+            test_task_name="test_all",
+            execution_mode=ExecutionMode.LOCAL,
+            test_indirect_selection=TestIndirectSelection.EAGER,
+            task_args={"project_dir": SAMPLE_PROJ_PATH, "dbt_cmd_flags": existing_flags},
+            render_config=render_config,
+        )
+
+        assert metadata.arguments["dbt_cmd_flags"] == ["--full-refresh", "--store-failures"]
+        assert existing_flags == ["--full-refresh"]
+
 
 @pytest.mark.parametrize(
     "source_rendering_behavior, expected_flag",


### PR DESCRIPTION
This updates the generated `TestBehavior.AFTER_ALL` dbt test task so it includes `--store-failures` by default while preserving any existing dbt command flags supplied by the caller. I added focused coverage for both the default flag injection and the existing-flags case.

Verification: `python3 -m compileall cosmos/airflow/graph.py tests/airflow/test_graph.py` and `git diff --check` passed. The targeted pytest command could not run in this environment because `hatch` is not installed and the fallback pytest run is missing the Airflow dependency.

Closes #2243
