### PR TITLE
Unify operator logging on self.log

### DIFF
--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:  # pragma: no cover
         from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 from cosmos.config import ProfileConfig
-from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBase,
     DbtBuildMixin,
@@ -23,8 +22,6 @@ from cosmos.operators.base import (
     DbtSourceMixin,
     DbtTestMixin,
 )
-
-logger = get_logger(__name__)
 
 DEFAULT_CONN_ID = "aws_default"
 DEFAULT_CONTAINER_NAME = "dbt"
@@ -129,7 +126,7 @@ class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignor
 
         result = EcsRunTaskOperator.execute(self, context)
 
-        logger.info(result)
+        self.log.info("%s", result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt

--- a/cosmos/operators/gcp_cloud_run_job.py
+++ b/cosmos/operators/gcp_cloud_run_job.py
@@ -11,7 +11,6 @@ if TYPE_CHECKING:  # pragma: no cover
         from airflow.utils.context import Context  # type: ignore[attr-defined]
 
 from cosmos.config import ProfileConfig
-from cosmos.log import get_logger
 from cosmos.operators.base import (
     AbstractDbtBase,
     DbtBuildMixin,
@@ -24,8 +23,6 @@ from cosmos.operators.base import (
     DbtSourceMixin,
     DbtTestMixin,
 )
-
-logger = get_logger(__name__)
 
 DEFAULT_ENVIRONMENT_VARIABLES: dict[str, str] = {}
 
@@ -129,7 +126,7 @@ class DbtGcpCloudRunJobBaseOperator(AbstractDbtBase, CloudRunExecuteJobOperator)
         self.build_command(context, cmd_flags)
         self.log.info(f"Running command: {self.command}")
         result = CloudRunExecuteJobOperator.execute(self, context)
-        logger.info(result)
+        self.log.info("%s", result)
 
     def build_command(self, context: Context, cmd_flags: list[str] | None = None) -> None:
         # For the first round, we're going to assume that the command is dbt

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -19,7 +19,6 @@ from cosmos import settings
 from cosmos.constants import InvocationMode
 from cosmos.exceptions import CosmosValueError
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
-from cosmos.log import get_logger
 from cosmos.operators.local import (
     DbtBuildLocalOperator,
     DbtCloneLocalOperator,
@@ -43,7 +42,6 @@ if TYPE_CHECKING:  # pragma: no cover
 
 PY_INTERPRETER = "python3"
 LOCK_FILENAME = "cosmos_virtualenv.lock"
-logger = get_logger(__name__)
 
 
 def depends_on_virtualenv_dir(method: Callable[[Any], Any]) -> Callable[[Any], Any]:
@@ -130,7 +128,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
         try:
             self.log.info(f"Checking if the virtualenv lock {str(self._lock_file)} exists")
             while not self._is_lock_available() and self.max_retries_lock:
-                logger.info("Waiting for virtualenv lock to be released")
+                self.log.info("Waiting for virtualenv lock to be released")
                 time.sleep(1)
                 self.max_retries_lock -= 1
 


### PR DESCRIPTION
PR #1108 established the convention that operator code uses self.log (Airflow's LoggingMixin) so messages land in the per-task-instance log shown in the Airflow UI, while library code uses cosmos.log.get_logger for branding and scoped log levels. PR #1079 deviated from that convention in three call sites because pytest's caplog could not capture self.log at the time; #1157 was filed to track cleaning up the workaround.

Current pytest/Airflow does capture self.log -- the neighbouring assertions in tests/operators/test_virtualenv.py already match self.log calls in the same file. Convert the three holdover sites to self.log so that:

- aws_ecs.py and gcp_cloud_run_job.py: the ECS/Cloud Run task result is emitted into the same task log as the "Running command" line above it instead of disappearing to worker stdout.
- virtualenv.py: the "Waiting for virtualenv lock" message routes to the task log alongside the other lock messages in the same method.

With the conversion the module-level `logger = get_logger(__name__)` and its import become dead in all three files; drop them.

test_run_command_with_virtualenv_dir, which asserts caplog.text.count("Waiting for virtualenv lock to be released") == 2, still passes after the change, confirming caplog captures self.log here.

closes #1157
