### PR TITLE
Break out of iframe from Airflow 2 dbt Docs 404 link

### DIFF
--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -158,13 +158,16 @@ class DbtDocsView(AirflowBaseView):  # type: ignore
 
     @expose("/dbt_docs_index.html")  # type: ignore[untyped-decorator]
     @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
-    def dbt_docs_index(self) -> tuple[str, int, dict[str, Any]]:
+    def dbt_docs_index(self) -> Any:
+        # The response is rendered inside the dbt_docs.html iframe, so a 404 here is also iframed.
+        # We serve a Cosmos-owned template whose "Return to the main page" link uses target="_top"
+        # to break out of the iframe (Airflow's default 404 link does not).
         if dbt_docs_dir is None:
-            abort(404)
+            return self.render_template("dbt_docs_iframe_404.html"), 404  # type: ignore[no-untyped-call]
         try:
             html = open_file(op.join(dbt_docs_dir, dbt_docs_index_file_name), conn_id=dbt_docs_conn_id)
         except FileNotFoundError:
-            abort(404)
+            return self.render_template("dbt_docs_iframe_404.html"), 404  # type: ignore[no-untyped-call]
         else:
             html = html.replace("</head>", f"{IFRAME_SCRIPT}</head>")
             return html, 200, {"Content-Security-Policy": "frame-ancestors 'self'"}

--- a/cosmos/plugin/templates/dbt_docs_iframe_404.html
+++ b/cosmos/plugin/templates/dbt_docs_iframe_404.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>dbt docs not available</title>
+    <style>
+        body { font-family: sans-serif; margin: 2rem; color: #333; }
+        a { color: #017cee; text-decoration: none; }
+        a:hover { text-decoration: underline; }
+    </style>
+</head>
+<body>
+    <h2>dbt docs are not available</h2>
+    <p>Cosmos could not load the dbt docs index from the configured location.</p>
+    <p><a href="{{ url_for('Airflow.index') }}" target="_top">Return to the main page</a></p>
+</body>
+</html>

--- a/cosmos/plugin/templates/dbt_docs_iframe_404.html
+++ b/cosmos/plugin/templates/dbt_docs_iframe_404.html
@@ -1,17 +1,15 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
-<head>
-    <meta charset="utf-8">
-    <title>dbt docs not available</title>
-    <style>
-        body { font-family: sans-serif; margin: 2rem; color: #333; }
-        a { color: #017cee; text-decoration: none; }
-        a:hover { text-decoration: underline; }
-    </style>
-</head>
-<body>
-    <h2>dbt docs are not available</h2>
-    <p>Cosmos could not load the dbt docs index from the configured location.</p>
-    <p><a href="{{ url_for('Airflow.index') }}" target="_top">Return to the main page</a></p>
-</body>
+  <head>
+    <title>Airflow 404</title>
+    <link rel="icon" type="image/png" href="{{ url_for('static', filename='pin_32.png') }}">
+  </head>
+  <body>
+    <div style="font-family: verdana; text-align: center; margin-top: 200px;">
+      <img src="{{ url_for('static', filename='pin_100.png') }}" width="50px" alt="pin-logo" />
+      <h1>Airflow 404</h1>
+      <p>Cosmos could not load the dbt docs index from the configured location.</p>
+      <a href="{{ url_for('Airflow.index') }}" target="_top">Return to the main page</a>
+    </div>
+  </body>
 </html>

--- a/tests/plugin/test_plugin_af2.py
+++ b/tests/plugin/test_plugin_af2.py
@@ -170,6 +170,22 @@ def test_dbt_docs_artifact_missing(app, artifact):
     assert response.status_code == 404
 
 
+@pytest.mark.integration
+@patch.object(cosmos.plugin.airflow2, "open_file")
+def test_dbt_docs_index_404_breaks_out_of_iframe(mock_open_file, monkeypatch, app):
+    # Regression test for https://github.com/astronomer/astronomer-cosmos/issues/1828:
+    # the dbt_docs_index 404 is rendered inside the dbt_docs iframe, so its
+    # "Return to the main page" link must use target="_top" to break out.
+    monkeypatch.setattr("cosmos.plugin.airflow2.dbt_docs_dir", "path/to/docs/dir")
+    mock_open_file.side_effect = FileNotFoundError
+
+    response = app.get("/cosmos/dbt_docs_index.html")
+
+    assert response.status_code == 404
+    assert 'target="_top"' in response.text
+    assert "Return to the main page" in response.text
+
+
 @pytest.mark.parametrize(
     "path,open_file_callback",
     [


### PR DESCRIPTION
## Summary

- Fix [#1828](https://github.com/astronomer/astronomer-cosmos/issues/1828): when `AIRFLOW__COSMOS__DBT_DOCS_DIR` points at a missing `index.html`, the `dbt_docs_index` endpoint called `abort(404)` and Flask served Airflow's default 404 template inside the `dbt_docs.html` iframe. Its "Return to the main page" anchor has no `target`, so clicking it navigated the iframe to `/home` — leaving the DAGs view nested inside the dbt Docs frame instead of replacing it.
- Serve a small Cosmos-owned `dbt_docs_iframe_404.html` whose home link uses `target="_top"` so the click escapes the iframe. `catalog.json` / `manifest.json` endpoints still use `abort(404)` because they are fetched by the docs JS, not rendered visually.
- Add a regression test asserting the 404 response body contains `target="_top"` and the "Return to the main page" copy.

## Test plan

- [ ] CI integration job passes `tests/plugin/test_plugin_af2.py`, including the new `test_dbt_docs_index_404_breaks_out_of_iframe`.
- [ ] Manual repro per the issue: set `AIRFLOW__COSMOS__DBT_DOCS_DIR` to a non-existent path, open **Browse → dbt Docs**, click "Return to the main page" → top window navigates to `/home` (no nested DAGs view inside the iframe).

Demo

https://github.com/user-attachments/assets/c242f4bc-9f0e-498d-842c-9c3f53ac5140



🤖 Generated with [Claude Code](https://claude.com/claude-code)