### PR TITLE
Fix altered_jaffle_shop seed-dep CTE refs

### DIFF
--- a/dev/dags/dbt/altered_jaffle_shop/models/staging/stg_orders.sql
+++ b/dev/dags/dbt/altered_jaffle_shop/models/staging/stg_orders.sql
@@ -12,7 +12,7 @@ force_seed_dep as (
     {#-
     This CTE is used to ensure tests wait for seeds to run if source_node_rendering = none
     #}
-    select * from {{ ref('raw_customers') }}
+    select * from {{ ref('raw_orders') }}
 ),
 
 renamed as (

--- a/dev/dags/dbt/altered_jaffle_shop/models/staging/stg_payments.sql
+++ b/dev/dags/dbt/altered_jaffle_shop/models/staging/stg_payments.sql
@@ -8,7 +8,7 @@ force_seed_dep as (
     {#-
     This CTE is used to ensure tests wait for seeds to run if source_node_rendering = none
     #}
-    select * from {{ ref('raw_customers') }}
+    select * from {{ ref('raw_payments') }}
 ),
 
 renamed as (


### PR DESCRIPTION
## Summary

- `stg_orders.sql` and `stg_payments.sql` in `altered_jaffle_shop` had a `force_seed_dep` CTE that referenced `ref('raw_customers')` instead of the corresponding `raw_orders` / `raw_payments` seeds — a copy-paste leftover from #1107. The CTE exists to keep tests waiting for the correct seed when `source_node_rendering = none`, so referencing the wrong seed defeated its purpose.
- #1374 fixed this exact issue in `jaffle_shop` but missed `altered_jaffle_shop`.
- The committed `target/manifest.json` snapshot already reflects the correct edges (regenerated in #2296), so only the two SQL files needed updating. The `cosmos_manifest_selectors_example.py` DAG that explicitly lists `raw_orders` / `raw_payments` in its `select=` workaround is now arguably redundant, but harmless — left as-is.

Closes #2599

## Test plan

- [x] 1513 non-integration unit tests pass under `hatch run tests.py3.11-2.10-1.9:test` (including `test_load_via_load_via_custom_parser`, `test_load_via_dbt_ls_with_selector_arg`, `test_load_via_dbt_ls_with_exclude`, and `test_create_symlinks`)
- [ ] Integration tests (require Postgres) — to verify on CI
- [ ] Manual run of `cosmos_manifest_selectors_example` example DAG

🤖 Generated with [Claude Code](https://claude.com/claude-code)