### PR TITLE
Update dbt and Airflow Spark URLs in profile mapping docstrings

### DIFF
--- a/cosmos/profiles/athena/access_key.py
+++ b/cosmos/profiles/athena/access_key.py
@@ -24,7 +24,7 @@ class AthenaAccessKeyProfileMapping(BaseProfileMapping):
     Information about the dbt Athena profile that is generated can be found here:
 
     https://github.com/dbt-athena/dbt-athena?tab=readme-ov-file#configuring-your-profile
-    https://docs.getdbt.com/docs/core/connect-data-platform/athena-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/athena-setup
     """
 
     airflow_connection_type: str = "aws"

--- a/cosmos/profiles/bigquery/oauth.py
+++ b/cosmos/profiles/bigquery/oauth.py
@@ -12,7 +12,7 @@ class GoogleCloudOauthProfileMapping(BaseProfileMapping):
     Maps Airflow GCP connections to dbt BigQuery profiles that uses oauth via gcloud,
     if they don't use key file or JSON.
 
-    https://docs.getdbt.com/docs/core/connect-data-platform/bigquery-setup#oauth-via-gcloud
+    https://docs.getdbt.com/docs/local/connect-data-platform/bigquery-setup
     https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
     """
 

--- a/cosmos/profiles/bigquery/service_account_file.py
+++ b/cosmos/profiles/bigquery/service_account_file.py
@@ -11,7 +11,7 @@ class GoogleCloudServiceAccountFileProfileMapping(BaseProfileMapping):
     """
     Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account file.
 
-    https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup#service-account-file
+    https://docs.getdbt.com/docs/local/connect-data-platform/bigquery-setup
     https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
     """
 

--- a/cosmos/profiles/bigquery/service_account_keyfile_dict.py
+++ b/cosmos/profiles/bigquery/service_account_keyfile_dict.py
@@ -13,7 +13,7 @@ class GoogleCloudServiceAccountDictProfileMapping(BaseProfileMapping):
     """
     Maps Airflow GCP connections to dbt BigQuery profiles if they use a service account keyfile dict/json.
 
-    https://docs.getdbt.com/reference/warehouse-setups/bigquery-setup#service-account-file
+    https://docs.getdbt.com/docs/local/connect-data-platform/bigquery-setup
     https://airflow.apache.org/docs/apache-airflow-providers-google/stable/connections/gcp.html
     """
 

--- a/cosmos/profiles/clickhouse/user_pass.py
+++ b/cosmos/profiles/clickhouse/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class ClickhouseUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow generic connections using user + password authentication to dbt Clickhouse profiles.
-    https://docs.getdbt.com/docs/core/connect-data-platform/clickhouse-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/clickhouse-setup
     """
 
     airflow_connection_type: str = "generic"

--- a/cosmos/profiles/databricks/oauth.py
+++ b/cosmos/profiles/databricks/oauth.py
@@ -11,7 +11,7 @@ class DatabricksOauthProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Databricks connections with the client auth to dbt profiles.
 
-    https://docs.getdbt.com/reference/warehouse-setups/databricks-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/databricks-setup
     https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/connections/databricks.html
     """
 

--- a/cosmos/profiles/databricks/token.py
+++ b/cosmos/profiles/databricks/token.py
@@ -11,7 +11,7 @@ class DatabricksTokenProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Databricks connections with a token to dbt profiles.
 
-    https://docs.getdbt.com/reference/warehouse-setups/databricks-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/databricks-setup
     https://airflow.apache.org/docs/apache-airflow-providers-databricks/stable/connections/databricks.html
     """
 

--- a/cosmos/profiles/duckdb/user_pass.py
+++ b/cosmos/profiles/duckdb/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class DuckDBUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow DuckDB connections using local path mapping to dbt profiles.
-    https://docs.getdbt.com/docs/core/connect-data-platform/duckdb-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/duckdb-setup
     https://github.com/astronomer/airflow-provider-duckdb
     """
 

--- a/cosmos/profiles/exasol/user_pass.py
+++ b/cosmos/profiles/exasol/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class ExasolUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Exasol connections with a username and password to dbt profiles.
-    https://docs.getdbt.com/reference/warehouse-setups/exasol-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/exasol-setup
     """
 
     airflow_connection_type: str = "exasol"

--- a/cosmos/profiles/mysql/user_pass.py
+++ b/cosmos/profiles/mysql/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class MysqlUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow MySQL connections using user + password authentication to dbt profiles.
-    https://docs.getdbt.com/reference/warehouse-setups/mysql-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/mysql-setup
     https://airflow.apache.org/docs/apache-airflow-providers-mysql/stable/connections/mysql.html
     """
 

--- a/cosmos/profiles/oracle/user_pass.py
+++ b/cosmos/profiles/oracle/user_pass.py
@@ -11,7 +11,7 @@ from ..base import BaseProfileMapping
 class OracleUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Oracle connections using user + password authentication to dbt profiles.
-    https://docs.getdbt.com/reference/warehouse-setups/oracle-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/oracle-setup
     https://airflow.apache.org/docs/apache-airflow-providers-oracle/stable/connections/oracle.html
     """
 

--- a/cosmos/profiles/postgres/user_pass.py
+++ b/cosmos/profiles/postgres/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class PostgresUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Postgres connections using user + password authentication to dbt profiles.
-    https://docs.getdbt.com/reference/warehouse-setups/postgres-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/postgres-setup
     https://airflow.apache.org/docs/apache-airflow-providers-postgres/stable/connections/postgres.html
     """
 

--- a/cosmos/profiles/redshift/user_pass.py
+++ b/cosmos/profiles/redshift/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class RedshiftUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Redshift connections to dbt Redshift profiles if they use a username and password.
-    https://docs.getdbt.com/reference/warehouse-setups/redshift-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/redshift-setup
     https://airflow.apache.org/docs/apache-airflow-providers-amazon/stable/connections/redshift.html
     """
 

--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SnowflakeEncryptedPrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping):
     """
     Maps Airflow Snowflake connections to dbt profiles if they use a user/private key.
-    https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication
+    https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup
     https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
     """
 

--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SnowflakeEncryptedPrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapping):
     """
     Maps Airflow Snowflake connections to dbt profiles if they use a user/private key path.
-    https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication
+    https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup
     https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
     """
 

--- a/cosmos/profiles/snowflake/user_pass.py
+++ b/cosmos/profiles/snowflake/user_pass.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SnowflakeUserPasswordProfileMapping(SnowflakeBaseProfileMapping):
     """
     Maps Airflow Snowflake connections to dbt profiles if they use a user/password.
-    https://docs.getdbt.com/reference/warehouse-setups/snowflake-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup
     https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
     """
 

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 class SnowflakePrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping):
     """
     Maps Airflow Snowflake connections to dbt profiles if they use a user/private key.
-    https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication
+    https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup
     https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
     """
 

--- a/cosmos/profiles/snowflake/user_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_privatekey_file.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 class SnowflakePrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapping):
     """
     Maps Airflow Snowflake connections to dbt profiles if they use a user/private key path without a passphrase.
-    https://docs.getdbt.com/docs/core/connect-data-platform/snowflake-setup#key-pair-authentication
+    https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup
     https://airflow.apache.org/docs/apache-airflow-providers-snowflake/stable/connections/snowflake.html
     """
 

--- a/cosmos/profiles/spark/thrift.py
+++ b/cosmos/profiles/spark/thrift.py
@@ -10,8 +10,8 @@ from ..base import BaseProfileMapping
 class SparkThriftProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Spark connections to dbt profiles if they use a thrift connection.
-    https://docs.getdbt.com/reference/warehouse-setups/spark-setup#thrift
-    https://airflow.apache.org/docs/apache-airflow-providers-apache-spark/stable/connections/spark.html
+    https://docs.getdbt.com/docs/local/connect-data-platform/spark-setup
+    https://airflow.apache.org/docs/apache-airflow-providers-apache-spark/stable/connections/index.html
     """
 
     airflow_connection_type: str = "spark"

--- a/cosmos/profiles/starrocks/user_pass.py
+++ b/cosmos/profiles/starrocks/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class StarrocksUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow MySQL connections using user + password authentication to dbt profiles.
-    https://docs.getdbt.com/docs/core/connect-data-platform/starrocks-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/starrocks-setup
     """
 
     airflow_connection_type: str = "mysql"  # StarRocks support mysql protocol

--- a/cosmos/profiles/teradata/user_pass.py
+++ b/cosmos/profiles/teradata/user_pass.py
@@ -10,7 +10,7 @@ from ..base import BaseProfileMapping
 class TeradataUserPasswordProfileMapping(BaseProfileMapping):
     """
     Maps Airflow Teradata connections using user + password authentication to dbt profiles.
-    https://docs.getdbt.com/docs/core/connect-data-platform/teradata-setup
+    https://docs.getdbt.com/docs/local/connect-data-platform/teradata-setup
     https://airflow.apache.org/docs/apache-airflow-providers-teradata/stable/connections/teradata.html
     """
 

--- a/cosmos/profiles/trino/certificate.py
+++ b/cosmos/profiles/trino/certificate.py
@@ -10,7 +10,7 @@ from .base import TrinoBaseProfileMapping
 class TrinoCertificateProfileMapping(TrinoBaseProfileMapping):
     """
     Maps Airflow Trino connections to Certificate Trino dbt profiles.
-    https://docs.getdbt.com/reference/warehouse-setups/trino-setup#certificate
+    https://docs.getdbt.com/docs/local/connect-data-platform/trino-setup#example-profilesyml-for-certificate
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 

--- a/cosmos/profiles/trino/jwt.py
+++ b/cosmos/profiles/trino/jwt.py
@@ -11,7 +11,7 @@ class TrinoJWTProfileMapping(TrinoBaseProfileMapping):
     """
     Maps Airflow Trino connections to JWT Trino dbt profiles.
 
-    https://docs.getdbt.com/reference/warehouse-setups/trino-setup#jwt
+    https://docs.getdbt.com/docs/local/connect-data-platform/trino-setup#example-profilesyml-for-jwt
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 

--- a/cosmos/profiles/trino/ldap.py
+++ b/cosmos/profiles/trino/ldap.py
@@ -11,7 +11,7 @@ class TrinoLDAPProfileMapping(TrinoBaseProfileMapping):
     """
     Maps Airflow Trino connections to LDAP Trino dbt profiles.
 
-    https://docs.getdbt.com/reference/warehouse-setups/trino-setup#ldap
+    https://docs.getdbt.com/docs/local/connect-data-platform/trino-setup#example-profilesyml-for-ldap
     https://airflow.apache.org/docs/apache-airflow-providers-trino/stable/connections.html
     """
 

--- a/cosmos/profiles/vertica/user_pass.py
+++ b/cosmos/profiles/vertica/user_pass.py
@@ -16,7 +16,7 @@ class VerticaUserPasswordProfileMapping(BaseProfileMapping):
        This seems to be a common approach also for `Postgres <https://github.com/apache/airflow/blob/0953e0f844fa5db81c2b461ec2433de1935260b3/airflow/providers/postgres/hooks/postgres.py#L138>`_, \
        Redshift and Exasol since there is no ``database`` field in Airflow connection and ``schema`` is not required for the database connection.
     .. seealso::
-       https://docs.getdbt.com/reference/warehouse-setups/vertica-setup
+       https://docs.getdbt.com/docs/local/connect-data-platform/vertica-setup
        https://airflow.apache.org/docs/apache-airflow-providers-vertica/stable/connections/vertica.html
     """
 


### PR DESCRIPTION
## Summary

- dbt restructured the docs site: `/docs/core/connect-data-platform/<X>-setup` and `/reference/warehouse-setups/<X>-setup` now 404 or redirect to `/docs/local/connect-data-platform/<X>-setup`. Linkcheck flagged ~20 profile pages as `[redirected permanently]` and 7 as `[broken]` (anchors not found).
- Updated the docstrings of every affected profile mapping class under `cosmos/profiles/`. The `docs/reference/profiles/*.rst` files are regenerated from these docstrings via `docs/generate_mappings.py` at build time, so the source-of-truth edit is the docstring (per `CLAUDE.md`).
- Also fixed the Airflow Apache Spark provider docs URL: `connections/spark.html` returns 404 now that the provider splits into spark-connect / spark-sql / spark-submit. Pointed at the `connections/index.html` instead.

## Anchor handling

- **Trino** (certificate / JWT / LDAP): the page kept the sections but renamed the anchors. Updated to `#example-profilesyml-for-{certificate,jwt,ldap}` (verified via WebFetch).
- **Snowflake key-pair, BigQuery oauth-via-gcloud, BigQuery service-account-file, Spark thrift**: the dbt page still exists but the anchor couldn't be confirmed via WebFetch (Docusaurus body is JS-rendered). Dropped the anchor and linked to the page top — readers can scroll/Ctrl-F. Picking a wrong anchor would silently land users at the top of the page anyway; explicit is better.

## Files changed

25 files under `cosmos/profiles/` (one docstring URL each, +2 in `spark/thrift.py`):

`athena/access_key.py`, `bigquery/{oauth,service_account_file,service_account_keyfile_dict}.py`, `clickhouse/user_pass.py`, `databricks/{oauth,token}.py`, `duckdb/user_pass.py`, `exasol/user_pass.py`, `mysql/user_pass.py`, `oracle/user_pass.py`, `postgres/user_pass.py`, `redshift/user_pass.py`, `snowflake/{user_pass,user_privatekey,user_privatekey_file,user_encrypted_privatekey_file,user_encrypted_privatekey_env_variable}.py`, `spark/thrift.py`, `starrocks/user_pass.py`, `teradata/user_pass.py`, `trino/{certificate,jwt,ldap}.py`, `vertica/user_pass.py`

## Test plan

- [x] `hatch run docs:build` passes with `--fail-on-warning` and regenerates `docs/reference/profiles/*.rst` from updated docstrings
- [x] `sphinx-build -b linkcheck docs docs/_build/linkcheck` — every previously-flagged dbt and Airflow-Spark link on profile pages is gone from the broken/redirected list
- [ ] Reviewer spot-checks one or two of the new URLs in a browser (e.g., `https://docs.getdbt.com/docs/local/connect-data-platform/snowflake-setup`)

## Out of scope (for follow-up PRs)

- `VerticaUserPassword` GitHub blob `#L72` / `#L138` anchors — always false positives in linkcheck (GitHub renders line anchors via JS).
- `AthenaAccessKey` `dbt-athena` GitHub README `#configuring-your-profile` anchor — community repo README, unrelated to the dbt docs migration.
- `AthenaAccessKey` `registry.astronomer.io` → `airflow.apache.org/registry/` redirect — registry consolidation, unrelated.
- Hand-written `.rst` pages that also reference the old dbt URL roots (`docs/getting_started/oss-quickstart.rst`, `docs/getting_started/dbt-airflow-concepts.rst`, `docs/guides/connect_database/profile-customise-per-node.rst`, `docs/reference/glossary.rst`) — these will be covered in the PR 3 cleanup of hand-written external links.

🤖 Generated with [Claude Code](https://claude.com/claude-code)