### PR TITLE
Remove outdated TODO on watcher terminal-status handling

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -303,8 +303,6 @@ def store_dbt_resource_status_from_log(
 
         logger.debug("Model: %s is in %s state", unique_id, dbt_node_status)
 
-        # Handle terminal statuses for both models (success/failed) and tests (pass/fail)
-        # TODO: handle all possible statuses including skipped, warn, etc.
         if is_dbt_node_status_terminal(dbt_node_status):
             context = extra_kwargs.get("context")
             if context is None:


### PR DESCRIPTION
## Summary

- `cosmos/operators/_watcher/base.py:306-307` carried a stale descriptive comment plus a `# TODO: handle all possible statuses including skipped, warn, etc.`.
- The TODO is already satisfied: `is_dbt_node_status_terminal()` in `cosmos/operators/_watcher/state.py:64` composes three frozensets that cover every dbt node status, including the ones the TODO explicitly named:

  ```python
  DBT_SUCCESS_STATUSES = frozenset({"success", "pass", "warn"})
  DBT_FAILED_STATUSES  = frozenset({"failed", "fail", "error", "runtime error"})
  DBT_SKIPPED_STATUSES = frozenset({"skipped"})
  ```
- The descriptive comment one line above (`# Handle terminal statuses for both models (success/failed) and tests (pass/fail)`) was itself out of date since it omitted `warn` and `skipped`.
- Removed both lines. `is_dbt_node_status_terminal` is self-documenting, and per `CLAUDE.md` we don't add WHAT-explaining comments for well-named identifiers.

## Test plan

- [x] Pre-commit hooks pass (ruff, black, mypy, codespell, etc.)
- [ ] No functional change; behavior of `store_dbt_resource_status_from_log` is unaffected (comment-only delta)

🤖 Generated with [Claude Code](https://claude.com/claude-code)