### PR TITLE
Teach AI agents to use pre-commit to pass before committing and pushing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,7 +63,7 @@ When writing or editing files under `docs/`, follow the Cosmos lightweight style
 
 ### Linting and Formatting
 
-**Always run the full pre-commit suite locally and ensure it passes before committing or pushing.** This includes the formatters, linters, type checks, and style checks (`scripts/check_docs_style.py` for `docs/`, configured via `.pre-commit-config.yaml`). The same hooks run in CI; catching failures locally avoids a wasted CI round-trip and a noisy PR history:
+**Always run the full pre-commit suite locally and ensure it passes before committing or pushing.** This includes the formatters, linters, type checks, and style checks (`scripts/check_docs_style.py` for `docs/`, configured via `.pre-commit-config.yaml`). The same hooks run in CI; catching failures locally avoids a wasted CI round-trip and a noisy PR history.
 
 ```bash
 pre-commit run --all-files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -63,12 +63,15 @@ When writing or editing files under `docs/`, follow the Cosmos lightweight style
 
 ### Linting and Formatting
 
-Pre-commit runs the configured linters/formatters (e.g., Black (formatter), Ruff (linter), mypy, codespell). See `.pre-commit-config.yaml` for the full list:
+**Always run the full pre-commit suite locally and ensure it passes before committing or pushing.** This includes the formatters, linters, type checks, and style checks (`scripts/check_docs_style.py` for `docs/`, configured via `.pre-commit-config.yaml`). The same hooks run in CI; catching failures locally avoids a wasted CI round-trip and a noisy PR history:
+
 ```bash
 pre-commit run --all-files
 ```
 
-Individual tools:
+Pre-commit's configured tools (Black, Ruff, mypy, codespell, check_docs_style, etc.) are listed in `.pre-commit-config.yaml`.
+
+Individual tools, if you need to iterate on a single one:
 ```bash
 black --line-length 120 cosmos/
 ruff check cosmos/


### PR DESCRIPTION
## Summary

CLAUDE.md already documented `pre-commit run --all-files` as the local
pre-flight command, but did not state that it **must pass** before a
commit lands or a PR is opened. In practice that meant a stale local
environment or a forgotten hook (notably `scripts/check_docs_style.py`
and mypy) could ship to CI and fail there.

This PR makes the requirement explicit:

- The "Linting and Formatting" section now leads with "Always run the
  full pre-commit suite locally and ensure it passes before committing
  or pushing", calling out style checks and CI parity.
- The individual-tool examples (`black`, `ruff`, `mypy`) are framed as
  "if you need to iterate on a single one" rather than an equivalent
  alternative to the full suite.

No code, tooling, or hook configuration changes — purely a guidance
update inside `CLAUDE.md`.

## Test plan

- [x] `git diff CLAUDE.md` reviewed — only the "Linting and Formatting" section is touched.
- [ ] CI run on this PR (docs-only / no code paths affected; the
      check-changed-files job should keep test/integration jobs from
      running).

🤖 Generated with [Claude Code](https://claude.com/claude-code)