### PR TITLE
Watcher: Surface watcher dbt 1.8+ requirement in the error message

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -18,10 +18,12 @@ from cosmos.constants import (
     PRODUCER_WATCHER_TASK_ID,
     WATCHER_TASK_WEIGHT_RULE,
 )
+from cosmos.exceptions import CosmosDbtRunError
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
 from cosmos.operators._watcher.state import (
+    WATCHER_MIN_DBT_VERSION_HINT,
     _iso_to_string,
     _log_dbt_event,
     build_producer_state_fetcher,
@@ -29,6 +31,7 @@ from cosmos.operators._watcher.state import (
     get_dbt_event_xcom_key,
     get_status_xcom_key,
     get_xcom_val,
+    is_dbt_log_format_option_error,
     is_dbt_node_status_skipped,
     is_dbt_node_status_success,
     is_dbt_node_status_terminal,
@@ -455,7 +458,12 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         model_selector = self.model_unique_id.split(".", 2)[2]
         cmd_flags = extra_flags + ["--select", model_selector]
 
-        self.build_and_run_cmd(context, cmd_flags=cmd_flags)  # type: ignore[attr-defined]
+        try:
+            self.build_and_run_cmd(context, cmd_flags=cmd_flags)  # type: ignore[attr-defined]
+        except Exception as exc:
+            if is_dbt_log_format_option_error(exc):
+                raise CosmosDbtRunError(f"{WATCHER_MIN_DBT_VERSION_HINT} Original error: {exc}") from exc
+            raise
 
         logger.info("dbt run completed successfully on retry for model '%s'", self.model_unique_id)
         return True

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -36,6 +36,25 @@ PRODUCER_TERMINAL_STATES = frozenset({"success", "failed", "skipped", "upstream_
 # final outcome and the trigger can exit early. Subset of PRODUCER_TERMINAL_STATES.
 PRODUCER_FINAL_STATES = frozenset({"failed", "success", "skipped"})
 
+# Substring of the dbt CLI error raised when the watcher's
+# ``dbt <subcommand> --log-format json …`` command is rejected because dbt < 1.8
+# only accepts ``--log-format`` as a global flag (before the subcommand).
+# See cosmos/issues/2698 and PR #2700 for full context.
+DBT_LOG_FORMAT_OPTION_ERROR_SUBSTR = "No such option '--log-format'"
+
+# User-facing hint that replaces the raw dbt CLI error message when the watcher
+# detects the dbt < 1.8 incompatibility, so users have a clear path to a fix
+# instead of an opaque ``No such option`` error.
+WATCHER_MIN_DBT_VERSION_HINT = (
+    "ExecutionMode.WATCHER requires dbt-core 1.8 or newer. The watcher passes "
+    "``--log-format json`` after the dbt subcommand (e.g. ``dbt build --log-format "
+    "json ...``), and dbt < 1.8 only accepts ``--log-format`` as a global flag "
+    "(before the subcommand), so the dbt CLI rejects the command before any "
+    "watcher logic runs. Either upgrade dbt-core to 1.8+ (recommended; dbt < 1.8 "
+    "is end-of-life per https://docs.getdbt.com/docs/dbt-versions/core) or switch "
+    "to ExecutionMode.LOCAL."
+)
+
 
 class DbtTestStatus(str, Enum):
     """Aggregated status of all tests for a given model."""
@@ -69,6 +88,16 @@ def is_dbt_node_status_terminal(status: str | None) -> bool:
 def is_producer_task_terminated(state: str | None) -> bool:
     """Return True when the producer task is in a terminal state."""
     return state in PRODUCER_TERMINAL_STATES
+
+
+def is_dbt_log_format_option_error(exc: BaseException) -> bool:
+    """Return True when ``exc`` is the dbt CLI's ``No such option '--log-format'`` error.
+
+    Surfaces on dbt < 1.8, where ``--log-format`` is a global flag only and
+    cannot appear after the subcommand. The watcher producer and the consumer
+    fallback both construct ``dbt <subcommand> --log-format json …`` commands.
+    """
+    return DBT_LOG_FORMAT_OPTION_ERROR_SUBSTR in str(exc)
 
 
 def get_status_xcom_key(unique_id: str) -> str:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -24,13 +24,19 @@ from cosmos.constants import (
 )
 from cosmos.dataset import get_dataset_namespace
 from cosmos.dbt.graph import DbtNode
+from cosmos.exceptions import CosmosDbtRunError
 from cosmos.log import get_logger
 from cosmos.operators._watcher import safe_xcom_push
 from cosmos.operators._watcher.base import (
     BaseConsumerSensor,
     store_dbt_resource_status_from_log,
 )
-from cosmos.operators._watcher.state import DBT_SOURCE_FRESHNESS_STALE_STATUSES, DBT_SUCCESS_STATUSES
+from cosmos.operators._watcher.state import (
+    DBT_SOURCE_FRESHNESS_STALE_STATUSES,
+    DBT_SUCCESS_STATUSES,
+    WATCHER_MIN_DBT_VERSION_HINT,
+    is_dbt_log_format_option_error,
+)
 from cosmos.operators._watcher.xcom import (
     _backup_xcom_to_variable,
     _delete_xcom_backup_variable,
@@ -464,9 +470,11 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             _delete_xcom_backup_variable(context)
             return return_value
 
-        except Exception:
+        except Exception as exc:
             safe_xcom_push(task_instance=context["ti"], key="task_status", value="completed")
             _backup_xcom_to_variable(context)
+            if is_dbt_log_format_option_error(exc):
+                raise CosmosDbtRunError(f"{WATCHER_MIN_DBT_VERSION_HINT} Original error: {exc}") from exc
             raise
 
 

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -15,6 +15,7 @@ from cosmos.operators._watcher.state import (
     get_compiled_sql_xcom_key,
     get_dbt_event_xcom_key,
     get_status_xcom_key,
+    is_dbt_log_format_option_error,
     is_dbt_node_status_failed,
     is_dbt_node_status_skipped,
     is_dbt_node_status_success,
@@ -104,6 +105,27 @@ class TestProducerTaskTerminated:
     @pytest.mark.parametrize("state", ["running", "deferred", "queued", "scheduled", "up_for_reschedule", None, ""])
     def test_non_terminal_states(self, state: str | None):
         assert is_producer_task_terminated(state) is False
+
+
+class TestIsDbtLogFormatOptionError:
+    """Tests for is_dbt_log_format_option_error helper (watcher requires dbt 1.8+)."""
+
+    def test_returns_true_for_log_format_option_error(self):
+        exc = RuntimeError("dbt invocation did not complete with unhandled error: No such option '--log-format'.")
+        assert is_dbt_log_format_option_error(exc) is True
+
+    def test_returns_true_when_substring_is_anywhere_in_message(self):
+        exc = ValueError("wrapped: <Click No such option '--log-format'> while running build")
+        assert is_dbt_log_format_option_error(exc) is True
+
+    def test_returns_false_for_unrelated_error(self):
+        exc = RuntimeError("dbt invocation completed with errors: model_a failed")
+        assert is_dbt_log_format_option_error(exc) is False
+
+    def test_returns_false_for_other_log_option_error(self):
+        # A different "No such option" error should not be mistaken for the --log-format one.
+        exc = RuntimeError("No such option '--log-level'.")
+        assert is_dbt_log_format_option_error(exc) is False
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

When a user runs `ExecutionMode.WATCHER` against dbt-core < 1.8, the watcher's `dbt <subcommand> --log-format json …` command is rejected by the dbt CLI parser. Today they see:

```
cosmos.exceptions.CosmosDbtRunError: dbt invocation did not complete with unhandled error: No such option '--log-format'.
```

No hint that the watcher's command shape is at fault, no minimum dbt version, no workaround. This PR detects that specific dbt CLI error in the two watcher entry points and re-raises with the limitation we documented in #2700:

```
cosmos.exceptions.CosmosDbtRunError: ExecutionMode.WATCHER requires dbt-core
1.8 or newer. The watcher passes ``--log-format json`` after the dbt subcommand
(e.g. ``dbt build --log-format json ...``), and dbt < 1.8 only accepts
``--log-format`` as a global flag (before the subcommand), so the dbt CLI
rejects the command before any watcher logic runs. Either upgrade dbt-core to
1.8+ (recommended; dbt < 1.8 is end-of-life per
https://docs.getdbt.com/docs/dbt-versions/core) or switch to
ExecutionMode.LOCAL. Original error: No such option '--log-format'.
```

The original exception is preserved via `raise ... from exc` so the dbt CLI traceback is still in the chained `__cause__` for debugging.

## Implementation

Reuses the existing pattern from #2698 (`DBT_UPSTREAM_FAILURE_SKIP_EVENT_NAMES` + `is_dbt_upstream_failure_skip_event`): a constant and a predicate live alongside the other watcher helpers in `cosmos/operators/_watcher/state.py`, and the two call sites wrap their existing `try/except` to translate before re-raising.

| Site | Before | After |
|---|---|---|
| `cosmos/operators/watcher.py` — `DbtProducerWatcherOperator.execute()` `except Exception:` block | re-raised the original exception | If `is_dbt_log_format_option_error(exc)`, re-raise as `CosmosDbtRunError(hint + original)` chained via `raise … from exc`; otherwise unchanged |
| `cosmos/operators/_watcher/base.py` — `BaseConsumerSensor._fallback_to_non_watcher_run` | called `build_and_run_cmd` and let exceptions propagate | Wrap that call in the same translation |

Both call sites import the new `WATCHER_MIN_DBT_VERSION_HINT` constant and the `is_dbt_log_format_option_error` predicate from `state.py`.

## Tests

`tests/operators/_watcher/test_state.py::TestIsDbtLogFormatOptionError` covers the four obvious branches:

- exact-match error message (`No such option '--log-format'.`)
- substring-anywhere match (the watcher tests showed the error wrapped inside a longer message)
- unrelated `CosmosDbtRunError` is **not** rewritten
- a different `No such option` (e.g. `--log-level`) is **not** mistaken for the `--log-format` case

All four pass locally:

```
$ PYTEST_ADDOPTS="-k TestIsDbtLogFormatOptionError" hatch run tests.py3.10-3.1-1.11:test
========== 4 passed, 2 skipped, 1647 deselected, 7 warnings in 5.00s ===========
```

End-to-end verification on dbt 1.5/1.6/1.7 wasn't viable through the existing watcher integration tests because those tests run `dbt ls` / `dbt deps` at DAG-parse time and fail there on older dbt (separate, pre-existing dbt incompatibilities) before reaching the watcher's `execute()`. The unit tests cover the helper logic comprehensively; the substring we match (`No such option '--log-format'`) is dbt CLI output that's stable across dbt versions (it's Click's standard error format).

## Why string-match instead of version-detect

A version check on dbt at producer-start would also work (e.g. import `dbt.version` or shell out to `dbt --version`). I chose the string-match approach because:

1. **No additional dependency on dbt's Python API** when running in SUBPROCESS mode (the env might intentionally not have `dbt-core` in the same venv as Airflow).
2. **No extra subprocess call** at every producer start in the common (1.8+) case.
3. The error path is naturally where you want the hint — at the point of failure, with the original exception attached.
4. Same approach Cosmos already uses elsewhere for matching dbt error strings.

If a future dbt release rewords the error to something other than `No such option '--log-format'`, the wrap stops firing and users fall back to seeing the original error. That's a strictly safe failure mode.

## Related

- #2698 — Watcher false-green on upstream-failure-skip (the public issue this PR's helper file lives alongside).
- #2684 — BOSS-401 fix that established the helper pattern (`is_dbt_*` predicate + constant in `state.py`).
- #2700 — Doc-only PR that introduced the user-facing minimum-dbt-version note; this PR's hint message mirrors that doc.

## Test plan

- [x] `TestIsDbtLogFormatOptionError` (4 cases) passes via `hatch run tests.py3.10-3.1-1.11:test`.
- [x] `ruff check`, `black`, `mypy` all pass via pre-commit.
- [ ] CI matrix passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)