### PR TITLE
Tighten `# type: ignore` to specify error codes

### DIFF
--- a/cosmos/_utils/importer.py
+++ b/cosmos/_utils/importer.py
@@ -7,7 +7,7 @@ def load_method_from_module(module_path: str, method_name: str) -> Callable[...,
     try:
         module = importlib.import_module(module_path)
         method = getattr(module, method_name)
-        return method  # type: ignore
+        return method  # type: ignore[no-any-return]
     except ModuleNotFoundError:
         raise ModuleNotFoundError(f"Module {module_path} not found")
     except AttributeError:

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -145,7 +145,7 @@ class SourceRenderingBehavior(Enum):
     WITH_TESTS_OR_FRESHNESS = "with_tests_or_freshness"
 
 
-class DbtResourceType(aenum.Enum):  # type: ignore
+class DbtResourceType(aenum.Enum):  # type: ignore[misc]
     """
     Type of dbt node.
     """
@@ -158,7 +158,7 @@ class DbtResourceType(aenum.Enum):  # type: ignore
     EXPOSURE = "exposure"
 
     @classmethod
-    def _missing_value_(cls, value):  # type: ignore
+    def _missing_value_(cls, value):  # type: ignore[no-untyped-def]
         aenum.extend_enum(cls, value.upper(), value.lower())
         return getattr(DbtResourceType, value.upper())
 

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -57,7 +57,7 @@ def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
     num = 0
-    for run_result in result.result.results:  # type: ignore
+    for run_result in result.result.results:  # type: ignore[union-attr]
         if run_result.status == "warn":
             num += 1
     return num
@@ -143,7 +143,7 @@ def extract_dbt_runner_issues(
     node_names = []
     node_results = []
 
-    for node_result in result.result.results:  # type: ignore
+    for node_result in result.result.results:  # type: ignore[union-attr]
         if node_result.status in status_levels:
             node_names.append(str(node_result.node.name))
             node_results.append(str(node_result.message))

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -203,7 +203,7 @@ class DbtModel:
                     and isinstance(node.args[0], jinja2.nodes.Const)
                     and node.node.name == "var"
                 ):
-                    value += self.dbt_vars[node.args[0].value]  # type: ignore
+                    value += self.dbt_vars[node.args[0].value]  # type: ignore[operator]
         elif isinstance(first_arg, jinja2.nodes.Const):
             # and add it to the config
             value = first_arg.value

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -126,7 +126,7 @@ def extract_message_by_status(
     node_names = []
     node_results = []
 
-    for node_result in result.result.results:  # type: ignore
+    for node_result in result.result.results:  # type: ignore[union-attr]
         if node_result.status in status_levels:
             node_names.append(str(node_result.node.name))
             node_results.append(str(node_result.message))
@@ -139,7 +139,7 @@ def parse_number_of_warnings(result: dbtRunnerResult) -> int:
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
     num = 0
-    for run_result in result.result.results:  # type: ignore
+    for run_result in result.result.results:  # type: ignore[union-attr]
         if run_result.status == "warn":
             num += 1
     return num

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -20,12 +20,12 @@ except ImportError:
 try:  # Airflow 3
     from airflow.sdk.definitions.asset import Asset
 except (ModuleNotFoundError, ImportError):  # Airflow 2
-    from airflow.datasets import Dataset as Asset  # type: ignore
+    from airflow.datasets import Dataset as Asset  # type: ignore[no-redef]
 
 try:
     from airflow.sdk.definitions.context import Context  # type: ignore[attr-defined]
 except ImportError:
-    from airflow.utils.context import Context  # type: ignore
+    from airflow.utils.context import Context  # type: ignore[attr-defined]
 from packaging.version import Version
 
 from cosmos import settings
@@ -91,7 +91,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
     ):
         self.project_dir = project_dir
         self.profile_config = profile_config
-        self.gcp_conn_id = self.profile_config.profile_mapping.conn_id  # type: ignore
+        self.gcp_conn_id = self.profile_config.profile_mapping.conn_id  # type: ignore[union-attr]
         self.extra_context = extra_context or {}
         self.configuration: dict[str, Any] = {}
         self.dbt_kwargs = dbt_kwargs or {}
@@ -105,7 +105,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             try:
                 from airflow.sdk.definitions.asset import AssetAlias as DatasetAlias
             except ImportError:
-                from airflow.datasets import DatasetAlias  # type: ignore
+                from airflow.datasets import DatasetAlias  # type: ignore[no-redef]
 
             # ignoring the type because older versions of Airflow raise the follow error in mypy
             # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
@@ -191,11 +191,11 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         )
 
         object_storage_path = ObjectStoragePath(remote_model_path, conn_id=remote_target_path_conn_id)
-        with object_storage_path.open() as fp:  # type: ignore
+        with object_storage_path.open() as fp:  # type: ignore[no-untyped-call]
             sql = fp.read()
             elapsed_time = time.time() - start_time
             self.log.info("SQL file download completed in %.2f seconds.", elapsed_time)
-            return sql  # type: ignore
+            return sql  # type: ignore[no-any-return]
 
     def execute(self, context: Context, **kwargs: Any) -> None:
         if self.async_context.get("run_id") is None:

--- a/cosmos/operators/aws_ecs.py
+++ b/cosmos/operators/aws_ecs.py
@@ -44,7 +44,7 @@ except ImportError:  # pragma: no cover
     )  # pragma: no cover
 
 
-class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignore
+class DbtAwsEcsBaseOperator(AbstractDbtBase, EcsRunTaskOperator):  # type: ignore[misc]
     """
     Executes a dbt core cli command in an ECS Task instance with dbt installed in it.
 

--- a/cosmos/operators/aws_eks.py
+++ b/cosmos/operators/aws_eks.py
@@ -71,7 +71,7 @@ class DbtAwsEksBaseOperator(DbtKubernetesBaseOperator):
         if self.config_file:
             raise AirflowException("The config_file is not an allowed parameter for the EksPodOperator.")
 
-    def execute(self, context: Context) -> Any | None:  # type: ignore
+    def execute(self, context: Context) -> Any | None:  # type: ignore[override]
         eks_hook = EksHook(
             aws_conn_id=self.aws_conn_id,
             region_name=self.region,

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -38,7 +38,7 @@ except ImportError:
     )
 
 
-class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInstancesOperator):  # type: ignore
+class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInstancesOperator):  # type: ignore[misc]
     """
     Executes a dbt core cli command in an Azure Container Instance
     """
@@ -129,7 +129,7 @@ class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInsta
         self.command: list[str] = dbt_cmd
 
 
-class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core build command.
     """
@@ -140,7 +140,7 @@ class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerIns
         super().__init__(*args, **kwargs)
 
 
-class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core ls command.
     """
@@ -149,7 +149,7 @@ class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceB
         super().__init__(*args, **kwargs)
 
 
-class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core seed command.
 
@@ -162,7 +162,7 @@ class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInsta
         super().__init__(*args, **kwargs)
 
 
-class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core snapshot command.
 
@@ -181,7 +181,7 @@ class DbtSourceAzureContainerInstanceOperator(DbtSourceMixin, DbtAzureContainerI
         super().__init__(*args, **kwargs)
 
 
-class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core run command.
     """
@@ -192,7 +192,7 @@ class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanc
         super().__init__(*args, **kwargs)
 
 
-class DbtTestAzureContainerInstanceOperator(DbtTestMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore
+class DbtTestAzureContainerInstanceOperator(DbtTestMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
     """
     Executes a dbt core test command.
     """

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 try:
     from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
-    from airflow.sdk.execution_time.context import context_to_airflow_vars  # type: ignore
+    from airflow.sdk.execution_time.context import context_to_airflow_vars  # type: ignore[no-redef]
 
 from airflow.utils.strings import to_boolean
 
@@ -170,7 +170,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
 
     # The following is necessary so that dynamic mapped classes work since Cosmos 1.9.0 subclass changes
     # Bug report: https://github.com/astronomer/astronomer-cosmos/issues/1546
-    __init__._BaseOperatorMeta__param_names = {  # type: ignore
+    __init__._BaseOperatorMeta__param_names = {  # type: ignore[attr-defined]
         name
         for (name, param) in inspect.signature(__init__).parameters.items()
         if param.name != "self" and param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
@@ -182,7 +182,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
         # Since this class is subclassed by all Cosmos operators, to do this here allows to avoid to have this
         # logic explicitly in all subclasses
         # Bug report: https://github.com/astronomer/astronomer-cosmos/issues/1546
-        cls.__init__._BaseOperatorMeta__param_names = {  # type: ignore
+        cls.__init__._BaseOperatorMeta__param_names = {  # type: ignore[attr-defined]
             name
             for (name, param) in inspect.signature(cls.__init__).parameters.items()
             if param.name != "self" and param.kind not in (param.VAR_POSITIONAL, param.VAR_KEYWORD)
@@ -328,7 +328,7 @@ class AbstractDbtBase(metaclass=ABCMeta):
     ) -> Any:
         """Override this method for the operator to execute the dbt command"""
 
-    def execute(self, context: Context, **kwargs) -> Any | None:  # type: ignore
+    def execute(self, context: Context, **kwargs) -> Any | None:  # type: ignore[no-untyped-def, return]
         if self.extra_context:
             context_merge(context, self.extra_context)
 
@@ -487,7 +487,7 @@ class DbtTestMixin:
         self.select = select
         self.exclude = exclude
         self.selector = selector
-        super().__init__(exclude=exclude, select=select, selector=selector, **kwargs)  # type: ignore
+        super().__init__(exclude=exclude, select=select, selector=selector, **kwargs)  # type: ignore[call-arg]
 
 
 class DbtRunOperationMixin:

--- a/cosmos/operators/docker.py
+++ b/cosmos/operators/docker.py
@@ -39,7 +39,7 @@ except ImportError:
     )
 
 
-class DbtDockerBaseOperator(AbstractDbtBase, DockerOperator):  # type: ignore
+class DbtDockerBaseOperator(AbstractDbtBase, DockerOperator):  # type: ignore[misc]
     """
     Executes a dbt core cli command in a Docker container.
 

--- a/cosmos/operators/gcp_cloud_run_job.py
+++ b/cosmos/operators/gcp_cloud_run_job.py
@@ -51,7 +51,7 @@ except ImportError:
     )
 
 
-class DbtGcpCloudRunJobBaseOperator(AbstractDbtBase, CloudRunExecuteJobOperator):  # type: ignore
+class DbtGcpCloudRunJobBaseOperator(AbstractDbtBase, CloudRunExecuteJobOperator):  # type: ignore[misc]
     """
     Executes a dbt core cli command in a Cloud Run Job instance with dbt installed in it.
 

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -63,7 +63,7 @@ except ImportError:  # Since Airflow 3.1, BaseHook is in the airflow.sdk.bases.h
     from airflow.hooks.base import BaseHook
 
 
-class DbtKubernetesBaseOperator(AbstractDbtBase, KubernetesPodOperator):  # type: ignore
+class DbtKubernetesBaseOperator(AbstractDbtBase, KubernetesPodOperator):  # type: ignore[misc]
     """
     Executes a dbt core cli command in a Kubernetes Pod.
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -70,7 +70,7 @@ except ImportError:
 try:  # Airflow 3
     from airflow.sdk.definitions.asset import Asset
 except (ModuleNotFoundError, ImportError):  # Airflow 2
-    from airflow.datasets import Dataset as Asset  # type: ignore
+    from airflow.datasets import Dataset as Asset  # type: ignore[no-redef]
 
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -157,7 +157,7 @@ except (ImportError, ModuleNotFoundError):
         )
 
         @define
-        class OperatorLineage:  # type: ignore
+        class OperatorLineage:  # type: ignore[no-redef]
             inputs: list[str] = list()
             outputs: list[str] = list()
             run_facets: dict[str, str] = dict()
@@ -852,8 +852,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         if openlineage_events_completes is not None:
             for completed in openlineage_events_completes:
-                [inputs.append(input_) for input_ in completed.inputs if input_ not in inputs]  # type: ignore
-                [outputs.append(output) for output in completed.outputs if output not in outputs]  # type: ignore
+                [inputs.append(input_) for input_ in completed.inputs if input_ not in inputs]  # type: ignore[func-returns-value, union-attr]
+                [outputs.append(output) for output in completed.outputs if output not in outputs]  # type: ignore[func-returns-value, union-attr]
                 run_facets = {**run_facets, **completed.run.facets}
                 job_facets = {**job_facets, **completed.job.facets}
         else:

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -206,7 +206,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
 
     @depends_on_virtualenv_dir
     def _acquire_venv_lock(self) -> None:
-        if not self.virtualenv_dir.is_dir():  # type: ignore
+        if not self.virtualenv_dir.is_dir():  # type: ignore[union-attr]
             os.mkdir(str(self.virtualenv_dir))
 
         with open(self._lock_file, "w") as lf:

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -123,7 +123,7 @@ def open_file(path: str, conn_id: str | None = None) -> str:
         return content  # type: ignore[no-any-return]
 
 
-class DbtDocsView(AirflowBaseView):  # type: ignore
+class DbtDocsView(AirflowBaseView):  # type: ignore[misc]
     default_view = "dbt_docs"
     route_base = "/cosmos"
     template_folder = op.join(op.dirname(__file__), "templates")

--- a/cosmos/profiles/athena/access_key.py
+++ b/cosmos/profiles/athena/access_key.py
@@ -60,7 +60,7 @@ class AthenaAccessKeyProfileMapping(BaseProfileMapping):
     def profile(self) -> dict[str, Any | None]:
         """Gets profile. The password is stored in an environment variable."""
 
-        self.temporary_credentials = self._get_temporary_credentials()  # type: ignore
+        self.temporary_credentials = self._get_temporary_credentials()  # type: ignore[no-untyped-call]
 
         profile = {
             **self.mapped_params,
@@ -91,13 +91,13 @@ class AthenaAccessKeyProfileMapping(BaseProfileMapping):
 
         return env_vars
 
-    def _get_temporary_credentials(self):  # type: ignore
+    def _get_temporary_credentials(self):  # type: ignore[no-untyped-def]
         """
         Helper function to retrieve temporary short lived credentials
         Returns an object including access_key, secret_key and token
         """
         from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
-        hook = AwsGenericHook(self.conn_id)  # type: ignore
+        hook = AwsGenericHook(self.conn_id)  # type: ignore[var-annotated]
         credentials = hook.get_credentials()
         return credentials

--- a/scripts/find_unused_type_ignores.py
+++ b/scripts/find_unused_type_ignores.py
@@ -1,0 +1,115 @@
+#!/usr/bin/env python3
+# Find `# type: ignore` comments reported as unused in *every* matrix cell.
+#
+# Usage:
+#   scripts/find_unused_type_ignores.py run [ENV ...]    # run mypy in each env, cache output
+#   scripts/find_unused_type_ignores.py intersect        # intersect cached outputs
+#
+# The default ENV set covers Airflow 2.x + 3.x and old + new dbt so any ignore
+# in the intersection should be removable without breaking the support matrix.
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+DEFAULT_ENVS = [
+    "tests.py3.10-2.9-1.5",
+    "tests.py3.11-2.10-1.9",
+    "tests.py3.12-3.0-1.9",
+    "tests.py3.12-3.2-2.0",
+]
+CACHE_DIR = Path(".unused_ignores_cache")
+UNUSED_RE = re.compile(r'^(?P<file>[^:]+):(?P<line>\d+): error: Unused "type: ignore.*?" comment')
+
+
+def env_to_filename(env: str) -> Path:
+    return CACHE_DIR / f"{env.replace('.', '_').replace('/', '_')}.txt"
+
+
+def run_one(env: str) -> Path:
+    out_path = env_to_filename(env)
+    print(f"[run] {env} -> {out_path}", file=sys.stderr)
+    proc = subprocess.run(
+        [
+            "hatch",
+            "-e",
+            env,
+            "run",
+            "python",
+            "-m",
+            "mypy",
+            "cosmos",
+            "--warn-unused-ignores",
+            "--no-incremental",
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # mypy exits non-zero when it reports errors (including unused-ignore), which is expected.
+    # Only abort if there's no output at all -- that usually means the env failed to provision.
+    if not proc.stdout.strip():
+        print(f"[run] {env} produced no output. stderr:\n{proc.stderr}", file=sys.stderr)
+        sys.exit(2)
+    out_path.write_text(proc.stdout)
+    return out_path
+
+
+def parse(path: Path) -> set[tuple[str, int]]:
+    hits: set[tuple[str, int]] = set()
+    for line in path.read_text().splitlines():
+        m = UNUSED_RE.match(line)
+        if m:
+            hits.add((m["file"], int(m["line"])))
+    return hits
+
+
+def intersect(paths: list[Path]) -> set[tuple[str, int]]:
+    if not paths:
+        return set()
+    sets = [parse(p) for p in paths]
+    common = set.intersection(*sets)
+    for path, hits in zip(paths, sets):
+        print(f"  {path.name}: {len(hits):4d} unused", file=sys.stderr)
+    print(f"  intersection: {len(common):4d}", file=sys.stderr)
+    return common
+
+
+def report(common: set[tuple[str, int]]) -> None:
+    by_file: dict[str, list[int]] = defaultdict(list)
+    for file, line in common:
+        by_file[file].append(line)
+    for file in sorted(by_file):
+        lines = sorted(by_file[file])
+        print(f"{len(lines):3d}  {file}  {','.join(str(line) for line in lines)}")
+    print(f"---\ntotal files: {len(by_file)}    total ignores: {sum(len(v) for v in by_file.values())}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    run = sub.add_parser("run", help="Run mypy in each env and cache output")
+    run.add_argument("envs", nargs="*", default=DEFAULT_ENVS)
+    sub.add_parser("intersect", help="Intersect cached outputs from a previous run")
+
+    args = parser.parse_args()
+    CACHE_DIR.mkdir(exist_ok=True)
+
+    if args.cmd == "run":
+        envs = args.envs or DEFAULT_ENVS
+        paths = [run_one(env) for env in envs]
+        report(intersect(paths))
+    else:
+        paths = sorted(CACHE_DIR.glob("*.txt"))
+        if not paths:
+            print(f"No cached outputs found in {CACHE_DIR}/. Run 'run' first.", file=sys.stderr)
+            return 1
+        report(intersect(paths))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/tighten_type_ignores.py
+++ b/scripts/tighten_type_ignores.py
@@ -1,0 +1,171 @@
+#!/usr/bin/env python3
+# Tighten every bare `# type: ignore` in cosmos/ into `# type: ignore[code, ...]`.
+#
+# Strategy:
+#   1. Strip every bare `# type: ignore` in cosmos/ in-memory and write the
+#      patched files to disk.
+#   2. Run `hatch -e <env> run python -m mypy cosmos --no-incremental` for each
+#      env in ENVS and collect the error codes mypy emits for each (file, line)
+#      where we removed an ignore.
+#   3. Restore the originals.
+#   4. Rewrite each bare ignore as `# type: ignore[<union of codes across envs>]`.
+#      Lines where no env emitted a code are left alone and printed as
+#      "candidate for deletion" (those belong in a later PR).
+#
+# Usage:
+#   scripts/tighten_type_ignores.py            # dry-run: show what would change
+#   scripts/tighten_type_ignores.py --apply    # actually rewrite files
+#   scripts/tighten_type_ignores.py --apply --envs tests.py3.11-2.10-1.9 ...
+from __future__ import annotations
+
+import argparse
+import re
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+ENVS = [
+    "tests.py3.10-2.9-1.5",
+    "tests.py3.11-2.10-1.9",
+    "tests.py3.12-3.0-1.9",
+    "tests.py3.12-3.2-2.0",
+]
+ROOT = Path("cosmos")
+BARE_RE = re.compile(r"#\s*type:\s*ignore(?!\[)")
+ERROR_RE = re.compile(r"^(?P<file>[^:]+):(?P<line>\d+): error: .*\[(?P<code>[a-z0-9\-, ]+)\]\s*$")
+
+
+def find_bare_ignores() -> dict[Path, set[int]]:
+    hits: dict[Path, set[int]] = defaultdict(set)
+    for py in ROOT.rglob("*.py"):
+        for i, line in enumerate(py.read_text().splitlines(), start=1):
+            if BARE_RE.search(line):
+                hits[py].add(i)
+    return hits
+
+
+def strip_bare(py: Path) -> str:
+    original = py.read_text()
+    patched = "\n".join(BARE_RE.sub("", line).rstrip() for line in original.splitlines())
+    if original.endswith("\n"):
+        patched += "\n"
+    py.write_text(patched)
+    return original
+
+
+def codes_per_env(env: str, targets: dict[Path, set[int]]) -> dict[tuple[str, int], set[str]]:
+    print(f"[mypy] {env}", file=sys.stderr)
+    proc = subprocess.run(
+        ["hatch", "-e", env, "run", "python", "-m", "mypy", str(ROOT), "--no-incremental"],
+        capture_output=True,
+        text=True,
+    )
+    if not proc.stdout.strip():
+        print(f"[mypy] {env} produced no stdout; stderr:\n{proc.stderr}", file=sys.stderr)
+        sys.exit(2)
+    codes: dict[tuple[str, int], set[str]] = defaultdict(set)
+    target_keys = {(str(p), line) for p, lines in targets.items() for line in lines}
+    for out_line in proc.stdout.splitlines():
+        m = ERROR_RE.match(out_line)
+        if not m:
+            continue
+        key = (m["file"], int(m["line"]))
+        if key not in target_keys:
+            continue
+        for code in m["code"].split(","):
+            codes[key].add(code.strip())
+    return codes
+
+
+def rewrite(py: Path, codes_by_line: dict[int, list[str]]) -> tuple[int, list[int]]:
+    text = py.read_text()
+    out_lines: list[str] = []
+    rewritten = 0
+    leave_alone: list[int] = []
+    for i, line in enumerate(text.splitlines(), start=1):
+        if not BARE_RE.search(line):
+            out_lines.append(line)
+            continue
+        codes = codes_by_line.get(i, [])
+        if codes:
+            replacement = f"# type: ignore[{', '.join(codes)}]"
+            out_lines.append(BARE_RE.sub(replacement, line))
+            rewritten += 1
+        else:
+            out_lines.append(line)
+            leave_alone.append(i)
+    result = "\n".join(out_lines)
+    if text.endswith("\n"):
+        result += "\n"
+    py.write_text(result)
+    return rewritten, leave_alone
+
+
+def gather_codes(envs: list[str], targets: dict[Path, set[int]]) -> dict[tuple[str, int], set[str]]:
+    originals: dict[Path, str] = {}
+    aggregated: dict[tuple[str, int], set[str]] = defaultdict(set)
+    try:
+        for py in targets:
+            originals[py] = strip_bare(py)
+        for env in envs:
+            for key, codes in codes_per_env(env, targets).items():
+                aggregated[key] |= codes
+    finally:
+        for py, text in originals.items():
+            py.write_text(text)
+    return aggregated
+
+
+def print_plan(
+    targets: dict[Path, set[int]],
+    rewrites: dict[Path, dict[int, list[str]]],
+) -> None:
+    print("\n=== Plan ===")
+    rewrite_count = 0
+    deletion_candidates: list[tuple[Path, int]] = []
+    for py, all_lines in sorted(targets.items()):
+        for line in sorted(all_lines):
+            codes = rewrites.get(py, {}).get(line)
+            if codes:
+                rewrite_count += 1
+                print(f"  rewrite {py}:{line}  -> [{', '.join(codes)}]")
+            else:
+                deletion_candidates.append((py, line))
+    print(f"\nrewrites: {rewrite_count}")
+    print(f"deletion candidates (no code in any env): {len(deletion_candidates)}")
+    for py, line in deletion_candidates:
+        print(f"  drop?   {py}:{line}")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--apply", action="store_true", help="Write changes (default: dry-run)")
+    parser.add_argument("--envs", nargs="*", default=ENVS, help="Hatch envs to query")
+    args = parser.parse_args()
+
+    targets = find_bare_ignores()
+    total = sum(len(v) for v in targets.values())
+    print(f"Found {total} bare # type: ignore across {len(targets)} files.", file=sys.stderr)
+    if not targets:
+        return 0
+
+    aggregated = gather_codes(args.envs, targets)
+    rewrites: dict[Path, dict[int, list[str]]] = defaultdict(dict)
+    for (file, line), codes in aggregated.items():
+        rewrites[Path(file)][line] = sorted(codes)
+
+    print_plan(targets, rewrites)
+
+    if args.apply:
+        print("\n=== Applying ===")
+        for py in sorted(rewrites):
+            n, leave = rewrite(py, rewrites[py])
+            print(f"  {py}: rewrote {n}, left {len(leave)} bare (deletion candidates)")
+    else:
+        print("\nDry run. Re-run with --apply to write changes.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

- Replace every bare `# type: ignore` in `cosmos/` (50 lines across 18
  files) with `# type: ignore[code, ...]` so each suppression names the
  specific mypy error it was added for.
- Codes are the union of what mypy emits across five provisioned matrix
  cells (Airflow 2.10 on Py 3.10/3.11; Airflow 3.0 on Py 3.11/3.12;
  Airflow 3.1 on Py 3.11), so the ignores stay valid in every
  configuration we currently exercise.
- 40 lines were rewritten with one or more codes. Ten bare ignores emit
  no error in any of the five envs and are left as-is here; they will
  be dropped in the planned per-area deletion PRs after the intersection
  has been re-run against the full support matrix (notably Airflow 2.9
  and 3.2).

## Why

Bare `# type: ignore` silently swallows any future type error on the
same line. After tightening, only the specific error code the ignore
was added for is suppressed; any new mypy error on that line surfaces
through `hatch run …:type-check` instead of hiding.

This also makes the planned follow-up PRs that *delete* genuinely-unused
ignores far easier to review — each ignore now declares exactly what it
suppresses, so reviewers can verify "this code can't fire here anymore"
without re-running mypy against every cell.

`no_warn_unused_ignores = true` in `pyproject.toml` is intentionally
kept on for now. It will be flipped back to `false` in the final PR of
the cleanup series, once the deletion PRs have removed every truly
unused ignore.

## Tooling included

Two helper scripts are added under `scripts/` so the same approach is
reproducible:

- `scripts/tighten_type_ignores.py` — the script used to produce the
  diff in this PR. Patches out every bare ignore, runs mypy in each
  named hatch env, restores the originals, then rewrites each bare
  ignore with the union of codes mypy emitted across the envs. Default
  envs in the script cover Airflow 2.9–3.2 and dbt 1.5–2.0 — adjust the
  `--envs` flag to match what is provisioned locally.
- `scripts/find_unused_type_ignores.py` — runs mypy with
  `--warn-unused-ignores` in each env, intersects the results across
  envs, and reports ignores reported unused in **every** cell. Intended
  for the planned per-area deletion PRs.

Both scripts are standalone (no new runtime dependencies) and live next
to the existing `scripts/check_docs_style.py` and
`scripts/ci_dbtf_delete_snowflake_resources.py` helpers.

## Test plan

- [x] `hatch run tests.py3.11-2.10-1.9:type-check` — `mypy-python ... Passed`
- [x] `pre-commit run --files` on every changed file — all hooks Passed
- [x] Diff is line-for-line (40 insertions, 40 deletions in `cosmos/`)
      with no surrounding code touched
- [ ] CI passes on the full matrix (this is where the 2.9 / 3.2 cells
      we couldn't exercise locally get verified)

## Out of scope (deferred to follow-up PRs)

- Removing the 10 bare ignores listed as deletion candidates in the
  tighten run.
- Removing already-coded ignores that mypy reports as unused (the bigger
  cleanup, ~163 reports in this env alone before intersection).
- Flipping `no_warn_unused_ignores` back to `false` in `pyproject.toml`.

## Breaking change?

No. Coded ignores are functionally equivalent to bare ignores for the
specific error codes they list; this PR strictly tightens what each
ignore catches and changes no runtime behavior.

🤖 Generated with [Claude Code](https://claude.com/claude-code)