### PR TITLE
Remove unused bare `# type: ignore` comments

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -146,7 +146,7 @@ def exclude_detached_tests_if_needed(
         exclude_items = current_exclude.split() if current_exclude else []
     else:
         exclude_items = []
-    tests_detached_from_this_node: list[DbtNode] = detached_from_parent.get(node.unique_id, [])  # type: ignore
+    tests_detached_from_this_node: list[DbtNode] = detached_from_parent.get(node.unique_id, [])
     for test_node in tests_detached_from_this_node:
         exclude_items.append(test_node.resource_name.split(".")[0])
     if exclude_items:
@@ -501,7 +501,7 @@ def generate_or_convert_task(
         task_id = task_meta.id
         logger.debug("Converting node <%s> task <%s> using <%s>", node.unique_id, task_id, conversion_function.__name__)
         # In Cosmos 2.0 we should review this implementation and use render_config or another simpler interface:
-        task = conversion_function(  # type: ignore
+        task = conversion_function(
             dag=dag,
             task_group=task_group,
             dbt_project_name=dbt_project_name,
@@ -626,7 +626,7 @@ def generate_task_or_group(
                     **generate_or_convert_task_args,
                     "task_group": model_task_group,
                     "task_meta": test_meta,
-                    "resource_type": DbtResourceType.TEST,  # type: ignore
+                    "resource_type": DbtResourceType.TEST,
                 }
                 test_task = generate_or_convert_task(**test_task_generate_or_convert_task_args)  # type: ignore[arg-type]
                 task >> test_task
@@ -1044,7 +1044,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
         test_task_args = {
             **task_or_group_args,
             "task_meta": test_meta,
-            "resource_type": DbtResourceType.TEST,  # type: ignore
+            "resource_type": DbtResourceType.TEST,
         }
         # AFTER_ALL test is a single DAG-level task: place it at root so task_id stays e.g. "astro_shop_test"
         test_task_args["task_group"] = parent_task_group
@@ -1070,7 +1070,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             test_task_args = {
                 **task_or_group_args,
                 "task_meta": test_meta,
-                "resource_type": node.resource_type,  # type: ignore
+                "resource_type": node.resource_type,
             }
             test_task = generate_or_convert_task(**test_task_args)  # type: ignore[arg-type]
             tasks_map[node_id] = test_task

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -111,9 +111,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
             dag_id = kwargs.get("dag")
             task_group_id = kwargs.get("task_group")
-            kwargs["outlets"] = [
-                DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
-            ]  # type: ignore
+            kwargs["outlets"] = [DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))]
 
         # This is a workaround for Airflow 3 compatibility. In Airflow 2, the super().__init__() call worked correctly,
         # but in Airflow 3, it attempts to re-initialize AbstractDbtLocalBase with filtered kwargs that only include
@@ -165,7 +163,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
 
         elapsed_time = time.time() - start_time
         self.log.info("SQL file download completed in %.2f seconds.", elapsed_time)
-        return sql_query  # type: ignore
+        return sql_query
 
     def get_remote_sql(self) -> str:
         start_time = time.time()
@@ -175,7 +173,7 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         except ImportError:
             from airflow.io.path import ObjectStoragePath
 
-        file_path = self.async_context["dbt_node_config"]["file_path"]  # type: ignore
+        file_path = self.async_context["dbt_node_config"]["file_path"]
         dbt_dag_task_group_identifier = self.async_context["dbt_dag_task_group_identifier"]
         run_id = self.async_context["run_id"]
 

--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -107,8 +107,6 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
             except ImportError:
                 from airflow.datasets import DatasetAlias  # type: ignore
 
-            # ignoring the type because older versions of Airflow raise the follow error in mypy
-            # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
             dag_id = kwargs.get("dag")
             task_group_id = kwargs.get("task_group")
             kwargs["outlets"] = [DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))]

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -951,7 +951,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
                 task_group_id = kwargs.get("task_group")
                 operator_kwargs["outlets"] = [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
-                ]  # type: ignore
+                ]
 
         if "task_id" in operator_kwargs:
             operator_kwargs.pop("task_id")
@@ -1127,7 +1127,7 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
     def execute(self, context: Context, **kwargs: Any) -> None:
         result = self.build_and_run_cmd(context=context, cmd_flags=self.add_cmd_flags())
         self._set_test_result_parsing_methods()
-        number_of_warnings = self.parse_number_of_warnings(result)  # type: ignore
+        number_of_warnings = self.parse_number_of_warnings(result)
         if self.on_warning_callback and number_of_warnings > 0:
             self._handle_warnings(result, context)
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -945,8 +945,6 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
             ):
                 from airflow.datasets import DatasetAlias
 
-                # ignoring the type because older versions of Airflow raise the follow error in mypy
-                # error: Incompatible types in assignment (expression has type "list[DatasetAlias]", target has type "str")
                 dag_id = kwargs.get("dag")
                 task_group_id = kwargs.get("task_group")
                 operator_kwargs["outlets"] = [


### PR DESCRIPTION
## Summary

Drop ten bare `# type: ignore` comments that no longer suppress any
mypy error in the matrix cells I could exercise locally. With
`no_warn_unused_ignores = true` in `pyproject.toml`, the build never
flagged them, so they accumulated unnoticed.

The removals span three files:

| File | Lines removed |
|---|---|
| `cosmos/airflow/graph.py` | 5 |
| `cosmos/operators/_asynchronous/bigquery.py` | 3 |
| `cosmos/operators/local.py` | 2 |

After this PR, `hatch run tests.py3.11-2.10-1.9:type-check` still
reports `mypy-python ... Passed`.

## How the candidates were identified

For each bare `# type: ignore` in `cosmos/`, I ran mypy in five
provisioned matrix cells with the ignore patched out and recorded the
error code mypy emitted. The ten removed lines emitted no error in any
of the five cells:

- `tests.py3.10-2.10-1.9` (Airflow 2.10 / Py 3.10 / dbt 1.9)
- `tests.py3.11-2.10-1.9` (Airflow 2.10 / Py 3.11 / dbt 1.9)
- `tests.py3.11-3.0-1.9`  (Airflow 3.0  / Py 3.11 / dbt 1.9)
- `tests.py3.11-3.1-1.9`  (Airflow 3.1  / Py 3.11 / dbt 1.9)
- `tests.py3.12-3.0-1.10` (Airflow 3.0  / Py 3.12 / dbt 1.10)

Other bare and coded ignores still emit at least one error in at least
one of these cells, so they are kept.

## Coverage caveat

The full support matrix also includes Airflow 2.9, 2.11, and 3.2, plus
dbt 1.5–1.8 and 2.0, none of which I could provision locally. **CI will
exercise those cells** — if any of them surfaces an error on a removed
line, that specific removal should be reverted (or the relevant ignore
re-added with a code). I have not seen any evidence that this will
happen, but I cannot prove it from this branch alone.

## Why these specific ignores were obsolete

The ignores have outlived whatever error they originally suppressed,
typically because either the surrounding code changed shape or
Airflow's typings now express the type that previously required the
ignore. None of them encoded a constraint that the current type
information cannot already express.

## One incidental formatting change

In `cosmos/operators/_asynchronous/bigquery.py:114`, removing the
trailing ignore lets black collapse the multi-line
`kwargs["outlets"] = [DatasetAlias(...)]` block to a single line. That
is the only structural change in this PR — no behavior change.

## Test plan

- [x] `hatch run tests.py3.11-2.10-1.9:type-check` — `mypy-python ... Passed`
- [x] `hatch -e tests.py3.11-2.10-1.9 run pre-commit run --files <changed>` — all hooks Passed
- [x] No bare `# type: ignore` remains on any of the 10 targeted lines
- [ ] CI passes on the full matrix (this is where the cells I couldn't
      exercise locally — Airflow 2.9/2.11/3.2, dbt 1.5-1.8/2.0 — get
      verified)

## Breaking change?

No. The removed ignores were not suppressing any error in the cells
tested, and the only structural change is a black-driven single-line
collapse in `bigquery.py`.

## Out of scope

- Tightening the remaining bare `# type: ignore` comments (40 lines)
  into `# type: ignore[code, ...]` form.
- Removing the larger set of *coded* ignores that mypy reports as
  unused (~150+ before intersection, dominated by ignores that depend
  on the matrix cell). Both depend on first extending local coverage
  to Airflow 2.9 and 3.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)