### PR TITLE
Use GA versions for `propagate_logs` in provider_info

### DIFF
--- a/cosmos/provider_info.py
+++ b/cosmos/provider_info.py
@@ -21,8 +21,8 @@ def get_provider_info() -> dict[str, Any]:
                 "options": {
                     "propagate_logs": {
                         "description": "Enable log propagation from Cosmos custom logger\n",
-                        "version_added": "1.3.0a1",
-                        "version_deprecated": "1.6.0a1",
+                        "version_added": "1.3.0",
+                        "version_deprecated": "1.6.0",
                         "deprecation_reason": "`propagate_logs` is no longer necessary as of Cosmos 1.6.0"
                         " because the issue this option was meant to address is no longer an"
                         " issue with Cosmos's new logging approach.",


### PR DESCRIPTION
## Summary

`cosmos/provider_info.py` currently claims that the `propagate_logs`
config option was added in `1.3.0a1` and deprecated in `1.6.0a1`.
Both references pre-date the changes they describe by weeks; switching
them to the GA versions (`1.3.0` and `1.6.0`) makes the metadata
accurate and matches the version style every other Airflow provider
uses in `provider.yaml`.

## Evidence from the release history

| Claim in `provider_info.py` | What actually happened |
|---|---|
| `"version_added": "1.3.0a1"` | `1.3.0a1` tagged 2023-10-27. The commit that introduced `propagate_logs` (`d063b5ed`, PR #648) merged on 2023-11-09 — **two weeks later**. First alpha containing it: `1.3.0a2`. First GA: `1.3.0` (2024-01-04). |
| `"version_deprecated": "1.6.0a1"` | `1.6.0a1` tagged 2024-07-05. The "Simplify logging" change (`89f5999e`, PR #1108) that made the option redundant merged 2024-08-15 — **six weeks later**. First alpha with the deprecation: `1.6.0a7`. First GA: `1.6.0` (both on 2024-08-20). |

The existing `deprecation_reason` string already refers to `Cosmos
1.6.0` (no alpha suffix), so the file's own narrative already assumes
the GA boundary — this PR just makes the structured fields agree with
that.

## Diff

```diff
-                        "version_added": "1.3.0a1",
-                        "version_deprecated": "1.6.0a1",
+                        "version_added": "1.3.0",
+                        "version_deprecated": "1.6.0",
```

## Test plan

- [x] `hatch -e tests.py3.11-2.10-1.9 run pre-commit run --files cosmos/provider_info.py` — all hooks Passed (including `mypy-python`)
- [x] Diff is exactly the two string literals; no other changes
- [ ] CI green

## Breaking change?

No. The `version_added` / `version_deprecated` fields are documentation
metadata surfaced through Airflow's `airflow config list` and the
provider listing — they don't affect runtime behavior. The option
itself remains deprecated either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)