### PR TITLE
Fix: watcher consumer retry logging dbt with `--log-format json`

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -446,7 +446,15 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
 
     @staticmethod
     def _filter_flags(flags: list[str]) -> list[str]:
-        """Filters out dbt flags that are incompatible with retry (e.g., --select, --exclude)."""
+        """Filters out dbt flags that should not propagate from the producer to the consumer's retry:
+
+        - ``--select`` / ``--exclude``: the consumer targets a single model and re-applies its own selector.
+        - ``--log-format``: the producer always sets ``--log-format json`` so it can parse dbt's structured
+          event stream; the consumer's retry is a user-facing dbt run and should default to text. Users who
+          want JSON on the retry can opt in via
+          ``operator_args={"dbt_cmd_flags": ["--log-format", "json"]}``, which is appended by ``build_cmd``
+          outside of this flag pipeline.
+        """
         filtered = []
         skip_next = False
         for token in flags:
@@ -455,7 +463,7 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
                     skip_next = False
                 else:
                     continue  # skip value of previous flag
-            if token in ("--select", "--exclude"):
+            if token in ("--select", "--exclude", "--log-format"):
                 skip_next = True
                 continue
             filtered.append(token)
@@ -465,7 +473,13 @@ class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
         """
         Handles logic for retrying a failed dbt model execution.
         Reconstructs the dbt command by cloning the project and re-running the model
-        with appropriate flags, while ensuring flags like `--select` or `--exclude` are excluded.
+        with appropriate flags, while ensuring flags like ``--select``, ``--exclude``,
+        and ``--log-format`` (the producer-only JSON event stream) are excluded.
+
+        Users who want JSON-formatted dbt output on retry can opt in by passing
+        ``operator_args={"dbt_cmd_flags": ["--log-format", "json"]}`` to their
+        ``DbtDag`` / ``DbtTaskGroup``; ``dbt_cmd_flags`` is appended automatically
+        by ``build_cmd`` and is not filtered here.
 
         Subclasses may override to issue a different dbt subcommand (e.g. ``dbt test``
         for test sensors or ``dbt source freshness`` for source sensors).

--- a/dev/failed_dags/example_watcher_downstream_not_skipped_json_logs.py
+++ b/dev/failed_dags/example_watcher_downstream_not_skipped_json_logs.py
@@ -1,0 +1,101 @@
+"""
+Variant of ``example_watcher_downstream_not_skipped`` that opts into JSON-formatted dbt
+logs on the watcher consumer's retry, via
+``operator_args={"dbt_cmd_flags": ["--log-format", "json"]}``.
+
+Use this DAG to verify that:
+
+1. The producer's hardcoded ``--log-format json`` (used internally for event-stream parsing)
+   is stripped from the consumer's retry dbt command — i.e. the fix in
+   ``cosmos/operators/_watcher/base.py`` (``_filter_flags``) is working.
+2. When the user *explicitly* opts in via ``dbt_cmd_flags``, the consumer's retry dbt
+   command does emit JSON-formatted output (since ``dbt_cmd_flags`` is appended by
+   ``build_cmd`` outside the filter pipeline).
+
+Expected behaviour on the retry of ``watcher_downstream_not_skipped_json_logs.model_retry_run``:
+
+- Log lines are structured JSON objects (``{"data": ..., "info": ...}``) — exactly what
+  the user asked for. Without the ``dbt_cmd_flags`` opt-in, the same retry would emit
+  dbt's default text format (see ``example_watcher_downstream_not_skipped``).
+
+Reuses the same dbt project as the original DAG (``watcher_downstream_not_skipped``) and
+the same ``public._cosmos_fail_once_seq`` sequence — do **not** run both DAGs concurrently
+or they will race on the fail-once marker.
+"""
+
+import os
+from datetime import datetime, timedelta
+from pathlib import Path
+
+from airflow.models import DAG
+from airflow.providers.common.sql.operators.sql import SQLExecuteQueryOperator
+
+try:
+    from airflow.providers.standard.operators.empty import EmptyOperator
+except ImportError:
+    from airflow.operators.empty import EmptyOperator
+
+from cosmos import DbtTaskGroup, ExecutionConfig, ProfileConfig, ProjectConfig
+from cosmos.constants import ExecutionMode
+from cosmos.profiles import PostgresUserPasswordProfileMapping
+
+DEFAULT_DBT_ROOT_PATH = Path(__file__).parent.parent / "dags/dbt"
+DBT_ROOT_PATH = Path(os.getenv("DBT_ROOT_PATH", DEFAULT_DBT_ROOT_PATH))
+DBT_PROJECT_PATH = DBT_ROOT_PATH / "watcher_downstream_not_skipped"
+
+profile_config = ProfileConfig(
+    profile_name="default",
+    target_name="dev",
+    profile_mapping=PostgresUserPasswordProfileMapping(
+        conn_id="example_conn",
+        profile_args={"schema": "public"},
+        disable_event_tracking=True,
+    ),
+)
+
+execution_config = ExecutionConfig(
+    execution_mode=ExecutionMode.WATCHER,
+)
+
+# The user opt-in for JSON-formatted dbt output on the consumer's retry.
+operator_args = {
+    "install_deps": True,
+    "execution_timeout": timedelta(seconds=120),
+    "dbt_cmd_flags": ["--log-format", "json"],
+}
+
+if os.getenv("CI"):
+    operator_args["trigger_rule"] = "all_success"
+
+default_args = {
+    "retries": 2,
+    "retry_delay": timedelta(seconds=0),
+    "depends_on_past": True,
+}
+
+with DAG(
+    dag_id="example_watcher_downstream_not_skipped_json_logs",
+    schedule="@daily",
+    start_date=datetime(2023, 1, 1),
+    catchup=False,
+    default_args=default_args,
+):
+    dbt_group = DbtTaskGroup(
+        group_id="watcher_downstream_not_skipped_json_logs",
+        execution_config=execution_config,
+        project_config=ProjectConfig(DBT_PROJECT_PATH),
+        profile_config=profile_config,
+        operator_args=operator_args,
+    )
+
+    post_dbt = EmptyOperator(task_id="post_dbt")
+
+    cleanup = SQLExecuteQueryOperator(
+        task_id="drop_fail_once_marker",
+        conn_id="example_conn",
+        sql="DROP SEQUENCE IF EXISTS public._cosmos_fail_once_seq;",
+        trigger_rule="all_done",
+    )
+
+    dbt_group >> post_dbt
+    dbt_group >> cleanup

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1229,6 +1229,42 @@ class TestDbtConsumerWatcherSensor:
         assert "--select" in kwargs["cmd_flags"]
         assert MODEL_UNIQUE_ID.split(".", 2)[2] in kwargs["cmd_flags"]
 
+    def test_fallback_strips_producer_log_format_by_default(self):
+        """Producer's ``--log-format json`` (internal, used for event-stream parsing) must not leak into
+        the consumer's user-facing retry dbt command when the user hasn't asked for JSON.
+        """
+        sensor = self.make_sensor()
+        ti = MagicMock()
+        ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--log-format", "json", "--threads", "2"]
+        context = self.make_context(ti)
+        sensor.build_and_run_cmd = MagicMock()
+
+        sensor._fallback_to_non_watcher_run(2, context)
+
+        cmd_flags = sensor.build_and_run_cmd.call_args.kwargs["cmd_flags"]
+        assert "--log-format" not in cmd_flags
+        assert "json" not in cmd_flags
+
+    def test_fallback_preserves_user_dbt_cmd_flags_opt_in_to_json(self):
+        """User opt-in path: ``operator_args={"dbt_cmd_flags": ["--log-format", "json"]}`` reaches the
+        consumer as ``self.dbt_cmd_flags``. ``build_cmd`` (inside ``build_and_run_cmd``) auto-appends
+        ``self.dbt_cmd_flags`` to whatever ``cmd_flags`` we pass, so this path keeps working through
+        normal extension — no special handling in ``_fallback_to_non_watcher_run`` needed. The fallback's
+        ``cmd_flags`` payload itself should remain free of ``--log-format`` because that's stripped from
+        the producer's flags; ``self.dbt_cmd_flags`` is preserved for ``build_cmd`` to pick up.
+        """
+        sensor = self.make_sensor(dbt_cmd_flags=["--log-format", "json"])
+        ti = MagicMock()
+        ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--log-format", "json", "--threads", "2"]
+        context = self.make_context(ti)
+        sensor.build_and_run_cmd = MagicMock()
+
+        sensor._fallback_to_non_watcher_run(2, context)
+
+        cmd_flags = sensor.build_and_run_cmd.call_args.kwargs["cmd_flags"]
+        assert "--log-format" not in cmd_flags  # appended later by build_cmd from self.dbt_cmd_flags
+        assert sensor.dbt_cmd_flags == ["--log-format", "json"]
+
     def test_fallback_selector_preserves_version_suffix(self):
         """For versioned dbt models (e.g. ``model.pkg.my_model.v1``) the selector must keep the version suffix."""
         sensor = self.make_sensor()
@@ -1244,12 +1280,18 @@ class TestDbtConsumerWatcherSensor:
         assert kwargs["cmd_flags"] == ["--select", "stg_orders.v1"]
 
     def test_filter_flags(self):
-        flags = ["--select", "model", "--exclude", "other", "--threads", "2"]
+        flags = ["--select", "model", "--exclude", "other", "--log-format", "json", "--threads", "2"]
         expected = ["--threads", "2"]
 
         result = DbtConsumerWatcherSensor._filter_flags(flags)
 
         assert result == expected
+
+    def test_filter_flags_strips_log_format_when_first(self):
+        """--log-format at the start of the producer's flags is stripped along with its value."""
+        flags = ["--log-format", "json", "--threads", "2"]
+        result = DbtConsumerWatcherSensor._filter_flags(flags)
+        assert result == ["--threads", "2"]
 
     @patch("cosmos.operators._watcher.base.get_xcom_val")
     def test_producer_state_failed(self, mock_get_xcom_val):


### PR DESCRIPTION
When a watcher consumer task retries via `_fallback_to_non_watcher_run`, it copies the producer's `add_cmd_flags()` output into its own dbt invocation. The producer hardcodes `log_format="json"` so it can parse dbt's structured event stream — but that internal choice was leaking into the consumer's user-facing retry dbt command, producing raw JSON (one structured event per line) instead of dbt's default formatted text in task logs.

Example of what users currently see on a retry task like `watcher_downstream_not_skipped.model_downstream_run`:

```
[2026-05-20 21:45:11] INFO - {"data": {"log_version": 3, "version": "=1.11.8"}, "info": {"category": "", "code": "A001", ...}}
[2026-05-20 21:45:11] INFO - {"data": {"adapter_name": "***", ...}, "info": {"category": "", "code": "E034", ...}}
```

## Fix

Add `--log-format` to `_filter_flags`'s skip list. The producer's hardcoded `--log-format json` is no longer propagated into the consumer's fallback dbt command, so retries default to dbt's normal text output.

## How users can still get JSON

Users who want JSON-formatted dbt output on retry can opt in via:

```python
DbtDag(
    ...,
    operator_args={"dbt_cmd_flags": ["--log-format", "json"]},
)
```

`dbt_cmd_flags` is appended to the dbt command by `build_cmd` outside of `_filter_flags`'s pipeline, so this path keeps working after the fix.

## Test plan

### Automated

- [x] `tests/operators/test_watcher.py` updated:
  - `test_filter_flags` — extended to assert `--log-format <value>` is filtered alongside `--select` / `--exclude`
  - `test_filter_flags_strips_log_format_when_first` (new) — covers the edge case where `--log-format` is the first flag in the input list
  - `test_fallback_strips_producer_log_format_by_default` (new) — end-to-end verifies the consumer's retry command has no `--log-format`
  - `test_fallback_preserves_user_dbt_cmd_flags_opt_in_to_json` (new) — documents the opt-in path via `operator_args["dbt_cmd_flags"]`
- [x] All 12 affected tests pass on `tests.py3.12-2.11-1.11`.

### Manual validation DAGs

Two example DAGs in `dev/failed_dags/` exercise both sides of the change. Both intentionally fail once on `model_retry` and retry via the watcher fallback path — inspect the retry task's logs to verify behaviour. Do **not** run them concurrently (they share `public._cosmos_fail_once_seq`).

- [x] **`dev/failed_dags/example_watcher_downstream_not_skipped.py`** — default config (no `dbt_cmd_flags`). On the `watcher_downstream_not_skipped.model_retry_run` retry, log lines should be dbt's normal **text format** (e.g. `INFO  [MainThread]: Running with dbt=1.11.8`). Before this fix, those lines came through as raw JSON; after the fix, they should read normally.
- [x] **`dev/failed_dags/example_watcher_downstream_not_skipped_json_logs.py`** (new in this PR) — adds `operator_args={"dbt_cmd_flags": ["--log-format", "json"]}`. On the `watcher_downstream_not_skipped_json_logs.model_retry_run` retry, log lines should be structured **JSON** objects (`{"data": ..., "info": ...}`). Confirms the user opt-in still works after the fix.

## How this was discovered

Reported while validating `example_watcher_downstream_not_skipped`'s `model_downstream_run` retry on the [1.14.2a3 release candidate](https://github.com/astronomer/astronomer-cosmos/pull/2708).

## Backport

Targeting `main`; needs a backport to `release-1.14` so it ships in **1.14.2**. Add `Cosmos 1.14.2` milestone after merge.
