### PR TITLE
Disclose `--no-static-parser` flag in DBT_RUNNER mode

### DIFF
--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -12,6 +12,10 @@ For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes
    In order to use this mode, dbt must be installed in the same local environment. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and is faster than ``InvocationMode.SUBPROCESS``. \
    This mode requires dbt version 1.5.0 or higher. It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
 
+.. note::
+
+   When ``InvocationMode.DBT_RUNNER`` is used with dbt 1.5.6 or later, Cosmos automatically appends ``--no-static-parser`` to every dbt command it invokes. Cosmos copies the dbt project into a temporary directory at both DAG parse time and task execution time, and the differing temp paths can interfere with dbt's static parser and cause task hangs. Disabling the static parser is a workaround for this interaction. If you rely on dbt's static parser, use ``InvocationMode.SUBPROCESS`` instead.
+
 The invocation mode can be set in the ``ExecutionConfig`` as shown below:
 
 .. code-block:: python

--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -14,7 +14,13 @@ For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes
 
 .. note::
 
-   When ``InvocationMode.DBT_RUNNER`` is used with dbt 1.5.6 or later, Cosmos automatically appends ``--no-static-parser`` to every dbt command it invokes. Cosmos copies the dbt project into a temporary directory at both DAG parse time and task execution time, and the differing temp paths can interfere with dbt's static parser and cause task hangs. Disabling the static parser is a workaround for this interaction. If you rely on dbt's static parser, use ``InvocationMode.SUBPROCESS`` instead.
+   When ``InvocationMode.DBT_RUNNER`` is used with dbt-core 1.5.6 or later,
+   Cosmos automatically appends ``--no-static-parser`` to every dbt command
+   it invokes. Cosmos copies the dbt project into a temporary directory at
+   both DAG parse time and task execution time, and the differing temp paths
+   can interfere with dbt's static parser and cause task hangs. Disabling the
+   static parser is a workaround for this interaction. If you rely on dbt's
+   static parser, use ``InvocationMode.SUBPROCESS`` instead.
 
 The invocation mode can be set in the ``ExecutionConfig`` as shown below:
 

--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -20,7 +20,10 @@ For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes
    both DAG parse time and task execution time, and the differing temp paths
    can interfere with dbt's static parser and cause task hangs. Disabling the
    static parser is a workaround for this interaction. If you rely on dbt's
-   static parser, use ``InvocationMode.SUBPROCESS`` instead.
+   static parser, use ``InvocationMode.SUBPROCESS`` instead. See
+   `#1751 <https://github.com/astronomer/astronomer-cosmos/issues/1751>`_ and
+   `#1760 <https://github.com/astronomer/astronomer-cosmos/pull/1760>`_ for the
+   investigation that led to this workaround.
 
 The invocation mode can be set in the ``ExecutionConfig`` as shown below:
 


### PR DESCRIPTION
## Summary

Cosmos appends `--no-static-parser` to every dbt command invoked through `InvocationMode.DBT_RUNNER` on dbt 1.5.6+, but the behavior was only documented in a source-code comment (`cosmos/operators/local.py:529-540`). Users who tried to opt into dbt's static parser for performance had no way to discover this from the docs.

Adds a note to the invocation-mode page explaining that the flag is injected automatically, why it is needed (temp-path interaction between DAG parsing and task execution can hang tasks), and that `InvocationMode.SUBPROCESS` is the alternative for users who rely on the static parser.

Closes #1925.