### PR TITLE
Document `compiled_sql` and `freshness` as output-only template fields

### DIFF
--- a/docs/guides/run_dbt/operators/operator-args.rst
+++ b/docs/guides/run_dbt/operators/operator-args.rst
@@ -161,6 +161,19 @@ The following template fields are only selectable when using the operators in a 
 
 Since Airflow resolves template fields during Airflow DAG execution and not DAG parsing, the args above cannot be templated via ``DbtDag`` and ``DbtTaskGroup`` because both need to select dbt nodes during DAG parsing.
 
-Additionally, the SQL for compiled dbt models is stored in the template fields, which is viewable in the Airflow UI for each task run.
-This is provided for telemetry on task execution, and is not an operator arg.
-For more information about this, see the :doc:`Compiled SQL </guides/cosmos_devex/compiled-sql>` docs.
+Output-only template fields
++++++++++++++++++++++++++++
+
+A small number of template fields on the local execution mode operators are
+*output-only*: Cosmos populates them as the task runs so the values appear in the
+Airflow UI, but any value passed in via ``operator_args`` is silently
+overwritten and has no effect.
+
+- ``compiled_sql`` — the SQL Cosmos compiled for a model. See the
+  :doc:`Compiled SQL </guides/cosmos_devex/compiled-sql>` docs for how it
+  is populated and how to disable it via ``should_store_compiled_sql``.
+- ``freshness`` — the JSON Cosmos captures from ``dbt source freshness`` when
+  source nodes run, reset on every task instance.
+
+If you need to set one of these values through ``operator_args`` for an
+upstream task to consume, use a separate, regular template field instead.

--- a/docs/guides/run_dbt/operators/operator-args.rst
+++ b/docs/guides/run_dbt/operators/operator-args.rst
@@ -174,6 +174,3 @@ overwritten and has no effect.
   is populated and how to disable it via ``should_store_compiled_sql``.
 - ``freshness`` — the JSON Cosmos captures from ``dbt source freshness`` when
   source nodes run, reset on every task instance.
-
-If you need to set one of these values through ``operator_args`` for an
-upstream task to consume, use a separate, regular template field instead.


### PR DESCRIPTION
## Description

Relates to: #2666.

`compiled_sql` and `freshness` are both registered in the local execution-mode operators' `template_fields` (`cosmos/operators/local.py`), which makes them look like user-settable Jinja-templatable args. In practice both are *output-only*:

- `__init__` unconditionally resets `self.compiled_sql = ""` and `self.freshness = ""` on every operator instantiation.
- `store_freshness_json` later overwrites `self.freshness` with the captured `sources.json` after `dbt source freshness` runs.

So any value a user passes via `operator_args={"freshness": ...}` (or `compiled_sql`) is silently discarded — no effect, no warning.

This PR is the documentation-only option proposed in #2666: expand the existing "Template fields" section in `docs/guides/run_dbt/operators/operator-args.rst` with a small "Output-only template fields" subsection that calls out both fields and explains why values supplied through `operator_args` have no effect. The runtime behavior is unchanged.

If you'd rather pursue option 1 (actually let users pass values), I'm happy to send a follow-up — but the docs clarification is useful regardless.

## Related Issue(s)

Relates to #2666

## Breaking Change?

No — docs-only change.

## Checklist

- [x] I have made corresponding changes to the documentation (this *is* the docs change)
- [ ] I have added tests that prove my fix is effective or that my feature works

No new tests — the change is documentation only.
