### PR TITLE
Document tradeoffs of remote cache and disabling dbt ls cache

### DIFF
--- a/docs/optimize_performance/caching.rst
+++ b/docs/optimize_performance/caching.rst
@@ -42,6 +42,18 @@ Variables. To do so, you need to configure a remote cache directory. See :ref:`r
 user feedback. The ``remote_cache_dir`` will eventually be merged into the :ref:`cache_dir` setting in upcoming
 releases.
 
+**Choosing between Variable cache and remote cache**
+
+By default, Cosmos stores this cache in an Airflow Variable, which is read directly from the Airflow metadata database
+and is typically the fastest option. The remote cache directory stores the cache in object storage (S3, GCS, Azure Blob)
+and trades that for portability across environments; in exchange, every DAG parse fetches the cache over the network.
+On busy deployments, this has been observed to add roughly 2 to 4 seconds of latency per parse. If parse time matters
+more than cross-environment portability for your workload, prefer the default Variable cache.
+
+Disabling this cache entirely (``AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS=0``) is also supported, but means ``dbt ls`` runs
+on every DAG parse cycle, which can significantly increase scheduler DAG processing time and task queueing time on
+deployments with many Cosmos DAGs.
+
 **How the cache is refreshed**
 
 If using the default Variables cache approach, users can purge or delete the cache via Airflow UI by identifying and
@@ -125,6 +137,18 @@ Variables. To do so, you need to configure a remote cache directory. See :ref:`r
 :ref:`remote_cache_dir_conn_id` for more information. This is an experimental feature introduced in 1.6.0 to gather
 user feedback. The ``remote_cache_dir`` will eventually be merged into the :ref:`cache_dir` setting in upcoming
 releases.
+
+**Choosing between Variable cache and remote cache**
+
+By default, Cosmos stores this cache in an Airflow Variable, which is read directly from the Airflow metadata database
+and is typically the fastest option. The remote cache directory stores the cache in object storage (S3, GCS, Azure Blob)
+and trades that for portability across environments; in exchange, every DAG parse fetches the cache over the network.
+On busy deployments, this has been observed to add roughly 2 to 4 seconds of latency per parse. If parse time matters
+more than cross-environment portability for your workload, prefer the default Variable cache.
+
+Disabling this cache entirely (``AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS=0``) is also supported, but means
+the YAML selectors are reparsed on every DAG parse cycle, which can increase scheduler DAG processing time on
+deployments with many Cosmos DAGs that use ``RenderConfig.selector``.
 
 **How the cache is refreshed**
 

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -48,6 +48,8 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 
 `enable_cache_dbt_ls`_:
     Enable or disable caching of the dbt ls command in case using ``LoadMode.DBT_LS`` in an Airflow Variable.
+    Disabling this causes ``dbt ls`` to run on every DAG parse, which can significantly increase scheduler
+    DAG processing and task queueing times on deployments with many Cosmos DAGs.
 
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS``
@@ -56,6 +58,8 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 
 `enable_cache_dbt_yaml_selectors`_:
     Enable or disable caching of the YAML selectors in case using ``LoadMode.DBT_MANIFEST`` with ``RenderConfig.selector`` in an Airflow Variable.
+    Disabling this causes the YAML selectors to be reparsed on every DAG parse, which can increase scheduler
+    DAG processing time on deployments with many Cosmos DAGs that use ``RenderConfig.selector``.
 
     - Default: ``True``
     - Environment Variable: ``AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS``
@@ -209,6 +213,10 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 
     This is an experimental feature available since Cosmos 1.6 to gather user feedback and will be merged into the
     ``cache_dir`` setting in upcoming releases.
+
+    Using a remote cache moves the read off the Airflow metadata database but adds network latency on every DAG
+    parse (observed at roughly 2 to 4 seconds per parse on busy deployments). Prefer the default Variable-backed
+    cache unless you specifically need the cache to be shared across deployments.
 
     - Default: ``None``
     - Environment Variable: ``AIRFLOW__COSMOS__REMOTE_CACHE_DIR``


### PR DESCRIPTION
## Summary

- Add a "Choosing between Variable cache and remote cache" subsection to both the dbt ls and YAML selectors cache sections in `docs/optimize_performance/caching.rst`, calling out the roughly 2 to 4 seconds of per-parse latency observed with remote cache on busy deployments, and the parse-time penalty of disabling either cache entirely.
- Add one-line tradeoff notes to the `enable_cache_dbt_ls`, `enable_cache_dbt_yaml_selectors`, and `remote_cache_dir` entries in `docs/reference/configs/cosmos-conf.rst`.

Both of these tradeoffs were previously folklore, easy to miss when choosing between cache backends or deciding whether to disable caching. Documenting them inline makes it easier for anyone reading the docs to pick the right setting for their deployment on the first attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)