### PR TITLE
Reject `compiled_sql` and freshness in `operator_args` at init

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -120,8 +120,6 @@ from cosmos.operators.base import (
 
 logger = get_logger(__name__)
 
-_OUTPUT_ONLY_TEMPLATE_FIELDS: tuple[str, ...] = ("compiled_sql", "freshness")
-
 
 def _read_target_sources_json(project_root: Path) -> dict[str, Any] | None:
     """Parse ``target/sources.json`` under ``project_root`` if the file exists."""
@@ -193,17 +191,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     _OUTPUT_ONLY_TEMPLATE_FIELDS: tuple[str, ...] = ("compiled_sql", "freshness")
     _process_log_line_callable: Callable[[str, Any], None] | None = None
 
-    def _warn_on_output_only_fields(self, kwargs: dict[str, Any]) -> None:
-        """Warn when output-only template fields are passed directly to local operators."""
-        for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
-            if field in kwargs:
-                self.log.warning(
-                    "The '%s' argument passed to %s will be overwritten at runtime; "
-                    "it is an output-only template field.",
-                    field,
-                    self.__class__.__name__,
-                )
-
     def __init__(
         self,
         task_id: str,
@@ -220,14 +207,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         dbt_runner_callbacks: list[Callable] | None = None,  # type: ignore[type-arg]
         **kwargs: Any,
     ) -> None:
-        forbidden = [f for f in self._OUTPUT_ONLY_TEMPLATE_FIELDS if f in kwargs]
-        if forbidden:
-            names = ", ".join(repr(f) for f in forbidden)
-            raise CosmosValueError(
-                f"{names} {'is' if len(forbidden) == 1 else 'are'} output-only "
-                "template field(s) populated by Cosmos at runtime; "
-                "remove them from operator_args."
-            )
         self.task_id = task_id
         self.profile_config = profile_config
         self.callback = callback
@@ -1003,13 +982,26 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
         # Airflow provider operators that enable deferrable SQL query execution. Since super().__init__() was removed
         # from AbstractDbtBase and different parent classes require distinct initialization arguments, we explicitly
         # initialize them (including the BaseOperator) here by segregating the required arguments for each parent class.
+        # ``compiled_sql`` and ``freshness`` are template fields populated by
+        # Cosmos at runtime, not constructor arguments. They are not part of any
+        # __init__ signature, so the argspec-based segregation below silently
+        # drops them — a user who sets them via ``operator_args`` would get no
+        # error and no effect. Reject them up front, before that split, so the
+        # misuse fails fast with a clear message.
+        forbidden = [f for f in self._OUTPUT_ONLY_TEMPLATE_FIELDS if f in kwargs]
+        if forbidden:
+            names = ", ".join(repr(f) for f in forbidden)
+            raise CosmosValueError(
+                f"{names} {'is' if len(forbidden) == 1 else 'are'} output-only "
+                "template field(s) populated by Cosmos at runtime; "
+                "remove them from operator_args."
+            )
+
         base_kwargs = {}
         operator_kwargs = {}
         operator_args = {*inspect.signature(BaseOperator.__init__).parameters.keys()}
 
         default_args = kwargs.get("default_args", {})
-
-        self._warn_on_output_only_fields(kwargs)
 
         for arg in operator_args:
             try:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -187,6 +187,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         "compiled_sql": "sql",
         "freshness": "json",
     }
+    # These template fields are populated by Cosmos at runtime; values supplied
+    # via ``operator_args`` (or directly to the operator) would be silently
+    # overwritten, so reject them at instantiation instead.
+    _OUTPUT_ONLY_TEMPLATE_FIELDS: tuple[str, ...] = ("compiled_sql", "freshness")
     _process_log_line_callable: Callable[[str, Any], None] | None = None
 
     def _warn_on_output_only_fields(self, kwargs: dict[str, Any]) -> None:
@@ -216,6 +220,14 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         dbt_runner_callbacks: list[Callable] | None = None,  # type: ignore[type-arg]
         **kwargs: Any,
     ) -> None:
+        forbidden = [f for f in self._OUTPUT_ONLY_TEMPLATE_FIELDS if f in kwargs]
+        if forbidden:
+            names = ", ".join(repr(f) for f in forbidden)
+            raise CosmosValueError(
+                f"{names} {'is' if len(forbidden) == 1 else 'are'} output-only "
+                "template field(s) populated by Cosmos at runtime; "
+                "remove them from operator_args."
+            )
         self.task_id = task_id
         self.profile_config = profile_config
         self.callback = callback

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -3019,11 +3019,16 @@ def test_dbt_seed_local_operator_is_full_refresh(full_refresh, expected):
     assert operator._is_full_refresh() is expected
 
 
-def test_dbt_local_operator_warns_on_output_only_template_fields(caplog):
-    """Test that passing compiled_sql or freshness to local operators emits a warning."""
+def test_dbt_run_local_operator_rejects_output_only_template_fields():
+    """A concrete local operator (through the mixin path) also rejects the fields.
+
+    Exercises the real ``operator_args`` path: ``DbtRunLocalOperator`` routes
+    through ``DbtLocalBaseOperator.__init__``, where the guard inspects the raw
+    kwargs before they are segregated by argspec.
+    """
     from cosmos.operators.local import DbtRunLocalOperator
 
-    with caplog.at_level("WARNING", logger="cosmos.operators.local"):
+    with pytest.raises(CosmosValueError, match="compiled_sql"):
         DbtRunLocalOperator(
             task_id="fake-task",
             profile_config=profile_config,
@@ -3031,7 +3036,3 @@ def test_dbt_local_operator_warns_on_output_only_template_fields(caplog):
             compiled_sql="SELECT 1",
             freshness="test",
         )
-
-    assert "compiled_sql" in caplog.text
-    assert "freshness" in caplog.text
-    assert "output-only template field" in caplog.text

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -184,6 +184,38 @@ def test_install_deps_false_skips_dependencies_file_probe(mock_has_deps_file):
     assert dbt_base_operator._should_install_deps() is False
 
 
+@pytest.mark.parametrize("field", ["compiled_sql", "freshness"])
+def test_dbt_local_operator_rejects_output_only_template_fields(field):
+    """``compiled_sql`` and ``freshness`` are populated by Cosmos at runtime.
+
+    Passing them via ``operator_args`` (i.e. as kwargs to the operator) used to
+    be silently overwritten in ``__init__``; we now fail fast at instantiation
+    with a clear error so the misuse is caught immediately.
+    """
+    with pytest.raises(CosmosValueError, match=field):
+        ConcreteDbtLocalBaseOperator(
+            profile_config=profile_config,
+            task_id="my-task",
+            project_dir="my/dir",
+            **{field: "value-the-user-tried-to-set"},
+        )
+
+
+def test_dbt_local_operator_rejects_multiple_output_only_template_fields():
+    """When both forbidden fields are passed, the error names both of them."""
+    with pytest.raises(CosmosValueError) as excinfo:
+        ConcreteDbtLocalBaseOperator(
+            profile_config=profile_config,
+            task_id="my-task",
+            project_dir="my/dir",
+            compiled_sql="x",
+            freshness="y",
+        )
+    message = str(excinfo.value)
+    assert "compiled_sql" in message
+    assert "freshness" in message
+
+
 def test_dbt_base_operator_add_global_flags() -> None:
     dbt_base_operator = ConcreteDbtLocalBaseOperator(
         profile_config=profile_config,


### PR DESCRIPTION
## Description

Follow-up to #2719, picking up the runtime change @tatiana proposed on [that PR](https://github.com/astronomer/astronomer-cosmos/pull/2719#pullrequestreview-3460200000).

`compiled_sql` and `freshness` are listed in `template_fields` on the local-execution-mode operators, which makes them look like user-settable Jinja-templatable args, but they are populated by Cosmos at runtime:

- `AbstractDbtLocalBase.__init__` unconditionally resets `self.compiled_sql = ""` and `self.freshness = ""`.
- The dbt run / `store_freshness_json` handlers fill them in afterwards.

So any value a user passed via `operator_args={"compiled_sql": ...}` (or directly to the operator) was silently overwritten and had no effect.

This PR fails fast in `AbstractDbtLocalBase.__init__`: if either field is present in `**kwargs`, raise `CosmosValueError` naming the field(s) so the misuse is caught at task instantiation rather than discarded at runtime.

```text
CosmosValueError: 'compiled_sql' is output-only template field(s) populated by
Cosmos at runtime; remove them from operator_args.
```

## Related Issue(s)

Closes #2666

## Breaking Change?

Technically yes — code that *passed* these fields was always a silent no-op, but it will now raise on task instantiation. The behaviour was never functional, so the surface area is narrow.

## Checklist

- [x] I have made corresponding changes to the documentation (the docs subsection landing in #2719 already calls these fields output-only)
- [x] I have added tests that prove my fix is effective (`tests/operators/test_local.py` — parametrised for both fields, plus a combined case)

Caveat on local verification: I could not run `hatch run tests …` locally because the docs/test env install fails on `openlineage-sql` (Rust toolchain needed on Windows). The change is small and surgical — a 7-line guard in `__init__` plus two test cases — and `ruff check` / `black --check` are clean. Happy to iterate on anything CI surfaces.
