### PR TITLE
Bump black from 26.3.1 to 26.5.1

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -106,7 +106,7 @@ repos:
     hooks:
       - id: blacken-docs
         alias: black
-        additional_dependencies: [black>=26.5.1]
+        additional_dependencies: [black==26.5.1]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # v2.1.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -97,7 +97,7 @@ repos:
       - id: ruff-check
         args: [ --fix ]
   - repo: https://github.com/psf/black-pre-commit-mirror
-    rev: fa505ab9c3e0fedafe1709fd7ac2b5f8996c670d  # 26.3.1
+    rev: 4160603246a6b365d4a2af661c6d71b0a0f50478  # 26.5.1
     hooks:
       - id: black
         args: ["--config", "./pyproject.toml"]
@@ -106,7 +106,7 @@ repos:
     hooks:
       - id: blacken-docs
         alias: black
-        additional_dependencies: [black>=26.3.1]
+        additional_dependencies: [black>=26.5.1]
   - repo: https://github.com/pre-commit/mirrors-mypy
     rev: d2823d321df3af8f878f7ee3414dc94d037145b9  # v2.1.0
     hooks:


### PR DESCRIPTION
## Summary

Align the `psf/black-pre-commit-mirror` hook `rev` with the `blacken-docs`
hook's `additional_dependencies` constraint so both pin black 26.5.1.
Previously only the `blacken-docs` constraint was being bumped, leaving
the main black hook running 26.3.1.

Related: #2706 

🤖 Generated with [Claude Code](https://claude.com/claude-code)