### PR TITLE
Allow templating dbt deps installation via ExecutionConfig

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -176,7 +176,9 @@ class ProjectConfig:
     :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True. Accepts a
         boolean or an Airflow Jinja-templated string (e.g. ``"{{ params.install_deps }}"``) that renders to a
         boolean or boolean-like string at task execution time. When a template string is provided, ``dbt deps``
-        is always run during DAG parsing (since templates are only rendered at task execution time).
+        runs during DAG parsing only when a non-empty ``packages.yml``/``dependencies.yml`` is present (since
+        templates are only rendered at task execution time); if no dependencies file exists, ``dbt deps`` is
+        skipped at both parse and execution time.
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
     :param models_relative_path: The relative path to the dbt models directory within the project. Defaults to models
     :param seeds_relative_path: The relative path to the dbt seeds directory within the project. Defaults to seeds

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -173,7 +173,10 @@ class ProjectConfig:
     Class for setting project config.
 
     :param dbt_project_path: The path to the dbt project directory. Example: /path/to/dbt/project. Defaults to None
-    :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True.
+    :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True. Accepts a
+        boolean or an Airflow Jinja-templated string (e.g. ``"{{ params.install_deps }}"``) that renders to a
+        boolean or boolean-like string at task execution time. When a template string is provided, ``dbt deps``
+        is always run during DAG parsing (since templates are only rendered at task execution time).
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
     :param models_relative_path: The relative path to the dbt models directory within the project. Defaults to models
     :param seeds_relative_path: The relative path to the dbt seeds directory within the project. Defaults to seeds
@@ -193,7 +196,7 @@ class ProjectConfig:
     """
 
     dbt_project_path: Path | None = None
-    install_dbt_deps: bool = True
+    install_dbt_deps: bool | str = True
     copy_dbt_packages: bool = settings.default_copy_dbt_packages
     manifest_path: Path | ObjectStoragePath | None = None
     models_path: Path | None = None
@@ -204,7 +207,7 @@ class ProjectConfig:
     def __init__(
         self,
         dbt_project_path: str | Path | None = None,
-        install_dbt_deps: bool = True,
+        install_dbt_deps: bool | str = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         models_relative_path: str | Path = "models",
         seeds_relative_path: str | Path = "seeds",

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -173,12 +173,9 @@ class ProjectConfig:
     Class for setting project config.
 
     :param dbt_project_path: The path to the dbt project directory. Example: /path/to/dbt/project. Defaults to None
-    :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True. Accepts a
-        boolean or an Airflow Jinja-templated string (e.g. ``"{{ params.install_deps }}"``) that renders to a
-        boolean or boolean-like string at task execution time. When a template string is provided, ``dbt deps``
-        runs during DAG parsing only when a non-empty ``packages.yml``/``dependencies.yml`` is present (since
-        templates are only rendered at task execution time); if no dependencies file exists, ``dbt deps`` is
-        skipped at both parse and execution time.
+    :param install_dbt_deps: Run dbt deps during DAG parsing and task execution. Defaults to True. To control
+        ``dbt deps`` per DAG run via an Airflow template (e.g. ``"{{ params.install_deps }}"``), set
+        ``ExecutionConfig.install_dbt_deps`` instead, which overrides this value at task execution time only.
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
     :param models_relative_path: The relative path to the dbt models directory within the project. Defaults to models
     :param seeds_relative_path: The relative path to the dbt seeds directory within the project. Defaults to seeds
@@ -198,7 +195,7 @@ class ProjectConfig:
     """
 
     dbt_project_path: Path | None = None
-    install_dbt_deps: bool | str = True
+    install_dbt_deps: bool = True
     copy_dbt_packages: bool = settings.default_copy_dbt_packages
     manifest_path: Path | ObjectStoragePath | None = None
     models_path: Path | None = None
@@ -209,7 +206,7 @@ class ProjectConfig:
     def __init__(
         self,
         dbt_project_path: str | Path | None = None,
-        install_dbt_deps: bool | str = True,
+        install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         models_relative_path: str | Path = "models",
         seeds_relative_path: str | Path = "seeds",
@@ -426,6 +423,11 @@ class ExecutionConfig:
     :param test_indirect_selection: The mode to configure the test behavior when performing indirect selection.
     :param dbt_executable_path: The path to the dbt executable for runtime execution. Defaults to dbt if available on the path.
     :param dbt_project_path: Configures the DBT project location accessible at runtime for dag execution. This is the project path in a docker container for ExecutionMode.DOCKER or ExecutionMode.KUBERNETES. Mutually Exclusive with ProjectConfig.dbt_project_path
+    :param install_dbt_deps: Whether to run ``dbt deps`` at task execution time. When set, overrides
+        ``ProjectConfig.install_dbt_deps`` for execution only (it does not affect DAG parsing). Accepts a
+        boolean or an Airflow Jinja-templated string (e.g. ``"{{ params.install_deps }}"``) that renders to a
+        boolean or boolean-like string, so ``dbt deps`` can be controlled per DAG run. Defaults to None
+        (fall back to ``ProjectConfig.install_dbt_deps``).
     :param virtualenv_dir: Directory path to locate the (cached) virtual env that
     should be used for execution when execution mode is set to `ExecutionMode.VIRTUALENV`
     :param async_py_requirements:  A list of Python packages to install when `ExecutionMode.AIRFLOW_ASYNC` is used. This parameter is required only if both `enable_setup_async_task` and `enable_teardown_async_task` are set to `True`.
@@ -440,6 +442,7 @@ class ExecutionConfig:
     test_indirect_selection: TestIndirectSelection = TestIndirectSelection.EAGER
     dbt_executable_path: str | Path = field(default_factory=get_system_dbt)
 
+    install_dbt_deps: bool | str | None = None
     dbt_project_path: InitVar[str | Path | None] = None
     virtualenv_dir: str | Path | None = None
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -135,13 +135,18 @@ def validate_arguments(
         has_non_empty_dependencies = execution_config.project_path and has_non_empty_dependencies_file(
             execution_config.project_path
         )
+        # When `install_dbt_deps` (or the deprecated `install_deps` operator_arg) is a Jinja-templated string,
+        # its actual value is only known at task execution time, so skip the parse-time consistency check.
+        install_deps_task_arg = task_args.get("install_deps", True)
+        is_templated_install_deps = isinstance(install_deps_task_arg, str) or isinstance(render_config.dbt_deps, str)
         if (
             has_non_empty_dependencies
             and (
                 render_config.load_method == LoadMode.DBT_LS
                 or (render_config.load_method == LoadMode.AUTOMATIC and not project_config.is_manifest_available())
             )
-            and (render_config.dbt_deps != task_args.get("install_deps", True))
+            and not is_templated_install_deps
+            and (render_config.dbt_deps != install_deps_task_arg)
         ):
             err_msg = f"When using `LoadMode.DBT_LS` and `{execution_config.execution_mode}`, the value of `dbt_deps` in `RenderConfig` should be the same as the `operator_args['install_deps']` value."
             raise CosmosValueError(err_msg)
@@ -454,8 +459,14 @@ class DbtToAirflowConverter:
 
         if render_config is not None:
             metadata["invocation_mode"] = str(render_config.invocation_mode.value)
+            # Telemetry captures the parse-time install-deps decision. When the value is a Jinja template
+            # string, the runtime value is not known until task execution, so we report the parse-time
+            # default (True, matching the behavior in DbtGraph).
+            effective_install_deps = (
+                render_config.dbt_deps if render_config.dbt_deps is not None else project_config.install_dbt_deps
+            )
             metadata["install_deps"] = (
-                bool(render_config.dbt_deps) if render_config.dbt_deps is not None else project_config.install_dbt_deps
+                bool(effective_install_deps) if isinstance(effective_install_deps, bool) else True
             )
             metadata["uses_node_converter"] = render_config.node_converters is not None
             metadata["test_behavior"] = str(render_config.test_behavior.value)

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -259,13 +259,12 @@ def override_configuration(
         operator_args["invocation_mode"] = execution_config.invocation_mode
 
     if execution_config.execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV, ExecutionMode.WATCHER):
-        if "install_deps" not in operator_args:
-            # ExecutionConfig.install_dbt_deps overrides ProjectConfig.install_dbt_deps for execution only.
-            operator_args["install_deps"] = (
-                execution_config.install_dbt_deps
-                if execution_config.install_dbt_deps is not None
-                else project_config.install_dbt_deps
-            )
+        # ExecutionConfig.install_dbt_deps overrides ProjectConfig.install_dbt_deps and the deprecated
+        # operator_args value for execution only; otherwise fall back to those existing values.
+        if execution_config.install_dbt_deps is not None:
+            operator_args["install_deps"] = execution_config.install_dbt_deps
+        elif "install_deps" not in operator_args:
+            operator_args["install_deps"] = project_config.install_dbt_deps
         if "copy_dbt_packages" not in operator_args:
             operator_args["copy_dbt_packages"] = project_config.copy_dbt_packages
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -12,8 +12,6 @@ from collections.abc import Callable
 from typing import Any
 from warnings import warn
 
-from airflow.utils.strings import to_boolean
-
 try:
     from airflow.sdk.exceptions import ParamValidationError
 except ImportError:
@@ -60,21 +58,6 @@ from cosmos.telemetry import _compress_telemetry_metadata, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
-
-
-def _is_jinja_template(value: Any) -> bool:
-    """Return True only for strings containing Jinja delimiters (``{{`` or ``{%``)."""
-    return isinstance(value, str) and ("{{" in value or "{%" in value)
-
-
-def _normalize_install_deps(value: Any) -> Any:
-    """Resolve non-templated string forms of ``install_deps`` (e.g. ``"False"``) to a real bool.
-
-    Real bools and Jinja-templated strings are returned unchanged.
-    """
-    if isinstance(value, str) and not _is_jinja_template(value):
-        return bool(to_boolean(value))
-    return value
 
 
 def migrate_to_new_interface(
@@ -152,20 +135,16 @@ def validate_arguments(
         has_non_empty_dependencies = execution_config.project_path and has_non_empty_dependencies_file(
             execution_config.project_path
         )
-        # When `install_dbt_deps` (or the deprecated `install_deps` operator_arg) is a Jinja-templated string,
-        # its actual value is only known at task execution time, so skip the parse-time consistency check.
-        # Literal strings like "True"/"False" are normalized to a bool so the check still runs.
-        install_deps_task_arg = _normalize_install_deps(task_args.get("install_deps", True))
-        normalized_dbt_deps = _normalize_install_deps(render_config.dbt_deps)
-        is_templated_install_deps = _is_jinja_template(install_deps_task_arg) or _is_jinja_template(normalized_dbt_deps)
         if (
             has_non_empty_dependencies
             and (
                 render_config.load_method == LoadMode.DBT_LS
                 or (render_config.load_method == LoadMode.AUTOMATIC and not project_config.is_manifest_available())
             )
-            and not is_templated_install_deps
-            and (normalized_dbt_deps != install_deps_task_arg)
+            # ExecutionConfig.install_dbt_deps intentionally overrides the parse-time value for execution only,
+            # so the parse-time consistency check does not apply when it is set.
+            and execution_config.install_dbt_deps is None
+            and (render_config.dbt_deps != task_args.get("install_deps", True))
         ):
             err_msg = f"When using `LoadMode.DBT_LS` and `{execution_config.execution_mode}`, the value of `dbt_deps` in `RenderConfig` should be the same as the `operator_args['install_deps']` value."
             raise CosmosValueError(err_msg)
@@ -281,7 +260,12 @@ def override_configuration(
 
     if execution_config.execution_mode in (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV, ExecutionMode.WATCHER):
         if "install_deps" not in operator_args:
-            operator_args["install_deps"] = project_config.install_dbt_deps
+            # ExecutionConfig.install_dbt_deps overrides ProjectConfig.install_dbt_deps for execution only.
+            operator_args["install_deps"] = (
+                execution_config.install_dbt_deps
+                if execution_config.install_dbt_deps is not None
+                else project_config.install_dbt_deps
+            )
         if "copy_dbt_packages" not in operator_args:
             operator_args["copy_dbt_packages"] = project_config.copy_dbt_packages
 
@@ -478,14 +462,8 @@ class DbtToAirflowConverter:
 
         if render_config is not None:
             metadata["invocation_mode"] = str(render_config.invocation_mode.value)
-            # Telemetry captures the parse-time install-deps decision. Real bools and literal string
-            # forms (e.g. "False") are recorded as their resolved bool. Jinja-templated values resolve
-            # at task execution time, so we fall back to True (matching the parse-time default in DbtGraph).
-            effective_install_deps = _normalize_install_deps(
-                render_config.dbt_deps if render_config.dbt_deps is not None else project_config.install_dbt_deps
-            )
             metadata["install_deps"] = (
-                bool(effective_install_deps) if isinstance(effective_install_deps, bool) else True
+                bool(render_config.dbt_deps) if render_config.dbt_deps is not None else project_config.install_dbt_deps
             )
             metadata["uses_node_converter"] = render_config.node_converters is not None
             metadata["test_behavior"] = str(render_config.test_behavior.value)

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -12,6 +12,8 @@ from collections.abc import Callable
 from typing import Any
 from warnings import warn
 
+from airflow.utils.strings import to_boolean
+
 try:
     from airflow.sdk.exceptions import ParamValidationError
 except ImportError:
@@ -58,6 +60,21 @@ from cosmos.telemetry import _compress_telemetry_metadata, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
+
+
+def _is_jinja_template(value: Any) -> bool:
+    """Return True only for strings containing Jinja delimiters (``{{`` or ``{%``)."""
+    return isinstance(value, str) and ("{{" in value or "{%" in value)
+
+
+def _normalize_install_deps(value: Any) -> Any:
+    """Resolve non-templated string forms of ``install_deps`` (e.g. ``"False"``) to a real bool.
+
+    Real bools and Jinja-templated strings are returned unchanged.
+    """
+    if isinstance(value, str) and not _is_jinja_template(value):
+        return bool(to_boolean(value))
+    return value
 
 
 def migrate_to_new_interface(
@@ -137,8 +154,10 @@ def validate_arguments(
         )
         # When `install_dbt_deps` (or the deprecated `install_deps` operator_arg) is a Jinja-templated string,
         # its actual value is only known at task execution time, so skip the parse-time consistency check.
-        install_deps_task_arg = task_args.get("install_deps", True)
-        is_templated_install_deps = isinstance(install_deps_task_arg, str) or isinstance(render_config.dbt_deps, str)
+        # Literal strings like "True"/"False" are normalized to a bool so the check still runs.
+        install_deps_task_arg = _normalize_install_deps(task_args.get("install_deps", True))
+        normalized_dbt_deps = _normalize_install_deps(render_config.dbt_deps)
+        is_templated_install_deps = _is_jinja_template(install_deps_task_arg) or _is_jinja_template(normalized_dbt_deps)
         if (
             has_non_empty_dependencies
             and (
@@ -146,7 +165,7 @@ def validate_arguments(
                 or (render_config.load_method == LoadMode.AUTOMATIC and not project_config.is_manifest_available())
             )
             and not is_templated_install_deps
-            and (render_config.dbt_deps != install_deps_task_arg)
+            and (normalized_dbt_deps != install_deps_task_arg)
         ):
             err_msg = f"When using `LoadMode.DBT_LS` and `{execution_config.execution_mode}`, the value of `dbt_deps` in `RenderConfig` should be the same as the `operator_args['install_deps']` value."
             raise CosmosValueError(err_msg)
@@ -459,10 +478,10 @@ class DbtToAirflowConverter:
 
         if render_config is not None:
             metadata["invocation_mode"] = str(render_config.invocation_mode.value)
-            # Telemetry captures the parse-time install-deps decision. When the value is a Jinja template
-            # string, the runtime value is not known until task execution, so we report the parse-time
-            # default (True, matching the behavior in DbtGraph).
-            effective_install_deps = (
+            # Telemetry captures the parse-time install-deps decision. Real bools and literal string
+            # forms (e.g. "False") are recorded as their resolved bool. Jinja-templated values resolve
+            # at task execution time, so we fall back to True (matching the parse-time default in DbtGraph).
+            effective_install_deps = _normalize_install_deps(
                 render_config.dbt_deps if render_config.dbt_deps is not None else project_config.install_dbt_deps
             )
             metadata["install_deps"] = (

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -233,7 +233,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         # Preserve the raw value (including Jinja templated strings) so Airflow can render the template
         # field at execution time; the effective boolean is resolved by ``self._should_install_deps()``.
-        self._has_dependencies_file = has_non_empty_dependencies_file(Path(self.project_dir))
+        # Skip the filesystem probe when deps are explicitly disabled to avoid extra per-task I/O at parse time.
+        self._has_dependencies_file = install_deps is not False and has_non_empty_dependencies_file(
+            Path(self.project_dir)
+        )
         self.install_deps = install_deps if self._has_dependencies_file else False
         self.copy_dbt_packages = copy_dbt_packages
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -18,6 +18,7 @@ from urllib.parse import urlparse
 import jinja2
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.models.taskinstance import TaskInstance
+from airflow.utils.strings import to_boolean
 from packaging.version import Version
 
 from cosmos.io import _construct_dest_file_path
@@ -171,7 +172,9 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     :param profile_args: Arguments to pass to the profile. See
         :py:class:`cosmos.providers.dbt.core.profiles.BaseProfileMapping`.
     :param profile_config: ProfileConfig Object
-    :param install_deps (deprecated): If true, install dependencies before running the command
+    :param install_deps (deprecated): If true, install dependencies before running the command. Accepts a
+        boolean, or an Airflow Jinja templated string (e.g. ``"{{ params.install_deps }}"``) that renders
+        to a boolean or boolean-like string.
     :param copy_dbt_packages: If true, copy pre-existing `dbt_packages` (before running dbt deps)
     :param callback: A callback function called on after a dbt run with a path to the dbt project directory.
     :param manifest_filepath: The path to the user-defined Manifest file. It's "" by default.
@@ -185,7 +188,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         and does not inherit the current process environment.
     """
 
-    template_fields: Sequence[str] = AbstractDbtBase.template_fields + ("compiled_sql", "freshness")  # type: ignore[operator]
+    template_fields: Sequence[str] = AbstractDbtBase.template_fields + ("compiled_sql", "freshness", "install_deps")  # type: ignore[operator]
     template_fields_renderers = {
         "compiled_sql": "sql",
         "freshness": "json",
@@ -197,7 +200,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         task_id: str,
         profile_config: ProfileConfig,
         invocation_mode: InvocationMode | None = None,
-        install_deps: bool = True,
+        install_deps: bool | str = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         manifest_filepath: str = "",
         callback: Callable[[str], None] | list[Callable[[str], None]] | None = None,
@@ -230,11 +233,30 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         # as it can break existing DAGs.
         self.append_env = append_env
 
-        # We should not spend time trying to install deps if the project doesn't have any dependencies
-        self.install_deps = install_deps and has_non_empty_dependencies_file(Path(self.project_dir))
+        # We should not spend time trying to install deps if the project doesn't have any dependencies.
+        # The raw value is preserved (including Jinja templated strings) so Airflow can render the field
+        # at task execution time. The effective boolean used at runtime is computed by
+        # ``self._should_install_deps()``.
+        self._has_dependencies_file = has_non_empty_dependencies_file(Path(self.project_dir))
+        self.install_deps = install_deps if self._has_dependencies_file else False
         self.copy_dbt_packages = copy_dbt_packages
 
         self.manifest_filepath = manifest_filepath
+
+    def _should_install_deps(self) -> bool:
+        """Resolve the effective ``install_deps`` flag.
+
+        ``install_deps`` is an Airflow template field, so by execution time it may be a real ``bool`` or
+        a rendered string such as ``"True"`` / ``"False"`` (when ``render_template_as_native_obj`` is
+        ``False``). This helper normalizes both forms and ensures we never try to run ``dbt deps`` for
+        projects without a dependencies file.
+        """
+        if not self._has_dependencies_file:
+            return False
+        value = self.install_deps
+        if isinstance(value, str):
+            return bool(to_boolean(value))
+        return bool(value)
 
     @cached_property
     def subprocess_hook(self) -> FullOutputSubprocessHook:
@@ -496,7 +518,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             tmp_dir_path,
             self.project_dir,
         )
-        should_not_create_dbt_deps_symbolic_link = self.install_deps or self.copy_dbt_packages
+        should_not_create_dbt_deps_symbolic_link = self._should_install_deps() or self.copy_dbt_packages
         create_symlinks(
             Path(self.project_dir), tmp_dir_path, ignore_dbt_packages=should_not_create_dbt_deps_symbolic_link
         )
@@ -670,7 +692,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
                 flags = self._generate_dbt_flags(tmp_project_dir, profile_path)
 
-                if self.install_deps:
+                if self._should_install_deps():
                     self._install_dependencies(
                         tmp_dir_path, flags + self._process_global_flag("--vars", self.vars), env
                     )

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -172,9 +172,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     :param profile_args: Arguments to pass to the profile. See
         :py:class:`cosmos.providers.dbt.core.profiles.BaseProfileMapping`.
     :param profile_config: ProfileConfig Object
-    :param install_deps (deprecated): If true, install dependencies before running the command. Accepts a
-        boolean, or an Airflow Jinja templated string (e.g. ``"{{ params.install_deps }}"``) that renders
-        to a boolean or boolean-like string.
+    :param install_deps (deprecated): If true, install dependencies before running the command
     :param copy_dbt_packages: If true, copy pre-existing `dbt_packages` (before running dbt deps)
     :param callback: A callback function called on after a dbt run with a path to the dbt project directory.
     :param manifest_filepath: The path to the user-defined Manifest file. It's "" by default.
@@ -233,10 +231,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         # as it can break existing DAGs.
         self.append_env = append_env
 
-        # We should not spend time trying to install deps if the project doesn't have any dependencies.
-        # The raw value is preserved (including Jinja templated strings) so Airflow can render the field
-        # at task execution time. The effective boolean used at runtime is computed by
-        # ``self._should_install_deps()``.
+        # Preserve the raw value (including Jinja templated strings) so Airflow can render the template
+        # field at execution time; the effective boolean is resolved by ``self._should_install_deps()``.
         self._has_dependencies_file = has_non_empty_dependencies_file(Path(self.project_dir))
         self.install_deps = install_deps if self._has_dependencies_file else False
         self.copy_dbt_packages = copy_dbt_packages
@@ -244,18 +240,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         self.manifest_filepath = manifest_filepath
 
     def _should_install_deps(self) -> bool:
-        """Resolve the effective ``install_deps`` flag.
-
-        ``install_deps`` is an Airflow template field, so by execution time it may be a real ``bool`` or
-        a rendered string such as ``"True"`` / ``"False"`` (when ``render_template_as_native_obj`` is
-        ``False``). This helper normalizes both forms and ensures we never try to run ``dbt deps`` for
-        projects without a dependencies file.
-        """
+        """Resolve the effective ``install_deps`` flag, normalizing a rendered template string to a bool."""
         if not self._has_dependencies_file:
             return False
         value = self.install_deps
         if isinstance(value, str):
-            return bool(to_boolean(value))
+            # ``to_boolean`` does not strip whitespace, so a rendered " true " would otherwise be False.
+            return bool(to_boolean(value.strip()))
         return bool(value)
 
     @cached_property

--- a/docs/reference/configs/execution-config.rst
+++ b/docs/reference/configs/execution-config.rst
@@ -16,3 +16,33 @@ The ``ExecutionConfig`` class takes the following arguments:
 - ``virtualenv_dir`` (new in v1.6): Directory path to locate the (cached) virtual env that should be used for execution when execution mode is set to ``ExecutionMode.VIRTUALENV``.
 - ``async_py_requirements`` (new in v1.9): A list of Python packages to install when ``ExecutionMode.AIRFLOW_ASYNC`` is used. This parameter is required only when ``enable_setup_async_task`` and ``enable_teardown_async_task`` are set to ``True``. Example value: ``["dbt-postgres==1.9.0"]``.
 - ``setup_operator_args`` (new in v1.12): A dictionary of `Apache Airflow® <https://airflow.apache.org/>`_ operator arguments to be passed to DbtProducerWatcherOperator when using ExecutionMode.WATCHER. These values override any arguments provided through operator_args for the producer task.
+- ``install_dbt_deps`` (new in v1.12): Whether to run ``dbt deps`` at task execution time. When set, it overrides ``ProjectConfig.install_dbt_deps`` for execution only (it does not affect DAG parsing). Accepts a boolean or an `Airflow Jinja-templated <https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#templates-reference>`_ string (e.g. ``"{{ params.install_deps }}"``) that resolves to a boolean at task execution time, so ``dbt deps`` can be controlled per DAG run. Only supported for ``ExecutionMode.LOCAL``, ``ExecutionMode.VIRTUALENV`` and ``ExecutionMode.WATCHER``.
+
+Control dbt deps per DAG run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ExecutionConfig.install_dbt_deps`` can be templated, which is useful when you want to decide whether to
+run ``dbt deps`` at task execution time — for example, only on the first run or when package dependencies
+change — driven by an Airflow ``Param``. Because Airflow templates are rendered only at task execution time,
+this overrides ``ProjectConfig.install_dbt_deps`` for execution only and does not affect DAG parsing.
+
+.. code-block:: python
+
+    from airflow.models.param import Param
+    from cosmos import DbtDag, ExecutionConfig, ProjectConfig
+
+    dag = DbtDag(
+        # ...
+        project_config=ProjectConfig(dbt_project_path="/path/to/dbt/project"),
+        execution_config=ExecutionConfig(install_dbt_deps="{{ params.install_deps }}"),
+        params={
+            "install_deps": Param(
+                False, type="boolean", description="Install dbt dependencies?"
+            ),
+        },
+        render_template_as_native_obj=True,
+    )
+
+Setting ``render_template_as_native_obj=True`` is recommended so the rendered value is a real boolean.
+Without it Airflow renders the template to a string (e.g. ``"False"``); Cosmos normalizes both forms to
+a boolean when deciding whether to run ``dbt deps``.

--- a/docs/reference/configs/project-config.rst
+++ b/docs/reference/configs/project-config.rst
@@ -26,8 +26,9 @@ variables that should be used for rendering and execution. It takes the followin
   Also accepts an `Airflow Jinja-templated <https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#templates-reference>`_
   string (e.g. ``"{{ params.install_deps }}"``) that resolves to a boolean at task execution time. This is
   useful when you want to control ``dbt deps`` per DAG run (e.g. via an Airflow ``Param``). When a template
-  string is provided, ``dbt deps`` is always run during DAG parsing (since templates are only rendered at
-  task execution time).
+  string is provided, ``dbt deps`` runs during DAG parsing whenever a non-empty ``packages.yml`` or
+  ``dependencies.yml`` is present (since templates are only rendered at task execution time); if no
+  dependencies file exists, ``dbt deps`` is skipped at both parse and execution time.
 - ``copy_dbt_packages``: (new in v1.10) Copy the dbt project ``dbt_packages`` instead of creating symbolic links, so Cosmos can run ``dbt deps`` incrementally.
 - ``partial_parse``: (new in v1.4) If True, then attempt to use the ``partial_parse.msgpack`` if it exists. This is only used
   for the ``LoadMode.DBT_LS`` load mode, and for the ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``

--- a/docs/reference/configs/project-config.rst
+++ b/docs/reference/configs/project-config.rst
@@ -23,6 +23,11 @@ variables that should be used for rendering and execution. It takes the followin
 - ``env_vars``: (new in v1.3) A dictionary of environment variables used for rendering and execution. Rendering with
   env vars is only supported when using ``RenderConfig.LoadMode.DBT_LS`` load mode.
 - ``install_dbt_deps``: (new in v1.9) Run dbt deps during DAG parsing and task execution if True (default).
+  Also accepts an `Airflow Jinja-templated <https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#templates-reference>`_
+  string (e.g. ``"{{ params.install_deps }}"``) that resolves to a boolean at task execution time. This is
+  useful when you want to control ``dbt deps`` per DAG run (e.g. via an Airflow ``Param``). When a template
+  string is provided, ``dbt deps`` is always run during DAG parsing (since templates are only rendered at
+  task execution time).
 - ``copy_dbt_packages``: (new in v1.10) Copy the dbt project ``dbt_packages`` instead of creating symbolic links, so Cosmos can run ``dbt deps`` incrementally.
 - ``partial_parse``: (new in v1.4) If True, then attempt to use the ``partial_parse.msgpack`` if it exists. This is only used
   for the ``LoadMode.DBT_LS`` load mode, and for the ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``
@@ -48,3 +53,33 @@ Project config example
             "end_time": "{{ data_interval_end.strftime('%Y%m%d%H%M%S') }}",
         },
     )
+
+Controlling dbt deps per DAG run
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``install_dbt_deps`` can be templated, which is useful when you want to decide whether to run ``dbt deps``
+at task execution time — for example, only on the first run or when package dependencies change — driven
+by an Airflow ``Param``.
+
+.. code-block:: python
+
+    from airflow.models.param import Param
+    from cosmos import DbtDag, ProjectConfig
+
+    dag = DbtDag(
+        # ...
+        project_config=ProjectConfig(
+            dbt_project_path="/path/to/dbt/project",
+            install_dbt_deps="{{ params.install_deps }}",
+        ),
+        params={
+            "install_deps": Param(
+                False, type="boolean", description="Install dbt dependencies?"
+            ),
+        },
+        render_template_as_native_obj=True,
+    )
+
+Setting ``render_template_as_native_obj=True`` is recommended so the rendered value is a real boolean.
+Without it Airflow renders the template to a string (e.g. ``"False"``); Cosmos normalizes both forms to
+a boolean when deciding whether to run ``dbt deps``.

--- a/docs/reference/configs/project-config.rst
+++ b/docs/reference/configs/project-config.rst
@@ -23,12 +23,8 @@ variables that should be used for rendering and execution. It takes the followin
 - ``env_vars``: (new in v1.3) A dictionary of environment variables used for rendering and execution. Rendering with
   env vars is only supported when using ``RenderConfig.LoadMode.DBT_LS`` load mode.
 - ``install_dbt_deps``: (new in v1.9) Run dbt deps during DAG parsing and task execution if True (default).
-  Also accepts an `Airflow Jinja-templated <https://airflow.apache.org/docs/apache-airflow/stable/templates-ref.html#templates-reference>`_
-  string (e.g. ``"{{ params.install_deps }}"``) that resolves to a boolean at task execution time. This is
-  useful when you want to control ``dbt deps`` per DAG run (e.g. via an Airflow ``Param``). When a template
-  string is provided, ``dbt deps`` runs during DAG parsing whenever a non-empty ``packages.yml`` or
-  ``dependencies.yml`` is present (since templates are only rendered at task execution time); if no
-  dependencies file exists, ``dbt deps`` is skipped at both parse and execution time.
+  To control ``dbt deps`` per DAG run via an Airflow template, set ``ExecutionConfig.install_dbt_deps``
+  instead, which overrides this value at task execution time only.
 - ``copy_dbt_packages``: (new in v1.10) Copy the dbt project ``dbt_packages`` instead of creating symbolic links, so Cosmos can run ``dbt deps`` incrementally.
 - ``partial_parse``: (new in v1.4) If True, then attempt to use the ``partial_parse.msgpack`` if it exists. This is only used
   for the ``LoadMode.DBT_LS`` load mode, and for the ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``
@@ -54,33 +50,3 @@ Project config example
             "end_time": "{{ data_interval_end.strftime('%Y%m%d%H%M%S') }}",
         },
     )
-
-Controlling dbt deps per DAG run
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-``install_dbt_deps`` can be templated, which is useful when you want to decide whether to run ``dbt deps``
-at task execution time — for example, only on the first run or when package dependencies change — driven
-by an Airflow ``Param``.
-
-.. code-block:: python
-
-    from airflow.models.param import Param
-    from cosmos import DbtDag, ProjectConfig
-
-    dag = DbtDag(
-        # ...
-        project_config=ProjectConfig(
-            dbt_project_path="/path/to/dbt/project",
-            install_dbt_deps="{{ params.install_deps }}",
-        ),
-        params={
-            "install_deps": Param(
-                False, type="boolean", description="Install dbt dependencies?"
-            ),
-        },
-        render_template_as_native_obj=True,
-    )
-
-Setting ``render_template_as_native_obj=True`` is recommended so the rendered value is a real boolean.
-Without it Airflow renders the template to a string (e.g. ``"False"``); Cosmos normalizes both forms to
-a boolean when deciding whether to run ``dbt deps``.

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -117,6 +117,59 @@ def test_install_deps_in_empty_dir_becomes_false(tmpdir):
         profile_config=profile_config, task_id="my-task", project_dir=tmpdir, install_deps=True
     )
     assert not dbt_base_operator.install_deps
+    assert not dbt_base_operator._should_install_deps()
+
+
+def test_install_deps_is_a_template_field():
+    """``install_deps`` must be a template field so users can pass Jinja-templated values
+    (e.g. ``"{{ params.install_deps }}"``)."""
+    assert "install_deps" in DbtLocalBaseOperator.template_fields
+
+
+@pytest.mark.parametrize(
+    "rendered_value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("True", True),
+        ("true", True),
+        ("1", True),
+        ("False", False),
+        ("false", False),
+        ("0", False),
+    ],
+)
+def test_should_install_deps_resolves_rendered_template_value(rendered_value, expected):
+    """After Airflow renders ``install_deps`` from a Jinja template, it can be either a real bool
+    (``render_template_as_native_obj=True``) or a bool-like string (default). ``_should_install_deps``
+    must normalize both to a real bool."""
+    dbt_base_operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config, task_id="my-task", project_dir=DBT_PROJ_DIR, install_deps=True
+    )
+    # Simulate Airflow having rendered the templated field on the operator instance.
+    dbt_base_operator.install_deps = rendered_value
+    assert dbt_base_operator._should_install_deps() is expected
+
+
+def test_should_install_deps_false_when_no_dependencies_file(tmpdir):
+    """If the project has no packages.yml / dependencies.yml, ``dbt deps`` is never run regardless of
+    the (possibly templated) ``install_deps`` value."""
+    dbt_base_operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config, task_id="my-task", project_dir=tmpdir, install_deps="{{ params.install_deps }}"
+    )
+    # Even with a "truthy" string value at runtime, no deps file means we skip.
+    dbt_base_operator.install_deps = "True"
+    assert dbt_base_operator._should_install_deps() is False
+
+
+def test_install_deps_preserves_template_string_when_dependencies_file_exists():
+    """When a dependencies file is present, the operator must preserve the raw template string so
+    Airflow can render it at task execution time."""
+    template = "{{ params.install_deps }}"
+    dbt_base_operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config, task_id="my-task", project_dir=DBT_PROJ_DIR, install_deps=template
+    )
+    assert dbt_base_operator.install_deps == template
 
 
 def test_dbt_base_operator_add_global_flags() -> None:
@@ -1314,6 +1367,7 @@ def test_run_command_passes_full_cmd_with_profiles_dir_to_openlineage_processor(
                 "dbt_cmd_flags",
                 "compiled_sql",
                 "freshness",
+                "install_deps",
                 "full_refresh",
             ),
         ),
@@ -1329,6 +1383,7 @@ def test_run_command_passes_full_cmd_with_profiles_dir_to_openlineage_processor(
                 "dbt_cmd_flags",
                 "compiled_sql",
                 "freshness",
+                "install_deps",
                 "full_refresh",
             ),
         ),
@@ -1344,12 +1399,24 @@ def test_run_command_passes_full_cmd_with_profiles_dir_to_openlineage_processor(
                 "dbt_cmd_flags",
                 "compiled_sql",
                 "freshness",
+                "install_deps",
                 "full_refresh",
             ),
         ),
         (
             DbtSourceLocalOperator,
-            ("env", "select", "exclude", "selector", "vars", "models", "dbt_cmd_flags", "compiled_sql", "freshness"),
+            (
+                "env",
+                "select",
+                "exclude",
+                "selector",
+                "vars",
+                "models",
+                "dbt_cmd_flags",
+                "compiled_sql",
+                "freshness",
+                "install_deps",
+            ),
         ),
     ],
 )

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -172,6 +172,17 @@ def test_install_deps_preserves_template_string_when_dependencies_file_exists():
     assert dbt_base_operator.install_deps == template
 
 
+@patch("cosmos.operators.local.has_non_empty_dependencies_file")
+def test_install_deps_false_skips_dependencies_file_probe(mock_has_deps_file):
+    """When ``install_deps`` is explicitly False, the dependencies-file probe must be skipped to avoid
+    extra per-task filesystem I/O during DAG parsing."""
+    dbt_base_operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config, task_id="my-task", project_dir=DBT_PROJ_DIR, install_deps=False
+    )
+    mock_has_deps_file.assert_not_called()
+    assert dbt_base_operator._should_install_deps() is False
+
+
 def test_dbt_base_operator_add_global_flags() -> None:
     dbt_base_operator = ConcreteDbtLocalBaseOperator(
         profile_config=profile_config,

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -945,6 +945,36 @@ def test_execution_config_install_dbt_deps_overrides_project_config(
     assert kwargs["task_args"].get("install_deps", None) == expected
 
 
+@patch("cosmos.config.ProjectConfig.validate_project")
+@patch("cosmos.converter.validate_initial_user_config")
+@patch("cosmos.converter.DbtGraph")
+@patch("cosmos.converter.build_airflow_graph")
+def test_execution_config_install_dbt_deps_takes_precedence_over_operator_args(
+    mock_build_airflow_graph,
+    mock_user_config,
+    mock_dbt_graph,
+    mock_validate_project,
+):
+    """ExecutionConfig.install_dbt_deps must win over a deprecated ``operator_args['install_deps']`` so the
+    skipped parse-time consistency check cannot mask a silent mismatch."""
+    project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL, install_dbt_deps=False)
+    render_config = MagicMock()
+    with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
+        DbtToAirflowConverter(
+            dag=dag,
+            nodes=nodes,
+            project_config=project_config,
+            profile_config=sample_profile_config,
+            execution_config=execution_config,
+            render_config=render_config,
+            operator_args={"install_deps": True},
+        )
+    _, kwargs = mock_build_airflow_graph.call_args
+
+    assert kwargs["task_args"].get("install_deps", None) is False
+
+
 @pytest.mark.parametrize("invocation_mode", [None, InvocationMode.SUBPROCESS, InvocationMode.DBT_RUNNER])
 @patch("cosmos.config.ProjectConfig.validate_project")
 @patch("cosmos.converter.validate_initial_user_config")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -93,6 +93,30 @@ def test_validate_arguments_exception():
     assert err.value.args[0] == expected
 
 
+def test_validate_arguments_skips_install_deps_mismatch_check_for_templated_value():
+    """A Jinja-templated ``install_deps`` is only resolved at task execution time, so the parse-time
+    mismatch check against ``RenderConfig.dbt_deps`` must be skipped to avoid spurious failures."""
+    render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=False)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(
+        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
+    )
+    project_config = ProjectConfig()
+
+    task_args = {"install_deps": "{{ params.install_deps }}"}
+    validate_arguments(
+        execution_config=execution_config,
+        profile_config=profile_config,
+        project_config=project_config,
+        render_config=render_config,
+        task_args=task_args,
+    )
+
+
 @pytest.mark.parametrize(
     "execution_mode",
     (ExecutionMode.LOCAL, ExecutionMode.VIRTUALENV),

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -18,13 +18,7 @@ from cosmos.constants import (
     LoadMode,
     TestBehavior,
 )
-from cosmos.converter import (
-    DbtToAirflowConverter,
-    _is_jinja_template,
-    _normalize_install_deps,
-    validate_arguments,
-    validate_initial_user_config,
-)
+from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
@@ -99,66 +93,9 @@ def test_validate_arguments_exception():
     assert err.value.args[0] == expected
 
 
-def test_validate_arguments_skips_install_deps_mismatch_check_for_templated_value():
-    """A Jinja-templated ``install_deps`` is only resolved at task execution time, so the parse-time
-    mismatch check against ``RenderConfig.dbt_deps`` must be skipped to avoid spurious failures."""
-    render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=False)
-    profile_config = ProfileConfig(
-        profile_name="test",
-        target_name="test",
-        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
-    )
-    execution_config = ExecutionConfig(
-        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
-    )
-    project_config = ProjectConfig()
-
-    task_args = {"install_deps": "{{ params.install_deps }}"}
-    validate_arguments(
-        execution_config=execution_config,
-        profile_config=profile_config,
-        project_config=project_config,
-        render_config=render_config,
-        task_args=task_args,
-    )
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        (True, True),
-        (False, False),
-        ("True", True),
-        ("False", False),
-        ("true", True),
-        ("0", False),
-        ("{{ params.install_deps }}", "{{ params.install_deps }}"),
-        ("{% if x %}True{% endif %}", "{% if x %}True{% endif %}"),
-    ],
-)
-def test_normalize_install_deps(value, expected):
-    """Literal string forms are resolved to a real bool; Jinja templates and bools pass through."""
-    assert _normalize_install_deps(value) == expected
-
-
-@pytest.mark.parametrize(
-    "value, expected",
-    [
-        (True, False),
-        ("True", False),
-        ("False", False),
-        ("{{ params.install_deps }}", True),
-        ("{% if x %}True{% endif %}", True),
-    ],
-)
-def test_is_jinja_template(value, expected):
-    """Only strings containing Jinja delimiters are considered templates."""
-    assert _is_jinja_template(value) is expected
-
-
-def test_validate_arguments_normalizes_literal_install_deps_string_and_raises_on_mismatch():
-    """A non-templated string like ``"False"`` must be normalized to a bool so the parse-time
-    consistency check between ``RenderConfig.dbt_deps`` and ``operator_args['install_deps']`` still runs."""
+def test_validate_arguments_skips_install_deps_mismatch_check_when_execution_config_overrides():
+    """When ExecutionConfig.install_dbt_deps is set, it intentionally overrides the parse-time value for
+    execution only, so the parse-time consistency check against RenderConfig.dbt_deps must be skipped."""
     render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=True)
     profile_config = ProfileConfig(
         profile_name="test",
@@ -166,30 +103,9 @@ def test_validate_arguments_normalizes_literal_install_deps_string_and_raises_on
         profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
     )
     execution_config = ExecutionConfig(
-        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
-    )
-    project_config = ProjectConfig()
-
-    with pytest.raises(CosmosValueError):
-        validate_arguments(
-            execution_config=execution_config,
-            profile_config=profile_config,
-            project_config=project_config,
-            render_config=render_config,
-            task_args={"install_deps": "False"},
-        )
-
-
-def test_validate_arguments_passes_when_literal_install_deps_string_matches_render_config():
-    """Matching literal-string and bool forms must satisfy the consistency check after normalization."""
-    render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=False)
-    profile_config = ProfileConfig(
-        profile_name="test",
-        target_name="test",
-        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
-    )
-    execution_config = ExecutionConfig(
-        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
+        execution_mode=ExecutionMode.LOCAL,
+        dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR,
+        install_dbt_deps="{{ params.install_deps }}",
     )
     project_config = ProjectConfig()
 
@@ -198,7 +114,7 @@ def test_validate_arguments_passes_when_literal_install_deps_string_matches_rend
         profile_config=profile_config,
         project_config=project_config,
         render_config=render_config,
-        task_args={"install_deps": "False"},
+        task_args={"install_deps": "{{ params.install_deps }}"},
     )
 
 
@@ -977,6 +893,52 @@ def test_project_config_install_dbt_deps_overrides_operator_args(
             execution_config=execution_config,
             render_config=render_config,
             operator_args=operator_args,
+        )
+    _, kwargs = mock_build_airflow_graph.call_args
+
+    assert kwargs["task_args"].get("install_deps", None) == expected
+
+
+@pytest.mark.parametrize(
+    "execution_install_dbt_deps,project_install_dbt_deps,expected",
+    [
+        # When set, ExecutionConfig.install_dbt_deps overrides ProjectConfig.install_dbt_deps for execution.
+        (False, True, False),
+        (True, False, True),
+        ("{{ params.install_deps }}", True, "{{ params.install_deps }}"),
+        # When None (default), it falls back to ProjectConfig.install_dbt_deps.
+        (None, False, False),
+        (None, True, True),
+    ],
+)
+@patch("cosmos.config.ProjectConfig.validate_project")
+@patch("cosmos.converter.validate_initial_user_config")
+@patch("cosmos.converter.DbtGraph")
+@patch("cosmos.converter.build_airflow_graph")
+def test_execution_config_install_dbt_deps_overrides_project_config(
+    mock_build_airflow_graph,
+    mock_user_config,
+    mock_dbt_graph,
+    mock_validate_project,
+    execution_install_dbt_deps,
+    project_install_dbt_deps,
+    expected,
+):
+    """ExecutionConfig.install_dbt_deps (which may be an Airflow template) overrides
+    ProjectConfig.install_dbt_deps for task execution; when None it falls back to the project value."""
+    project_config = ProjectConfig(project_name="fake-project", dbt_project_path="/some/project/path")
+    project_config.install_dbt_deps = project_install_dbt_deps
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL, install_dbt_deps=execution_install_dbt_deps)
+    render_config = MagicMock()
+    with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
+        DbtToAirflowConverter(
+            dag=dag,
+            nodes=nodes,
+            project_config=project_config,
+            profile_config=sample_profile_config,
+            execution_config=execution_config,
+            render_config=render_config,
+            operator_args={},
         )
     _, kwargs = mock_build_airflow_graph.call_args
 

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -18,7 +18,13 @@ from cosmos.constants import (
     LoadMode,
     TestBehavior,
 )
-from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
+from cosmos.converter import (
+    DbtToAirflowConverter,
+    _is_jinja_template,
+    _normalize_install_deps,
+    validate_arguments,
+    validate_initial_user_config,
+)
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
@@ -114,6 +120,85 @@ def test_validate_arguments_skips_install_deps_mismatch_check_for_templated_valu
         project_config=project_config,
         render_config=render_config,
         task_args=task_args,
+    )
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (True, True),
+        (False, False),
+        ("True", True),
+        ("False", False),
+        ("true", True),
+        ("0", False),
+        ("{{ params.install_deps }}", "{{ params.install_deps }}"),
+        ("{% if x %}True{% endif %}", "{% if x %}True{% endif %}"),
+    ],
+)
+def test_normalize_install_deps(value, expected):
+    """Literal string forms are resolved to a real bool; Jinja templates and bools pass through."""
+    assert _normalize_install_deps(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        (True, False),
+        ("True", False),
+        ("False", False),
+        ("{{ params.install_deps }}", True),
+        ("{% if x %}True{% endif %}", True),
+    ],
+)
+def test_is_jinja_template(value, expected):
+    """Only strings containing Jinja delimiters are considered templates."""
+    assert _is_jinja_template(value) is expected
+
+
+def test_validate_arguments_normalizes_literal_install_deps_string_and_raises_on_mismatch():
+    """A non-templated string like ``"False"`` must be normalized to a bool so the parse-time
+    consistency check between ``RenderConfig.dbt_deps`` and ``operator_args['install_deps']`` still runs."""
+    render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=True)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(
+        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
+    )
+    project_config = ProjectConfig()
+
+    with pytest.raises(CosmosValueError):
+        validate_arguments(
+            execution_config=execution_config,
+            profile_config=profile_config,
+            project_config=project_config,
+            render_config=render_config,
+            task_args={"install_deps": "False"},
+        )
+
+
+def test_validate_arguments_passes_when_literal_install_deps_string_matches_render_config():
+    """Matching literal-string and bool forms must satisfy the consistency check after normalization."""
+    render_config = RenderConfig(load_method=LoadMode.DBT_LS, dbt_deps=False)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(
+        execution_mode=ExecutionMode.LOCAL, dbt_project_path=DBT_PROJECTS_PROJ_WITH_DEPS_DIR
+    )
+    project_config = ProjectConfig()
+
+    validate_arguments(
+        execution_config=execution_config,
+        profile_config=profile_config,
+        project_config=project_config,
+        render_config=render_config,
+        task_args={"install_deps": "False"},
     )
 
 


### PR DESCRIPTION
## Summary

- Add `ExecutionConfig.install_dbt_deps`, which controls whether `dbt deps` runs **at task execution time**. It accepts a `bool` or an Airflow Jinja-templated string (e.g. `"{{ params.install_deps }}"`), so dependency installation can be decided per DAG run — typically driven by an Airflow `Param`.
- When set, it overrides `ProjectConfig.install_dbt_deps` **for execution only**; it does not affect DAG parsing. When unset (`None`, the default) it falls back to `ProjectConfig.install_dbt_deps`.
- `ProjectConfig.install_dbt_deps` stays a plain `bool` and remains the parse-time / project-level setting.
- Operator support: `install_deps` is added to `AbstractDbtLocalBase.template_fields` so Airflow can render the template at execute time, and a `_should_install_deps()` helper resolves either a real `bool` or a rendered string (`"True"`/`"False"` via `to_boolean`, whitespace-stripped) while keeping the existing safeguard that skips `dbt deps` when the project has no `packages.yml`/`dependencies.yml`.
- The parse-time `RenderConfig.dbt_deps` vs `operator_args["install_deps"]` consistency check is skipped when `ExecutionConfig.install_dbt_deps` is set, since the parse-time and execution-time values are now intentionally allowed to differ.

## Why

`ProjectConfig` is consumed during DAG parsing (via `DbtGraph`), but Airflow templates are only rendered at task execution time. Allowing `ProjectConfig.install_dbt_deps` itself to be templated was therefore ambiguous: a user could set `install_dbt_deps="{{ params.install_deps }}"` expecting the param to control dependency installation, yet Cosmos would still run `dbt deps` during parsing because the unresolved template was treated as truthy — silent and surprising, with no way to opt out of the parse-time install.

Splitting the setting across the two configs makes the phase boundary explicit: `ProjectConfig.install_dbt_deps` governs parse time, and only `ExecutionConfig.install_dbt_deps` — which is what actually runs at execution — supports templating.

## Test plan

- [x] New/updated unit tests:
  - `test_execution_config_install_dbt_deps_overrides_project_config` — override wins for bools/templates; falls back to the project value when `None`.
  - `test_validate_arguments_skips_install_deps_mismatch_check_when_execution_config_overrides` — converter no longer rejects a divergent/templated execution override.
  - `test_install_deps_is_a_template_field`, `test_should_install_deps_resolves_rendered_template_value`, `test_should_install_deps_false_when_no_dependencies_file`, `test_install_deps_preserves_template_string_when_dependencies_file_exists`.
- [x] `hatch run docs:build` succeeds; new "Control dbt deps per DAG run" section in `docs/reference/configs/execution-config.rst`.
- [x] `pre-commit` (black, ruff, mypy, docs style) passes.

Closes #1227

🤖 Generated with [Claude Code](https://claude.com/claude-code)