### PR TITLE
Drop Python <3.9 fallback for functools.cache

### DIFF
--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import gc
 import sys
 from collections.abc import Callable
+from functools import cache as functools_cache
 from functools import lru_cache
 from typing import TYPE_CHECKING, Any
 
@@ -15,11 +16,7 @@ if "pytest" in sys.modules:
     # running tests
     cache = lru_cache(maxsize=0)
 else:  # pragma: no cover
-    try:
-        # Available since Python 3.9
-        from functools import cache
-    except ImportError:
-        cache = lru_cache(maxsize=None)
+    cache = functools_cache
 
 
 logger = get_logger(__name__)


### PR DESCRIPTION
## Summary

- Remove the `try/except ImportError` fallback to `lru_cache(maxsize=None)` in `cosmos/dbt/runner.py` that was guarding against `from functools import cache` on Python < 3.9.
- Cosmos requires Python >= 3.10 (see `CLAUDE.md` and `pyproject.toml`), so the fallback path is unreachable.
- Keep the pytest-only `lru_cache(maxsize=0)` branch — that one is intentional, to disable caching during tests.

## Test plan

- [x] `pre-commit run --files cosmos/dbt/runner.py` passes locally (ruff, mypy, black).
- [x] CI green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)