### PR TITLE
Improve coverage for DbtRunAirflowAsyncBigqueryOperator

### DIFF
--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -355,3 +355,77 @@ def test_register_event_with_uri(mock_register_dataset, profile_config_mock):
         assert args[1][0].uri == "bigquery://my_project/my_dataset/my_complex_table_name"
     else:
         assert args[1][0].uri == "bigquery://my_project.my_dataset.my_complex_table_name/"
+
+
+@pytest.mark.skipif(AIRFLOW_VERSION < Version("2.10.0"), reason="DatasetAlias outlets require Airflow >= 2.10")
+@patch("cosmos.operators._asynchronous.bigquery.settings.enable_dataset_alias", True)
+def test_init_sets_outlets_when_dataset_alias_enabled(profile_config_mock):
+    """When ``settings.enable_dataset_alias`` is True and Airflow >= 2.10, ``__init__`` populates
+    ``kwargs['outlets']`` with a DatasetAlias derived from the task_id (and optional task_group)."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+    assert operator.outlets, "Expected outlets to be populated when dataset_alias is enabled"
+    assert len(operator.outlets) == 1
+    outlet = operator.outlets[0]
+    assert outlet.__class__.__name__ in {"DatasetAlias", "AssetAlias"}
+    assert "test_task" in outlet.name
+
+
+@patch("cosmos.operators._asynchronous.bigquery.settings.enable_dataset_alias", False)
+def test_init_skips_outlets_when_dataset_alias_disabled(profile_config_mock):
+    """When ``settings.enable_dataset_alias`` is False the outlets branch in ``__init__`` is skipped."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/path/to/project",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+    assert not operator.outlets
+
+
+def _object_storage_path_target() -> str:
+    """``get_remote_sql`` imports ``ObjectStoragePath`` from one of two locations depending on the
+    installed Airflow version. Return the patch target that exists in the current environment."""
+    try:
+        import airflow.sdk  # noqa: F401
+
+        return "airflow.sdk.ObjectStoragePath"
+    except ImportError:
+        return "airflow.io.path.ObjectStoragePath"
+
+
+def test_get_remote_sql_reads_from_object_storage(profile_config_mock):
+    """``get_remote_sql`` builds the remote path from the project / run / file path triple and
+    reads the SQL via ``ObjectStoragePath.open``. This test exercises the real body of the method
+    (previous tests only patched it out)."""
+    operator = DbtRunAirflowAsyncBigqueryOperator(
+        task_id="test_task",
+        project_dir="/tmp/myproject/subdir",
+        profile_config=profile_config_mock,
+        dbt_kwargs={"task_id": "test_task"},
+    )
+    operator.async_context = {
+        "dbt_node_config": {"file_path": "/tmp/myproject/target/run/models/foo.sql"},
+        "dbt_dag_task_group_identifier": "tg1",
+        "run_id": "rid123",
+    }
+
+    fake_file = MagicMock()
+    fake_file.read.return_value = "SELECT 1;"
+    fake_path = MagicMock()
+    fake_path.open.return_value.__enter__.return_value = fake_file
+
+    with (
+        patch("cosmos.operators._asynchronous.bigquery.remote_target_path", "s3://bucket/cosmos-async/"),
+        patch("cosmos.operators._asynchronous.bigquery.remote_target_path_conn_id", "aws_default"),
+        patch(_object_storage_path_target(), return_value=fake_path),
+    ):
+        result = operator.get_remote_sql()
+
+    assert result == "SELECT 1;"
+    fake_file.read.assert_called_once()
+    fake_path.open.assert_called_once()


### PR DESCRIPTION
## Summary

Adds three targeted unit tests that exercise previously-uncovered lines in
`cosmos/operators/_asynchronous/bigquery.py`. Follow-up to the codecov
patch-coverage gap flagged on #2711 (4 hits / 2 misses on the patch).

- `test_init_sets_outlets_when_dataset_alias_enabled` — covers the
  `settings.enable_dataset_alias and AIRFLOW_VERSION >= 2.10` branch in
  `__init__` and asserts `operator.outlets` is populated with a
  DatasetAlias whose name embeds the task_id.
- `test_init_skips_outlets_when_dataset_alias_disabled` — covers the
  false-branch (no outlets when `enable_dataset_alias=False`).
- `test_get_remote_sql_reads_from_object_storage` — exercises the real
  body of `get_remote_sql` by patching `ObjectStoragePath` (at whichever
  import location the current Airflow version uses), `remote_target_path`,
  and `remote_target_path_conn_id`. Previous tests only patched
  `get_remote_sql` out, so its body was never exercised.

Each construction of the operator also exercises `__init__` lines that
codecov flagged (e.g. `self.gcp_conn_id = ...`).

## Test plan

- [x] `pytest tests/operators/_asynchronous/test_bigquery.py -m "not integration"` — 18 passed locally.
- [x] All pre-commit hooks pass on the modified file.
- [x] CI green and codecov patch coverage rises above the threshold for this file.

Refs: #2711

🤖 Generated with [Claude Code](https://claude.com/claude-code)