### PR TITLE
fix: unify default and postgres_profile in example profiles.yml files

### DIFF
--- a/dev/dags/dbt/altered_jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/altered_jaffle_shop/profiles.yml
@@ -16,9 +16,10 @@ postgres_profile:
   outputs:
     dev:
       type: postgres
-      dbname: "{{ env_var('POSTGRES_DB') }}"
       host: "{{ env_var('POSTGRES_HOST') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4

--- a/dev/dags/dbt/jaffle_shop/profiles.yml
+++ b/dev/dags/dbt/jaffle_shop/profiles.yml
@@ -30,9 +30,10 @@ postgres_profile:
   outputs:
     dev:
       type: postgres
-      dbname: "{{ env_var('POSTGRES_DB') }}"
       host: "{{ env_var('POSTGRES_HOST') }}"
-      pass: "{{ env_var('POSTGRES_PASSWORD') }}"
-      port: 5432 # "{{ env_var('POSTGRES_PORT') | as_number }}"
-      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
       user: "{{ env_var('POSTGRES_USER') }}"
+      password: "{{ env_var('POSTGRES_PASSWORD') }}"
+      port: "{{ env_var('POSTGRES_PORT') | int }}"
+      dbname: "{{ env_var('POSTGRES_DB') }}"
+      schema: "{{ env_var('POSTGRES_SCHEMA') }}"
+      threads: 4

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2365,9 +2365,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
         # Different macOS versions have produced different hashes for this directory. The first value below is a
         # historical macOS-specific hash, while the second matches the Linux hash asserted in the else-branch. We
         # allow both here so that the test is stable across macOS versions and when macOS hashing matches Linux.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "2efdb9c716ac73d272ae2d1456b93132")
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "2efdb9c716ac73d272ae2d1456b93132"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2407,9 +2407,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
         # Some macOS versions compute a different directory hash than Linux, while others match the Linux behavior.
         # The first value is the macOS-specific hash; the second value is the Linux hash, which certain macOS versions also produce.
         # We allow both here to keep the test stable across macOS releases, while non-macOS platforms assert only the Linux hash.
-        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "5c1aed937708e585054c874ff8f33fd1")
+        assert hash_dir in ("9d95cbf6529e2ab51fadd6a3f0a3971f", "2efdb9c716ac73d272ae2d1456b93132")
     else:
-        assert hash_dir == "5c1aed937708e585054c874ff8f33fd1"
+        assert hash_dir == "2efdb9c716ac73d272ae2d1456b93132"
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")


### PR DESCRIPTION
## Summary

Closes #1384

The `postgres_profile` in both example dbt projects was inconsistent with the `default` profile despite connecting to the same Postgres instance.

**Changes in both `dev/dags/dbt/jaffle_shop/profiles.yml` and `dev/dags/dbt/altered_jaffle_shop/profiles.yml`:**

| Field | Before | After |
|---|---|---|
| Password key | `pass:` | `password:` |
| Port | `5432` (hardcoded) | `env_var('POSTGRES_PORT') \| int` |
| Threads | missing | `threads: 4` |
| Field order | inconsistent | matches `default` |

Both profiles now use identical connection configuration, eliminating the divergence that caused unexpected behaviour when switching between them.