### PR TITLE
Warn when users pass output-only template fields to local operators

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1176,6 +1176,9 @@ class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
 
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
+
 
 class DbtDocsLocalOperator(DbtLocalBaseOperator):
     """

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -820,7 +820,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         try:
             from airflow.sdk import DAG
         except ImportError:
-            from airflow.models.dag import DAG  # type: ignore[assignment]
+            from airflow.models.dag import DAG
 
         if AIRFLOW_VERSION.major >= 3 and not settings.enable_dataset_alias:
             logger.error("To emit datasets with Airflow 3, the setting `enable_dataset_alias` must be True (default).")
@@ -881,14 +881,14 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         if openlineage_events_completes is not None:
             for completed in openlineage_events_completes:
-                for input_ in completed.inputs:
+                for input_ in completed.inputs or []:
                     if input_ not in inputs:
                         inputs.append(input_)
-                for output in completed.outputs:
+                for output in completed.outputs or []:
                     if output not in outputs:
                         outputs.append(output)
-                run_facets = {**run_facets, **completed.run.facets}
-                job_facets = {**job_facets, **completed.job.facets}
+                run_facets = {**run_facets, **(completed.run.facets or {})}
+                job_facets = {**job_facets, **(completed.job.facets or {})}
         else:
             logger.info("Unable to emit OpenLineage events due to lack of dependencies or data.")
 
@@ -935,8 +935,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.subprocess_hook.send_sigterm()
 
 
-class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[misc]
-    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields  # type: ignore[operator]
+class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
+    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
@@ -1420,7 +1420,7 @@ class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
     Executes a dbt core clone command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1178,6 +1178,9 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
 
 
 class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
     """
     Executes a dbt core run-operation command.
 
@@ -1425,6 +1428,9 @@ class DbtCompileLocalOperator(DbtCompileMixin, DbtLocalBaseOperator):
 
 
 class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
+
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
+        super().__init__(*args, **kwargs)
     """
     Executes a dbt core clone command.
     """

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -820,7 +820,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         try:
             from airflow.sdk import DAG
         except ImportError:
-            from airflow.models.dag import DAG
+            from airflow.models.dag import DAG  # type: ignore[assignment]
 
         if AIRFLOW_VERSION.major >= 3 and not settings.enable_dataset_alias:
             logger.error("To emit datasets with Airflow 3, the setting `enable_dataset_alias` must be True (default).")
@@ -881,14 +881,14 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         if openlineage_events_completes is not None:
             for completed in openlineage_events_completes:
-                for input_ in completed.inputs or []:
+                for input_ in completed.inputs:
                     if input_ not in inputs:
                         inputs.append(input_)
-                for output in completed.outputs or []:
+                for output in completed.outputs:
                     if output not in outputs:
                         outputs.append(output)
-                run_facets = {**run_facets, **(completed.run.facets or {})}
-                job_facets = {**job_facets, **(completed.job.facets or {})}
+                run_facets = {**run_facets, **completed.run.facets}
+                job_facets = {**job_facets, **completed.job.facets}
         else:
             logger.info("Unable to emit OpenLineage events due to lack of dependencies or data.")
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -118,6 +118,8 @@ from cosmos.operators.base import (
 
 logger = get_logger(__name__)
 
+_OUTPUT_ONLY_TEMPLATE_FIELDS: tuple[str, ...] = ("compiled_sql", "freshness")
+
 
 def _read_target_sources_json(project_root: Path) -> dict[str, Any] | None:
     """Parse ``target/sources.json`` under ``project_root`` if the file exists."""
@@ -192,6 +194,17 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         "freshness": "json",
     }
     _process_log_line_callable: Callable[[str, Any], None] | None = None
+
+    def _warn_on_output_only_fields(self, kwargs: dict[str, Any]) -> None:
+        """Warn when output-only template fields are passed directly to local operators."""
+        for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
+            if field in kwargs:
+                logger.warning(
+                    "The '%s' argument passed to %s will be overwritten at runtime; "
+                    "it is an output-only template field.",
+                    field,
+                    self.__class__.__name__,
+                )
 
     def __init__(
         self,
@@ -938,6 +951,16 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
 
         default_args = kwargs.get("default_args", {})
 
+        # Warn when output-only template fields are passed directly to local operators
+        for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
+            if field in kwargs:
+                logger.warning(
+                    "The '%s' argument passed to %s will be overwritten at runtime; "
+                    "it is an output-only template field.",
+                    field,
+                    self.__class__.__name__,
+                )
+
         for arg in operator_args:
             try:
                 operator_kwargs[arg] = kwargs[arg]
@@ -1160,9 +1183,6 @@ class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
     """
 
     template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields + DbtRunOperationMixin.template_fields  # type: ignore[operator]
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
 
 
 class DbtDocsLocalOperator(DbtLocalBaseOperator):
@@ -1405,7 +1425,7 @@ class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
     Executes a dbt core clone command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1181,6 +1181,7 @@ class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
     """
     Executes a dbt core run-operation command.
 
@@ -1431,6 +1432,7 @@ class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
+
     """
     Executes a dbt core clone command.
     """

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -935,8 +935,20 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.subprocess_hook.send_sigterm()
 
 
-class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
-    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields
+def _warn_on_output_only_fields(kwargs: dict[str, Any], class_name: str) -> None:
+    """Warn when output-only template fields are passed directly to local operators."""
+    for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
+        if field in kwargs:
+            logger.warning(
+                "The '%s' argument passed to %s will be overwritten at runtime; "
+                "it is an output-only template field.",
+                field,
+                class_name,
+            )
+
+
+class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[misc]
+    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields  # type: ignore[operator]
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
@@ -951,15 +963,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
 
         default_args = kwargs.get("default_args", {})
 
-        # Warn when output-only template fields are passed directly to local operators
-        for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
-            if field in kwargs:
-                logger.warning(
-                    "The '%s' argument passed to %s will be overwritten at runtime; "
-                    "it is an output-only template field.",
-                    field,
-                    self.__class__.__name__,
-                )
+        _warn_on_output_only_fields(kwargs, self.__class__.__name__)
 
         for arg in operator_args:
             try:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -935,18 +935,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.subprocess_hook.send_sigterm()
 
 
-def _warn_on_output_only_fields(kwargs: dict[str, Any], class_name: str) -> None:
-    """Warn when output-only template fields are passed directly to local operators."""
-    for field in _OUTPUT_ONLY_TEMPLATE_FIELDS:
-        if field in kwargs:
-            logger.warning(
-                "The '%s' argument passed to %s will be overwritten at runtime; "
-                "it is an output-only template field.",
-                field,
-                class_name,
-            )
-
-
 class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[misc]
     template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields  # type: ignore[operator]
 
@@ -963,7 +951,7 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[
 
         default_args = kwargs.get("default_args", {})
 
-        _warn_on_output_only_fields(kwargs, self.__class__.__name__)
+        self._warn_on_output_only_fields(kwargs)
 
         for arg in operator_args:
             try:
@@ -1178,10 +1166,6 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
 
 
 class DbtRunOperationLocalOperator(DbtRunOperationMixin, DbtLocalBaseOperator):
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
     """
     Executes a dbt core run-operation command.
 
@@ -1429,10 +1413,6 @@ class DbtCompileLocalOperator(DbtCompileMixin, DbtLocalBaseOperator):
 
 
 class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
-
-    def __init__(self, *args: Any, **kwargs: Any) -> None:
-        super().__init__(*args, **kwargs)
-
     """
     Executes a dbt core clone command.
     """

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -2577,7 +2577,25 @@ class TestReadTargetSourcesJson:
         target = tmp_path / "target"
         target.mkdir()
         sources_file = target / "sources.json"
-        sources_file.write_text("not valid json {{{")
+        sources_file.write_text("not valid json {{{{")
 
         result = _read_target_sources_json(tmp_path)
         assert result is None
+
+
+def test_dbt_local_operator_warns_on_output_only_template_fields(caplog):
+    """Test that passing compiled_sql or freshness to local operators emits a warning."""
+    from cosmos.operators.local import DbtRunLocalOperator
+
+    with caplog.at_level("WARNING", logger="cosmos.operators.local"):
+        DbtRunLocalOperator(
+            task_id="fake-task",
+            profile_config=profile_config,
+            project_dir="fake-dir",
+            compiled_sql="SELECT 1",
+            freshness="test",
+        )
+
+    assert "compiled_sql" in caplog.text
+    assert "freshness" in caplog.text
+    assert "output-only template field" in caplog.text


### PR DESCRIPTION
## Summary

The local execution mode operators register compiled_sql and freshness in template_fields, but both are overwritten at runtime. Any value a user passes via operator_args is silently discarded, which is confusing (see #2666).

## Changes

- Log a warning when compiled_sql or freshness is passed as a kwarg to a local operator so users know their value will not be used.
- Uses the project's cosmos.log.get_logger helper for consistent logging.

## Test Plan

- Existing tests continue to pass.
- Manually verified that passing operator_args={"freshness": "..."} now emits a warning log.

Closes #2666

🤖 Generated with Claude Code (https://claude.com/claude-code)