### PR TITLE
Add unit tests pinning insecure_mode and connect_args propagation via profile_args in Snowflake encrypted PEM mapping

### DIFF
--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -217,6 +217,24 @@ def test_profile_args_overrides(
     }
 
 
+def test_profile_args_insecure_mode(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that `insecure_mode: True` passed via profile_args lands in the rendered profile.
+
+    `insecure_mode` is not part of `airflow_param_mapping`, so it can only reach the profile
+    via `profile_args`. This guards against a regression where the merge order or null
+    filtering would drop it.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+        profile_args={"insecure_mode": True},
+    )
+    assert profile_mapping.profile_args == {"insecure_mode": True}
+    assert profile_mapping.profile["insecure_mode"] is True
+
+
 def test_profile_env_vars(
     mock_snowflake_conn: Connection,
 ) -> None:

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -235,6 +235,25 @@ def test_profile_args_insecure_mode(
     assert profile_mapping.profile["insecure_mode"] is True
 
 
+def test_profile_args_connect_args(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """
+    Tests that a nested `connect_args` dict passed via profile_args lands in the rendered profile.
+
+    In newer `snowflake-connector-python` releases, `insecure_mode` is deprecated in favour of
+    `disable_ocsp_checks`, which dbt-snowflake expects under a `connect_args` block. This guards
+    against any regression that would flatten, drop, or otherwise mangle nested values from
+    `profile_args`.
+    """
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+        profile_args={"connect_args": {"disable_ocsp_checks": True}},
+    )
+    assert profile_mapping.profile_args == {"connect_args": {"disable_ocsp_checks": True}}
+    assert profile_mapping.profile["connect_args"] == {"disable_ocsp_checks": True}
+
+
 def test_profile_env_vars(
     mock_snowflake_conn: Connection,
 ) -> None:


### PR DESCRIPTION
## Description

`SnowflakeEncryptedPrivateKeyPemProfileMapping.airflow_param_mapping` does not forward Snowflake connection extras like `insecure_mode` into the rendered dbt profile. Customers who need driver-level settings have to pass them via `profile_args` — either as a top-level field (e.g. the now-deprecated `insecure_mode: True`) or, for the modern equivalent, nested under a `connect_args` block (`connect_args: {disable_ocsp_checks: True}`, the documented replacement in newer `snowflake-connector-python` releases — see <https://docs.snowflake.com/en/developer-guide/python-connector/python-connector-connect>).

This PR adds two unit tests pinning both paths as hard contracts on the rendered profile:

- `test_profile_args_insecure_mode` — `profile_args={"insecure_mode": True}` lands as `insecure_mode: True` in the rendered profile.
- `test_profile_args_connect_args` — `profile_args={"connect_args": {"disable_ocsp_checks": True}}` lands as a preserved nested dict in the rendered profile (i.e. not flattened or stringified).

Together these guard against regressions in:

- the merge order of `mapped_params` / `profile_defaults` / `profile_args` in `SnowflakeBaseProfileMapping.profile`,
- `BaseProfileMapping.filter_null` accidentally widening its definition of "null" to include `False`/`0`/empty dicts,
- any future change to how nested values are handled in the profile dict.

Context: this came up while triaging a customer ticket (MGIC) where Cosmos dbt tasks fail to connect to Snowflake after an Airflow 2.11 → 3.2.1 upgrade, while their non-Cosmos Snowflake operators succeed using the same connection. The root-cause investigation continues separately; these tests are a small, self-contained piece of that work that's worth landing on its own.

A likely follow-up PR will extend the `airflow_param_mapping` for the Snowflake mappings so customers don't have to use `profile_args` to forward `insecure_mode` (or the connector-modern equivalent) from the connection — but that's intentionally scoped out of this PR.

## Related Issue(s)

N/A

## Breaking Change?

No.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works