### PR TITLE
Add Cosmos 1.14.2 row to the watcher-retry behavior history

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
@@ -53,6 +53,13 @@ Does the Airflow state match dbt's?
        retry, so the DAG appears successful even though dbt failed.
    * - **1.14.1**
      - **Yes**.
+   * - **1.14.2**
+     - **Yes**. Same as 1.14.1, plus a previously unreported "false green" gap is closed:
+       when a model fails on its first attempt and dbt skips downstream nodes via the
+       ``upstream_failure`` path, those downstream models are now re-run when their upstream
+       recovers via consumer fallback, instead of being silently marked SKIPPED while the DAG
+       completes ``success`` with the downstream tables un-materialized
+       (`#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_).
 
 Task-level retry — consumer
 +++++++++++++++++++++++++++++
@@ -91,6 +98,19 @@ Task-level retry — consumer
    * - **1.14.1**
      - Similar to 1.12.0. Consumers always read correct model statuses thanks to the producer's
        XCom backup mechanism — see *Task-level retry — producer*.
+   * - **1.14.2**
+     - Similar to 1.14.1, with two additions. First, consumers for models that dbt marked as
+       skipped due to upstream failure (``upstream_failure``) now fail on attempt 1 rather than
+       skipping — Cosmos rewrites those ``"skipped"`` statuses to ``"failed"`` in the
+       producer-side log parser, so Airflow retries and the existing
+       ``_fallback_to_non_watcher_run`` path runs the model locally once its upstream has
+       recovered (`#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_).
+       Second, the consumer's fallback ``dbt`` invocation no longer inherits the producer's
+       internal ``--log-format json`` flag, so retry task logs default to dbt's normal text
+       output instead of one structured event per line
+       (`#2713 <https://github.com/astronomer/astronomer-cosmos/pull/2713>`_); users who want
+       JSON output on retry can opt in via
+       ``operator_args={"dbt_cmd_flags": ["--log-format", "json"]}``.
 
 Task-level retry — producer
 +++++++++++++++++++++++++++++
@@ -132,7 +152,7 @@ Task-level retry — producer
        restores it on retry, so consumers always read correct model statuses. The backup Variable
        is cleaned up on success.
 
-       **Known issues with the XCom backup mechanism:**
+       **Known issues with the XCom backup mechanism (both fixed in 1.14.2):**
 
        - `#2619 <https://github.com/astronomer/astronomer-cosmos/issues/2619>`_ — backup Variable
          key is not sanitized for ``:`` and ``+`` in Airflow 3 default ``run_id`` formats; strict-naming
@@ -141,6 +161,18 @@ Task-level retry — producer
        - `#2625 <https://github.com/astronomer/astronomer-cosmos/issues/2625>`_ — on Airflow 2,
          ``_get_task_group_id()`` returns ``None``, so multiple ``DbtTaskGroup`` producers in the
          same DAG run share one backup key and log ``UniqueViolation`` on every model completion.
+   * - **1.14.2**
+     - Same as 1.14.1, with both XCom-backup known issues from 1.14.1 fixed. The key generator now
+       sanitises every component to ``[A-Za-z0-9_-]`` — the safest subset across the secrets
+       backends Airflow ships with — so ``:`` / ``+`` from default Airflow 3 ``run_id`` formats no
+       longer break strict-naming backends
+       (`#2629 <https://github.com/astronomer/astronomer-cosmos/pull/2629>`_, closes
+       `#2619 <https://github.com/astronomer/astronomer-cosmos/issues/2619>`_). And
+       ``_get_task_group_id`` now reads ``task.task_group.group_id`` (the correct attribute) instead
+       of the non-existent ``task.task_group_id`` it was reading before, so each ``DbtTaskGroup``
+       producer in a DAG writes to a distinct backup Variable
+       (`#2683 <https://github.com/astronomer/astronomer-cosmos/pull/2683>`_, closes
+       `#2625 <https://github.com/astronomer/astronomer-cosmos/issues/2625>`_).
 
 Automatic retries
 +++++++++++++++++
@@ -180,6 +212,13 @@ Automatic retries
      - **Works.** Producer auto-retries raise ``AirflowSkipException``; XCom is restored from the
        Variable backup so consumers read correct model statuses. Subject to the XCom backup known
        issues — see *Task-level retry — producer*.
+   * - **1.14.2**
+     - **Works.** Same as 1.14.1, with the XCom-backup known issues fixed
+       (`#2629 <https://github.com/astronomer/astronomer-cosmos/pull/2629>`_,
+       `#2683 <https://github.com/astronomer/astronomer-cosmos/pull/2683>`_ — see
+       *Task-level retry — producer*). Additionally, downstream models whose upstream failed on
+       the producer's first attempt are now re-run on Airflow retry instead of staying SKIPPED
+       (`#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_).
 
 Full DAG / TaskGroup clear
 ++++++++++++++++++++++++++
@@ -221,6 +260,11 @@ Full DAG / TaskGroup clear
        so it does not propagate to tasks downstream of the group
        (`#2594 <https://github.com/astronomer/astronomer-cosmos/issues/2594>`_). The gateway is
        only added for ``DbtTaskGroup`` — ``DbtDag`` does not need it.
+   * - **1.14.2**
+     - **Works.** Same as 1.14.1, with the XCom-backup known issues fixed
+       (`#2629 <https://github.com/astronomer/astronomer-cosmos/pull/2629>`_,
+       `#2683 <https://github.com/astronomer/astronomer-cosmos/pull/2683>`_ — see
+       *Task-level retry — producer*).
 
 Avoid duplicate or concurrent runs of the same dbt transformation in the same DAG run
 ++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
@@ -266,3 +310,13 @@ Avoid duplicate or concurrent runs of the same dbt transformation in the same DA
        Cosmos now checks the producer's state first: if it is still running, the sensor keeps
        polling instead of launching a duplicate ``dbt`` invocation; only after the producer reaches
        a terminal state does the consumer fall back to ``ExecutionMode.LOCAL``.
+   * - **1.14.2**
+     - **Met.** Same as 1.14.1. When ``depends_on_past=True`` is set on a ``DbtTaskGroup``, the
+       cross-run risk where the next DAG run's producer could start before the previous run's
+       consumers had completed
+       (`#2596 <https://github.com/astronomer/astronomer-cosmos/issues/2596>`_) is now mitigated:
+       the producer-done gateway is wired downstream of every consumer task and the task-group
+       leaves carry ``wait_for_downstream=True``
+       (`#2615 <https://github.com/astronomer/astronomer-cosmos/pull/2615>`_), so the task group
+       behaves as a single atomic unit across runs. Topology is unchanged for the default
+       ``depends_on_past=False``.

--- a/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
@@ -52,7 +52,9 @@ Does the Airflow state match dbt's?
        The consumer tasks for those models are marked successful instead of running their fallback
        retry, so the DAG appears successful even though dbt failed.
    * - **1.14.1**
-     - **Yes**.
+     - **Mostly**, except upstream-failure-skipped downstream nodes could produce a "false
+       green" — fixed in 1.14.2 by
+       `#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_.
    * - **1.14.2**
      - **Yes**. Same as 1.14.1, plus a previously unreported "false green" gap is closed:
        when a model fails on its first attempt and dbt skips downstream nodes via the
@@ -315,8 +317,8 @@ Avoid duplicate or concurrent runs of the same dbt transformation in the same DA
        cross-run risk where the next DAG run's producer could start before the previous run's
        consumers had completed
        (`#2596 <https://github.com/astronomer/astronomer-cosmos/issues/2596>`_) is now mitigated:
-       the producer-done gateway is wired downstream of every consumer task and the task-group
-       leaves carry ``wait_for_downstream=True``
+       leaf consumer tasks are wired upstream of the producer-done gateway, and the producer
+       plus watcher tasks carry ``wait_for_downstream=True``
        (`#2615 <https://github.com/astronomer/astronomer-cosmos/pull/2615>`_), so the task group
        behaves as a single atomic unit across runs. Topology is unchanged for the default
        ``depends_on_past=False``.

--- a/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
@@ -52,15 +52,15 @@ Does the Airflow state match dbt's?
        The consumer tasks for those models are marked successful instead of running their fallback
        retry, so the DAG appears successful even though dbt failed.
    * - **1.14.1**
-     - **Mostly**, except upstream-failure-skipped downstream nodes could produce a "false
-       green" — fixed in 1.14.2 by
-       `#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_.
+     - **Yes**.
    * - **1.14.2**
      - **Yes**. Same as 1.14.1, plus a previously unreported "false green" gap is closed:
        when a model fails on its first attempt and dbt skips downstream nodes via the
-       ``upstream_failure`` path, those downstream models are now re-run when their upstream
-       recovers via consumer fallback, instead of being silently marked SKIPPED while the DAG
-       completes ``success`` with the downstream tables un-materialized
+       ``upstream_failure`` path, those downstream nodes are now rewritten from SKIPPED to
+       **failed** instead of being silently marked successful. The DAG therefore fails rather
+       than completing ``success`` with the tables un-materialized, and Airflow's automatic
+       retries re-run the affected models via consumer fallback — so the whole DAG recovers on
+       retry without any manual intervention
        (`#2684 <https://github.com/astronomer/astronomer-cosmos/pull/2684>`_).
 
 Task-level retry — consumer
@@ -165,7 +165,7 @@ Task-level retry — producer
          same DAG run share one backup key and log ``UniqueViolation`` on every model completion.
    * - **1.14.2**
      - Same as 1.14.1, with both XCom-backup known issues from 1.14.1 fixed. The key generator now
-       sanitises every component to ``[A-Za-z0-9_-]`` — the safest subset across the secrets
+       sanitizes every component to ``[A-Za-z0-9_-]`` — the safest subset across the secrets
        backends Airflow ships with — so ``:`` / ``+`` from default Airflow 3 ``run_id`` formats no
        longer break strict-naming backends
        (`#2629 <https://github.com/astronomer/astronomer-cosmos/pull/2629>`_, closes


### PR DESCRIPTION
## Summary

Walk each of the six tables in [`docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst`](https://github.com/astronomer/astronomer-cosmos/blob/main/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst) forward by one release, capturing every retry-mechanism PR that ships in [Cosmos 1.14.2](https://github.com/astronomer/astronomer-cosmos/blob/main/CHANGELOG.rst#1142-2026-05-21).

## PR coverage

| PR | Where it appears in the new 1.14.2 rows |
|---|---|
| #2615 — Watcher + `depends_on_past` | *Avoid duplicate or concurrent runs* — atomic-TaskGroup-across-runs note, closing the cross-run risk from #2596 |
| #2629 — Sanitize disallowed chars from XCom backup variable key (closes #2619) | *Task-level retry — producer* (primary); cross-referenced from *Automatic retries* and *Full DAG / TaskGroup clear* |
| #2683 — Prevent watcher producers from colliding on one XCom-backup key (closes #2625) | Same as #2629 |
| #2684 — Retry watcher downstream models on upstream-failure recovery | *Does the Airflow state match dbt's?* (closes the "false green"), *Task-level retry — consumer* (skip-to-fail rewrite), *Automatic retries* |
| #2713 — Strip `--log-format` from watcher consumer-retry flags | *Task-level retry — consumer* — retry logs now default to dbt's text format, with the `operator_args={"dbt_cmd_flags": [...]}` opt-in path |

## One historical-row tweak

In *Task-level retry — producer*, the 1.14.1 known-issue list header changes from `**Known issues with the XCom backup mechanism:**` to `**Known issues with the XCom backup mechanism (both fixed in 1.14.2):**`. The two listed bullets stay verbatim — readers landing on the 1.14.1 row see the issues as documented, with a forward-pointer to the version that resolves them.

The 1.14.1 row in *Does the Airflow state match dbt's?* is intentionally **not** edited. It stays as the `**Yes.**` it shipped with; the new 1.14.2 row carries the "false green was here, now closed" story so the historical rows remain immutable.

## Test plan

- [x] `hatch run docs:build` succeeds — the 2 build warnings on the resulting build are pre-existing on `main` (`docs/guides/run_dbt/customization/scheduling.rst` duplicate-target labels), unrelated to this change.
- [x] `python3 scripts/check_docs_style.py docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst` — clean.
- [x] `codespell docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst` — clean.
- [x] Heading hierarchy, bullet style (`-`), and PR-link `\`#NNNN <url>\`_` formatting match the rest of the file.

Drafted; promote out of draft once the 1.14.2 stable release goes out (or sooner if you want to merge the doc-update first and let the release-notes link point at it).

🤖 Generated with Claude Code (https://claude.com/claude-code)