### PR TITLE
Forward Snowflake `insecure_mode` from connection Extra into dbt profile

### DIFF
--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_env_variable.py
@@ -45,6 +45,7 @@ class SnowflakeEncryptedPrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping)
         "private_key": "extra.private_key_content",
         "private_key_passphrase": "password",
         "query_tag": "extra.query_tag",
+        "insecure_mode": "extra.insecure_mode",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_encrypted_privatekey_file.py
@@ -44,6 +44,7 @@ class SnowflakeEncryptedPrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapp
         "private_key_passphrase": "password",
         "private_key_path": "extra.private_key_file",
         "query_tag": "extra.query_tag",
+        "insecure_mode": "extra.insecure_mode",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_pass.py
+++ b/cosmos/profiles/snowflake/user_pass.py
@@ -43,6 +43,7 @@ class SnowflakeUserPasswordProfileMapping(SnowflakeBaseProfileMapping):
         "host": "extra.host",
         "port": "extra.port",
         "query_tag": "extra.query_tag",
+        "insecure_mode": "extra.insecure_mode",
     }
 
     def can_claim_connection(self) -> bool:

--- a/cosmos/profiles/snowflake/user_privatekey.py
+++ b/cosmos/profiles/snowflake/user_privatekey.py
@@ -42,6 +42,7 @@ class SnowflakePrivateKeyPemProfileMapping(SnowflakeBaseProfileMapping):
         "role": "extra.role",
         "private_key": "extra.private_key_content",
         "query_tag": "extra.query_tag",
+        "insecure_mode": "extra.insecure_mode",
     }
 
     @property

--- a/cosmos/profiles/snowflake/user_privatekey_file.py
+++ b/cosmos/profiles/snowflake/user_privatekey_file.py
@@ -38,6 +38,7 @@ class SnowflakePrivateKeyFilePemProfileMapping(SnowflakeBaseProfileMapping):
         "role": "extra.role",
         "private_key_path": "extra.private_key_file",
         "query_tag": "extra.query_tag",
+        "insecure_mode": "extra.insecure_mode",
     }
 
     def can_claim_connection(self) -> bool:

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -317,3 +317,43 @@ def test_old_snowflake_format() -> None:
             "warehouse": conn.extra_dejson.get("warehouse"),
             "threads": 4,
         }
+
+
+def test_insecure_mode_from_connection_extra() -> None:
+    """
+    Tests that `insecure_mode` set on the Airflow connection's Extra is forwarded to the profile.
+
+    `insecure_mode` is a first-class field of the Airflow Snowflake connection form. It must reach
+    the rendered dbt profile via `airflow_param_mapping` (not only via `profile_args`), otherwise
+    users behind PrivateLink who rely on it to bypass OCSP checks silently lose the setting.
+    """
+    conn = Connection(
+        conn_id="my_snowflake_pk_connection_insecure",
+        conn_type="snowflake",
+        login="my_user",
+        schema="my_schema",
+        extra=json.dumps(
+            {
+                "account": "my_account",
+                "database": "my_database",
+                "warehouse": "my_warehouse",
+                "private_key_content": "my_private_key",
+                "private_key_passphrase": "my_passphrase",
+                "insecure_mode": True,
+            }
+        ),
+    )
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = SnowflakeEncryptedPrivateKeyPemProfileMapping(conn)
+        assert profile_mapping.profile["insecure_mode"] is True
+
+
+def test_insecure_mode_absent_when_not_set(
+    mock_snowflake_conn: Connection,
+) -> None:
+    """Tests that `insecure_mode` is omitted from the profile when it is not set on the connection."""
+    profile_mapping = get_automatic_profile_mapping(
+        mock_snowflake_conn.conn_id,
+    )
+    assert "insecure_mode" not in profile_mapping.profile

--- a/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
+++ b/tests/profiles/snowflake/test_snowflake_user_encrypted_privatekey_env_variable.py
@@ -9,7 +9,11 @@ from airflow.models.connection import Connection
 
 from cosmos.profiles import get_automatic_profile_mapping
 from cosmos.profiles.snowflake import (
+    SnowflakeEncryptedPrivateKeyFilePemProfileMapping,
     SnowflakeEncryptedPrivateKeyPemProfileMapping,
+    SnowflakePrivateKeyFilePemProfileMapping,
+    SnowflakePrivateKeyPemProfileMapping,
+    SnowflakeUserPasswordProfileMapping,
 )
 
 PLAIN_TEXT_KEY = "mocked-private-key-content"
@@ -319,7 +323,61 @@ def test_old_snowflake_format() -> None:
         }
 
 
-def test_insecure_mode_from_connection_extra() -> None:
+# Each entry pairs a Snowflake profile mapping with the connection password and Extra
+# fields required to satisfy that mapping's ``required_fields``. ``insecure_mode`` lives in
+# every mapping's ``airflow_param_mapping``, so the tests below run against all of them to
+# guard against a regression slipping into any single mapping.
+SNOWFLAKE_PROFILE_MAPPINGS = [
+    pytest.param(SnowflakeUserPasswordProfileMapping, "my_password", {}, id="user_password"),
+    pytest.param(
+        SnowflakePrivateKeyPemProfileMapping,
+        None,
+        {"private_key_content": "my_private_key"},
+        id="private_key_pem",
+    ),
+    pytest.param(
+        SnowflakePrivateKeyFilePemProfileMapping,
+        None,
+        {"private_key_file": "/path/to/key.p8"},
+        id="private_key_file",
+    ),
+    pytest.param(
+        SnowflakeEncryptedPrivateKeyFilePemProfileMapping,
+        "my_passphrase",
+        {"private_key_file": "/path/to/key.p8"},
+        id="encrypted_private_key_file",
+    ),
+    pytest.param(
+        SnowflakeEncryptedPrivateKeyPemProfileMapping,
+        "my_passphrase",
+        {"private_key_content": "my_private_key"},
+        id="encrypted_private_key_pem",
+    ),
+]
+
+
+def _build_snowflake_conn(password: str | None, extra_fields: dict, insecure_mode: bool | None = None) -> Connection:
+    """Builds a Snowflake connection valid for any of the profile mappings under test."""
+    extra = {
+        "account": "my_account",
+        "database": "my_database",
+        "warehouse": "my_warehouse",
+        **extra_fields,
+    }
+    if insecure_mode is not None:
+        extra["insecure_mode"] = insecure_mode
+    return Connection(
+        conn_id="my_snowflake_insecure_conn",
+        conn_type="snowflake",
+        login="my_user",
+        schema="my_schema",
+        password=password,
+        extra=json.dumps(extra),
+    )
+
+
+@pytest.mark.parametrize("mapping_class, password, extra_fields", SNOWFLAKE_PROFILE_MAPPINGS)
+def test_insecure_mode_from_connection_extra(mapping_class, password, extra_fields) -> None:
     """
     Tests that `insecure_mode` set on the Airflow connection's Extra is forwarded to the profile.
 
@@ -327,33 +385,18 @@ def test_insecure_mode_from_connection_extra() -> None:
     the rendered dbt profile via `airflow_param_mapping` (not only via `profile_args`), otherwise
     users behind PrivateLink who rely on it to bypass OCSP checks silently lose the setting.
     """
-    conn = Connection(
-        conn_id="my_snowflake_pk_connection_insecure",
-        conn_type="snowflake",
-        login="my_user",
-        schema="my_schema",
-        extra=json.dumps(
-            {
-                "account": "my_account",
-                "database": "my_database",
-                "warehouse": "my_warehouse",
-                "private_key_content": "my_private_key",
-                "private_key_passphrase": "my_passphrase",
-                "insecure_mode": True,
-            }
-        ),
-    )
+    conn = _build_snowflake_conn(password, extra_fields, insecure_mode=True)
 
     with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
-        profile_mapping = SnowflakeEncryptedPrivateKeyPemProfileMapping(conn)
+        profile_mapping = mapping_class(conn)
         assert profile_mapping.profile["insecure_mode"] is True
 
 
-def test_insecure_mode_absent_when_not_set(
-    mock_snowflake_conn: Connection,
-) -> None:
+@pytest.mark.parametrize("mapping_class, password, extra_fields", SNOWFLAKE_PROFILE_MAPPINGS)
+def test_insecure_mode_absent_when_not_set(mapping_class, password, extra_fields) -> None:
     """Tests that `insecure_mode` is omitted from the profile when it is not set on the connection."""
-    profile_mapping = get_automatic_profile_mapping(
-        mock_snowflake_conn.conn_id,
-    )
-    assert "insecure_mode" not in profile_mapping.profile
+    conn = _build_snowflake_conn(password, extra_fields)
+
+    with patch("cosmos.profiles.base.BaseHook.get_connection", return_value=conn):
+        profile_mapping = mapping_class(conn)
+        assert "insecure_mode" not in profile_mapping.profile


### PR DESCRIPTION
## Summary

The Snowflake profile mappings forward only the fields listed in each mapping's `airflow_param_mapping` allowlist. `insecure_mode` was missing from all of them, so when a user sets **Insecure Mode** on an Airflow Snowflake connection, Cosmos silently dropped it from the rendered dbt profile.

## Root Cause

`BaseProfileMapping.mapped_params` builds the profile only from keys present in `airflow_param_mapping` (`cosmos/profiles/base.py`). None of the five mappings under `cosmos/profiles/snowflake/` included `insecure_mode`, so the value never reached the profile — even though the upstream `SnowflakeHook` forwards it to the connector.

## Changes

- Add `"insecure_mode": "extra.insecure_mode"` to the `airflow_param_mapping` of all five Snowflake mappings, so the value is read from the connection Extra.
- Add two tests on the encrypted-PEM mapping: a connection-Extra round-trip, and an absence check confirming the key is omitted when unset.

## Why This Is Safe

All five Snowflake mappings already null-filter their profile (`filter_null`), and `get_dbt_value` skips falsy values. So `insecure_mode` that is unset or `False` is omitted from the profile — which matches `dbt-snowflake`'s default — meaning **no behaviour change** for connections that don't set it. Only an explicit `True` is forwarded.

## Testing

Full Snowflake profile suite (`tests/profiles/snowflake/`): **55 passed**. Black, Ruff, and mypy pass on the changed files.

### Reproduce bug (before fix)
```text
>   assert profile_mapping.profile["insecure_mode"] is True
E   KeyError: 'insecure_mode'
```

### Validate fix (after fix)
```text
55 passed in 1.21s
```

## Related

- Closes #2740
- Related: #2738 (covers the `profile_args` workaround; this PR adds the connection-Extra path requested in #2740's acceptance criteria)