### PR TITLE
Stop stale bot from auto-closing PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -16,10 +16,9 @@ jobs:
           stale-issue-label: "stale"
           stale-issue-message: "This issue is stale because it has been open for 30 days with no activity."
           days-before-pr-stale: 30
-          days-before-pr-close: 10
+          days-before-pr-close: -1  # Never closes PRs, more information in https://github.com/actions/stale/
           stale-pr-label: "stale"
           exempt-issue-labels: "do-not-stale"
           exempt-pr-labels: "do-not-stale"
           stale-pr-message: "This PR is stale because it has been open for 30 days with no activity."
-          close-pr-message: "This PR was closed because it has been inactive for 10 days since being marked as stale."
           repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Description

The stale workflow currently marks PRs stale after 30 days and then auto-closes them 10 days later (`days-before-pr-close: 10`). This closes contributor PRs that are otherwise healthy but simply haven't received a maintainer review, e.g. #2006.

This sets `days-before-pr-close: -1` so PRs are never auto-closed, mirroring the existing behavior for issues (`days-before-issue-close: -1`). PRs are still labeled `stale` after 30 days of inactivity to surface them, but they remain open. The now-unused `close-pr-message` is removed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)