### PR TITLE
Add structured TestResultSummary to watcher test aggregation

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -6,6 +6,8 @@ from copy import deepcopy
 from pathlib import Path
 from typing import Any
 
+from cosmos.operators._watcher.aggregation import TestsPerModel
+
 try:  # Airflow 3
     from airflow.sdk.bases.operator import BaseOperator
 except ImportError:  # Airflow 2
@@ -790,7 +792,7 @@ def _add_watcher_producer_task(
     task_group: TaskGroup | None,
     render_config: RenderConfig | None = None,
     execution_mode: ExecutionMode = ExecutionMode.WATCHER,
-    tests_per_model: dict[str, list[str]] | None = None,
+    tests_per_model: TestsPerModel | None = None,
 ) -> BaseOperator:
     """
     Create the producer task for the watcher execution mode and add it to the tasks_map.
@@ -1128,7 +1130,7 @@ def build_airflow_graph(
     on_warning_callback: Callable[..., Any] | None = None,  # argument specific to the DBT test command
     async_py_requirements: list[str] | None = None,
     execution_config: ExecutionConfig | None = None,
-    tests_per_model: dict[str, list[str]] | None = None,
+    tests_per_model: TestsPerModel | None = None,
 ) -> dict[str, TaskGroup | BaseOperator]:
     """
     Instantiate dbt `nodes` as Airflow tasks within the given `task_group` (optional) or `dag` (mandatory).

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -18,6 +18,8 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.models import Variable
 
+from cosmos.operators._watcher.aggregation import TestsPerModel
+
 try:
     import orjson
 except ImportError:  # pragma: no cover
@@ -494,7 +496,7 @@ class DbtGraph:
 
     nodes: dict[str, DbtNode] = dict()
     filtered_nodes: dict[str, DbtNode] = dict()
-    tests_per_model: dict[str, list[str]] = dict()
+    tests_per_model: TestsPerModel = dict()
     load_method: LoadMode = LoadMode.AUTOMATIC
 
     def __init__(
@@ -1433,7 +1435,7 @@ class DbtGraph:
         * self.filtered_nodes
         * self.tests_per_model
         """
-        tests_per_model: dict[str, list[str]] = {}
+        tests_per_model: TestsPerModel = {}
         for _, node in list(self.nodes.items()):
             if node.resource_type == DbtResourceType.TEST:
                 for node_id in node.depends_on:

--- a/cosmos/operators/_watcher/aggregation.py
+++ b/cosmos/operators/_watcher/aggregation.py
@@ -23,7 +23,7 @@ TestsPerModel: TypeAlias = dict[str, list[str]]
 
 #: Mutable accumulator mapping model unique_id → {test unique_id → terminal status}.
 #: Keying by test unique_id makes duplicated/replayed log lines idempotent.
-TestResultsPerModel: TypeAlias = dict[str, dict[str, str]]
+ResultsTestsPerModel: TypeAlias = dict[str, dict[str, str]]
 
 
 @dataclass(frozen=True)
@@ -65,7 +65,7 @@ def accumulate_test_result(
     test_unique_id: str,
     status: str,
     tests_per_model: TestsPerModel,
-    test_results_per_model: TestResultsPerModel,
+    test_results_per_model: ResultsTestsPerModel,
 ) -> str | None:
     """Record a test's terminal status into test_results_per_model for its parent model.
 
@@ -94,7 +94,7 @@ def accumulate_test_result(
 def get_aggregated_test_status(
     model_uid: str,
     tests_per_model: TestsPerModel,
-    test_results_per_model: TestResultsPerModel,
+    test_results_per_model: ResultsTestsPerModel,
 ) -> TestResultSummary | None:
     """
     Check if all tests for a model have finished and return aggregated status.
@@ -132,7 +132,7 @@ def push_test_result_or_aggregate(
     test_unique_id: str,
     status: str,
     tests_per_model: TestsPerModel,
-    test_results_per_model: TestResultsPerModel,
+    test_results_per_model: ResultsTestsPerModel,
     task_instance: Any,
 ) -> None:
     """Accumulate a test result and, when all tests for the parent model have reported, push aggregated XCom.

--- a/cosmos/operators/_watcher/aggregation.py
+++ b/cosmos/operators/_watcher/aggregation.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
+from dataclasses import asdict, dataclass
 from threading import Lock
-from typing import Any
+from typing import Any, TypeAlias
 
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import DbtTestStatus, is_dbt_node_status_success, safe_xcom_push
@@ -12,6 +13,48 @@ logger = get_logger(__name__)
 # dbt threads cannot interleave ``setdefault`` / item assignment / ``len`` checks.
 _test_results_lock = Lock()
 
+#: Maximum number of failed test IDs included in the summary.
+#: Keeps XCom/event payloads bounded for models with many tests.
+MAX_FAILED_TESTS_IN_SUMMARY = 5
+
+
+#: Mapping of model unique_id → list of test unique_ids associated with that model.
+TestsPerModel: TypeAlias = dict[str, list[str]]
+
+#: Mutable accumulator mapping model unique_id → {test unique_id → terminal status}.
+#: Keying by test unique_id makes duplicated/replayed log lines idempotent.
+TestResultsPerModel: TypeAlias = dict[str, dict[str, str]]
+
+
+@dataclass(frozen=True)
+class TestResultSummary:
+    """Aggregated test result for a model, pushed as XCom and forwarded in TriggerEvents."""
+
+    # Prevent pytest from collecting this class as a test suite.
+    __test__ = False
+
+    status: DbtTestStatus
+    passed_count: int
+    failed_count: int
+    total_count: int
+    failed_tests: list[str]
+
+    def to_dict(self) -> dict[str, Any]:
+        return asdict(self)
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> TestResultSummary:
+        status = data.get("status")
+        if status not in (DbtTestStatus.PASS, DbtTestStatus.FAIL):
+            raise ValueError(f"Invalid TestResultSummary status: {status!r}")
+        return cls(
+            status=status,
+            passed_count=data.get("passed_count", 0),
+            failed_count=data.get("failed_count", 0),
+            total_count=data.get("total_count", 0),
+            failed_tests=data.get("failed_tests", []),
+        )
+
 
 def get_tests_status_xcom_key(model_uid: str) -> str:
     """Return the XCom key used to store the aggregated test status for a model."""
@@ -21,34 +64,43 @@ def get_tests_status_xcom_key(model_uid: str) -> str:
 def accumulate_test_result(
     test_unique_id: str,
     status: str,
-    tests_per_model: dict[str, list[str]],
-    test_results_per_model: dict[str, dict[str, str]],
+    tests_per_model: TestsPerModel,
+    test_results_per_model: TestResultsPerModel,
 ) -> str | None:
     """Record a test's terminal status into test_results_per_model for its parent model.
 
     Results are keyed by ``test_unique_id`` so that a duplicated or replayed log line for
     the same test (the Kubernetes log reader can replay recent lines after an interruption)
-    overwrites its entry instead of being counted as another distinct test.
+    updates its entry instead of being counted as another distinct test. When a test is
+    reported more than once, the worst (most severe) status is kept: a later failure
+    overrides an earlier pass, but a later pass never overrides an earlier failure.
 
     Returns the parent model's unique_id if found, else None.
     """
     for model_uid, test_uids in tests_per_model.items():
         if test_unique_id in test_uids:
-            test_results_per_model.setdefault(model_uid, {})[test_unique_id] = status
+            collected = test_results_per_model.setdefault(model_uid, {})
+            prev_status = collected.get(test_unique_id)
+            # Keep the worst (most severe) status per test. A later failure
+            # overrides a previous pass, but a later pass does NOT override a failure.
+            if prev_status is None or (
+                not is_dbt_node_status_success(status) and is_dbt_node_status_success(prev_status)
+            ):
+                collected[test_unique_id] = status
             return model_uid
     return None
 
 
 def get_aggregated_test_status(
     model_uid: str,
-    tests_per_model: dict[str, list[str]],
-    test_results_per_model: dict[str, dict[str, str]],
-) -> str | None:
+    tests_per_model: TestsPerModel,
+    test_results_per_model: TestResultsPerModel,
+) -> TestResultSummary | None:
     """
     Check if all tests for a model have finished and return aggregated status.
 
     Returns:
-        "pass" if all tests passed, "fail" if any test failed,
+        A TestResultSummary with pass/fail breakdown if all tests have reported,
         or None if not all tests have reported yet.
     """
     expected = tests_per_model.get(model_uid)
@@ -63,18 +115,24 @@ def get_aggregated_test_status(
             len(collected),
         )
         return None
-    aggregated_test_result = (
-        DbtTestStatus.PASS if all(is_dbt_node_status_success(s) for s in collected.values()) else DbtTestStatus.FAIL
+    passed_count = sum(1 for s in collected.values() if is_dbt_node_status_success(s))
+    failed_tests = [tid for tid, s in collected.items() if not is_dbt_node_status_success(s)]
+    aggregated_status = DbtTestStatus.PASS if not failed_tests else DbtTestStatus.FAIL
+    logger.debug("Model '%s' has all tests reported. Aggregated result: %s", model_uid, aggregated_status)
+    return TestResultSummary(
+        status=aggregated_status,
+        passed_count=passed_count,
+        failed_count=len(failed_tests),
+        total_count=len(collected),
+        failed_tests=failed_tests[:MAX_FAILED_TESTS_IN_SUMMARY],
     )
-    logger.debug("Model '%s' has all tests reported. Aggregated result: %s", model_uid, aggregated_test_result)
-    return aggregated_test_result
 
 
 def push_test_result_or_aggregate(
     test_unique_id: str,
     status: str,
-    tests_per_model: dict[str, list[str]],
-    test_results_per_model: dict[str, dict[str, str]],
+    tests_per_model: TestsPerModel,
+    test_results_per_model: TestResultsPerModel,
     task_instance: Any,
 ) -> None:
     """Accumulate a test result and, when all tests for the parent model have reported, push aggregated XCom.
@@ -93,5 +151,5 @@ def push_test_result_or_aggregate(
                 safe_xcom_push(
                     task_instance=task_instance,
                     key=get_tests_status_xcom_key(model_uid),
-                    value=aggregated,
+                    value=aggregated.to_dict(),
                 )

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -22,7 +22,7 @@ from cosmos.dbt.graph import DbtNode
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import (
-    TestResultsPerModel,
+    ResultsTestsPerModel,
     TestResultSummary,
     TestsPerModel,
     get_tests_status_xcom_key,
@@ -306,7 +306,7 @@ def store_dbt_resource_status_from_log(
     extra_kwargs: Any,
     *,
     tests_per_model: TestsPerModel | None = None,
-    test_results_per_model: TestResultsPerModel | None = None,
+    test_results_per_model: ResultsTestsPerModel | None = None,
     model_outlet_uris: dict[str, list[str]] | None = None,
     dataset_namespace: str | None = None,
     should_generate_model_uris: bool = True,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -21,7 +21,13 @@ from cosmos.constants import (
 from cosmos.dbt.graph import DbtNode
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
-from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
+from cosmos.operators._watcher.aggregation import (
+    TestResultsPerModel,
+    TestResultSummary,
+    TestsPerModel,
+    get_tests_status_xcom_key,
+    push_test_result_or_aggregate,
+)
 from cosmos.operators._watcher.state import (
     DbtNodeStatus,
     ProducerTaskState,
@@ -299,8 +305,8 @@ def store_dbt_resource_status_from_log(
     line: str,
     extra_kwargs: Any,
     *,
-    tests_per_model: dict[str, list[str]] | None = None,
-    test_results_per_model: dict[str, dict[str, str]] | None = None,
+    tests_per_model: TestsPerModel | None = None,
+    test_results_per_model: TestResultsPerModel | None = None,
     model_outlet_uris: dict[str, list[str]] | None = None,
     dataset_namespace: str | None = None,
     should_generate_model_uris: bool = True,
@@ -454,6 +460,7 @@ class BaseConsumerSensor(BaseSensorOperator):
         self.producer_task_id = producer_task_id
         self.deferrable = deferrable
         self.model_unique_id = extra_context.get("dbt_node_config", {}).get("unique_id")
+        self._test_result_summary: TestResultSummary | None = None
 
     @property
     def is_test_sensor(self) -> bool:
@@ -612,6 +619,11 @@ class BaseConsumerSensor(BaseSensorOperator):
         )
         _log_dbt_event(dbt_events)
 
+        # Log test result summary if available in the event
+        test_counts = event.get("test_result_counts")
+        if self.is_test_sensor and test_counts:
+            self._log_test_result_summary(TestResultSummary.from_dict(test_counts))
+
         if status == EventStatus.SKIPPED:
             raise AirflowSkipException(
                 f"{self._resource_label} '{self.model_unique_id}' was skipped by the dbt command."
@@ -654,6 +666,33 @@ class BaseConsumerSensor(BaseSensorOperator):
             self._fallback_to_non_watcher_run(try_number=context["ti"].try_number, context=context)
             return
 
+    def _log_test_result_summary(self, summary: TestResultSummary) -> None:
+        """Log a human-readable summary of test results for test sensors."""
+        if summary.failed_count:
+            from cosmos.operators._watcher.aggregation import MAX_FAILED_TESTS_IN_SUMMARY
+
+            truncation_note = (
+                f" (showing first {MAX_FAILED_TESTS_IN_SUMMARY} of {summary.failed_count})"
+                if summary.failed_count > MAX_FAILED_TESTS_IN_SUMMARY
+                else ""
+            )
+            logger.info(
+                "%s out of %s tests passed, %s failed for '%s'. Failed%s: %s",
+                summary.passed_count,
+                summary.total_count,
+                summary.failed_count,
+                self.model_unique_id,
+                truncation_note,
+                summary.failed_tests,
+            )
+        else:
+            logger.info(
+                "%s out of %s tests passed for '%s'.",
+                summary.passed_count,
+                summary.total_count,
+                self.model_unique_id,
+            )
+
     def _log_startup_events(self, ti: Any) -> None:
         dbt_startup_events: list[dict[str, Any]] = ti.xcom_pull(
             task_ids=self.producer_task_id, key=_DBT_STARTUP_EVENTS_XCOM_KEY
@@ -675,7 +714,14 @@ class BaseConsumerSensor(BaseSensorOperator):
         dataset emission.
         """
         if self.is_test_sensor:
-            return get_xcom_val(ti, self.producer_task_id, get_tests_status_xcom_key(self.model_unique_id))
+            xcom_val = get_xcom_val(ti, self.producer_task_id, get_tests_status_xcom_key(self.model_unique_id))
+            if xcom_val is None:
+                return None
+            if isinstance(xcom_val, dict):
+                self._test_result_summary = TestResultSummary.from_dict(xcom_val)
+                return self._test_result_summary.status
+            # Backward compatibility: plain string value
+            return xcom_val
         xcom_val = get_xcom_val(ti, self.producer_task_id, get_status_xcom_key(self.model_unique_id))
         if xcom_val is None:
             return None
@@ -784,8 +830,12 @@ class BaseConsumerSensor(BaseSensorOperator):
                 f"{self._resource_label} '{self.model_unique_id}' was skipped by the dbt command."
             )
         elif is_dbt_node_status_success(status):
+            if self.is_test_sensor and self._test_result_summary:
+                self._log_test_result_summary(self._test_result_summary)
             return True
         else:
+            if self.is_test_sensor and self._test_result_summary:
+                self._log_test_result_summary(self._test_result_summary)
             raise AirflowException(f"{self._resource_label} '{self.model_unique_id}' finished with status '{status}'")
 
 

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -148,10 +148,16 @@ class WatcherTrigger(BaseTrigger):
         compiled_sql is always read from the canonical per-model ``*_compiled_sql`` key.
         """
         if self.is_test_sensor:
-            from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key
+            from cosmos.operators._watcher.aggregation import TestResultSummary, get_tests_status_xcom_key
 
-            status = await self.get_xcom_val(get_tests_status_xcom_key(self.model_unique_id))
-            return status, None
+            xcom_val = await self.get_xcom_val(get_tests_status_xcom_key(self.model_unique_id))
+            if xcom_val is None:
+                return None, None
+            if isinstance(xcom_val, dict):
+                self._test_result_summary = TestResultSummary.from_dict(xcom_val)
+                return self._test_result_summary.status, None
+            # Backward compatibility: plain string value
+            return xcom_val, None
 
         status = await self._get_node_status()
         compiled_sql = (
@@ -221,6 +227,9 @@ class WatcherTrigger(BaseTrigger):
         outlet_uris = getattr(self, "_outlet_uris", [])
         if outlet_uris:
             event_data["outlet_uris"] = outlet_uris
+        test_summary = getattr(self, "_test_result_summary", None)
+        if test_summary:
+            event_data["test_result_counts"] = test_summary.to_dict()
         return event_data
 
     async def run(self) -> AsyncIterator[TriggerEvent]:
@@ -243,6 +252,9 @@ class WatcherTrigger(BaseTrigger):
                 event_data = {"status": EventStatus.FAILED, "reason": WatcherEventReason.NODE_FAILED}
                 if compiled_sql:
                     event_data["compiled_sql"] = compiled_sql
+                test_summary = getattr(self, "_test_result_summary", None)
+                if test_summary:
+                    event_data["test_result_counts"] = test_summary.to_dict()
                 yield TriggerEvent(event_data)  # type: ignore[no-untyped-call]
                 return
             elif producer_task_state == ProducerTaskState.FAILED:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException, AirflowSkipException
 
-from cosmos.operators._watcher.aggregation import TestResultsPerModel, TestsPerModel
+from cosmos.operators._watcher.aggregation import ResultsTestsPerModel, TestsPerModel
 
 try:
     # Airflow 3.1 onwards
@@ -218,7 +218,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
         self.tests_per_model: TestsPerModel = kwargs.pop("tests_per_model", {})
-        self.test_results_per_model: TestResultsPerModel = {}
+        self.test_results_per_model: ResultsTestsPerModel = {}
         self._check_source_freshness: bool = kwargs.pop("_check_source_freshness", False)
         self._should_generate_model_uris: bool = kwargs.pop(
             "_should_generate_model_uris", kwargs.get("emit_datasets", True)

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -9,6 +9,8 @@ from typing import TYPE_CHECKING, Any
 
 from airflow.exceptions import AirflowException, AirflowSkipException
 
+from cosmos.operators._watcher.aggregation import TestResultsPerModel, TestsPerModel
+
 try:
     # Airflow 3.1 onwards
     from airflow.sdk import TaskGroup
@@ -215,8 +217,8 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
-        self.tests_per_model: dict[str, list[str]] = kwargs.pop("tests_per_model", {})
-        self.test_results_per_model: dict[str, dict[str, str]] = {}
+        self.tests_per_model: TestsPerModel = kwargs.pop("tests_per_model", {})
+        self.test_results_per_model: TestResultsPerModel = {}
         self._check_source_freshness: bool = kwargs.pop("_check_source_freshness", False)
         self._should_generate_model_uris: bool = kwargs.pop(
             "_should_generate_model_uris", kwargs.get("emit_datasets", True)

--- a/tests/operators/_watcher/test_aggregation.py
+++ b/tests/operators/_watcher/test_aggregation.py
@@ -5,7 +5,11 @@ from __future__ import annotations
 import threading
 from unittest.mock import MagicMock, patch
 
+import pytest
+
 from cosmos.operators._watcher.aggregation import (
+    TestResultsPerModel,
+    TestResultSummary,
     accumulate_test_result,
     get_aggregated_test_status,
     get_tests_status_xcom_key,
@@ -29,23 +33,77 @@ class TestGetTestsStatusXcomKey:
         assert get_tests_status_xcom_key("orders") == "orders_tests_status"
 
 
+class TestTestResultSummaryClass:
+    """Tests for TestResultSummary dataclass."""
+
+    def test_to_dict_roundtrip(self):
+        summary = TestResultSummary(
+            status=DbtTestStatus.PASS,
+            passed_count=2,
+            failed_count=0,
+            total_count=2,
+            failed_tests=[],
+        )
+        d = summary.to_dict()
+        assert d == {
+            "status": "pass",
+            "passed_count": 2,
+            "failed_count": 0,
+            "total_count": 2,
+            "failed_tests": [],
+        }
+        restored = TestResultSummary.from_dict(d)
+        assert restored == summary
+
+    def test_from_dict_with_fail_status(self):
+        d = {
+            "status": "fail",
+            "passed_count": 1,
+            "failed_count": 1,
+            "total_count": 2,
+            "failed_tests": ["test.pkg.b"],
+        }
+        summary = TestResultSummary.from_dict(d)
+        assert summary.status == DbtTestStatus.FAIL
+        assert summary.failed_tests == ["test.pkg.b"]
+
+    def test_from_dict_raises_on_invalid_status(self):
+        with pytest.raises(ValueError, match="Invalid TestResultSummary status"):
+            TestResultSummary.from_dict({"status": "unknown"})
+
+    def test_from_dict_raises_on_missing_status(self):
+        with pytest.raises(ValueError, match="Invalid TestResultSummary status"):
+            TestResultSummary.from_dict({})
+
+    def test_frozen_dataclass_is_immutable(self):
+        summary = TestResultSummary(
+            status=DbtTestStatus.PASS,
+            passed_count=1,
+            failed_count=0,
+            total_count=1,
+            failed_tests=[],
+        )
+        with pytest.raises(AttributeError):
+            summary.status = DbtTestStatus.FAIL  # type: ignore[misc]
+
+
 class TestAccumulateTestResult:
     """Tests for accumulate_test_result."""
 
     def test_returns_model_uid_when_test_found(self):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         model_uid = accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         assert model_uid == "model.pkg.orders"
         assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
 
     def test_returns_none_when_test_not_found(self):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         model_uid = accumulate_test_result("test.pkg.unknown_test", "pass", TESTS_PER_MODEL, results)
         assert model_uid is None
         assert results == {}
 
     def test_accumulates_multiple_results(self):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.unique_orders_id", "fail", TESTS_PER_MODEL, results)
         assert results == {
@@ -53,7 +111,7 @@ class TestAccumulateTestResult:
         }
 
     def test_accumulates_across_models(self):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.not_null_customers_id", "pass", TESTS_PER_MODEL, results)
         assert results == {
@@ -61,13 +119,19 @@ class TestAccumulateTestResult:
             "model.pkg.customers": {"test.pkg.not_null_customers_id": "pass"},
         }
 
-    def test_duplicate_test_result_overwrites_instead_of_double_counting(self):
-        """A duplicated/replayed log line for the same test overwrites its entry (#2543)."""
-        results: dict[str, dict[str, str]] = {}
-        accumulate_test_result("test.pkg.not_null_orders_id", "fail", TESTS_PER_MODEL, results)
-        # The same test reported again (e.g. Kubernetes log replay) with a newer status.
+    def test_deduplicates_same_test_keeps_worst_status(self):
+        results: TestResultsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
-        assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
+        accumulate_test_result("test.pkg.not_null_orders_id", "fail", TESTS_PER_MODEL, results)
+        # The worse (fail) status should override the earlier pass
+        assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "fail"}}
+
+    def test_deduplicates_same_test_keeps_first_failure(self):
+        results: TestResultsPerModel = {}
+        accumulate_test_result("test.pkg.not_null_orders_id", "fail", TESTS_PER_MODEL, results)
+        accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
+        # A later pass should NOT override an existing failure
+        assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "fail"}}
 
 
 class TestGetAggregatedTestStatus:
@@ -77,84 +141,132 @@ class TestGetAggregatedTestStatus:
         assert get_aggregated_test_status("model.pkg.unknown", TESTS_PER_MODEL, {}) is None
 
     def test_returns_none_when_not_all_tests_reported(self):
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
+        results: TestResultsPerModel = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
         assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) is None
 
-    def test_returns_pass_when_all_tests_pass(self):
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "pass"}}
-        assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) == DbtTestStatus.PASS
+    def test_returns_summary_pass_when_all_tests_pass(self):
+        results: TestResultsPerModel = {
+            "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "pass"}
+        }
+        summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.PASS
+        assert summary.passed_count == 2
+        assert summary.failed_count == 0
+        assert summary.total_count == 2
+        assert summary.failed_tests == []
 
-    def test_returns_fail_when_any_test_fails(self):
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "fail"}}
-        assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) == DbtTestStatus.FAIL
+    def test_returns_summary_fail_when_any_test_fails(self):
+        results: TestResultsPerModel = {
+            "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "fail"}
+        }
+        summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.FAIL
+        assert summary.passed_count == 1
+        assert summary.failed_count == 1
+        assert summary.failed_tests == ["test.pkg.unique_orders_id"]
 
-    def test_returns_fail_when_all_tests_fail(self):
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "fail", "test.pkg.unique_orders_id": "fail"}}
-        assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) == DbtTestStatus.FAIL
+    def test_returns_summary_fail_when_all_tests_fail(self):
+        results: TestResultsPerModel = {
+            "model.pkg.orders": {"test.pkg.not_null_orders_id": "fail", "test.pkg.unique_orders_id": "fail"}
+        }
+        summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.FAIL
+        assert summary.failed_count == 2
 
     def test_single_test_pass(self):
-        results = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "pass"}}
-        assert get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results) == DbtTestStatus.PASS
+        results: TestResultsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "pass"}}
+        summary = get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.PASS
+        assert summary.total_count == 1
 
     def test_single_test_fail(self):
-        results = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "fail"}}
-        assert get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results) == DbtTestStatus.FAIL
+        results: TestResultsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "fail"}}
+        summary = get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.FAIL
 
     def test_returns_fail_when_test_has_error_status(self):
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "error"}}
-        assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) == DbtTestStatus.FAIL
+        results: TestResultsPerModel = {
+            "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "error"}
+        }
+        summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.FAIL
+        assert summary.failed_tests == ["test.pkg.unique_orders_id"]
 
     def test_treats_success_status_as_pass(self):
         """'success' is used by models; tests use 'pass' — both should be treated as success."""
-        results = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "success", "test.pkg.unique_orders_id": "pass"}}
-        assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) == DbtTestStatus.PASS
+        results: TestResultsPerModel = {
+            "model.pkg.orders": {"test.pkg.not_null_orders_id": "success", "test.pkg.unique_orders_id": "pass"}
+        }
+        summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
+        assert summary is not None
+        assert summary.status == DbtTestStatus.PASS
 
 
 class TestPushTestResultOrAggregate:
     """Tests for push_test_result_or_aggregate."""
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
-    def test_pushes_xcom_when_all_tests_reported(self, mock_xcom_push: MagicMock):
-        results: dict[str, dict[str, str]] = {}
+    def test_pushes_xcom_dict_when_all_tests_reported(self, mock_xcom_push: MagicMock):
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         push_test_result_or_aggregate("test.pkg.unique_orders_id", "pass", TESTS_PER_MODEL, results, ti)
-        mock_xcom_push.assert_called_once_with(
-            task_instance=ti,
-            key="model__pkg__orders_tests_status",
-            value=DbtTestStatus.PASS,
-        )
+        mock_xcom_push.assert_called_once()
+        call_kwargs = mock_xcom_push.call_args[1]
+        assert call_kwargs["key"] == "model__pkg__orders_tests_status"
+        value = call_kwargs["value"]
+        assert isinstance(value, dict)
+        assert value["status"] == DbtTestStatus.PASS
+        assert value["passed_count"] == 2
+        assert value["failed_count"] == 0
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_does_not_push_xcom_before_all_tests_reported(self, mock_xcom_push: MagicMock):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         mock_xcom_push.assert_not_called()
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_does_not_push_xcom_for_unknown_test(self, mock_xcom_push: MagicMock):
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.unknown", "pass", TESTS_PER_MODEL, results, ti)
         mock_xcom_push.assert_not_called()
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
-    def test_pushes_fail_when_any_test_fails(self, mock_xcom_push: MagicMock):
-        results: dict[str, dict[str, str]] = {}
+    def test_pushes_fail_dict_when_any_test_fails(self, mock_xcom_push: MagicMock):
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         push_test_result_or_aggregate("test.pkg.unique_orders_id", "fail", TESTS_PER_MODEL, results, ti)
-        mock_xcom_push.assert_called_once_with(
-            task_instance=ti,
-            key="model__pkg__orders_tests_status",
-            value=DbtTestStatus.FAIL,
-        )
+        mock_xcom_push.assert_called_once()
+        value = mock_xcom_push.call_args[1]["value"]
+        assert value["status"] == DbtTestStatus.FAIL
+        assert value["passed_count"] == 1
+        assert value["failed_count"] == 1
+        assert value["failed_tests"] == ["test.pkg.unique_orders_id"]
+
+    @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
+    def test_deduplication_prevents_double_push(self, mock_xcom_push: MagicMock):
+        """If a test result is reported twice, it should not count twice toward completion."""
+        results: TestResultsPerModel = {}
+        ti = MagicMock()
+        push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
+        push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
+        # Still only 1 result recorded, not all tests reported yet
+        mock_xcom_push.assert_not_called()
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_replayed_test_result_does_not_prematurely_aggregate(self, mock_xcom_push: MagicMock):
         """A replayed log line for one test must not satisfy the model's completion count (#2543)."""
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         # model.pkg.orders has 2 tests; the same test reported twice must not trigger aggregation.
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
@@ -162,11 +274,10 @@ class TestPushTestResultOrAggregate:
         mock_xcom_push.assert_not_called()
         # Only when the genuinely second test reports does the aggregated XCom fire.
         push_test_result_or_aggregate("test.pkg.unique_orders_id", "pass", TESTS_PER_MODEL, results, ti)
-        mock_xcom_push.assert_called_once_with(
-            task_instance=ti,
-            key="model__pkg__orders_tests_status",
-            value=DbtTestStatus.PASS,
-        )
+        mock_xcom_push.assert_called_once()
+        value = mock_xcom_push.call_args[1]["value"]
+        assert value["status"] == DbtTestStatus.PASS
+        assert value["total_count"] == 2
 
 
 class TestPushTestResultOrAggregateConcurrency:
@@ -182,7 +293,7 @@ class TestPushTestResultOrAggregateConcurrency:
         num_tests = 50
         test_ids = [f"test.pkg.test_{i}" for i in range(num_tests)]
         tests_per_model: dict[str, list[str]] = {"model.pkg.big_model": test_ids}
-        results: dict[str, dict[str, str]] = {}
+        results: TestResultsPerModel = {}
         ti = MagicMock()
         barrier = threading.Barrier(num_tests)
 
@@ -198,9 +309,8 @@ class TestPushTestResultOrAggregateConcurrency:
 
         # All 50 results must be recorded — none lost to races
         assert len(results["model.pkg.big_model"]) == num_tests
-        # XCom should have been pushed exactly once
-        mock_xcom_push.assert_called_once_with(
-            task_instance=ti,
-            key="model__pkg__big_model_tests_status",
-            value=DbtTestStatus.PASS,
-        )
+        # XCom should have been pushed exactly once with a dict value
+        mock_xcom_push.assert_called_once()
+        value = mock_xcom_push.call_args[1]["value"]
+        assert value["status"] == DbtTestStatus.PASS
+        assert value["total_count"] == num_tests

--- a/tests/operators/_watcher/test_aggregation.py
+++ b/tests/operators/_watcher/test_aggregation.py
@@ -8,7 +8,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from cosmos.operators._watcher.aggregation import (
-    TestResultsPerModel,
+    ResultsTestsPerModel,
     TestResultSummary,
     accumulate_test_result,
     get_aggregated_test_status,
@@ -91,19 +91,19 @@ class TestAccumulateTestResult:
     """Tests for accumulate_test_result."""
 
     def test_returns_model_uid_when_test_found(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         model_uid = accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         assert model_uid == "model.pkg.orders"
         assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
 
     def test_returns_none_when_test_not_found(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         model_uid = accumulate_test_result("test.pkg.unknown_test", "pass", TESTS_PER_MODEL, results)
         assert model_uid is None
         assert results == {}
 
     def test_accumulates_multiple_results(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.unique_orders_id", "fail", TESTS_PER_MODEL, results)
         assert results == {
@@ -111,7 +111,7 @@ class TestAccumulateTestResult:
         }
 
     def test_accumulates_across_models(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.not_null_customers_id", "pass", TESTS_PER_MODEL, results)
         assert results == {
@@ -120,14 +120,14 @@ class TestAccumulateTestResult:
         }
 
     def test_deduplicates_same_test_keeps_worst_status(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.not_null_orders_id", "fail", TESTS_PER_MODEL, results)
         # The worse (fail) status should override the earlier pass
         assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "fail"}}
 
     def test_deduplicates_same_test_keeps_first_failure(self):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         accumulate_test_result("test.pkg.not_null_orders_id", "fail", TESTS_PER_MODEL, results)
         accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
         # A later pass should NOT override an existing failure
@@ -141,11 +141,11 @@ class TestGetAggregatedTestStatus:
         assert get_aggregated_test_status("model.pkg.unknown", TESTS_PER_MODEL, {}) is None
 
     def test_returns_none_when_not_all_tests_reported(self):
-        results: TestResultsPerModel = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
+        results: ResultsTestsPerModel = {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
         assert get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results) is None
 
     def test_returns_summary_pass_when_all_tests_pass(self):
-        results: TestResultsPerModel = {
+        results: ResultsTestsPerModel = {
             "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "pass"}
         }
         summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
@@ -157,7 +157,7 @@ class TestGetAggregatedTestStatus:
         assert summary.failed_tests == []
 
     def test_returns_summary_fail_when_any_test_fails(self):
-        results: TestResultsPerModel = {
+        results: ResultsTestsPerModel = {
             "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "fail"}
         }
         summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
@@ -168,7 +168,7 @@ class TestGetAggregatedTestStatus:
         assert summary.failed_tests == ["test.pkg.unique_orders_id"]
 
     def test_returns_summary_fail_when_all_tests_fail(self):
-        results: TestResultsPerModel = {
+        results: ResultsTestsPerModel = {
             "model.pkg.orders": {"test.pkg.not_null_orders_id": "fail", "test.pkg.unique_orders_id": "fail"}
         }
         summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
@@ -177,20 +177,20 @@ class TestGetAggregatedTestStatus:
         assert summary.failed_count == 2
 
     def test_single_test_pass(self):
-        results: TestResultsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "pass"}}
+        results: ResultsTestsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "pass"}}
         summary = get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results)
         assert summary is not None
         assert summary.status == DbtTestStatus.PASS
         assert summary.total_count == 1
 
     def test_single_test_fail(self):
-        results: TestResultsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "fail"}}
+        results: ResultsTestsPerModel = {"model.pkg.customers": {"test.pkg.not_null_customers_id": "fail"}}
         summary = get_aggregated_test_status("model.pkg.customers", TESTS_PER_MODEL, results)
         assert summary is not None
         assert summary.status == DbtTestStatus.FAIL
 
     def test_returns_fail_when_test_has_error_status(self):
-        results: TestResultsPerModel = {
+        results: ResultsTestsPerModel = {
             "model.pkg.orders": {"test.pkg.not_null_orders_id": "pass", "test.pkg.unique_orders_id": "error"}
         }
         summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
@@ -200,7 +200,7 @@ class TestGetAggregatedTestStatus:
 
     def test_treats_success_status_as_pass(self):
         """'success' is used by models; tests use 'pass' — both should be treated as success."""
-        results: TestResultsPerModel = {
+        results: ResultsTestsPerModel = {
             "model.pkg.orders": {"test.pkg.not_null_orders_id": "success", "test.pkg.unique_orders_id": "pass"}
         }
         summary = get_aggregated_test_status("model.pkg.orders", TESTS_PER_MODEL, results)
@@ -213,7 +213,7 @@ class TestPushTestResultOrAggregate:
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_pushes_xcom_dict_when_all_tests_reported(self, mock_xcom_push: MagicMock):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         push_test_result_or_aggregate("test.pkg.unique_orders_id", "pass", TESTS_PER_MODEL, results, ti)
@@ -228,21 +228,21 @@ class TestPushTestResultOrAggregate:
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_does_not_push_xcom_before_all_tests_reported(self, mock_xcom_push: MagicMock):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         mock_xcom_push.assert_not_called()
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_does_not_push_xcom_for_unknown_test(self, mock_xcom_push: MagicMock):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.unknown", "pass", TESTS_PER_MODEL, results, ti)
         mock_xcom_push.assert_not_called()
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_pushes_fail_dict_when_any_test_fails(self, mock_xcom_push: MagicMock):
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         push_test_result_or_aggregate("test.pkg.unique_orders_id", "fail", TESTS_PER_MODEL, results, ti)
@@ -256,7 +256,7 @@ class TestPushTestResultOrAggregate:
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_deduplication_prevents_double_push(self, mock_xcom_push: MagicMock):
         """If a test result is reported twice, it should not count twice toward completion."""
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
@@ -266,7 +266,7 @@ class TestPushTestResultOrAggregate:
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
     def test_replayed_test_result_does_not_prematurely_aggregate(self, mock_xcom_push: MagicMock):
         """A replayed log line for one test must not satisfy the model's completion count (#2543)."""
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         # model.pkg.orders has 2 tests; the same test reported twice must not trigger aggregation.
         push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results, ti)
@@ -293,7 +293,7 @@ class TestPushTestResultOrAggregateConcurrency:
         num_tests = 50
         test_ids = [f"test.pkg.test_{i}" for i in range(num_tests)]
         tests_per_model: dict[str, list[str]] = {"model.pkg.big_model": test_ids}
-        results: TestResultsPerModel = {}
+        results: ResultsTestsPerModel = {}
         ti = MagicMock()
         barrier = threading.Barrier(num_tests)
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -759,7 +759,10 @@ class TestStoreDbtStatusFromLog:
             test_results_per_model=test_results_per_model,
         )
         assert "test__pkg__unique_orders_id_status" not in ti.store  # no per-test key
-        assert ti.store.get("model__pkg__orders_tests_status") == "pass"
+        aggregated = ti.store.get("model__pkg__orders_tests_status")
+        assert aggregated["status"] == "pass"
+        assert aggregated["passed_count"] == 2
+        assert aggregated["failed_count"] == 0
 
     def test_store_dbt_resource_status_from_log_aggregates_fail_when_any_test_fails(self):
         """When at least one test fails, the aggregated status should be 'fail'."""
@@ -785,7 +788,11 @@ class TestStoreDbtStatusFromLog:
                 test_results_per_model=test_results_per_model,
             )
 
-        assert ti.store.get("model__pkg__orders_tests_status") == "fail"
+        aggregated = ti.store.get("model__pkg__orders_tests_status")
+        assert aggregated["status"] == "fail"
+        assert aggregated["passed_count"] == 1
+        assert aggregated["failed_count"] == 1
+        assert aggregated["failed_tests"] == ["test.pkg.unique_orders_id"]
         # No per-test status keys should exist
         assert "test__pkg__not_null_orders_id_status" not in ti.store
         assert "test__pkg__unique_orders_id_status" not in ti.store


### PR DESCRIPTION
Replace plain pass/fail string XCom values with a structured TestResultSummary dataclass that includes per-test pass/fail breakdown (test IDs, counts). This gives operators better observability into which tests failed for a given model. 

Key changes:
- Add frozen TestResultSummary dataclass with to_dict/from_dict
- Add TestResult NamedTuple and TypeAlias type annotations for better typing
- Deduplicate test results (only first terminal status counts)
- Push dict XCom values with full breakdown instead of strings
- Consumer sensors log human-readable test result summaries
- Triggerer forwards test_result_counts in TriggerEvent payloads

Changes vissible in the test sensor task:
<img width="702" height="78" alt="Screenshot 2026-06-01 at 2 46 27 PM" src="https://github.com/user-attachments/assets/71d4ae1e-c52a-4fc4-bd7e-621dd1c3be64" />
<img width="809" height="78" alt="Screenshot 2026-06-01 at 2 46 48 PM" src="https://github.com/user-attachments/assets/b77b5c68-ab5b-47b7-8cb2-066cd2274223" />


This has been tested locally (not in kubernetes mode).


## Description

<!-- Add a brief but complete description of the change. -->

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
