### PR TITLE
Pin dbt-core<2.0 in virtualenv example DAGs to avoid alpha pickup

### DIFF
--- a/dev/Dockerfile.postgres_profile_docker_k8s
+++ b/dev/Dockerfile.postgres_profile_docker_k8s
@@ -1,6 +1,6 @@
 FROM python:3.12
 
-RUN pip install --force-reinstall 'dbt-postgres>=1.8'
+RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<2.0'
 RUN pip install --force-reinstall dbt-adapters
 RUN pip install --force-reinstall awscli
 

--- a/dev/Dockerfile.watcher_failing_tests_k8s
+++ b/dev/Dockerfile.watcher_failing_tests_k8s
@@ -1,6 +1,6 @@
 FROM python:3.12
 
-RUN pip install --force-reinstall 'dbt-postgres>=1.8'
+RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<2.0'
 RUN pip install --force-reinstall dbt-adapters
 RUN pip install --force-reinstall awscli
 

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -57,7 +57,7 @@ def example_virtualenv() -> None:
         ),
         operator_args={
             "py_system_site_packages": False,
-            "py_requirements": ["dbt-postgres"],
+            "py_requirements": ["dbt-postgres", "dbt-core<2.0"],
             "install_deps": True,
             "emit_datasets": False,  # Example of how to not set inlets and outlets
             # --------------------------------------------------------------------------
@@ -91,7 +91,7 @@ def example_virtualenv() -> None:
         ),
         operator_args={
             "py_system_site_packages": False,
-            "py_requirements": ["dbt-postgres"],
+            "py_requirements": ["dbt-postgres", "dbt-core<2.0"],
             "install_deps": True,
         },
     )

--- a/dev/dags/example_virtualenv_mini.py
+++ b/dev/dags/example_virtualenv_mini.py
@@ -29,7 +29,7 @@ with DAG("example_virtualenv_mini", start_date=datetime(2022, 1, 1)) as dag:
         install_deps=True,
         append_env=True,
         py_system_site_packages=False,
-        py_requirements=["dbt-postgres"],
+        py_requirements=["dbt-postgres", "dbt-core<2.0"],
         virtualenv_dir=Path("/tmp/persistent-venv2"),
     )
     seed_operator


### PR DESCRIPTION
## Summary

- The `ExecutionMode.VIRTUALENV` example DAGs (`example_virtualenv.py`, `example_virtualenv_mini.py`) pass `py_requirements=["dbt-postgres"]` into a fresh per-task venv created via Airflow's `prepare_virtualenv`.
- `dbt-postgres==1.10.0` declares `Requires-Dist: dbt-core>=1.8.0rc1`. Per PEP 440, a specifier that contains a pre-release token enables pre-release resolution for that requirement, so pip happily selects `dbt-core==2.0.0a1` (alpha) over stable `1.11.x` — see the install snippet `Collecting dbt-core>=1.8.0rc1 (from dbt-postgres) … Using cached dbt_core-2.0.0a1-…whl`.
- The alpha is incompatible with cosmos and breaks the `Run-Integration-Tests` job (e.g. https://github.com/astronomer/astronomer-cosmos/actions/runs/26790814505/job/78976631093).
- Fix: add an explicit `dbt-core<2.0` constraint to `py_requirements`, which excludes the alpha for that single requirement without touching CI install scripts or pip flags.

The same `py_requirements` pattern in `tests/operators/test_virtualenv.py` already pins exact dbt-postgres versions and the async examples pin dbt-bigquery to `DBT_ADAPTER_VERSION`, so those paths are unaffected.

## Test plan

- [ ] CI `Run-Integration-Tests` job (`3.11, 2.9, 1.11`, split 1) — the venv install should now resolve `dbt-core==1.11.x` instead of `2.0.0a1`, and `example_virtualenv_mini` should run to completion.
- [ ] CI `Run-Integration-Tests` other splits/cells covering `example_virtualenv` task groups.
- [ ] Skim test logs for `Successfully installed … dbt-core-2.0.0a1` — should no longer appear.

🤖 Generated with [Claude Code](https://claude.com/claude-code)