### PR TITLE
Replace openlineage-airflow with apache-airflow-providers-openlineage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,7 +77,7 @@ dbt-spark = ["dbt-spark"]
 dbt-sqlserver = ["dbt-sqlserver"]
 dbt-teradata = ["dbt-teradata"]
 dbt-vertica = ["dbt-vertica<=1.5.4"]
-openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
+openlineage = ["openlineage-integration-common!=1.15.0", "apache-airflow-providers-openlineage"]
 amazon = [
     "apache-airflow-providers-amazon[s3fs]>=3.0.0",
 ]


### PR DESCRIPTION
## Description

Replaces the standalone `openlineage-airflow` package with the official Apache Airflow provider `apache-airflow-providers-openlineage` in the `openlineage` optional-dependencies group.

```diff
-openlineage = ["openlineage-integration-common!=1.15.0", "openlineage-airflow"]
+openlineage = ["openlineage-integration-common!=1.15.0", "apache-airflow-providers-openlineage"]
```

`openlineage-airflow` is the deprecated, pre-Airflow-2.7 OpenLineage integration. Since Cosmos 1.14 dropped support for Airflow 2.8 and below, the official provider can be used instead.

No source changes are required: `cosmos/operators/local.py` already imports `OperatorLineage` from `airflow.providers.openlineage.extractors.base` (with a fallback to the old `openlineage.airflow` for backward compatibility). `openlineage-integration-common` is retained for parsing dbt artifacts into OpenLineage URIs — it is a core Cosmos dependency (needed for Airflow assets/datasets) and is also a transitive dependency of the provider.

## Airflow version compatibility

Every Airflow version Cosmos supports has a compatible `apache-airflow-providers-openlineage` release, so pip resolves an appropriate provider version per Airflow version (the dependency is intentionally left unpinned):

| Airflow (Cosmos test matrix) | Compatible provider versions |
|---|---|
| 2.9  | `>=2.0.0,<2.3.0` (2.0.0 bumped min Airflow to 2.9) |
| 2.10 | `>=2.3.0,<2.9.0` (2.3.0 bumped min Airflow to 2.10) |
| 2.11 | `>=2.9.0` incl. latest (2.9.0 bumped min Airflow to 2.11) |
| 3.0 / 3.1 / 3.2 | latest (min `apache-airflow>=2.11.0` is satisfied by 3.x) |

Provider min-Airflow history: `1.11.0` → 2.8, `2.0.0` → 2.9, `2.3.0` → 2.10, `2.9.0` → 2.11.

## Notes

- The `requirements/requirements-airflow-3.1-dbt-1.11.txt` frozen test-constraint file still pins `openlineage-airflow==1.41.0`. These freeze files are regenerated separately; left untouched here to keep the PR focused on the dependency declaration.

Closes #2325

🤖 Generated with [Claude Code](https://claude.com/claude-code)