### PR TITLE
Centralize version-aware EmptyOperator imports in a compatibility module

### DIFF
--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -13,7 +13,7 @@ from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 if AIRFLOW_VERSION.major >= _AIRFLOW3_MAJOR_VERSION:
     try:
         from airflow.providers.standard.operators.empty import EmptyOperator as EmptyOperator
-    except ImportError as exc:
+    except ImportError as exc:  # pragma: no cover
         raise ImportError(
             "Cosmos on Airflow 3 requires `apache-airflow-providers-standard` to import `EmptyOperator`."
         ) from exc

--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -1,64 +1,28 @@
 """Version-aware imports for Airflow objects whose import path differs across Airflow 2 and 3.
 
-Names exported here are resolved lazily on first attribute access (PEP 562), so importing
-this module is free: the underlying Airflow object is only imported when the name is actually
-used. Use sites keep referencing the object by its real name (e.g. ``EmptyOperator``) rather
-than a version-specific dotted path.
+``EmptyOperator`` moved to the standard provider in Airflow 3; the legacy
+``airflow.operators.empty`` path still resolves there but emits a ``DeprecatedImportWarning``,
+so on Airflow 3 we import it from the standard provider. Compare on the major version so that
+Airflow 3 pre-releases (e.g. 3.0.0rc1) are treated as Airflow 3.
 """
 
 from __future__ import annotations
 
-import importlib
-from typing import TYPE_CHECKING
-
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 
-if TYPE_CHECKING:
-    # Resolved for type checkers / IDEs only; no import happens at runtime here. The standard
-    # provider path is tried first so the type resolves to the real class on Airflow 3 (the
-    # legacy module is a deprecated shim typed as ``Any`` there).
+if AIRFLOW_VERSION.major >= _AIRFLOW3_MAJOR_VERSION:
     try:
         from airflow.providers.standard.operators.empty import EmptyOperator as EmptyOperator
-    except ImportError:
-        from airflow.operators.empty import EmptyOperator as EmptyOperator  # type: ignore[no-redef]
+    except ImportError as exc:
+        raise ImportError(
+            "Cosmos on Airflow 3 requires `apache-airflow-providers-standard` to import `EmptyOperator`."
+        ) from exc
+else:
+    # The redundant ``as EmptyOperator`` alias marks the name as an explicit re-export for type
+    # checkers; the ``no-redef`` ignore silences the duplicate binding mypy sees across branches.
+    from airflow.operators.empty import EmptyOperator as EmptyOperator  # type: ignore[no-redef]
 
-# Single source of truth for where ``EmptyOperator`` lives. The operator moved to the standard
-# provider in Airflow 3; the legacy ``airflow.operators.empty`` path still resolves there but
-# emits a ``DeprecatedImportWarning``, so on Airflow 3 we select the standard provider path.
-# Compare on the major version so Airflow 3 pre-releases (e.g. 3.0.0rc1) are treated as Airflow 3.
-_EMPTY_OPERATOR_MODULE = (
-    "airflow.operators.empty"
-    if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION
-    else "airflow.providers.standard.operators.empty"
-)
-
-# Maps the exported name to the module it should be imported from for this Airflow version.
-_LAZY_IMPORTS = {
-    "EmptyOperator": _EMPTY_OPERATOR_MODULE,
-}
-
-
-def __getattr__(name: str) -> object:
-    module_path = _LAZY_IMPORTS.get(name)
-    if module_path is None:
-        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    # Cache the resolved symbol in the module namespace so subsequent attribute access skips
-    # __getattr__ entirely (PEP 562 only invokes it for names missing from globals()).
-    resolved = getattr(importlib.import_module(module_path), name)
-    globals()[name] = resolved
-    return resolved
-
-
-def get_version_aware_operator_class_path(operator: type) -> str:
-    """Return the fully qualified import path for the given operator class.
-
-    The path is read from the class itself (``__module__`` + ``__name__``), so it reflects
-    the actual module the class lives in for the running Airflow version. Pair it with the
-    version-aware classes exported from this module, e.g.::
-
-        get_version_aware_operator_class_path(EmptyOperator)
-
-    Used where Cosmos stores the operator as a dotted string for later dynamic import
-    (e.g. ``Task.operator_class``) instead of referencing the class directly.
-    """
-    return f"{operator.__module__}.{operator.__name__}"
+# Dotted import path for the version-appropriate EmptyOperator, for the places that store the
+# operator as a string for later dynamic import (e.g. ``Task.operator_class``) rather than
+# referencing the class. Derived from the class itself, so it always matches the imported one.
+EMPTY_OPERATOR_CLASS_PATH = f"{EmptyOperator.__module__}.{EmptyOperator.__name__}"

--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -11,9 +11,7 @@ from __future__ import annotations
 import importlib
 from typing import TYPE_CHECKING
 
-from packaging.version import Version
-
-from cosmos.constants import AIRFLOW_VERSION
+from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 
 if TYPE_CHECKING:
     # Resolved for type checkers / IDEs only; no import happens at runtime here. The standard
@@ -27,8 +25,11 @@ if TYPE_CHECKING:
 # Single source of truth for where ``EmptyOperator`` lives. The operator moved to the standard
 # provider in Airflow 3; the legacy ``airflow.operators.empty`` path still resolves there but
 # emits a ``DeprecatedImportWarning``, so on Airflow 3 we select the standard provider path.
+# Compare on the major version so Airflow 3 pre-releases (e.g. 3.0.0rc1) are treated as Airflow 3.
 _EMPTY_OPERATOR_MODULE = (
-    "airflow.operators.empty" if AIRFLOW_VERSION < Version("3.0") else "airflow.providers.standard.operators.empty"
+    "airflow.operators.empty"
+    if AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION
+    else "airflow.providers.standard.operators.empty"
 )
 
 # Maps the exported name to the module it should be imported from for this Airflow version.
@@ -41,7 +42,11 @@ def __getattr__(name: str) -> object:
     module_path = _LAZY_IMPORTS.get(name)
     if module_path is None:
         raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
-    return getattr(importlib.import_module(module_path), name)
+    # Cache the resolved symbol in the module namespace so subsequent attribute access skips
+    # __getattr__ entirely (PEP 562 only invokes it for names missing from globals()).
+    resolved = getattr(importlib.import_module(module_path), name)
+    globals()[name] = resolved
+    return resolved
 
 
 def get_version_aware_operator_class_path(operator: type) -> str:

--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -1,0 +1,59 @@
+"""Version-aware imports for Airflow objects whose import path differs across Airflow 2 and 3.
+
+Names exported here are resolved lazily on first attribute access (PEP 562), so importing
+this module is free: the underlying Airflow object is only imported when the name is actually
+used. Use sites keep referencing the object by its real name (e.g. ``EmptyOperator``) rather
+than a version-specific dotted path.
+"""
+
+from __future__ import annotations
+
+import importlib
+from typing import TYPE_CHECKING
+
+from packaging.version import Version
+
+from cosmos.constants import AIRFLOW_VERSION
+
+if TYPE_CHECKING:
+    # Resolved for type checkers / IDEs only; no import happens at runtime here. The standard
+    # provider path is tried first so the type resolves to the real class on Airflow 3 (the
+    # legacy module is a deprecated shim typed as ``Any`` there).
+    try:
+        from airflow.providers.standard.operators.empty import EmptyOperator as EmptyOperator
+    except ImportError:
+        from airflow.operators.empty import EmptyOperator as EmptyOperator  # type: ignore[no-redef]
+
+# Single source of truth for where ``EmptyOperator`` lives. The operator moved to the standard
+# provider in Airflow 3; the legacy ``airflow.operators.empty`` path still resolves there but
+# emits a ``DeprecatedImportWarning``, so on Airflow 3 we select the standard provider path.
+_EMPTY_OPERATOR_MODULE = (
+    "airflow.operators.empty" if AIRFLOW_VERSION < Version("3.0") else "airflow.providers.standard.operators.empty"
+)
+
+# Maps the exported name to the module it should be imported from for this Airflow version.
+_LAZY_IMPORTS = {
+    "EmptyOperator": _EMPTY_OPERATOR_MODULE,
+}
+
+
+def __getattr__(name: str) -> object:
+    module_path = _LAZY_IMPORTS.get(name)
+    if module_path is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    return getattr(importlib.import_module(module_path), name)
+
+
+def get_version_aware_operator_class_path(operator: type) -> str:
+    """Return the fully qualified import path for the given operator class.
+
+    The path is read from the class itself (``__module__`` + ``__name__``), so it reflects
+    the actual module the class lives in for the running Airflow version. Pair it with the
+    version-aware classes exported from this module, e.g.::
+
+        get_version_aware_operator_class_path(EmptyOperator)
+
+    Used where Cosmos stores the operator as a dotted string for later dynamic import
+    (e.g. ``Task.operator_class``) instead of referencing the class directly.
+    """
+    return f"{operator.__module__}.{operator.__name__}"

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -24,12 +24,12 @@ except ImportError:
     from airflow.utils.task_group import TaskGroup
 
 from cosmos import settings
+from cosmos.airflow.compatibility import EmptyOperator, get_version_aware_operator_class_path
 from cosmos.config import ExecutionConfig, RenderConfig
 from cosmos.constants import (
     DBT_SETUP_ASYNC_TASK_ID,
     DBT_TEARDOWN_ASYNC_TASK_ID,
     DEFAULT_DBT_RESOURCES,
-    EMPTY_OPERATOR_CLASS,
     PRODUCER_WATCHER_DONE_TASK_ID,
     PRODUCER_WATCHER_TASK_ID,
     SUPPORTED_BUILD_RESOURCES,
@@ -418,7 +418,11 @@ def create_task_metadata(  # noqa: C901
                     args = {"task_display_name": args["task_display_name"]}
                 else:
                     args = {}
-                return TaskMetadata(id=task_id, operator_class=EMPTY_OPERATOR_CLASS, arguments=args)
+                return TaskMetadata(
+                    id=task_id,
+                    operator_class=get_version_aware_operator_class_path(EmptyOperator),
+                    arguments=args,
+                )
         else:  # DbtResourceType.MODEL, DbtResourceType.SEED and DbtResourceType.SNAPSHOT
             if node.fqn and len(node.fqn) > 0:
                 args[models_select_key] = f"fqn:{'.'.join(node.fqn)}"

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -29,6 +29,7 @@ from cosmos.constants import (
     DBT_SETUP_ASYNC_TASK_ID,
     DBT_TEARDOWN_ASYNC_TASK_ID,
     DEFAULT_DBT_RESOURCES,
+    EMPTY_OPERATOR_CLASS,
     PRODUCER_WATCHER_DONE_TASK_ID,
     PRODUCER_WATCHER_TASK_ID,
     SUPPORTED_BUILD_RESOURCES,
@@ -417,7 +418,7 @@ def create_task_metadata(  # noqa: C901
                     args = {"task_display_name": args["task_display_name"]}
                 else:
                     args = {}
-                return TaskMetadata(id=task_id, operator_class="airflow.operators.empty.EmptyOperator", arguments=args)
+                return TaskMetadata(id=task_id, operator_class=EMPTY_OPERATOR_CLASS, arguments=args)
         else:  # DbtResourceType.MODEL, DbtResourceType.SEED and DbtResourceType.SNAPSHOT
             if node.fqn and len(node.fqn) > 0:
                 args[models_select_key] = f"fqn:{'.'.join(node.fqn)}"

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -24,7 +24,7 @@ except ImportError:
     from airflow.utils.task_group import TaskGroup
 
 from cosmos import settings
-from cosmos.airflow.compatibility import EmptyOperator, get_version_aware_operator_class_path
+from cosmos.airflow.compatibility import EMPTY_OPERATOR_CLASS_PATH
 from cosmos.config import ExecutionConfig, RenderConfig
 from cosmos.constants import (
     DBT_SETUP_ASYNC_TASK_ID,
@@ -420,7 +420,7 @@ def create_task_metadata(  # noqa: C901
                     args = {}
                 return TaskMetadata(
                     id=task_id,
-                    operator_class=get_version_aware_operator_class_path(EmptyOperator),
+                    operator_class=EMPTY_OPERATOR_CLASS_PATH,
                     arguments=args,
                 )
         else:  # DbtResourceType.MODEL, DbtResourceType.SEED and DbtResourceType.SNAPSHOT

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -9,14 +9,6 @@ from packaging.version import Version
 
 AIRFLOW_VERSION = Version(airflow.__version__)
 
-# The EmptyOperator import path changed in Airflow 3: it moved to the standard provider. The legacy
-# ``airflow.operators.empty`` path still works in Airflow 3 but emits a DeprecatedImportWarning.
-EMPTY_OPERATOR_CLASS = (
-    "airflow.operators.empty.EmptyOperator"
-    if AIRFLOW_VERSION < Version("3.0")
-    else "airflow.providers.standard.operators.empty.EmptyOperator"
-)
-
 BIGQUERY_PROFILE_TYPE = "bigquery"
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DBT_PROJECT_FILENAME = "dbt_project.yml"

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -9,6 +9,14 @@ from packaging.version import Version
 
 AIRFLOW_VERSION = Version(airflow.__version__)
 
+# The EmptyOperator import path changed in Airflow 3: it moved to the standard provider. The legacy
+# ``airflow.operators.empty`` path still works in Airflow 3 but emits a DeprecatedImportWarning.
+EMPTY_OPERATOR_CLASS = (
+    "airflow.operators.empty.EmptyOperator"
+    if AIRFLOW_VERSION < Version("3.0")
+    else "airflow.providers.standard.operators.empty.EmptyOperator"
+)
+
 BIGQUERY_PROFILE_TYPE = "bigquery"
 DBT_PROFILE_PATH = Path(os.path.expanduser("~")).joinpath(".dbt/profiles.yml")
 DBT_PROJECT_FILENAME = "dbt_project.yml"

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -51,7 +51,7 @@ if TYPE_CHECKING:
         from airflow.sdk import DAG
     except ImportError:
         from airflow.models.dag import DAG  # type: ignore[assignment]
-    from airflow.operators.empty import EmptyOperator
+    from cosmos.airflow.compatibility import EmptyOperator
 
     try:
         from airflow.sdk import TaskGroup
@@ -779,10 +779,7 @@ def create_producer_done_task(dag: DAG, task_group: TaskGroup, task_id: str) -> 
     is skipped on retry, this task still succeeds (trigger_rule=NONE_FAILED), preventing
     the skip from propagating to tasks downstream of the group.
     """
-    try:
-        from airflow.providers.standard.operators.empty import EmptyOperator
-    except ImportError:
-        from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
+    from cosmos.airflow.compatibility import EmptyOperator
 
     try:
         from airflow.task.trigger_rule import TriggerRule

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -16,12 +16,8 @@ import kubernetes.client as k8s
 from airflow.exceptions import AirflowException, AirflowSkipException
 from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCallback, client_type
 
-try:
-    from airflow.providers.standard.operators.empty import EmptyOperator
-except ImportError:  # pragma: no cover
-    from airflow.operators.empty import EmptyOperator  # type: ignore[no-redef]
-
 from cosmos.airflow._override import CosmosKubernetesPodManager
+from cosmos.airflow.compatibility import EmptyOperator
 from cosmos.log import get_logger
 from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
 from cosmos.operators._watcher.xcom import (

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -18,7 +18,7 @@ except ImportError:
     from airflow.operators.empty import EmptyOperator
     from airflow.utils.task_group import TaskGroup
 
-from cosmos.airflow.compatibility import get_version_aware_operator_class_path
+from cosmos.airflow.compatibility import EMPTY_OPERATOR_CLASS_PATH
 from cosmos.airflow.graph import (
     _add_teardown_task,
     _add_watcher_producer_task,
@@ -692,7 +692,7 @@ def test_create_task_metadata_model_use_task_group(caplog):
             False,
             SOURCE_RENDERING_BEHAVIOR,
             "my_source_source",
-            get_version_aware_operator_class_path(EmptyOperator),
+            EMPTY_OPERATOR_CLASS_PATH,
         ),
         (
             f"{DbtResourceType.SOURCE.value}.my_folder.my_source",

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -34,6 +34,7 @@ from cosmos.airflow.graph import (
 )
 from cosmos.config import ProfileConfig, RenderConfig
 from cosmos.constants import (
+    EMPTY_OPERATOR_CLASS,
     SUPPORTED_BUILD_RESOURCES,
     DbtResourceType,
     ExecutionMode,
@@ -691,7 +692,7 @@ def test_create_task_metadata_model_use_task_group(caplog):
             False,
             SOURCE_RENDERING_BEHAVIOR,
             "my_source_source",
-            "airflow.operators.empty.EmptyOperator",
+            EMPTY_OPERATOR_CLASS,
         ),
         (
             f"{DbtResourceType.SOURCE.value}.my_folder.my_source",

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -18,6 +18,7 @@ except ImportError:
     from airflow.operators.empty import EmptyOperator
     from airflow.utils.task_group import TaskGroup
 
+from cosmos.airflow.compatibility import get_version_aware_operator_class_path
 from cosmos.airflow.graph import (
     _add_teardown_task,
     _add_watcher_producer_task,
@@ -34,7 +35,6 @@ from cosmos.airflow.graph import (
 )
 from cosmos.config import ProfileConfig, RenderConfig
 from cosmos.constants import (
-    EMPTY_OPERATOR_CLASS,
     SUPPORTED_BUILD_RESOURCES,
     DbtResourceType,
     ExecutionMode,
@@ -692,7 +692,7 @@ def test_create_task_metadata_model_use_task_group(caplog):
             False,
             SOURCE_RENDERING_BEHAVIOR,
             "my_source_source",
-            EMPTY_OPERATOR_CLASS,
+            get_version_aware_operator_class_path(EmptyOperator),
         ),
         (
             f"{DbtResourceType.SOURCE.value}.my_folder.my_source",


### PR DESCRIPTION
Introduces `cosmos/airflow/compatibility.py`, a small module that centralizes the version-specific import of Airflow objects whose path changed between Airflow 2 and 3. The first such object is `EmptyOperator`, which moved to the standard provider in Airflow 3. The legacy `airflow.operators.empty` path still resolves on Airflow 3 but emits a `DeprecatedImportWarning`, so the module imports from the standard provider on Airflow 3 and from the legacy path on Airflow 2. The selection compares on the Airflow major version, so pre-releases such as `3.0.0rc1` are treated as Airflow 3.

The module also exposes `EMPTY_OPERATOR_CLASS_PATH`, the dotted import path for the version-appropriate `EmptyOperator`, derived from the imported class so it always stays in sync.

Call sites reference the operator by name or via the constant instead of duplicating the version check:
- `watcher_kubernetes.py` and `_watcher/base.py` import `EmptyOperator` from the module, replacing their duplicated try/except import blocks.
- `graph.py` serializes the `operator_class` string via `EMPTY_OPERATOR_CLASS_PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-authored-by: Tatiana Al-Chueyr <tatiana.alchueyr@gmail.com>
