### PR TITLE
CI: carve dbt-loom tests into a dedicated job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    # TEMP: ci/separate-dbt-loom-tests is included so the new
-    # Run-Integration-Tests-DBT-Loom job (added in this branch) actually runs in
-    # CI for review. pull_request_target uses the base branch's workflow file,
-    # so the new job would not otherwise appear. REVERT this line before merge.
-    branches: [main, ci/separate-dbt-loom-tests]
+    branches: [main]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run
@@ -910,6 +906,7 @@ jobs:
       - Authorize
       - Run-Unit-Tests
       - Run-Integration-Tests
+      - Run-Integration-Tests-DBT-Loom
       - Run-Integration-Tests-Expensive
       - Run-Kubernetes-Tests
       - Run-Telemetry-Tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -539,7 +539,7 @@ jobs:
       POSTGRES_SCHEMA: public
       POSTGRES_PORT: 5432
 
-  Run-Integration-Tests-DBT-Loom:
+  Run-Integration-Tests-dbt-Loom:
     # Dedicated job for cross_project_manifest_dag.py, which exercises dbt-loom.
     # Carved out of Run-Integration-Tests so the loom job's dbt + loom versions
     # can move independently of the main matrix.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,11 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    # TEMP: ci/separate-dbt-loom-tests is included so the new
+    # Run-Integration-Tests-DBT-Loom job (added in this branch) actually runs in
+    # CI for review. pull_request_target uses the base branch's workflow file,
+    # so the new job would not otherwise appear. REVERT this line before merge.
+    branches: [main, ci/separate-dbt-loom-tests]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -539,6 +539,85 @@ jobs:
       POSTGRES_SCHEMA: public
       POSTGRES_PORT: 5432
 
+  Run-Integration-Tests-DBT-Loom:
+    # Dedicated job for cross_project_manifest_dag.py, which exercises dbt-loom.
+    # Carved out of Run-Integration-Tests so the loom job's dbt + loom versions
+    # can move independently of the main matrix.
+    needs: [Authorize, Check-changed-files]
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        airflow-version: ["3.2"]
+        dbt-version: ["1.11"]
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: integration-dbt-loom-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Test cross_project_manifest_dag with dbt-loom installed
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-loom
+
+      - name: Upload coverage to Github
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-integration-dbt-loom-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
+          path: .coverage
+          include-hidden-files: true
+
+    env:
+      AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
+      PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+      AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+      AIRFLOW__COSMOS__ENABLE_CACHE: 0
+      DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+
+      # cross_project_manifest_dag's profiles.yml references these
+      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+      POSTGRES_HOST: localhost
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_SCHEMA: public
+      POSTGRES_PORT: 5432
+
   Run-Integration-dbt-fusion-Tests:
     needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -906,7 +906,7 @@ jobs:
       - Authorize
       - Run-Unit-Tests
       - Run-Integration-Tests
-      - Run-Integration-Tests-DBT-Loom
+      - Run-Integration-Tests-dbt-Loom
       - Run-Integration-Tests-Expensive
       - Run-Kubernetes-Tests
       - Run-Telemetry-Tests

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -199,6 +199,7 @@ test-integration-dbtf-setup = 'sh scripts/test/integration-dbtf-setup.sh'
 test-integration-dbtf = 'sh scripts/test/integration-dbtf.sh'
 test-integration-dbt-1-5-4 = 'sh scripts/test/integration-dbt-1-5-4.sh'
 test-integration-dbt-async = 'sh scripts/test/integration-dbt-async.sh {matrix:dbt}'
+test-integration-dbt-loom = 'sh scripts/test/integration-dbt-loom.sh {matrix:dbt}'
 test-integration-expensive = 'sh scripts/test/integration-expensive.sh'
 test-telemetry = 'sh scripts/test/telemetry.sh'
 

--- a/scripts/test/integration-dbt-loom.sh
+++ b/scripts/test/integration-dbt-loom.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+
+set -v
+set -x
+set -e
+
+DBT_VERSION="$1"
+echo "DBT_VERSION: $DBT_VERSION"
+
+# Calculate next minor version (e.g. "1.11" -> "1.12")
+NEXT_MINOR_VERSION=$(echo "$DBT_VERSION" | awk -F. '{print $1"."$2+1}')
+
+# Runs the cross-project example DAG that exercises dbt-loom. Carved out of
+# the main integration suite so the loom-specific install and the loom job's
+# dbt version can evolve independently of the main matrix.
+
+echo "Pinning dbt-core to $DBT_VERSION + installing dbt-loom and dbt-postgres in the main env"
+pip uninstall dbt-adapters dbt-common dbt-core dbt-extractor dbt-postgres dbt-semantic-interfaces -y || true
+pip install -U "dbt-core>=$DBT_VERSION,<$NEXT_MINOR_VERSION" dbt-loom dbt-postgres
+
+# cross_project_manifest_dag.py runs dbt subprocesses via venv-subprocess/.
+# Ensure that env also has dbt-loom for the cross-project reference path.
+if [ -d "venv-subprocess" ]; then
+    echo "Installing dbt-loom and dbt-postgres in venv-subprocess/"
+    venv-subprocess/bin/pip install -U "dbt-core>=$DBT_VERSION,<$NEXT_MINOR_VERSION" dbt-loom dbt-postgres
+fi
+
+actual_dbt_version=$(dbt --version | awk '/installed:/ { split($3, v, "."); print v[1]"."v[2] }')
+if [ "$actual_dbt_version" = "$DBT_VERSION" ]; then
+    echo "Version is as expected: $DBT_VERSION"
+else
+    echo "Version does not match. Expected: $DBT_VERSION, but got: $actual_dbt_version"
+    exit 1
+fi
+
+# Reset Airflow state before running the DAG
+rm -rf airflow.*
+
+AIRFLOW_VERSION=$(airflow version)
+AIRFLOW_MAJOR_VERSION=$(echo "$AIRFLOW_VERSION" | cut -d. -f1)
+if [ "$AIRFLOW_MAJOR_VERSION" -ge 3 ]; then
+    echo "Detected Airflow $AIRFLOW_VERSION. Running 'airflow db migrate'..."
+    airflow db migrate
+else
+    echo "Detected Airflow $AIRFLOW_VERSION. Running 'airflow db init'..."
+    airflow db init
+fi
+
+# Run only the cross-project example DAG that exercises dbt-loom
+pytest -vv \
+    --cov=cosmos \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    "tests/test_example_dags.py::test_example_dag[cross_project_manifest_dag]"

--- a/scripts/test/integration-dbt-loom.sh
+++ b/scripts/test/integration-dbt-loom.sh
@@ -46,7 +46,12 @@ else
     airflow db init
 fi
 
-# Run only the cross-project example DAG that exercises dbt-loom
+# Run only the cross-project example DAG that exercises dbt-loom.
+# TEST_SINGLE_DAG makes test_example_dags.py build a DagBag containing only this
+# DAG (see get_dag_bag_single_dag). Without it, collection loads every example
+# DAG and asserts no import errors, which fails here because other DAGs need
+# secrets this job doesn't provide (e.g. DATABRICKS_CLUSTER_ID, S3 access).
+export TEST_SINGLE_DAG="cross_project_manifest_dag.py"
 pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -86,9 +86,9 @@ else
 fi
 
 # Installation of dbt in a separate Python virtual environment:
-# Pin dbt-core to the matrix version. Previously dbt-loom (installed here) held
-# dbt-core below 2.0; with dbt-loom moved to the dedicated loom job, the pin is
+# Cap dbt-core below 2.0. Previously dbt-loom (installed here) held dbt-core in
+# the 1.x range; with dbt-loom moved to the dedicated loom job, the bound is
 # explicit so `pip install -U` doesn't pull dbt-core 2.0 (Fusion), which lacks
 # the postgres adapter the subprocess tests rely on.
 python -m venv venv-subprocess
-venv-subprocess/bin/pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres
+venv-subprocess/bin/pip install -U "dbt-core<2.0" dbt-postgres

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -60,7 +60,8 @@ else
   uv pip install "apache-airflow-providers-microsoft-azure" --constraint /tmp/constraint.txt
   uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
   uv pip install 'dbt-duckdb' "airflow-provider-duckdb>=0.2.0" apache-airflow==$AIRFLOW_VERSION
-  uv pip install dbt-loom
+  # dbt-loom is installed by the dedicated Run-Integration-Tests-DBT-Loom job
+  # (scripts/test/integration-dbt-loom.sh), not by the common pre-install path.
 
   # Delete the no longer needed constraint file
   rm /tmp/constraint.txt
@@ -87,5 +88,7 @@ else
 fi
 
 # Installation of dbt in a separate Python virtual environment:
+# dbt-loom is added to this venv by the dedicated Run-Integration-Tests-DBT-Loom
+# job (scripts/test/integration-dbt-loom.sh), not by the common pre-install path.
 python -m venv venv-subprocess
-venv-subprocess/bin/pip install -U dbt-postgres dbt-loom
+venv-subprocess/bin/pip install -U dbt-postgres

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -86,5 +86,9 @@ else
 fi
 
 # Installation of dbt in a separate Python virtual environment:
+# Pin dbt-core to the matrix version. Previously dbt-loom (installed here) held
+# dbt-core below 2.0; with dbt-loom moved to the dedicated loom job, the pin is
+# explicit so `pip install -U` doesn't pull dbt-core 2.0 (Fusion), which lacks
+# the postgres adapter the subprocess tests rely on.
 python -m venv venv-subprocess
-venv-subprocess/bin/pip install -U dbt-postgres
+venv-subprocess/bin/pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -60,8 +60,6 @@ else
   uv pip install "apache-airflow-providers-microsoft-azure" --constraint /tmp/constraint.txt
   uv pip install -U "dbt-core~=$DBT_VERSION" dbt-postgres dbt-bigquery dbt-vertica dbt-databricks pyspark
   uv pip install 'dbt-duckdb' "airflow-provider-duckdb>=0.2.0" apache-airflow==$AIRFLOW_VERSION
-  # dbt-loom is installed by the dedicated Run-Integration-Tests-DBT-Loom job
-  # (scripts/test/integration-dbt-loom.sh), not by the common pre-install path.
 
   # Delete the no longer needed constraint file
   rm /tmp/constraint.txt
@@ -88,7 +86,5 @@ else
 fi
 
 # Installation of dbt in a separate Python virtual environment:
-# dbt-loom is added to this venv by the dedicated Run-Integration-Tests-DBT-Loom
-# job (scripts/test/integration-dbt-loom.sh), not by the common pre-install path.
 python -m venv venv-subprocess
 venv-subprocess/bin/pip install -U dbt-postgres

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -31,7 +31,7 @@ IGNORED_DAG_FILES = [
 ]
 
 # cross_project_manifest_dag.py runs dbt subprocesses that need dbt-loom.
-# When dbt-loom isn't installed, the dedicated Run-Integration-Tests-DBT-Loom
+# When dbt-loom isn't installed, the dedicated Run-Integration-Tests-dbt-Loom
 # CI job covers this DAG instead.
 if importlib.util.find_spec("dbt_loom") is None:
     IGNORED_DAG_FILES.append("cross_project_manifest_dag.py")

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import importlib.util
 import os
 from functools import cache
 from pathlib import Path
@@ -28,6 +29,12 @@ IGNORED_DAG_FILES = [
     "jaffle_shop_watcher_kubernetes.py",
     "cross_project_dbt_ls_dag.py",
 ]
+
+# cross_project_manifest_dag.py runs dbt subprocesses that need dbt-loom.
+# When dbt-loom isn't installed, the dedicated Run-Integration-Tests-DBT-Loom
+# CI job covers this DAG instead.
+if importlib.util.find_spec("dbt_loom") is None:
+    IGNORED_DAG_FILES.append("cross_project_manifest_dag.py")
 
 
 @provide_session


### PR DESCRIPTION
## Summary

Carves the one dbt-loom-dependent test path out of the main integration suite into a dedicated CI job, so the main matrix can move to dbt versions that dbt-loom doesn't yet support.

## Motivation

`dbt-loom 0.9.4` (latest on PyPI as of 2026-06-02) declares `dbt-core>=1.6.0,<1.12.0`. When dbt-loom is installed alongside dbt-core in the common pre-install path, `uv` silently downgrades `dbt-core` to satisfy the cap — so a future bump of the integration matrix to dbt-1.12+ would resolve back to dbt-1.11 without erroring. Pulling dbt-loom out of the common path removes that downgrade pressure and lets the main matrix bump independently.

This is a prerequisite for [#2754 (Add dbt-core 1.12 to test matrix)](https://github.com/astronomer/astronomer-cosmos/pull/2754) actually delivering dbt-1.12 CI coverage.

## What changes

| File | Change |
|---|---|
| `scripts/test/integration-dbt-loom.sh` *(new)* | Pins dbt-core to a loom-supported version, installs `dbt-loom` in both the main env and `venv-subprocess/`, then runs only `tests/test_example_dags.py::test_example_dag[cross_project_manifest_dag]`. Modeled on `integration-dbt-async.sh`. |
| `.github/workflows/test.yml` | Adds `Run-Integration-Tests-DBT-Loom` job — single matrix cell (py3.11, airflow-3.2, dbt-1.11) with the postgres service that `cross_project_manifest_dag`'s profile expects. |
| `pyproject.toml` | Adds `test-integration-dbt-loom = 'sh scripts/test/integration-dbt-loom.sh {matrix:dbt}'` hatch script entry. |
| `scripts/test/pre-install-airflow.sh` | Removes `uv pip install dbt-loom` from the else-branch and from the `venv-subprocess` install. Both call-sites get a comment pointing at the dedicated job. |
| `tests/test_example_dags.py` | If `dbt_loom` isn't importable, appends `cross_project_manifest_dag.py` to `IGNORED_DAG_FILES`. Lets the main example-DAG test pass on matrix cells where dbt-loom isn't installed; the dedicated job covers the DAG on supported versions. |

## Footprint check

`dbt-loom` is referenced by name in `cosmos/dbt/graph.py`, `cosmos/dbt/selector.py`, `tests/dbt/test_selector.py`, `tests/dbt/test_graph.py`, and two example DAGs — but **no Python code in cosmos imports the `dbt_loom` package**. The references are in docstrings, defensive handling of external-node data shapes, and example-DAG strings/tags. The only runtime dependency on the installed `dbt-loom` package is `cross_project_manifest_dag.py`, which spawns dbt subprocesses (via `venv-subprocess/bin/dbt`) against a project that uses dbt-loom's cross-project references. That single DAG is what the new job covers.

`cross_project_dbt_ls_dag.py` is already in `IGNORED_DAG_FILES` (pre-existing exclusion, unrelated to dbt-loom).

## Re-merge condition

Once `dbt-loom` publishes a release that supports the main matrix's dbt version, this job can either:
- Update its matrix to follow main's (and continue running as a dedicated cell), or
- Be merged back into `Run-Integration-Tests` and the file deleted.

## Follow-up

`Run-Integration-Tests-DBT-Loom` shares ~25 lines of boilerplate (checkout + cache + setup-python + install) with `Run-Integration-Tests-DBT-Async` and `Run-Integration-Tests`. A separate follow-up PR will extract a `setup-cosmos-test-env` composite action and refactor the loom + async jobs to use it. Deliberately kept out of this PR so reviewers can focus on the carve-out without bikeshedding the action's interface.

## Test plan

- [x] CI runs the new `Run-Integration-Tests-DBT-Loom` job to completion
- [ ] Main integration tests still pass — `cross_project_manifest_dag` is conditionally ignored on cells where dbt-loom isn't installed; still runs on cells where it is (current dbt-1.11 cells)
- [ ] Async + unit jobs unaffected

CI: https://github.com/astronomer/astronomer-cosmos/actions/runs/26838876022/job/79145312925

## Reviewer checklist

- [ ] Carve-out scope matches the footprint check (one DAG, no `dbt_loom` imports in source/tests)
- [ ] The `dbt_loom` install removals from `pre-install-airflow.sh` don't break any non-carved test path
- [ ] Conditional `IGNORED_DAG_FILES` logic in `test_example_dags.py` reads cleanly
- [ ] New hatch entry + workflow job follow repo conventions
- [ ] Re-merge plan acceptable
- [ ] Ready to mark non-draft

---

Drafted with the [`lib-upgrader`](https://github.com/astronomer/oss-integrations-private/pull/438) Claude Code skill (BOSS-432).
