### PR TITLE
Remove unused `# type: ignore` comments and re-enable `warn_unused_ignores`

### DIFF
--- a/cosmos/airflow/dag.py
+++ b/cosmos/airflow/dag.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from airflow.models.dag import DAG  # type: ignore[assignment]
+from airflow.models.dag import DAG
 
 from cosmos.converter import DbtToAirflowConverter, airflow_kwargs, specific_kwargs
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -788,7 +788,7 @@ def _add_watcher_dependencies(
         )
         for task in node_tasks:
             if hasattr(task, "producer_task_id"):
-                task.producer_task_id = producer_airflow_task.task_id  # type: ignore[union-attr]
+                task.producer_task_id = producer_airflow_task.task_id
             if needs_wait_for_downstream:
                 task.wait_for_downstream = True  # type: ignore[union-attr]
 

--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -70,7 +70,7 @@ def _configure_remote_cache_dir() -> Path | ObjectStoragePath | None:
     remote_cache_conn_id = remote_cache_dir_conn_id
     if not remote_cache_conn_id:
         cache_dir_schema = cache_dir_str.split("://")[0]
-        remote_cache_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(cache_dir_schema, None)  # type: ignore[assignment]
+        remote_cache_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(cache_dir_schema, None)
     if remote_cache_conn_id is None:
         return _configured_cache_dir
 
@@ -81,7 +81,7 @@ def _configure_remote_cache_dir() -> Path | ObjectStoragePath | None:
 
     _configured_cache_dir = ObjectStoragePath(cache_dir_str, conn_id=remote_cache_conn_id)
 
-    if not _configured_cache_dir.exists():  # type: ignore[no-untyped-call]
+    if not _configured_cache_dir.exists():
         # TODO: Check if we should raise an error instead in case the provided path does not exist.
         _configured_cache_dir.mkdir(parents=True, exist_ok=True)
 

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -16,7 +16,7 @@ if TYPE_CHECKING:
     from cosmos.config import ProfileConfig
 
     try:
-        from airflow.sdk import DAG  # type: ignore[assignment]
+        from airflow.sdk import DAG
 
         # Airflow 3.1 onwards
         from airflow.utils.task_group import TaskGroup

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -21,7 +21,7 @@ from airflow.models import Variable
 try:
     import orjson
 except ImportError:  # pragma: no cover
-    orjson = None  # type: ignore[assignment]
+    orjson = None
 
 if TYPE_CHECKING:
     try:

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -8,7 +8,7 @@ import deprecation
 if TYPE_CHECKING:
     from dbt.cli.main import dbtRunnerResult
 
-from cosmos import __version__ as cosmos_version  # type: ignore[attr-defined]
+from cosmos import __version__ as cosmos_version
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 from cosmos.log import get_logger
 
@@ -58,7 +58,7 @@ def parse_number_of_warnings_dbt_runner(result: dbtRunnerResult) -> int:
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
     num = 0
-    for run_result in result.result.results:  # type: ignore[union-attr]
+    for run_result in result.result.results:
         if run_result.status == "warn":
             num += 1
     return num
@@ -127,7 +127,7 @@ def extract_log_issues(log_list: list[str]) -> tuple[list[str], list[str]]:
 )  # type: ignore[untyped-decorator]
 def extract_dbt_runner_issues(
     result: dbtRunnerResult, status_levels: list[str] | None = None
-) -> tuple[list[str], list[str]]:  # type: ignore[misc]
+) -> tuple[list[str], list[str]]:
     """
     Extracts messages from the dbt runner result and returns them as a formatted string.
 
@@ -144,7 +144,7 @@ def extract_dbt_runner_issues(
     node_names = []
     node_results = []
 
-    for node_result in result.result.results:  # type: ignore[union-attr]
+    for node_result in result.result.results:
         if node_result.status in status_levels:
             node_names.append(str(node_result.node.name))
             node_results.append(str(node_result.message))

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -203,7 +203,7 @@ class DbtModel:
                     and isinstance(node.args[0], jinja2.nodes.Const)
                     and node.node.name == "var"
                 ):
-                    value += self.dbt_vars[node.args[0].value]  # type: ignore[operator]
+                    value += self.dbt_vars[node.args[0].value]
         elif isinstance(first_arg, jinja2.nodes.Const):
             # and add it to the config
             value = first_arg.value

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -123,7 +123,7 @@ def extract_message_by_status(
     node_names = []
     node_results = []
 
-    for node_result in result.result.results:  # type: ignore[union-attr]
+    for node_result in result.result.results:
         if node_result.status in status_levels:
             node_names.append(str(node_result.node.name))
             node_results.append(str(node_result.message))
@@ -136,7 +136,7 @@ def parse_number_of_warnings(result: dbtRunnerResult) -> int:
     from invoking dbt build, compile, run, seed, snapshot, test, or run-operation.
     """
     num = 0
-    for run_result in result.result.results:  # type: ignore[union-attr]
+    for run_result in result.result.results:
         if run_result.status == "warn":
             num += 1
     return num

--- a/cosmos/hooks/subprocess.py
+++ b/cosmos/hooks/subprocess.py
@@ -34,7 +34,7 @@ class FullOutputSubprocessHook(BaseHook):  # type: ignore[misc]
 
     def __init__(self) -> None:
         self.sub_process: Popen[str] | None = None
-        super().__init__()  # type: ignore[no-untyped-call]
+        super().__init__()
 
     def run_command(
         self,

--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -197,13 +197,13 @@ def _configure_remote_target_path() -> tuple[Path | ObjectStoragePath, str] | tu
     remote_conn_id = settings.remote_target_path_conn_id
     if not remote_conn_id:
         target_path_schema = urlparse(target_path_str).scheme
-        remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)  # type: ignore[assignment]
+        remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)
     if remote_conn_id is None:
         return None, None
 
     _configured_target_path = ObjectStoragePath(target_path_str, conn_id=remote_conn_id)
 
-    if not _configured_target_path.exists():  # type: ignore[no-untyped-call]
+    if not _configured_target_path.exists():
         _configured_target_path.mkdir(parents=True, exist_ok=True)
 
     return _configured_target_path, remote_conn_id

--- a/cosmos/listeners/task_instance_listener.py
+++ b/cosmos/listeners/task_instance_listener.py
@@ -182,7 +182,7 @@ def _build_task_metrics(task_instance: TaskInstance, status: str) -> dict[str, o
 
 
 @hookimpl
-def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:
     """Handle task instance success for both Airflow 2 (with session) and Airflow 3 (without session)."""
     if not _is_cosmos_task(task_instance):
         return
@@ -193,7 +193,7 @@ def on_task_instance_success(previous_state: Any, task_instance: TaskInstance, *
 
 
 @hookimpl
-def on_task_instance_failed(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:  # type: ignore[override]
+def on_task_instance_failed(previous_state: Any, task_instance: TaskInstance, *args: Any, **kwargs: Any) -> None:
     """Handle task instance failure for both Airflow 2 (with session) and Airflow 3 (with error and without session)."""
     if not _is_cosmos_task(task_instance):
         return

--- a/cosmos/operators/_asynchronous/base.py
+++ b/cosmos/operators/_asynchronous/base.py
@@ -29,7 +29,7 @@ def _create_async_operator_class(profile_type: str, dbt_class: str) -> Any:
         raise ImportError(f"Error in loading class: {class_path}. Unable to find the specified operator class.") from e
 
 
-class DbtRunAirflowAsyncFactoryOperator(DbtRunLocalOperator):  # type: ignore[misc]
+class DbtRunAirflowAsyncFactoryOperator(DbtRunLocalOperator):
 
     def __init__(
         self,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -251,7 +251,7 @@ def _ensure_subprocess_model_outlet_uris(
         manifest_path = Path(project_dir) / "target" / "manifest.json"
         if manifest_path.exists():
             model_outlet_uris.update(compute_model_outlet_uris(manifest_path, dataset_namespace))
-        model_outlet_uris[_MODEL_OUTLET_URIS_ATTEMPTED_KEY] = []  # type: ignore[assignment]
+        model_outlet_uris[_MODEL_OUTLET_URIS_ATTEMPTED_KEY] = []
 
 
 def _rewrite_upstream_failure_skip_status(
@@ -406,8 +406,8 @@ def store_dbt_resource_status_from_log(
 _PRODUCER_ONLY_FLAGS: tuple[str, ...] = ("--select", "--exclude", "--log-format")
 
 
-class BaseConsumerSensor(BaseSensorOperator):  # type: ignore[misc]
-    template_fields: tuple[str, ...] = ("model_unique_id", "compiled_sql")  # type: ignore[operator]
+class BaseConsumerSensor(BaseSensorOperator):
+    template_fields: tuple[str, ...] = ("model_unique_id", "compiled_sql")
     poke_retry_number: int = 0
 
     def __init__(
@@ -787,9 +787,9 @@ def create_producer_done_task(dag: DAG, task_group: TaskGroup, task_id: str) -> 
     try:
         from airflow.task.trigger_rule import TriggerRule
     except ImportError:
-        from airflow.utils.trigger_rule import TriggerRule  # type: ignore[no-redef]
+        from airflow.utils.trigger_rule import TriggerRule
 
-    return EmptyOperator(  # type: ignore[no-untyped-call]
+    return EmptyOperator(
         task_id=task_id,
         dag=dag,
         task_group=task_group,

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -85,8 +85,8 @@ def _init_xcom_backup(context: Any) -> None:
     dag_id = ti.dag_id
     run_id = context["run_id"]
     task_group_id = _get_task_group_id(ti)
-    ti._cosmos_xcom_backup_var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)  # type: ignore[attr-defined]
-    ti._cosmos_xcom_backup_buffer = {}  # type: ignore[attr-defined]
+    ti._cosmos_xcom_backup_var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
+    ti._cosmos_xcom_backup_buffer = {}
 
 
 def _persist_backup(var_key: str, backup_buffer: dict[str, Any]) -> None:

--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -129,7 +129,7 @@ class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInsta
         self.command: list[str] = dbt_cmd
 
 
-class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core build command.
     """
@@ -140,7 +140,7 @@ class DbtBuildAzureContainerInstanceOperator(DbtBuildMixin, DbtAzureContainerIns
         super().__init__(*args, **kwargs)
 
 
-class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core ls command.
     """
@@ -149,7 +149,7 @@ class DbtLSAzureContainerInstanceOperator(DbtLSMixin, DbtAzureContainerInstanceB
         super().__init__(*args, **kwargs)
 
 
-class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core seed command.
 
@@ -162,7 +162,7 @@ class DbtSeedAzureContainerInstanceOperator(DbtSeedMixin, DbtAzureContainerInsta
         super().__init__(*args, **kwargs)
 
 
-class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtSnapshotAzureContainerInstanceOperator(DbtSnapshotMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core snapshot command.
 
@@ -181,7 +181,7 @@ class DbtSourceAzureContainerInstanceOperator(DbtSourceMixin, DbtAzureContainerI
         super().__init__(*args, **kwargs)
 
 
-class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core run command.
     """
@@ -192,7 +192,7 @@ class DbtRunAzureContainerInstanceOperator(DbtRunMixin, DbtAzureContainerInstanc
         super().__init__(*args, **kwargs)
 
 
-class DbtTestAzureContainerInstanceOperator(DbtTestMixin, DbtAzureContainerInstanceBaseOperator):  # type: ignore[misc]
+class DbtTestAzureContainerInstanceOperator(DbtTestMixin, DbtAzureContainerInstanceBaseOperator):
     """
     Executes a dbt core test command.
     """

--- a/cosmos/operators/base.py
+++ b/cosmos/operators/base.py
@@ -24,7 +24,7 @@ if TYPE_CHECKING:  # pragma: no cover
 try:
     from airflow.utils.operator_helpers import context_to_airflow_vars  # type: ignore[attr-defined]
 except ImportError:  # pragma: no cover
-    from airflow.sdk.execution_time.context import context_to_airflow_vars  # type: ignore[no-redef]
+    from airflow.sdk.execution_time.context import context_to_airflow_vars
 
 from airflow.utils.strings import to_boolean
 

--- a/cosmos/operators/kubernetes.py
+++ b/cosmos/operators/kubernetes.py
@@ -217,7 +217,7 @@ class DbtTestWarningHandler(KubernetesPodOperatorCallback):  # type: ignore[misc
         self.operator = operator
         self.context = context
 
-    def on_pod_completion(  # type: ignore[override]
+    def on_pod_completion(
         self,
         *,
         pod: k8s.V1Pod,
@@ -362,9 +362,9 @@ class DbtWarningKubernetesOperator(DbtKubernetesBaseOperator, ABC):
             self.warning_handler = DbtTestWarningHandler(on_warning_callback, operator=self)
             # Support for handling multiple operator callbacks via self.callbacks was added in provider version 10.2.0
             if isinstance(self.callbacks, list):  # type: ignore[has-type]
-                self.callbacks.append(self.warning_handler)  # type: ignore[has-type,arg-type]
+                self.callbacks.append(self.warning_handler)  # type: ignore[has-type]
             else:
-                self.callbacks = self.warning_handler  # type: ignore[assignment]
+                self.callbacks = self.warning_handler
 
     def build_and_run_cmd(
         self,
@@ -434,7 +434,7 @@ class DbtDocsKubernetesOperator(DbtKubernetesBaseOperator):
     Use the `callback` parameter to specify a callback function to run after the command completes.
     """
 
-    template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtKubernetesBaseOperator.template_fields
 
     ui_color = "#8194E0"
     required_files = ["index.html", "manifest.json", "catalog.json"]
@@ -460,13 +460,13 @@ class DbtDocsCloudKubernetesOperator(DbtDocsKubernetesOperator, ABC):
     the generated documentation to cloud storage *also inside the Pod*.
     """
 
-    template_fields: Sequence[str] = DbtDocsKubernetesOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtDocsKubernetesOperator.template_fields
 
     def __init__(self, **kwargs: Any) -> None:
         super().__init__(**kwargs)
 
         # In Kubernetes mode, we do NOT use callback-based upload on the Airflow worker.
-        self.callback = None  # type: ignore[assignment]
+        self.callback = None
 
     @abstractmethod
     def build_upload_shell_command(self, docs_target: str) -> str:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -337,7 +337,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         remote_conn_id = remote_target_path_conn_id
         if not remote_conn_id:
             target_path_schema = urlparse(target_path_str).scheme
-            remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)  # type: ignore[assignment]
+            remote_conn_id = FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP.get(target_path_schema, None)
         if remote_conn_id is None:
             logger.info(
                 "Remote target connection not set. Please, configure [cosmos][remote_target_path_conn_id] or set the environment variable AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID"
@@ -346,7 +346,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         _configured_target_path = ObjectStoragePath(target_path_str, conn_id=remote_conn_id)
 
-        if not _configured_target_path.exists():  # type: ignore[no-untyped-call]
+        if not _configured_target_path.exists():
             _configured_target_path.mkdir(parents=True, exist_ok=True)
 
         return _configured_target_path, remote_conn_id
@@ -825,7 +825,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                     if task.task_id == self.task_id:
                         task.outlets.extend(new_outlets)
                         task.inlets.extend(new_inlets)
-                DAG.bulk_write_to_db([self.dag], session=session)  # type: ignore[attr-defined, call-arg, arg-type]
+                DAG.bulk_write_to_db([self.dag], session=session)  # type: ignore[attr-defined]
                 session.commit()
         else:
             dataset_alias_name = get_dataset_alias_name(self.dag, self.task_group, self.task_id)  # type: ignore[attr-defined]
@@ -840,7 +840,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 from airflow.sdk.definitions.asset import AssetAlias
 
                 # This line was necessary in Airflow 3.0.0, but this may become automatic in newer versions
-                self.outlets.append(AssetAlias(dataset_alias_name))  # type: ignore[attr-defined, call-arg, arg-type]
+                self.outlets.append(AssetAlias(dataset_alias_name))  # type: ignore[attr-defined]
                 for outlet in new_outlets:
                     context["outlet_events"][AssetAlias(dataset_alias_name)].add(outlet)
 
@@ -868,10 +868,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         if openlineage_events_completes is not None:
             for completed in openlineage_events_completes:
-                for input_ in completed.inputs:  # type: ignore[union-attr]
+                for input_ in completed.inputs:
                     if input_ not in inputs:
                         inputs.append(input_)
-                for output in completed.outputs:  # type: ignore[union-attr]
+                for output in completed.outputs:
                     if output not in outputs:
                         outputs.append(output)
                 run_facets = {**run_facets, **completed.run.facets}
@@ -922,8 +922,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
                 self.subprocess_hook.send_sigterm()
 
 
-class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):  # type: ignore[misc]
-    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields  # type: ignore[operator]
+class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
+    template_fields: Sequence[str] = AbstractDbtLocalBase.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # In PR #1474, we refactored cosmos.operators.base.AbstractDbtBase to remove its inheritance from BaseOperator
@@ -1020,7 +1020,7 @@ class DbtLSLocalOperator(DbtLSMixin, DbtLocalBaseOperator):
     Executes a dbt core ls command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -1042,7 +1042,7 @@ class DbtSnapshotLocalOperator(DbtSnapshotMixin, DbtLocalBaseOperator):
     Executes a dbt core snapshot command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -1053,7 +1053,7 @@ class DbtSourceLocalOperator(DbtSourceMixin, DbtLocalBaseOperator):
     Executes a dbt source freshness command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, on_warning_callback: Callable[..., Any] | None = None, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)
@@ -1105,7 +1105,7 @@ class DbtTestLocalOperator(DbtTestMixin, DbtLocalBaseOperator):
         and "test_results" of type `List`. Each index in "test_names" corresponds to the same index in "test_results".
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(
         self,
@@ -1171,7 +1171,7 @@ class DbtDocsLocalOperator(DbtLocalBaseOperator):
     Use the `callback` parameter to specify a callback function to run after the command completes.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     ui_color = "#8194E0"
     required_files = ["index.html", "manifest.json", "catalog.json"]
@@ -1196,7 +1196,7 @@ class DbtDocsCloudLocalOperator(DbtDocsLocalOperator, ABC):
     Abstract class for operators that upload the generated documentation to cloud storage.
     """
 
-    template_fields: Sequence[str] = DbtDocsLocalOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtDocsLocalOperator.template_fields
 
     def __init__(
         self,
@@ -1393,7 +1393,7 @@ class DbtDepsLocalOperator(DbtLocalBaseOperator):
 
 
 class DbtCompileLocalOperator(DbtCompileMixin, DbtLocalBaseOperator):
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         kwargs["should_upload_compiled_sql"] = True
@@ -1405,7 +1405,7 @@ class DbtCloneLocalOperator(DbtCloneMixin, DbtLocalBaseOperator):
     Executes a dbt core clone command.
     """
 
-    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtLocalBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -228,7 +228,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
             self.log.warning("Lockfile owned by process of pid %s, while operator has pid %s", lock_file_pid, self._pid)
 
 
-class DbtBuildVirtualenvOperator(DbtVirtualenvBaseOperator, DbtBuildLocalOperator):  # type: ignore[misc]
+class DbtBuildVirtualenvOperator(DbtVirtualenvBaseOperator, DbtBuildLocalOperator):
     """
     Executes a dbt core build command within a Python Virtual Environment, that is created before running the dbt command
     and deleted just after.
@@ -244,13 +244,13 @@ class DbtLSVirtualenvOperator(DbtVirtualenvBaseOperator, DbtLSLocalOperator):
     and deleted just after.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
 
-class DbtSeedVirtualenvOperator(DbtVirtualenvBaseOperator, DbtSeedLocalOperator):  # type: ignore[misc]
+class DbtSeedVirtualenvOperator(DbtVirtualenvBaseOperator, DbtSeedLocalOperator):
     """
     Executes a dbt core seed command within a Python Virtual Environment, that is created before running the dbt command
     and deleted just after.
@@ -266,7 +266,7 @@ class DbtSnapshotVirtualenvOperator(DbtVirtualenvBaseOperator, DbtSnapshotLocalO
     command and deleted just after.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -278,13 +278,13 @@ class DbtSourceVirtualenvOperator(DbtVirtualenvBaseOperator, DbtSourceLocalOpera
     command and deleted just after.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
 
-class DbtRunVirtualenvOperator(DbtVirtualenvBaseOperator, DbtRunLocalOperator):  # type: ignore[misc]
+class DbtRunVirtualenvOperator(DbtVirtualenvBaseOperator, DbtRunLocalOperator):
     """
     Executes a dbt core run command within a Python Virtual Environment, that is created before running the dbt command
     and deleted just after.
@@ -300,13 +300,13 @@ class DbtTestVirtualenvOperator(DbtVirtualenvBaseOperator, DbtTestLocalOperator)
     and deleted just after.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
 
 
-class DbtRunOperationVirtualenvOperator(DbtVirtualenvBaseOperator, DbtRunOperationLocalOperator):  # type: ignore[misc]
+class DbtRunOperationVirtualenvOperator(DbtVirtualenvBaseOperator, DbtRunOperationLocalOperator):
     """
     Executes a dbt core run-operation command within a Python Virtual Environment, that is created before running the
     dbt command and deleted just after.
@@ -322,7 +322,7 @@ class DbtDocsVirtualenvOperator(DbtVirtualenvBaseOperator, DbtDocsLocalOperator)
     command and deleted just after.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)
@@ -333,7 +333,7 @@ class DbtCloneVirtualenvOperator(DbtVirtualenvBaseOperator, DbtCloneLocalOperato
     Executes a dbt core clone command.
     """
 
-    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields  # type: ignore[operator]
+    template_fields: Sequence[str] = DbtVirtualenvBaseOperator.template_fields
 
     def __init__(self, *args: Any, **kwargs: Any):
         super().__init__(*args, **kwargs)

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -352,7 +352,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         try:
             self.base_cmd = ["source", "freshness"]
             self.indirect_selection = None  # ``dbt source freshness`` does not support --indirect-selection
-            self.full_refresh = False  # type: ignore[assignment]  # ``dbt source freshness`` does not support --full-refresh
+            self.full_refresh = False
             self.dbt_cmd_flags = []  # clear build-specific flags (e.g. --resource-type)
             full_cmd, env = self.build_cmd(context=context, cmd_flags=self.add_cmd_flags())
             context["_check_source_freshness"] = True  # type: ignore[typeddict-unknown-key]
@@ -478,7 +478,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             raise
 
 
-class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type: ignore[misc]
+class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):
     template_fields: tuple[str, ...] = BaseConsumerSensor.template_fields + DbtRunLocalOperator.template_fields  # type: ignore[operator]
 
     def __init__(
@@ -525,7 +525,7 @@ class DbtConsumerWatcherSensor(BaseConsumerSensor, DbtRunLocalOperator):  # type
         if settings.enable_uri_xcom:
             context["ti"].xcom_push(key="uri", value=outlet_uris)
 
-    def execute(self, context: Context, **kwargs: Any) -> None:  # type: ignore[override]
+    def execute(self, context: Context, **kwargs: Any) -> None:
         super().execute(context, **kwargs)
         # If we reach here without deferring, the model succeeded — emit datasets
         self._emit_datasets(context)
@@ -547,7 +547,7 @@ class DbtBuildWatcherOperator:
         )
 
 
-class DbtSeedWatcherOperator(DbtSeedMixin, DbtConsumerWatcherSensor):  # type: ignore[misc]
+class DbtSeedWatcherOperator(DbtSeedMixin, DbtConsumerWatcherSensor):
     """
     Watches for the progress of dbt seed execution, run by the producer task (DbtProducerWatcherOperator).
     """
@@ -558,7 +558,7 @@ class DbtSeedWatcherOperator(DbtSeedMixin, DbtConsumerWatcherSensor):  # type: i
         super().__init__(*args, **kwargs)
 
 
-class DbtSnapshotWatcherOperator(DbtSnapshotMixin, DbtConsumerWatcherSensor):  # type: ignore[misc]
+class DbtSnapshotWatcherOperator(DbtSnapshotMixin, DbtConsumerWatcherSensor):
     """
     Watches for the progress of dbt snapshot execution, run by the producer task (DbtProducerWatcherOperator).
     """
@@ -566,7 +566,7 @@ class DbtSnapshotWatcherOperator(DbtSnapshotMixin, DbtConsumerWatcherSensor):  #
     template_fields: tuple[str, ...] = DbtConsumerWatcherSensor.template_fields
 
 
-class DbtSourceWatcherOperator(BaseConsumerSensor, DbtSourceLocalOperator):  # type: ignore[misc]
+class DbtSourceWatcherOperator(BaseConsumerSensor, DbtSourceLocalOperator):
     """Watches for source freshness results from the producer task.
 
     When the producer has ``_check_source_freshness`` enabled it runs
@@ -593,7 +593,7 @@ class DbtSourceWatcherOperator(BaseConsumerSensor, DbtSourceLocalOperator):  # t
         )
         resource_name = self.model_unique_id.split(".", 2)[2]
         cmd_flags = ["--select", f"source:{resource_name}"]
-        self.build_and_run_cmd(context, cmd_flags=cmd_flags)  # type: ignore[attr-defined]
+        self.build_and_run_cmd(context, cmd_flags=cmd_flags)
         logger.info("dbt source freshness completed successfully on retry for source '%s'", self.model_unique_id)
         return True
 
@@ -609,7 +609,7 @@ class DbtRunWatcherOperator(DbtConsumerWatcherSensor):
         super().__init__(*args, **kwargs)
 
 
-class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
+class DbtTestWatcherOperator(DbtConsumerWatcherSensor):
     """Sensor that watches the aggregated test status for a dbt model in watcher execution mode.
 
     The producer task (``DbtProducerWatcherOperator``) collects individual test
@@ -628,7 +628,7 @@ class DbtTestWatcherOperator(DbtConsumerWatcherSensor):  # type: ignore[misc]
     back to running ``dbt test --select <model>`` locally for this specific model.
     """
 
-    template_fields: tuple[str, ...] = DbtConsumerWatcherSensor.template_fields  # type: ignore[operator]
+    template_fields: tuple[str, ...] = DbtConsumerWatcherSensor.template_fields
 
     # Hardcode base_cmd = ["test"] (overriding DbtRunMixin inherited via
     # DbtConsumerWatcherSensor) rather than inheriting from DbtTestMixin: due

--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -163,7 +163,7 @@ class DbtBuildWatcherKubernetesOperator:
         )
 
 
-class DbtSeedWatcherKubernetesOperator(DbtSeedMixin, DbtConsumerWatcherKubernetesSensor):  # type: ignore[misc]
+class DbtSeedWatcherKubernetesOperator(DbtSeedMixin, DbtConsumerWatcherKubernetesSensor):
     """
     Watches for the progress of dbt seed execution, run by the producer task (DbtProducerWatcherOperator).
     """
@@ -174,7 +174,7 @@ class DbtSeedWatcherKubernetesOperator(DbtSeedMixin, DbtConsumerWatcherKubernete
         super().__init__(*args, **kwargs)
 
 
-class DbtSnapshotWatcherKubernetesOperator(DbtSnapshotMixin, DbtConsumerWatcherKubernetesSensor):  # type: ignore[misc]
+class DbtSnapshotWatcherKubernetesOperator(DbtSnapshotMixin, DbtConsumerWatcherKubernetesSensor):
     """
     Watches for the progress of dbt snapshot execution, run by the producer task (DbtProducerWatcherOperator).
     """
@@ -187,7 +187,7 @@ class DbtSourceWatcherKubernetesOperator(DbtSourceKubernetesOperator):
     Executes a dbt source freshness command, synchronously, as ExecutionMode.LOCAL.
     """
 
-    template_fields: tuple[str, ...] = tuple(DbtSourceKubernetesOperator.template_fields)  # type: ignore[arg-type]
+    template_fields: tuple[str, ...] = tuple(DbtSourceKubernetesOperator.template_fields)
 
 
 class DbtRunWatcherKubernetesOperator(DbtConsumerWatcherKubernetesSensor):
@@ -210,4 +210,4 @@ class DbtTestWatcherKubernetesOperator(EmptyOperator):
     def __init__(self, *args: Any, **kwargs: Any):
         desired_keys = ("dag", "task_group", "task_id")
         new_kwargs = {key: value for key, value in kwargs.items() if key in desired_keys}
-        super().__init__(**new_kwargs)  # type: ignore[no-untyped-call]
+        super().__init__(**new_kwargs)

--- a/cosmos/plugin/__init__.py
+++ b/cosmos/plugin/__init__.py
@@ -19,11 +19,11 @@ def __getattr__(name: str) -> _CosmosPluginType | _CosmosAF3PluginType | None:
         global _CosmosPlugin
         if _CosmosPlugin is None:
             if version.parse(airflow_version).major < _AIRFLOW3_MAJOR_VERSION:
-                from .airflow2 import CosmosPlugin  # type: ignore[assignment]  # noqa: F401
+                from .airflow2 import CosmosPlugin
 
                 _CosmosPlugin = CosmosPlugin  # type: ignore[assignment]
             else:
-                from .airflow3 import CosmosAF3Plugin  # type: ignore[assignment]  # noqa: F401
+                from .airflow3 import CosmosAF3Plugin
 
                 _CosmosPlugin = CosmosAF3Plugin  # type: ignore[assignment]
         return _CosmosPlugin

--- a/cosmos/plugin/airflow2.py
+++ b/cosmos/plugin/airflow2.py
@@ -120,7 +120,7 @@ def open_file(path: str, conn_id: str | None = None) -> str:
     else:
         with open(path) as f:
             content = f.read()
-        return content  # type: ignore[no-any-return]
+        return content
 
 
 class DbtDocsView(AirflowBaseView):  # type: ignore[misc]
@@ -153,8 +153,8 @@ class DbtDocsView(AirflowBaseView):  # type: ignore[misc]
         )
 
         if dbt_docs_dir is None:
-            return self.render_template("dbt_docs_not_set_up.html")  # type: ignore[no-any-return,no-untyped-call]
-        return self.render_template("dbt_docs.html")  # type: ignore[no-any-return,no-untyped-call]
+            return self.render_template("dbt_docs_not_set_up.html")  # type: ignore[no-any-return]
+        return self.render_template("dbt_docs.html")  # type: ignore[no-any-return]
 
     @expose("/dbt_docs_index.html")  # type: ignore[untyped-decorator]
     @has_access(MENU_ACCESS_PERMISSIONS)  # type: ignore[untyped-decorator]
@@ -163,11 +163,11 @@ class DbtDocsView(AirflowBaseView):  # type: ignore[misc]
         # We serve a Cosmos-owned template whose "Return to the main page" link uses target="_top"
         # to break out of the iframe (Airflow's default 404 link does not).
         if dbt_docs_dir is None:
-            return self.render_template("dbt_docs_iframe_404.html"), 404  # type: ignore[no-untyped-call]
+            return self.render_template("dbt_docs_iframe_404.html"), 404
         try:
             html = open_file(op.join(dbt_docs_dir, dbt_docs_index_file_name), conn_id=dbt_docs_conn_id)
         except FileNotFoundError:
-            return self.render_template("dbt_docs_iframe_404.html"), 404  # type: ignore[no-untyped-call]
+            return self.render_template("dbt_docs_iframe_404.html"), 404
         else:
             html = html.replace("</head>", f"{IFRAME_SCRIPT}</head>")
             return html, 200, {"Content-Security-Policy": "frame-ancestors 'self'"}

--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -75,12 +75,12 @@ def _read_content_via_object_storage(path: str, conn_id: str | None = None) -> A
         with connection_env(conn_id):
             p = ObjectStoragePath(path, conn_id=conn_id) if conn_id else ObjectStoragePath(path)
             with p.open("r") as f:  # type: ignore[no-untyped-call]
-                content = f.read()  # type: ignore[no-any-return]
+                content = f.read()
             return content
     else:
         p = ObjectStoragePath(path, conn_id=conn_id) if conn_id else ObjectStoragePath(path)
         with p.open("r") as f:  # type: ignore[no-untyped-call]
-            content = f.read()  # type: ignore[no-any-return]
+            content = f.read()
         return content
 
 
@@ -95,7 +95,7 @@ def open_file(path: str, conn_id: str | None = None) -> Any:
     else:
         with open(path) as f:
             content = f.read()
-        return content  # type: ignore[no-any-return]
+        return content
 
 
 def _load_projects_from_conf() -> dict[str, dict[str, str | None]]:
@@ -140,7 +140,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
     for slug, cfg in projects.items():
         # Simple HTML wrapper to embed the dbt docs UI
         @app.get(f"/{slug}/dbt_docs", response_class=HTMLResponse)
-        def dbt_docs_view(slug_alias: str = slug) -> str:  # type: ignore[no-redef]
+        def dbt_docs_view(slug_alias: str = slug) -> str:
             cfg_local = projects.get(slug_alias, {})
             if not cfg_local.get("dir"):
                 return "<div>dbt Docs are not configured.</div>"
@@ -157,7 +157,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
             f"/{slug}/dbt_docs_index.html",
             response_class=HTMLResponse,
         )
-        def dbt_docs_index(slug_alias: str = slug) -> Response:  # type: ignore[no-redef]
+        def dbt_docs_index(slug_alias: str = slug) -> Response:
             # Emit telemetry for dbt docs access
             cfg_local = projects.get(slug_alias, {})
             docs_dir_local = cfg_local.get("dir")
@@ -212,7 +212,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
 
         # JSON artifacts
         @app.get(f"/{slug}/manifest.json")
-        def manifest(slug_alias: str = slug) -> Response:  # type: ignore[no-redef]
+        def manifest(slug_alias: str = slug) -> Response:
             cfg_local = projects.get(slug_alias, {})
             docs_dir_local = cfg_local.get("dir")
             conn_id_local = cfg_local.get("conn_id")
@@ -250,7 +250,7 @@ def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
             return JSONResponse(content=json.loads(data))
 
         @app.get(f"/{slug}/catalog.json")
-        def catalog(slug_alias: str = slug) -> Response:  # type: ignore[no-redef]
+        def catalog(slug_alias: str = slug) -> Response:
             cfg_local = projects.get(slug_alias, {})
             docs_dir_local = cfg_local.get("dir")
             conn_id_local = cfg_local.get("conn_id")

--- a/cosmos/profiles/athena/access_key.py
+++ b/cosmos/profiles/athena/access_key.py
@@ -98,6 +98,6 @@ class AthenaAccessKeyProfileMapping(BaseProfileMapping):
         """
         from airflow.providers.amazon.aws.hooks.base_aws import AwsGenericHook
 
-        hook = AwsGenericHook(self.conn_id)  # type: ignore[var-annotated]
+        hook = AwsGenericHook(self.conn_id)
         credentials = hook.get_credentials()
         return credentials

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -75,7 +75,7 @@ in_astro_cloud = os.getenv("ASTRONOMER_ENVIRONMENT") == "cloud"
 try:
     from airflow.sdk._shared.configuration.exceptions import AirflowConfigException as SdkConfigException
 except ImportError:
-    SdkConfigException = airflow.exceptions.AirflowConfigException  # type: ignore[misc]
+    SdkConfigException = airflow.exceptions.AirflowConfigException
 
 try:
     LINEAGE_NAMESPACE = conf.get("openlineage", "namespace")

--- a/cosmos/telemetry.py
+++ b/cosmos/telemetry.py
@@ -30,7 +30,7 @@ def collect_standard_usage_metrics() -> dict[str, object]:
     Return standard telemetry metrics.
     """
     metrics: dict[str, object] = {
-        "cosmos_version": cosmos.__version__,  # type: ignore[attr-defined]
+        "cosmos_version": cosmos.__version__,
         "airflow_version": parse.quote(airflow_version),
         "python_version": platform.python_version(),
         "platform_system": platform.system(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -254,7 +254,7 @@ known_third_party = ["airflow", "jinja2"]
 [tool.mypy]
 strict = true
 ignore_missing_imports = true
-no_warn_unused_ignores = true
+no_warn_unused_ignores = false
 
 [tool.ruff]
 line-length = 120


### PR DESCRIPTION
## Summary

Final follow-up to the `# type: ignore` cleanup series (#2710, #2711).
Flip `no_warn_unused_ignores` back to `false` in `pyproject.toml` so mypy
once again reports suppressions that no longer suppress anything — and
remove the 95 it flags across `cosmos/`.

- **90** coded ignores that suppressed no mypy error are removed entirely.
- **5** ignores listed one *used* + one *unused* code; the unused code is
  trimmed (the ignore stays, narrower):

  | File | Before | After |
  |---|---|---|
  | `operators/local.py` (×2) | `[attr-defined, call-arg, arg-type]` | `[attr-defined]` |
  | `operators/kubernetes.py` | `[has-type, arg-type]` | `[has-type]` |
  | `plugin/airflow2.py` (×2) | `[no-any-return, no-untyped-call]` | `[no-any-return]` |

## Why this is the natural follow-up

#2711 made every suppression name its error code(s). That's the
prerequisite for this step: with coded ignores, mypy reports unused
suppressions *per code* (it can tell `arg-type` is dead while `has-type`
is still needed on the same line) — impossible with bare ignores. While
`no_warn_unused_ignores = true` mypy reported **no** unused ignores at
all; flipping it to `false` is what surfaces the 95 cleaned up here.

After this PR, any future ignore that stops suppressing an error fails
`hatch run ...:type-check` instead of accumulating silently.

## Scope / correctness

- The diff is **comment-only** plus the one-line config flip — no runtime
  behavior changes (`# type: ignore` has no runtime effect).
- "Unused" is defined by the repo's canonical type-check, which runs mypy
  via pre-commit in a single isolated env (`apache-airflow<3.1`). That is
  exactly what CI enforces (`tests.py3.10-3.1-1.9:type-check` in
  `test.yml`), so a single local run is authoritative — no matrix sweep
  needed for this hook.

## Test plan

- [x] `hatch run tests.py3.11-2.10-1.9:type-check` → `mypy-python ... Passed`
- [x] `pre-commit` (all hooks) on changed files → Passed
- [x] Diff is comment-only + the single `pyproject.toml` flag flip
- [ ] CI green

## Related

- #2711 (tighten bare → coded ignores) — prerequisite
- #2710 (remove unused bare ignores)

🤖 Generated with [Claude Code](https://claude.com/claude-code)