### PR TITLE
docs: document `self.log` vs `get_logger` logging convention

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,13 +124,15 @@ Substitute the equivalent for whichever agent was used. The convention is "visib
 
 ### Logging
 
-Get loggers via `cosmos.log.get_logger`, not the stdlib `logging` module. This adds the `(astronomer-cosmos)` prefix when `rich_logging` is enabled and respects scoped log-level configuration.
+In library / module-level code, get loggers via `cosmos.log.get_logger`, not the stdlib `logging` module. This adds the `(astronomer-cosmos)` prefix when `rich_logging` is enabled and respects scoped log-level configuration. Inside operators and hooks (anything with `LoggingMixin`), log via `self.log` instead, so messages land in the per-task-instance log shown in the Airflow UI.
 
 Yes:
 ```python
 from cosmos.log import get_logger
 
-logger = get_logger(__name__)
+logger = get_logger(__name__)  # library / module-level code
+
+self.log.info("Running command: %s", self.command)  # inside an operator/hook
 ```
 
 No:
@@ -139,6 +141,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 logging.error(...)  # never call the root logger directly either
+
+logger = get_logger(__name__)  # inside an operator/hook — use self.log instead
 ```
 
 Use **lazy logging**: pass the format string and arguments separately. Do not embed f-strings, `.format()`, or `%` interpolation in log messages — the logger formats them only when the record passes the level filter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -124,15 +124,13 @@ Substitute the equivalent for whichever agent was used. The convention is "visib
 
 ### Logging
 
-In library / module-level code, get loggers via `cosmos.log.get_logger`, not the stdlib `logging` module. This adds the `(astronomer-cosmos)` prefix when `rich_logging` is enabled and respects scoped log-level configuration. Inside operators and hooks (anything with `LoggingMixin`), log via `self.log` instead, so messages land in the per-task-instance log shown in the Airflow UI.
+In library / module-level code, get loggers via `cosmos.log.get_logger`, not the stdlib `logging` module. This adds the `(astronomer-cosmos)` prefix when `rich_logging` is enabled and respects scoped log-level configuration.
 
 Yes:
 ```python
 from cosmos.log import get_logger
 
-logger = get_logger(__name__)  # library / module-level code
-
-self.log.info("Running command: %s", self.command)  # inside an operator/hook
+logger = get_logger(__name__)
 ```
 
 No:
@@ -141,8 +139,12 @@ import logging
 
 logger = logging.getLogger(__name__)
 logging.error(...)  # never call the root logger directly either
+```
 
-logger = get_logger(__name__)  # inside an operator/hook — use self.log instead
+Inside operators, log via `self.log` (provided by Airflow's `LoggingMixin`) rather than a module-level logger, so messages land in the per-task-instance log shown in the Airflow UI:
+```python
+def execute(self, context):
+    self.log.info("Running command: %s", self.command)
 ```
 
 Use **lazy logging**: pass the format string and arguments separately. Do not embed f-strings, `.format()`, or `%` interpolation in log messages — the logger formats them only when the record passes the level filter.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -141,11 +141,12 @@ logger = logging.getLogger(__name__)
 logging.error(...)  # never call the root logger directly either
 ```
 
-Inside operators, log via `self.log` (provided by Airflow's `LoggingMixin`) rather than a module-level logger, so messages land in the per-task-instance log shown in the Airflow UI:
+Inside operator instance methods, log via `self.log` (Cosmos's `AbstractDbtBase` routes it through `get_logger`, so it keeps the `(astronomer-cosmos)` prefix and scoped log levels):
 ```python
 def execute(self, context):
     self.log.info("Running command: %s", self.command)
 ```
+Use module-level `get_logger(__name__)` where `self` isn't available (module-level helpers, `@staticmethod`s).
 
 Use **lazy logging**: pass the format string and arguments separately. Do not embed f-strings, `.format()`, or `%` interpolation in log messages — the logger formats them only when the record passes the level filter.
 


### PR DESCRIPTION
## Summary

The "Python Coding Standards → Logging" section in `AGENTS.md` told
contributors to "get loggers via `cosmos.log.get_logger`"
unconditionally. Read literally, that guides someone working in an
operator to add a module-level `get_logger` — the exact inconsistency
[#1157](https://github.com/astronomer/astronomer-cosmos/issues/1157) set
out to fix.

This scopes that guidance to library / module-level code and states the
operator rule explicitly: inside operator instance methods, log via
`self.log`. Cosmos's `AbstractDbtBase` routes `self.log` through
`get_logger`, so messages keep the `(astronomer-cosmos)` prefix and
scoped log levels. Module-level `get_logger(__name__)` stays correct
where `self` isn't available (module-level helpers, `@staticmethod`s).
The Yes/No examples show both cases.

## Why

The logging cleanup PRs (#2670, #2680, #2681) established the
conventions in code but they weren't all written down:

- `cosmos.log.get_logger` for library code — already documented ✅
- lazy logging — already documented ✅
- **`self.log` inside operator instance methods — not documented** ❌ (this PR)

Capturing it keeps human contributors and AI agents (Cursor, Copilot,
Claude) from re-introducing the workaround #1157 removed.

Docs-only; one-paragraph + example change to `AGENTS.md`.

## Related

- closes the documentation gap from #1157
- documents the convention landed in #2798 (operator logging consistency)
- follows #2670, #2680, #2681 (logging cleanup) and #2679 (logging docs)
