### PR TITLE
Remove stale Airflow 2.3 comment on registry_conn_id default

### DIFF
--- a/cosmos/operators/azure_container_instance.py
+++ b/cosmos/operators/azure_container_instance.py
@@ -57,7 +57,7 @@ class DbtAzureContainerInstanceBaseOperator(AbstractDbtBase, AzureContainerInsta
         profile_config: ProfileConfig | None = None,
         remove_on_error: bool = False,
         fail_if_exists: bool = False,
-        registry_conn_id: str | None = None,  # need to add a default for Airflow 2.3 support
+        registry_conn_id: str | None = None,
         **kwargs: Any,
     ) -> None:
         self.profile_config = profile_config


### PR DESCRIPTION
## Summary

- The comment `# need to add a default for Airflow 2.3 support` next to `registry_conn_id: str | None = None` in `DbtAzureContainerInstanceBaseOperator.__init__` is obsolete.
- Cosmos requires `apache-airflow>=2.9.0` (`pyproject.toml:32`) and the CI test matrix runs against Airflow 2.9–3.2, so the "for Airflow 2.3 support" justification no longer applies.
- The default `None` itself is correct on its own merits — `registry_conn_id` is optional and only needed for private registries — so the value is kept; just the stale comment is removed.

## Test plan

- [x] CI passes (no behavioral change; this is a comment-only edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)