### PR TITLE
Skip redundant logging in the producer watcher task

### DIFF
--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -255,6 +255,13 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             upstream_failure_skipped_ids=self._upstream_failure_skipped_ids,
         )
 
+    def handle_exception_subprocess(self, result: Any) -> None:
+        """Skip the full_output dump — the process_log_line callback already logged each line."""
+        if self.skip_exit_code is not None and result.exit_code == self.skip_exit_code:
+            raise AirflowSkipException(f"dbt command returned exit code {self.skip_exit_code}. Skipping.")
+        elif result.exit_code != 0:
+            raise AirflowException(f"dbt command failed. The command returned a non-zero exit code {result.exit_code}.")
+
     def run_subprocess(self, command: list[str], env: dict[str, str], cwd: str, **kwargs: Any) -> Any:
         """Wire up per-line JSON log parsing before delegating to the subprocess runner.
 


### PR DESCRIPTION
## Description

Override `handle_exception_subprocess` on `DbtProducerWatcherOperator` to skip the redundant `logger.error("\n".join(result.full_output))` call on non-zero exit.

 In `WATCHER` mode, each dbt JSON log line is already parsed and logged individually by the process_log_line callback (`store_dbt_resource_status_from_log` → `_log_dbt_msg`). When dbt exits non-zero (e.g. test
  warnings/failures), the parent `DbtLocalBaseOperator.handle_exception_subprocess` re-dumps the entire captured subprocess output as a single `ERROR` log entry. This is redundant and makes producer watcher task logs extremely noisy — every run with a test warning produces a massive `ERROR` block containing all model start/finish events, snowflake tags, etc. that were already logged line-by-line.

 The override preserves the same exception behavior (raises A`irflowSkipException` for skip exit codes, `AirflowException` for all other non-zero exits) — it just removes the full output dump.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
