### PR TITLE
Instruct Claude Code to read AGENTS.md for commands before running them

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,4 +4,6 @@ This file is read by [Claude Code](https://claude.com/claude-code) (`claude.ai/c
 
 For project conventions (commands, architecture, coding standards, commit-message format, documentation style, etc.), see [`AGENTS.md`](AGENTS.md). That file is the single source of truth for agent-neutral guidance and is read by other AI coding agents (Cursor, Codex, Copilot, …) as well.
 
-This file is reserved for Claude Code-specific instructions that should not apply to other agents. There are currently none.
+## Always read AGENTS.md before running commands
+
+Before running tests, type-checks, linters, docs builds, or any project command — or before telling the user a command does not exist — read the relevant section of [`AGENTS.md`](AGENTS.md) and use the exact command written there. Do not guess, and do not fall back to a bare `pytest`/`mypy`/`black` invocation. In particular, tests run through hatch matrix environments whose names are not discoverable by guessing (e.g. `hatch run tests.py3.11-2.10-1.9:test`); the canonical form lives in the "Running Tests" section of AGENTS.md.


### PR DESCRIPTION
Adds a directive to CLAUDE.md telling Claude Code to read the relevant section of AGENTS.md and use the exact command written there before running tests, type-checks, linters, or docs builds (or before claiming a command does not exist), rather than guessing or falling back to a bare `pytest`/`mypy`/`black` invocation. Calls out the hatch matrix env naming (e.g. `hatch run tests.py3.11-2.10-1.9:test`) as the concrete reason, without duplicating the command list that already lives in AGENTS.md.

I believe this may have regressed after #2703, which moved every command/convention section out of CLAUDE.md into the new AGENTS.md and slimmed CLAUDE.md to a thin pointer. Command discovery worked fine before that, and I have been observing the agent miss these commands recurrently since. CLAUDE.md is still the file read on session start, so the commands are no longer in front of the agent by default and the non-obvious hatch env names get missed. This directive points the agent back to AGENTS.md without re-duplicating the content #2703 deliberately consolidated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)