### PR TITLE
Re-enable cross-project dbt ls example DAG in the dbt-loom CI job

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -540,9 +540,10 @@ jobs:
       POSTGRES_PORT: 5432
 
   Run-Integration-Tests-dbt-Loom:
-    # Dedicated job for cross_project_manifest_dag.py, which exercises dbt-loom.
-    # Carved out of Run-Integration-Tests so the loom job's dbt + loom versions
-    # can move independently of the main matrix.
+    # Dedicated job for the cross-project example DAGs (cross_project_manifest_dag.py
+    # and cross_project_dbt_ls_dag.py), which exercise dbt-loom. Carved out of
+    # Run-Integration-Tests so the loom job's dbt + loom versions can move
+    # independently of the main matrix.
     needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
@@ -591,7 +592,7 @@ jobs:
           uv pip install --system "hatch>=1.14.2"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
-      - name: Test cross_project_manifest_dag with dbt-loom installed
+      - name: Test cross-project dbt-loom example DAGs (manifest + dbt ls)
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-loom
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, enable-dbt-ls-cross-project-loom-ci]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, enable-dbt-ls-cross-project-loom-ci]
+    branches: [main]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/scripts/test/integration-dbt-loom.sh
+++ b/scripts/test/integration-dbt-loom.sh
@@ -46,14 +46,23 @@ else
     airflow db init
 fi
 
-# Run only the cross-project example DAG that exercises dbt-loom.
-# TEST_SINGLE_DAG makes test_example_dags.py build a DagBag containing only this
-# DAG (see get_dag_bag_single_dag). Without it, collection loads every example
-# DAG and asserts no import errors, which fails here because other DAGs need
-# secrets this job doesn't provide (e.g. DATABRICKS_CLUSTER_ID, S3 access).
+# Run the cross-project example DAGs that exercise dbt-loom: the manifest-based
+# DAG and the dbt ls-based DAG. Each is run in its own invocation because
+# TEST_SINGLE_DAG makes test_example_dags.py build a DagBag containing only the
+# named DAG (see get_dag_bag_single_dag). Without it, collection loads every
+# example DAG and asserts no import errors, which fails here because other DAGs
+# need secrets this job doesn't provide (e.g. DATABRICKS_CLUSTER_ID, S3 access).
 export TEST_SINGLE_DAG="cross_project_manifest_dag.py"
 pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
     "tests/test_example_dags.py::test_example_dag[cross_project_manifest_dag]"
+
+export TEST_SINGLE_DAG="cross_project_dbt_ls_dag.py"
+pytest -vv \
+    --cov=cosmos \
+    --cov-append \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    "tests/test_example_dags.py::test_example_dag[cross_project_dbt_ls_dag]"

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -27,14 +27,14 @@ IGNORED_DAG_FILES = [
     "performance_dag.py",
     "jaffle_shop_kubernetes.py",
     "jaffle_shop_watcher_kubernetes.py",
-    "cross_project_dbt_ls_dag.py",
 ]
 
-# cross_project_manifest_dag.py runs dbt subprocesses that need dbt-loom.
-# When dbt-loom isn't installed, the dedicated Run-Integration-Tests-dbt-Loom
-# CI job covers this DAG instead.
+# cross_project_manifest_dag.py and cross_project_dbt_ls_dag.py exercise dbt-loom
+# cross-project references and need dbt-loom installed. When it isn't, the
+# dedicated Run-Integration-Tests-dbt-Loom CI job covers these DAGs instead.
 if importlib.util.find_spec("dbt_loom") is None:
     IGNORED_DAG_FILES.append("cross_project_manifest_dag.py")
+    IGNORED_DAG_FILES.append("cross_project_dbt_ls_dag.py")
 
 
 @provide_session


### PR DESCRIPTION
`cross_project_dbt_ls_dag` (the `LoadMode.DBT_LS` cross-project example that exercises dbt-loom) has been disabled in the example-DAG tests since #2343. At that time dbt-loom had to be installed in a separate virtual environment due to dependency conflicts, so it was not resolvable in the DAG-parse process where `dbt ls` runs, and the DAG was added to the unconditional `IGNORED_DAG_FILES` list.

That constraint no longer applies in the dedicated dbt-loom CI job added in #2761:

- `scripts/test/integration-dbt-loom.sh` installs dbt-loom in both the main env and `venv-subprocess`, so loom is resolvable where `dbt ls` runs.
- The upstream `manifest.json` that dbt-loom reads (via `downstream/dbt_loom.config.yml`) is committed under `dev/dags/dbt/cross_project/upstream/target`, so it already exists at parse time with no generation step required.

The manifest DAG was re-enabled conditionally in #2761, but the dbt ls DAG was left unconditionally ignored, only as leftover from #2343.

This change:

- Removes `cross_project_dbt_ls_dag.py` from the unconditional `IGNORED_DAG_FILES` and guards it behind `find_spec("dbt_loom")` alongside `cross_project_manifest_dag.py`, so non-loom runs still skip it.
- Runs the dbt ls DAG in the dbt-loom CI job via a second `TEST_SINGLE_DAG` invocation.
- Updates the related job comment and step name to cover both cross-project DAGs.


🤖 Generated with [Claude Code](https://claude.com/claude-code)