### PR TITLE
Add test coverage for DbtModel._extract_config branches

### DIFF
--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -221,7 +221,6 @@ class DbtModel:
                     selector_config |= set(extracted_config) if isinstance(extracted_config, (str, list)) else set()
         return selector_config
 
-    # TODO following needs coverage:
     def _extract_config(self, kwarg: Any, config_name: str) -> Any:
         if hasattr(kwarg, "key") and kwarg.key == config_name:
             try:

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -151,6 +151,10 @@ class KeywordArgValueStr(KeywordArgValue, str):
     pass
 
 
+class KeywordArgValueInt(KeywordArgValue, int):
+    pass
+
+
 @dataclass
 class KeywordArg:
     key: str
@@ -196,6 +200,22 @@ def test_dbtmodelconfig_extract_config_with_kwarg_str():
     computed = dbt_model._extract_config(kwarg, config_name)
     expected = ["some_conf:abc"]
     assert computed == expected
+
+
+def test_dbtmodelconfig_extract_config_with_kwarg_key_mismatch():
+    dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=SAMPLE_MODEL_SQL_PATH)
+    kwarg = KeywordArg(key="other_conf", value=KeywordArgValueStr("abc"))
+    config_name = "some_conf"
+    computed = dbt_model._extract_config(kwarg, config_name)
+    assert computed is None
+
+
+def test_dbtmodelconfig_extract_config_with_kwarg_non_list_non_str():
+    dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=SAMPLE_MODEL_SQL_PATH)
+    kwarg = KeywordArg(key="some_conf", value=KeywordArgValueInt(5))
+    config_name = "some_conf"
+    computed = dbt_model._extract_config(kwarg, config_name)
+    assert computed == 5
 
 
 def test_dbtmodelconfig_with_sources(tmp_path):


### PR DESCRIPTION
## Description

`DbtModel._extract_config` carried a `# TODO following needs coverage:` comment, but it already had four tests. Two real branches were still uncovered, so this PR closes those gaps and removes the now-satisfied TODO.

### Branches now covered

1. **Key mismatch** — `kwarg` has a `.key` but it doesn't equal `config_name`, so the method short-circuits and returns `None`. The pre-existing `non_kwarg` test only exercised the `hasattr(kwarg, "key")` -False path (via a plain `dict`).
2. **Non-list / non-str value** — `kwarg.value.as_const()` returns a value that is neither a `list` nor a `str` (e.g. an `int`), which is returned raw without the `config_name:` prefix.

### Changes

- `cosmos/dbt/parser/project.py` — remove the stale `# TODO following needs coverage:` comment.
- `tests/dbt/parser/test_project.py` — add a `KeywordArgValueInt` test helper plus `test_dbtmodelconfig_extract_config_with_kwarg_key_mismatch` and `test_dbtmodelconfig_extract_config_with_kwarg_non_list_non_str`.

### Testing

`tests/dbt/parser/test_project.py` — 17 passed (was 15). No production behavior changes; tests only (plus a comment removal).

🤖 Generated with [Claude Code](https://claude.com/claude-code)