### PR TITLE
Save dependency cache in unit, telemetry and performance CI jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -159,7 +159,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -728,7 +728,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip
@@ -788,7 +788,7 @@ jobs:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
 
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: |
             ~/.cache/pip


### PR DESCRIPTION
## What

Switch the **unit**, **telemetry**, and **performance** test jobs from `actions/cache/restore` (restore-only) to `actions/cache` (read-write), so their dependency caches actually populate and get reused.

## Why

Those three jobs use restore-only cache steps, but **no job ever writes** the `unit-`, `telemetry-`, or `perf-test-` cache keys, and there's no `restore-keys` fallback. So the keys can never be populated — every run is a guaranteed cache miss.

Verified against the latest `main` run:

```
Run-Unit-Tests:        Cache not found for input keys: unit-Linux-3.11-2.10-1.10-…
                       → cold install: uv resolves ~390 packages, builds dbt-core/airflow (~40-60s)

Run-Integration-Tests: Cache hit for: integration-Linux-3.11-2.10--1.11…
                       Cache restored successfully   ← read-write cache, already works
```

The only difference between the two is restore-only vs read-write. This affects **~31 jobs per run** (20 unit + 10 performance + 1 telemetry), each redoing the full hatch-env build before any test executes — and it delays the unit-test signal contributors wait on first.

## The fix

3 lines — `actions/cache/restore@…` → `actions/cache@…` in those jobs, matching the integration jobs.

## Storage tradeoff (please sanity-check)

This adds ~23 frequently-used cache keys (≈1.6–2 GB, extrapolated from existing per-key sizes: integration ~71 MB, async ~123 MB) to a repo that **already carries a large cache footprint — ~13.5 GB across 147 entries** (`actions/cache/usage` API).

GitHub's LRU eviction should absorb this: of the 46 `integration` and 36 `integration-dbt-async` entries, only ~20 and ~12 are current — the rest are stale `pyproject.toml`/version variants that get evicted first, while the new caches stay warm since they run on every CI invocation. A maintainer with visibility into this repo's cache limit may want to confirm the added footprint is comfortable.

🤖 Generated with Claude Code (https://claude.com/claude-code)