### PR TITLE
Support per-node callbacks via string import paths

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -178,7 +178,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     :param profile_config: ProfileConfig Object
     :param install_deps (deprecated): If true, install dependencies before running the command
     :param copy_dbt_packages: If true, copy pre-existing `dbt_packages` (before running dbt deps)
-    :param callback: A callback function called on after a dbt run with a path to the dbt project directory.
+    :param callback: A callback function, or list of functions, called after a dbt run with a path to the dbt
+        project directory. Each callback may also be given as a string import path (for example
+        "cosmos.io.upload_to_aws_s3"), which is resolved at runtime. This makes it possible to set a callback
+        per dbt node through meta.cosmos.operator_kwargs, where a function object cannot be expressed.
     :param manifest_filepath: The path to the user-defined Manifest file. It's "" by default.
     :param target_name: A name to use for the dbt target. If not provided, and no target is found
         in your project's dbt_project.yml, "cosmos_target" is used.
@@ -216,7 +219,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         install_deps: bool | str = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         manifest_filepath: str = "",
-        callback: Callable[[str], None] | list[Callable[[str], None]] | None = None,
+        callback: str | Callable[[str], None] | list[str | Callable[[str], None]] | None = None,
         callback_args: dict[str, Any] | None = None,
         should_store_compiled_sql: bool = True,
         should_upload_compiled_sql: bool = False,
@@ -645,11 +648,12 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
         if self.callback:
             self.callback_args.update({"context": context})
-            if isinstance(self.callback, list):
-                for callback_fn in self.callback:
-                    callback_fn(tmp_project_dir, **self.callback_args)
-            else:
-                self.callback(tmp_project_dir, **self.callback_args)
+            callbacks = self.callback if isinstance(self.callback, list) else [self.callback]
+            for callback_fn in callbacks:
+                if isinstance(callback_fn, str):
+                    module_path, method_name = callback_fn.rsplit(".", 1)
+                    callback_fn = load_method_from_module(module_path, method_name)
+                callback_fn(tmp_project_dir, **self.callback_args)
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if settings.enable_setup_async_task:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -219,7 +219,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         install_deps: bool | str = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         manifest_filepath: str = "",
-        callback: str | Callable[[str], None] | list[str | Callable[[str], None]] | None = None,
+        callback: str | Callable[..., Any] | list[str | Callable[..., Any]] | None = None,
         callback_args: dict[str, Any] | None = None,
         should_store_compiled_sql: bool = True,
         should_upload_compiled_sql: bool = False,
@@ -650,10 +650,23 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.callback_args.update({"context": context})
             callbacks = self.callback if isinstance(self.callback, list) else [self.callback]
             for callback_fn in callbacks:
-                if isinstance(callback_fn, str):
-                    module_path, method_name = callback_fn.rsplit(".", 1)
-                    callback_fn = load_method_from_module(module_path, method_name)
-                callback_fn(tmp_project_dir, **self.callback_args)
+                self._resolve_callback(callback_fn)(tmp_project_dir, **self.callback_args)
+
+    @staticmethod
+    def _resolve_callback(callback: str | Callable[..., Any]) -> Callable[..., Any]:
+        """Resolve a callback given as a string import path into a callable. Callables are returned as-is."""
+        if not isinstance(callback, str):
+            return callback
+        if "." not in callback:
+            raise CosmosValueError(
+                f"Invalid callback import path {callback!r}. Use a full import path, "
+                f"for example 'cosmos.io.upload_to_aws_s3'."
+            )
+        module_path, method_name = callback.rsplit(".", 1)
+        resolved = load_method_from_module(module_path, method_name)
+        if not callable(resolved):
+            raise CosmosValueError(f"Callback {callback!r} did not resolve to a callable.")
+        return resolved
 
     def _handle_async_execution(self, tmp_project_dir: str, context: Context, async_context: dict[str, Any]) -> None:
         if settings.enable_setup_async_task:

--- a/docs/guides/run_dbt/callbacks/callbacks.rst
+++ b/docs/guides/run_dbt/callbacks/callbacks.rst
@@ -69,6 +69,30 @@ The path naming convention is:
 
 If users are unhappy with this structure or format, they can implement similar methods, which can be based (or not) on the Cosmos standard ones.
 
+Example: Per-Node Callbacks
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Individual dbt nodes can override operator arguments through ``meta.cosmos.operator_kwargs`` in the dbt YAML.
+A function object cannot be expressed in YAML, so the ``callback`` is given here as a string import path that
+Cosmos resolves at runtime. ``callback_args`` are passed through unchanged.
+
+.. code-block:: yaml
+
+    version: 2
+
+    models:
+      - name: model_with_custom_callback
+        meta:
+          cosmos:
+            operator_kwargs:
+              callback: "cosmos.io.upload_to_aws_s3"
+              callback_args:
+                aws_conn_id: "aws_s3_conn"
+                bucket_name: "cosmos-artifacts-upload"
+
+The string can point to a built-in helper in ``cosmos/io.py`` or to any importable function in your project.
+A list of import paths is also accepted, and the entries may mix string paths with function objects.
+
 Custom Callbacks
 ~~~~~~~~~~~~~~~~
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -2141,6 +2141,18 @@ def test_handle_post_execution_with_mixed_callbacks(
     resolved_callback.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)
 
 
+def test_resolve_callback_rejects_path_without_module():
+    with pytest.raises(CosmosValueError, match="Invalid callback import path"):
+        ConcreteDbtLocalBaseOperator._resolve_callback("upload_to_aws_s3")
+
+
+@patch("cosmos.operators.local.load_method_from_module")
+def test_resolve_callback_rejects_non_callable(mock_load_method):
+    mock_load_method.return_value = "not-a-callable"
+    with pytest.raises(CosmosValueError, match="did not resolve to a callable"):
+        ConcreteDbtLocalBaseOperator._resolve_callback("cosmos.io.SOME_CONSTANT")
+
+
 @pytest.mark.integration
 @patch("cosmos.operators.local.AbstractDbtLocalBase._configure_remote_target_path")
 @patch("cosmos.operators.local.ObjectStoragePath")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -2091,6 +2091,56 @@ def test_handle_post_execution_with_multiple_callbacks(
         callback_fn.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)
 
 
+@patch("cosmos.operators.local.load_method_from_module")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_freshness_json")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_compiled_sql")
+@patch("cosmos.operators.local.AbstractDbtLocalBase._override_rtif")
+def test_handle_post_execution_with_string_callback(
+    mock_override_rtif, mock_store_compiled_sql, mock_store_freshness_json, mock_load_method
+):
+    resolved_callback = MagicMock()
+    mock_load_method.return_value = resolved_callback
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config,
+        task_id="my-task",
+        project_dir="my/dir",
+        callback="cosmos.io.upload_to_aws_s3",
+        callback_args={"arg1": "value1"},
+    )
+
+    context = {"dag_run": MagicMock(), "task": MagicMock()}
+    operator._handle_post_execution("/tmp/project_dir", context)
+
+    mock_load_method.assert_called_once_with("cosmos.io", "upload_to_aws_s3")
+    resolved_callback.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)
+
+
+@patch("cosmos.operators.local.load_method_from_module")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_freshness_json")
+@patch("cosmos.operators.local.AbstractDbtLocalBase.store_compiled_sql")
+@patch("cosmos.operators.local.AbstractDbtLocalBase._override_rtif")
+def test_handle_post_execution_with_mixed_callbacks(
+    mock_override_rtif, mock_store_compiled_sql, mock_store_freshness_json, mock_load_method
+):
+    resolved_callback = MagicMock()
+    mock_load_method.return_value = resolved_callback
+    direct_callback = MagicMock()
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config,
+        task_id="my-task",
+        project_dir="my/dir",
+        callback=[direct_callback, "cosmos.io.upload_to_aws_s3"],
+        callback_args={"arg1": "value1"},
+    )
+
+    context = {"dag_run": MagicMock(), "task": MagicMock()}
+    operator._handle_post_execution("/tmp/project_dir", context)
+
+    mock_load_method.assert_called_once_with("cosmos.io", "upload_to_aws_s3")
+    direct_callback.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)
+    resolved_callback.assert_called_once_with("/tmp/project_dir", arg1="value1", context=context)
+
+
 @pytest.mark.integration
 @patch("cosmos.operators.local.AbstractDbtLocalBase._configure_remote_target_path")
 @patch("cosmos.operators.local.ObjectStoragePath")


### PR DESCRIPTION
## Description

Per-node `operator_kwargs` already forwards `callback` to the local operator, but a callback set through dbt YAML comes throughh as a string import path and was called as-is, which fails... this resolves string callbacks to callables at runtime with the existing `load_method_from_module` helper, so a callback can be set per dbt node via `meta.cosmos.operator_kwargs`. A list may mix string paths and function objects.

## Related Issue(s)

Closes #1515

## Breaking Change?

No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works