### PR TITLE
fix: suppress Asset URI warning when use_data_set_airflow3_uri_standa…

### DIFF
--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -224,17 +224,17 @@ def construct_dataset_uri(namespace: str, name: str) -> str:
         )
         return airflow_2_uri
 
-        if not settings.use_dataset_airflow3_uri_standard:
-            logger.warning(
-                "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
-                "(standard used by Cosmos) are no longer accepted. "
-                "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
-                "Before, with Airflow 2.x, the URI used to be <%s>. "
-                "Please, change any DAGs that were scheduled using the old standard to the new one.",
-                airflow_3_uri,
-                airflow_2_uri,
-            )
-        return airflow_3_uri
+    if not settings.use_dataset_airflow3_uri_standard:
+        logger.warning(
+            "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
+            "(standard used by Cosmos) are no longer accepted. "
+            "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
+            "Before, with Airflow 2.x, the URI used to be <%s>. "
+            "Please, change any DAGs that were scheduled using the old standard to the new one.",
+            airflow_3_uri,
+            airflow_2_uri,
+        )
+    return airflow_3_uri
 
 
 def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict[str, list[str]]:

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -226,14 +226,14 @@ def construct_dataset_uri(namespace: str, name: str) -> str:
 
         if not settings.use_dataset_airflow3_uri_standard:
             logger.warning(
-           "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
-           "(standard used by Cosmos) are no longer accepted. "
-           "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
-           "Before, with Airflow 2.x, the URI used to be <%s>. "
-           "Please, change any DAGs that were scheduled using the old standard to the new one.",
-           airflow_3_uri,
-           airflow_2_uri,
-        )
+                "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
+                "(standard used by Cosmos) are no longer accepted. "
+                "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
+                "Before, with Airflow 2.x, the URI used to be <%s>. "
+                "Please, change any DAGs that were scheduled using the old standard to the new one.",
+                airflow_3_uri,
+                airflow_2_uri,
+            )
         return airflow_3_uri
 
 

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -224,16 +224,17 @@ def construct_dataset_uri(namespace: str, name: str) -> str:
         )
         return airflow_2_uri
 
-    logger.warning(
-        "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
-        "(standard used by Cosmos) are no longer accepted. "
-        "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
-        "Before, with Airflow 2.x, the URI used to be <%s>. "
-        "Please, change any DAGs that were scheduled using the old standard to the new one.",
-        airflow_3_uri,
-        airflow_2_uri,
-    )
-    return airflow_3_uri
+        if not settings.use_dataset_airflow3_uri_standard:
+            logger.warning(
+           "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
+           "(standard used by Cosmos) are no longer accepted. "
+           "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
+           "Before, with Airflow 2.x, the URI used to be <%s>. "
+           "Please, change any DAGs that were scheduled using the old standard to the new one.",
+           airflow_3_uri,
+           airflow_2_uri,
+        )
+        return airflow_3_uri
 
 
 def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict[str, list[str]]:

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -246,7 +246,7 @@ class TestConstructDatasetUri:
         mock_settings.use_dataset_airflow3_uri_standard = True
         uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
         assert uri == "postgres://host:5432/mydb/public/customers"
-  
+
     @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
     @patch("cosmos.dataset.settings")
     def test_airflow3_uri(self, mock_settings):
@@ -260,6 +260,7 @@ class TestConstructDatasetUri:
         mock_settings.use_dataset_airflow3_uri_standard = True
         uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
         assert uri == "postgres://host:5432/mydb/public/customers"
+
 
 # --- Tests for compute_model_outlet_uris ---
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -246,12 +246,20 @@ class TestConstructDatasetUri:
         mock_settings.use_dataset_airflow3_uri_standard = True
         uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
         assert uri == "postgres://host:5432/mydb/public/customers"
-
+  
     @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
-    def test_airflow3_uri(self):
+    @patch("cosmos.dataset.settings")
+    def test_airflow3_uri(self, mock_settings):
+        mock_settings.use_dataset_airflow3_uri_standard = False
         uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
         assert uri == "postgres://host:5432/mydb/public/customers"
 
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_airflow3_uri_no_warning_when_flag_set(self, mock_settings):
+        mock_settings.use_dataset_airflow3_uri_standard = True
+        uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
+        assert uri == "postgres://host:5432/mydb/public/customers"
 
 # --- Tests for compute_model_outlet_uris ---
 


### PR DESCRIPTION

…rds is set on Airflow 3

## Description

When `USE_DATASET_AIRFLOW3_URI_STANDARD=True` is set, the Asset URI 
migration warning was still being logged on every model in Airflow 3, 
causing 1000+ noisy warnings per run.

The Airflow 2 code path already correctly skips the warning when the 
flag is set, but the Airflow 3 code path was unconditionally logging it.

Added the same `if not settings.use_dataset_airflow3_uri_standard` 
check to the Airflow 3 code path to suppress the warning when the 
user has already opted into the new URI standard.

## Related Issue(s)

Closes #2778

## Breaking Change?

No

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works