### PR TITLE
Refactor seed checksum hashing and caching helpers

### DIFF
--- a/cosmos/cache.py
+++ b/cosmos/cache.py
@@ -153,11 +153,11 @@ def _create_seed_checksum_key(dag_task_group_identifier: str, unique_id: str) ->
     store the checksum under a fixed-length key: a readable prefix plus a stable hash of the full
     identifier, ensuring long DAG ids / nested task groups / package+resource names never overflow it.
     """
-    digest = hashlib.sha1(f"{dag_task_group_identifier}:{unique_id}".encode()).hexdigest()
+    digest = hashlib.md5(f"{dag_task_group_identifier}:{unique_id}".encode()).hexdigest()
     return f"{VAR_KEY_SEED_CHECKSUM_PREFIX}{digest}"
 
 
-def get_seed_checksum(dag_task_group_identifier: str, unique_id: str) -> str | None:
+def get_cache_seed_checksum(dag_task_group_identifier: str, unique_id: str) -> str | None:
     """Return the seed's last persisted checksum, or ``None`` when none is stored or it cannot be read.
 
     Best-effort: change detection must never fail a seed task, so a missing value or a transient
@@ -172,7 +172,7 @@ def get_seed_checksum(dag_task_group_identifier: str, unique_id: str) -> str | N
     return checksum
 
 
-def store_seed_checksum(dag_task_group_identifier: str, unique_id: str, checksum: str) -> None:
+def store_cache_seed_checksum(dag_task_group_identifier: str, unique_id: str, checksum: str) -> None:
     """Persist a seed's checksum after a successful run.
 
     Best-effort: a failure to store the checksum must never fail a seed that already loaded successfully,

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -65,7 +65,7 @@ from cosmos.dbt.project import (
     has_non_empty_dependencies_file,
 )
 from cosmos.dbt.selector import YamlSelectors, select_nodes
-from cosmos.fs import calculate_file_checksum
+from cosmos.fs import _calculate_file_checksum
 from cosmos.log import get_logger
 
 logger = get_logger(__name__)
@@ -127,7 +127,7 @@ class DbtNode:
         """
         if self.resource_type != DbtResourceType.SEED:
             return None
-        return calculate_file_checksum(self.file_path)
+        return _calculate_file_checksum(self.file_path)
 
     @property
     def has_ephemeral_materialization(self) -> bool:

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import base64
 import datetime
 import functools
-import hashlib
 import itertools
 import json
 import os
@@ -66,26 +65,10 @@ from cosmos.dbt.project import (
     has_non_empty_dependencies_file,
 )
 from cosmos.dbt.selector import YamlSelectors, select_nodes
+from cosmos.fs import calculate_file_checksum
 from cosmos.log import get_logger
 
 logger = get_logger(__name__)
-
-# Read the seed file in fixed-size chunks when checksumming so a large CSV does not have to be loaded
-# into memory all at once.
-_CHECKSUM_READ_CHUNK_SIZE = 1024 * 1024
-
-
-def _calculate_file_checksum(file_path: Path) -> str | None:
-    """Return the SHA256 checksum of a file, streaming it in chunks, or ``None`` if it cannot be read."""
-    digest = hashlib.sha256()
-    try:
-        with open(file_path, "rb") as file:
-            for chunk in iter(lambda: file.read(_CHECKSUM_READ_CHUNK_SIZE), b""):
-                digest.update(chunk)
-    except OSError as exc:
-        logger.warning("Unable to read file `%s` to compute its checksum: %s", file_path, exc)
-        return None
-    return digest.hexdigest()
 
 
 def _normalize_path(path: str | None) -> str:
@@ -131,17 +114,20 @@ class DbtNode:
         """Combined path to the node's file (path_base / original_file_path)."""
         return self.path_base / self.original_file_path
 
-    @property
+    @cached_property
     def checksum(self) -> str | None:
-        """SHA256 checksum of a seed's CSV content, used by ``SeedRenderingBehavior.WHEN_SEED_CHANGES``.
+        """MD5 checksum of a seed's CSV content, used by ``SeedRenderingBehavior.WHEN_SEED_CHANGES``.
 
         Although ``manifest.json`` records a checksum per node, we always recompute it from the seed file
         here so the value is consistent regardless of whether the project was loaded via ``LoadMode.MANIFEST``
         or ``LoadMode.DBT_LS``. Returns ``None`` for non-seed nodes or when the file cannot be read.
+
+        Cached because the value is derived from the seed file at parse time and is read again when building
+        the task's ``extra_context``; the file is not expected to change within a single parse.
         """
         if self.resource_type != DbtResourceType.SEED:
             return None
-        return _calculate_file_checksum(self.file_path)
+        return calculate_file_checksum(self.file_path)
 
     @property
     def has_ephemeral_materialization(self) -> bool:

--- a/cosmos/fs.py
+++ b/cosmos/fs.py
@@ -1,9 +1,35 @@
 from __future__ import annotations
 
+import hashlib
 import os
 import shutil
 import tempfile
 from pathlib import Path
+
+from cosmos.log import get_logger
+
+logger = get_logger(__name__)
+
+# Read the file in fixed-size chunks when checksumming so a large file (e.g. a seed CSV) does not have
+# to be loaded into memory all at once.
+_CHECKSUM_READ_CHUNK_SIZE = 1024 * 1024
+
+
+def calculate_file_checksum(file_path: Path) -> str | None:
+    """Return the MD5 checksum of a file, streaming it in chunks, or ``None`` if it cannot be read.
+
+    MD5 is used for consistency with the other non-cryptographic content/identifier hashes across Cosmos
+    (e.g. ``cosmos/cache.py``, ``cosmos/versioning.py``); this is change detection, not a security boundary.
+    """
+    digest = hashlib.md5()
+    try:
+        with open(file_path, "rb") as file:
+            for chunk in iter(lambda: file.read(_CHECKSUM_READ_CHUNK_SIZE), b""):
+                digest.update(chunk)
+    except OSError as exc:
+        logger.warning("Unable to read file `%s` to compute its checksum: %s", file_path, exc)
+        return None
+    return digest.hexdigest()
 
 
 def safe_copy(src: Path, dst: Path) -> None:

--- a/cosmos/fs.py
+++ b/cosmos/fs.py
@@ -15,7 +15,7 @@ logger = get_logger(__name__)
 _CHECKSUM_READ_CHUNK_SIZE = 1024 * 1024
 
 
-def calculate_file_checksum(file_path: Path) -> str | None:
+def _calculate_file_checksum(file_path: Path) -> str | None:
     """Return the MD5 checksum of a file, streaming it in chunks, or ``None`` if it cannot be read.
 
     MD5 is used for consistency with the other non-cryptographic content/identifier hashes across Cosmos

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -41,9 +41,9 @@ from cosmos._utils.importer import load_method_from_module
 from cosmos.cache import (
     _copy_cached_package_lockfile_to_project,
     _get_latest_cached_package_lockfile,
-    get_seed_checksum,
+    get_cache_seed_checksum,
     is_cache_package_lockfile_enabled,
-    store_seed_checksum,
+    store_cache_seed_checksum,
 )
 from cosmos.constants import (
     _AIRFLOW3_MAJOR_VERSION,
@@ -1072,7 +1072,7 @@ class DbtSeedLocalOperator(DbtSeedMixin, DbtLocalBaseOperator):
         # under. When both are available, skip the run if the checksum matches the last successful run;
         # otherwise fall back to always running the seed (change detection is best-effort).
         if current_seed_checksum and dag_task_group_identifier and unique_id:
-            last_run_seed_checksum = get_seed_checksum(dag_task_group_identifier, unique_id)
+            last_run_seed_checksum = get_cache_seed_checksum(dag_task_group_identifier, unique_id)
             should_run = last_run_seed_checksum != current_seed_checksum
             if not should_run:
                 # Return successfully (do NOT raise AirflowSkipException) so downstream models that depend
@@ -1080,7 +1080,7 @@ class DbtSeedLocalOperator(DbtSeedMixin, DbtLocalBaseOperator):
                 self.log.info("Seed `%s` is unchanged since its last successful run; skipping `dbt seed`.", unique_id)
                 return
             super().execute(context, **kwargs)
-            store_seed_checksum(dag_task_group_identifier, unique_id, current_seed_checksum)
+            store_cache_seed_checksum(dag_task_group_identifier, unique_id, current_seed_checksum)
             return
 
         super().execute(context, **kwargs)

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -138,7 +138,7 @@ def test_dbt_node_name_and_select(unique_id, expected_name, expected_select):
     assert node.resource_name == expected_select
 
 
-def test_dbt_node_checksum_computes_sha256_of_seed_file(tmp_path):
+def test_dbt_node_checksum_computes_md5_of_seed_file(tmp_path):
     import hashlib
 
     content = b"id,name\n1,alice\n"
@@ -150,7 +150,7 @@ def test_dbt_node_checksum_computes_sha256_of_seed_file(tmp_path):
         path_base=tmp_path,
         original_file_path=Path("my_seed.csv"),
     )
-    assert node.checksum == hashlib.sha256(content).hexdigest()
+    assert node.checksum == hashlib.md5(content).hexdigest()
 
 
 def test_dbt_node_checksum_is_none_for_non_seed_nodes(tmp_path):

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -38,11 +38,11 @@ from cosmos.cache import (
     _update_partial_parse_cache,
     create_cache_profile,
     delete_unused_dbt_cache,
+    get_cache_seed_checksum,
     get_cached_profile,
-    get_seed_checksum,
     is_cache_package_lockfile_enabled,
     is_profile_cache_enabled,
-    store_seed_checksum,
+    store_cache_seed_checksum,
     were_yaml_selectors_modified,
 )
 from cosmos.constants import (
@@ -494,33 +494,33 @@ def test_create_seed_checksum_key_is_bounded_prefixed_and_scoped():
 
 
 @patch("cosmos.cache.Variable")
-def test_get_seed_checksum_returns_stored_value(mock_variable):
+def test_get_cache_seed_checksum_returns_stored_value(mock_variable):
     mock_variable.get.return_value = "stored-checksum"
-    assert get_seed_checksum("my_dag", "seed.pkg.my_seed") == "stored-checksum"
+    assert get_cache_seed_checksum("my_dag", "seed.pkg.my_seed") == "stored-checksum"
     mock_variable.get.assert_called_once_with(_create_seed_checksum_key("my_dag", "seed.pkg.my_seed"), default_var=None)
 
 
 @patch("cosmos.cache.Variable")
-def test_get_seed_checksum_swallows_backend_errors(mock_variable, caplog):
+def test_get_cache_seed_checksum_swallows_backend_errors(mock_variable, caplog):
     from sqlalchemy.exc import SQLAlchemyError
 
     mock_variable.get.side_effect = SQLAlchemyError("db down")
     caplog.set_level(logging.WARNING)
-    assert get_seed_checksum("my_dag", "seed.pkg.my_seed") is None
+    assert get_cache_seed_checksum("my_dag", "seed.pkg.my_seed") is None
     assert "Failed to read seed checksum" in caplog.text
 
 
 @patch("cosmos.cache.Variable")
-def test_store_seed_checksum_persists_value(mock_variable):
-    store_seed_checksum("my_dag", "seed.pkg.my_seed", "new-checksum")
+def test_store_cache_seed_checksum_persists_value(mock_variable):
+    store_cache_seed_checksum("my_dag", "seed.pkg.my_seed", "new-checksum")
     mock_variable.set.assert_called_once_with(_create_seed_checksum_key("my_dag", "seed.pkg.my_seed"), "new-checksum")
 
 
 @patch("cosmos.cache.Variable")
-def test_store_seed_checksum_swallows_backend_errors(mock_variable, caplog):
+def test_store_cache_seed_checksum_swallows_backend_errors(mock_variable, caplog):
     from airflow.exceptions import AirflowException
 
     mock_variable.set.side_effect = AirflowException("cannot write")
     caplog.set_level(logging.WARNING)
-    store_seed_checksum("my_dag", "seed.pkg.my_seed", "new-checksum")  # must not raise
+    store_cache_seed_checksum("my_dag", "seed.pkg.my_seed", "new-checksum")  # must not raise
     assert "Failed to persist seed checksum" in caplog.text

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import hashlib
+import logging
 from pathlib import Path
 from unittest.mock import patch
 
 import pytest
 
-from cosmos.fs import safe_copy
+from cosmos.fs import calculate_file_checksum, safe_copy
 
 
 def test_safe_copy_writes_destination(tmp_path: Path) -> None:
@@ -41,3 +43,25 @@ def test_safe_copy_cleans_up_temp_file_on_failure(tmp_path: Path) -> None:
     # The temp file created next to dst must not be left behind.
     assert list(tmp_path.iterdir()) == [src]
     assert not dst.exists()
+
+
+def test_calculate_file_checksum_matches_md5(tmp_path: Path) -> None:
+    content = b"id,name\n1,alice\n2,bob\n"
+    file_path = tmp_path / "seed.csv"
+    file_path.write_bytes(content)
+
+    assert calculate_file_checksum(file_path) == hashlib.md5(content).hexdigest()
+
+
+def test_calculate_file_checksum_is_stable_across_calls(tmp_path: Path) -> None:
+    file_path = tmp_path / "seed.csv"
+    file_path.write_bytes(b"a" * (2 * 1024 * 1024))  # larger than one read chunk
+
+    assert calculate_file_checksum(file_path) == calculate_file_checksum(file_path)
+
+
+def test_calculate_file_checksum_returns_none_when_unreadable(tmp_path: Path, caplog) -> None:
+    caplog.set_level(logging.WARNING)
+
+    assert calculate_file_checksum(tmp_path / "missing.csv") is None
+    assert "Unable to read file" in caplog.text

--- a/tests/test_fs.py
+++ b/tests/test_fs.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
-from cosmos.fs import calculate_file_checksum, safe_copy
+from cosmos.fs import _calculate_file_checksum, safe_copy
 
 
 def test_safe_copy_writes_destination(tmp_path: Path) -> None:
@@ -50,18 +50,18 @@ def test_calculate_file_checksum_matches_md5(tmp_path: Path) -> None:
     file_path = tmp_path / "seed.csv"
     file_path.write_bytes(content)
 
-    assert calculate_file_checksum(file_path) == hashlib.md5(content).hexdigest()
+    assert _calculate_file_checksum(file_path) == hashlib.md5(content).hexdigest()
 
 
 def test_calculate_file_checksum_is_stable_across_calls(tmp_path: Path) -> None:
     file_path = tmp_path / "seed.csv"
     file_path.write_bytes(b"a" * (2 * 1024 * 1024))  # larger than one read chunk
 
-    assert calculate_file_checksum(file_path) == calculate_file_checksum(file_path)
+    assert _calculate_file_checksum(file_path) == _calculate_file_checksum(file_path)
 
 
 def test_calculate_file_checksum_returns_none_when_unreadable(tmp_path: Path, caplog) -> None:
     caplog.set_level(logging.WARNING)
 
-    assert calculate_file_checksum(tmp_path / "missing.csv") is None
+    assert _calculate_file_checksum(tmp_path / "missing.csv") is None
     assert "Unable to read file" in caplog.text


### PR DESCRIPTION
## Description

Follow-up to #2755 addressing review feedback on the seed rendering work.

- Move the streaming file-checksum helper out of `cosmos/dbt/graph.py` into `cosmos/fs.py` as `_calculate_file_checksum`, alongside `safe_copy`, since it is a generic, dependency-free file utility. The seed-cache persistence stays in `cosmos/cache.py`.
- Make `DbtNode.checksum` a `cached_property`: the value is derived from the seed file at parse time and read again when building the task `extra_context`.
- Standardize seed checksum hashing on `md5`, matching the other non-cryptographic content and identifier hashes across Cosmos (`cosmos/cache.py`, `cosmos/versioning.py`, `cosmos/dbt/selector.py`). Both the seed content checksum and the Airflow Variable key derivation now use `md5`.
- Rename `get_seed_checksum`/`store_seed_checksum` to `get_cache_seed_checksum`/`store_cache_seed_checksum` to convey that they read and write the last cached seed checksum.

The seed-content checksum algorithm changed from `sha256` to `md5` and the Variable key derivation from `sha1` to `md5`. This feature has not been released, so no persisted checksum Variables depend on the previous derivation.

## Related Issue(s)

Closes astronomer/oss-integrations-private#444

🤖 Generated with [Claude Code](https://claude.com/claude-code)