### PR TITLE
Bump codecov-action to v6.0.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, worktree-codecov-action-bump]
+    branches: [main]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    branches: [main, worktree-codecov-action-bump]
   # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
   # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
   # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -937,7 +937,7 @@ jobs:
           coverage report
           coverage xml
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@e79a6962e0d4c0c17b229090214935d2e33f8354  # v6.0.1
+        uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f  # v6.0.2
         with:
           fail_ci_if_error: true
           token: ${{ secrets.CODECOV_TOKEN }}


### PR DESCRIPTION
## Description

Bumps `codecov/codecov-action` from `v6.0.1` to `v6.0.2`, pinned to commit `fb8b3582c8e4def4969c97caa2f19720cb33a72f`.

`v6.0.1` and earlier are broken by Codecov's Keybase/GPG account migration, which fails GPG verification and causes the coverage upload to fail on **every PR** as can be seen in our [failed CI run](https://github.com/astronomer/astronomer-cosmos/actions/runs/27127281043/job/80085509401?pr=2784#step:7:320)  (see [codecov/codecov-action#1956](https://github.com/codecov/codecov-action/issues/1956)). `v6.0.2` carries the fix.

### Cooldown exception

We are intentionally making an exception to the Dependabot 7-day github-actions cooldown (`.github/dependabot.yml`) for this bump. `v6.0.2` was released on 2026-06-07, so Dependabot would not pick it up for several more days, during which Codecov keeps failing on all PRs. Bumping manually now unblocks CI.

### Version choice

`v6.0.2` and `v7.0.0` were both released on 2026-06-07 and dereference to the **same commit** (`fb8b3582...`). Codecov published `v6.0.2` as a copy of `v7.0.0` to make patch-level updates easier. We take the patch bump from `v6.0.1` rather than the major to avoid major-version semantics, while landing the identical fix.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
