### PR TITLE
Cache lockfile regardless of dependencies install

### DIFF
--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -575,7 +575,6 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def _install_dependencies(
         self, tmp_dir_path: Path, flags: list[str], env: dict[str, str | bytes | os.PathLike[Any]]
     ) -> None:
-        self._cache_package_lockfile(tmp_dir_path)
         deps_command = [self.dbt_executable_path, "deps"] + flags
 
         for filename in DBT_DEPENDENCIES_FILE_NAMES:
@@ -717,6 +716,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
 
                 flags = self._generate_dbt_flags(tmp_project_dir, profile_path)
 
+                self._cache_package_lockfile(tmp_dir_path)
                 if self._should_install_deps():
                     self._install_dependencies(
                         tmp_dir_path, flags + self._process_global_flag("--vars", self.vars), env


### PR DESCRIPTION
## Description

Caching the packages lockfile should be done independently of dependencies installation. This PR fixes the case where the lockfile is already present, and dependencies are not reinstalled at runtime

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
