### PR TITLE
Reduce Airflow 3 Asset URI migration warning noise in WATCHER producer runs

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -767,6 +767,10 @@ def _add_watcher_producer_task(
     The producer task is the task that will be used to produce the events for the watcher execution mode.
     """
     producer_task_args = task_args.copy()
+    # The producer never emits datasets itself (consumer tasks do), but it must still compute
+    # per-model outlet URIs when consumers will emit. Carry that intent as an explicit flag so the
+    # producer can decide whether to generate model URIs without overloading other signals.
+    producer_task_args["_should_generate_model_uris"] = task_args.get("emit_datasets", True)
     # Producer should not emit datasets — consumer tasks handle their own emission
     producer_task_args["emit_datasets"] = False
     if tests_per_model is not None:

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import urllib.parse
+from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -193,7 +194,7 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
     return None
 
 
-def construct_dataset_uri(namespace: str, name: str) -> str:
+def construct_dataset_uri(namespace: str, name: str, warn_uri_migration: bool = True) -> str:
     """
     Construct an Airflow Asset/Dataset URI from an OL-compatible namespace and
     dataset name.
@@ -204,6 +205,9 @@ def construct_dataset_uri(namespace: str, name: str) -> str:
 
     :param namespace: The OL-compatible dataset namespace (e.g. ``postgres://host:5432``).
     :param name: The dot-delimited dataset name (e.g. ``database.schema.table``).
+    :param warn_uri_migration: Whether to emit the Airflow 3 URI migration warning for this URI.
+        Callers that create multiple URIs in one task run should pass ``False`` after
+        the first generated URI.
     """
     airflow_2_uri = namespace + "/" + urllib.parse.quote(name)
     airflow_3_uri = namespace + "/" + urllib.parse.quote(name).replace(".", "/")
@@ -211,29 +215,56 @@ def construct_dataset_uri(namespace: str, name: str) -> str:
     if AIRFLOW_VERSION < Version("3.0.0"):
         if settings.use_dataset_airflow3_uri_standard:
             return airflow_3_uri
+        if warn_uri_migration:
+            logger.warning(
+                "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
+                "(standard used by Cosmos) will no longer be valid. "
+                "Therefore, if using Cosmos with Airflow 3, the Airflow Dataset URIs will be changed to <%s>. "
+                "Previously, with Airflow 2.x, the URI was <%s>. "
+                "If you want to use the Airflow 3 URI standard while still using Airflow 2, please set: "
+                "export AIRFLOW__COSMOS__USE_DATASET_AIRFLOW3_URI_STANDARD=1 "
+                "Remember to update any DAGs that are scheduled using this dataset.",
+                airflow_3_uri,
+                airflow_2_uri,
+            )
+        return airflow_2_uri
+
+    if warn_uri_migration and not settings.use_dataset_airflow3_uri_standard:
         logger.warning(
             "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
-            "(standard used by Cosmos) will no longer be valid. "
-            "Therefore, if using Cosmos with Airflow 3, the Airflow Dataset URIs will be changed to <%s>. "
-            "Previously, with Airflow 2.x, the URI was <%s>. "
-            "If you want to use the Airflow 3 URI standard while still using Airflow 2, please set: "
-            "export AIRFLOW__COSMOS__USE_DATASET_AIRFLOW3_URI_STANDARD=1 "
-            "Remember to update any DAGs that are scheduled using this dataset.",
+            "(standard used by Cosmos) are no longer accepted. "
+            "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
+            "Before, with Airflow 2.x, the URI used to be <%s>. "
+            "Please, change any DAGs that were scheduled using the old standard to the new one.",
             airflow_3_uri,
             airflow_2_uri,
         )
-        return airflow_2_uri
-
-    logger.warning(
-        "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed and OpenLineage URIs "
-        "(standard used by Cosmos) are no longer accepted. "
-        "Therefore, if using Cosmos with Airflow 3, the Airflow Asset (Dataset) URI is now <%s>. "
-        "Before, with Airflow 2.x, the URI used to be <%s>. "
-        "Please, change any DAGs that were scheduled using the old standard to the new one.",
-        airflow_3_uri,
-        airflow_2_uri,
-    )
     return airflow_3_uri
+
+
+def make_dataset_uri_builder() -> Callable[[str, str], str]:
+    """Return a :func:`construct_dataset_uri` wrapper that emits the Airflow 3 URI
+    migration warning only for the first URI it builds.
+
+    A single task run can generate many dataset URIs -- one per dbt
+    model/seed/snapshot, plus OpenLineage inputs/outputs -- and emitting the
+    migration warning for every one floods the logs (#2778). Callers that build
+    URIs in bulk should route them all through one builder so the guidance is
+    logged once instead of once per dataset.
+
+    The "already warned" state lives in the returned closure rather than at
+    module level, so each new builder (i.e. each task run) warns once again
+    instead of being silenced permanently for the lifetime of the worker process.
+    """
+    warned = False
+
+    def build(namespace: str, name: str) -> str:
+        nonlocal warned
+        uri = construct_dataset_uri(namespace, name, warn_uri_migration=not warned)
+        warned = True
+        return uri
+
+    return build
 
 
 def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict[str, list[str]]:
@@ -260,6 +291,7 @@ def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict
         return {}
 
     result: dict[str, list[str]] = {}
+    build_uri = make_dataset_uri_builder()
     for unique_id, node in manifest.get("nodes", {}).items():
         resource_type = node.get("resource_type", "")
         if resource_type not in _DATASET_EMITTING_RESOURCE_TYPES:
@@ -272,7 +304,6 @@ def compute_model_outlet_uris(manifest_path: str | Path, namespace: str) -> dict
         if not all([database, schema, alias]):
             continue
 
-        uri = construct_dataset_uri(namespace, f"{database}.{schema}.{alias}")
-        result[unique_id] = [uri]
+        result[unique_id] = [build_uri(namespace, f"{database}.{schema}.{alias}")]
 
     return result

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -298,6 +298,7 @@ def store_dbt_resource_status_from_log(
     test_results_per_model: dict[str, dict[str, str]] | None = None,
     model_outlet_uris: dict[str, list[str]] | None = None,
     dataset_namespace: str | None = None,
+    should_generate_model_uris: bool = True,
     upstream_failure_skipped_ids: set[str] | None = None,
 ) -> None:
     """
@@ -320,6 +321,9 @@ def store_dbt_resource_status_from_log(
     :param model_outlet_uris: Mutable dict mapping unique_id to outlet URIs.
         Populated lazily from the manifest on first terminal status detection.
     :param dataset_namespace: The OL-compatible dataset namespace for URI construction.
+    :param should_generate_model_uris: Explicit control for whether per-model outlet URIs are
+        computed from the manifest. When ``False`` (e.g. consumers won't emit datasets), URI
+        generation is skipped regardless of ``dataset_namespace``.
     :param upstream_failure_skipped_ids: Mutable accumulator set of node unique_ids
         that dbt skipped because of an upstream-node failure. Populated when this
         function sees a ``SkippingDetails`` or ``LogSkipBecauseError`` event; later
@@ -369,10 +373,11 @@ def store_dbt_resource_status_from_log(
                     unique_id, dbt_node_status, tests_per_model, test_results_per_model, context["ti"]
                 )
             else:
-                # Lazily populate per-model outlet URIs from the manifest, but only for
-                # resource types that can emit datasets (models/seeds/snapshots).
+                # Lazily populate per-model outlet URIs from the manifest, but only when the
+                # producer is configured to generate them and the resource type can emit datasets
+                # (models/seeds/snapshots).
                 outlet_uris: list[str] = []
-                if dbt_node_resource_type in _DATASET_EMITTING_RESOURCE_TYPES:
+                if should_generate_model_uris and dbt_node_resource_type in _DATASET_EMITTING_RESOURCE_TYPES:
                     project_dir = extra_kwargs.get("project_dir")
                     _ensure_subprocess_model_outlet_uris(model_outlet_uris, dataset_namespace, project_dir)
                     outlet_uris = model_outlet_uris.get(unique_id, []) if model_outlet_uris else []

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -52,7 +52,7 @@ from cosmos.constants import (
     FILE_SCHEME_AIRFLOW_DEFAULT_CONN_ID_MAP,
     InvocationMode,
 )
-from cosmos.dataset import construct_dataset_uri, get_dataset_alias_name
+from cosmos.dataset import get_dataset_alias_name, make_dataset_uri_builder
 from cosmos.dbt.project import (
     copy_dbt_packages,
     copy_manifest_file_if_exists,
@@ -825,10 +825,12 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         """
         uris = []
 
+        # Build all URIs through one builder so the Airflow 3 URI migration warning is logged
+        # once for this call instead of once per dataset (#2778).
+        build_uri = make_dataset_uri_builder()
         for completed in self.openlineage_events_completes:
             for output in getattr(completed, source):
-                dataset_uri = construct_dataset_uri(output.namespace, output.name)
-                uris.append(dataset_uri)
+                uris.append(build_uri(output.namespace, output.name))
         self.log.debug("URIs to be converted to Asset: %s", uris)
 
         assets = [Asset(uri) for uri in uris]

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -214,6 +214,9 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self.tests_per_model: dict[str, list[str]] = kwargs.pop("tests_per_model", {})
         self.test_results_per_model: dict[str, dict[str, str]] = {}
         self._check_source_freshness: bool = kwargs.pop("_check_source_freshness", False)
+        self._should_generate_model_uris: bool = kwargs.pop(
+            "_should_generate_model_uris", kwargs.get("emit_datasets", True)
+        )
         self._freshness_callback: Callable[
             [Context, Any, TaskGroup | None, dict[str, DbtNode] | None, dict[str, Any] | None],
             list[tuple[str, str]],
@@ -252,6 +255,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
             test_results_per_model=self.test_results_per_model,
             model_outlet_uris=self._model_outlet_uris,
             dataset_namespace=self._dataset_namespace,
+            should_generate_model_uris=self._should_generate_model_uris,
             upstream_failure_skipped_ids=self._upstream_failure_skipped_ids,
         )
 
@@ -449,8 +453,14 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         self._apply_node_state_tokens(context, freshness_results)
 
     def execute(self, context: Context, **kwargs: Any) -> Any:
-        # Pre-compute the dataset namespace for per-model outlet URI generation.
-        self._dataset_namespace = get_dataset_namespace(self.profile_config)
+        # Resolve the dataset namespace only when the producer will generate per-model outlet
+        # URIs. With emit_datasets=False the producer does no dataset work, so we skip the
+        # namespace's profile resolution and leave it None. URI generation is gated explicitly by
+        # should_generate_model_uris in the log parser -- this None is just the disabled-state
+        # invariant, not a control signal.
+        self._dataset_namespace = (
+            get_dataset_namespace(self.profile_config) if self._should_generate_model_uris else None
+        )
         self._model_outlet_uris.clear()
         self._upstream_failure_skipped_ids.clear()
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2339,6 +2339,27 @@ def test_add_watcher_producer_task_sets_check_source_freshness_flag(source_rende
             assert "_check_source_freshness" not in task_metadata.arguments
 
 
+@pytest.mark.parametrize("emit_datasets", [True, False])
+def test_add_watcher_producer_task_preserves_consumer_emit_datasets_flag(emit_datasets):
+    """The producer does not emit datasets, but it needs to know whether consumers will."""
+    task_args = {"project_dir": "/tmp/sample_project", "profile_config": None, "emit_datasets": emit_datasets}
+
+    with patch("cosmos.airflow.graph.create_airflow_task") as mock_create_task:
+        mock_create_task.return_value = MagicMock()
+
+        _add_watcher_producer_task(
+            dag=MagicMock(),
+            task_group=None,
+            tasks_map={},
+            render_config=RenderConfig(),
+            task_args=task_args,
+        )
+
+    task_metadata = mock_create_task.call_args[0][0]
+    assert task_metadata.arguments["emit_datasets"] is False
+    assert task_metadata.arguments["_should_generate_model_uris"] is emit_datasets
+
+
 def test_add_watcher_producer_task_passes_freshness_callback_via_setup_operator_args():
     """freshness_callback supplied via setup_operator_args (merged into task_args before the call) is forwarded to the producer."""
     my_callback = MagicMock()

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1174,6 +1174,35 @@ def test_run_operator_emits_events_without_openlineage_events_completes(caplog):
     assert "Unable to emit OpenLineage events due to lack of dependencies or data." in caplog.text
 
 
+@patch("cosmos.dataset.AIRFLOW_VERSION", new=version.Version("3.0.0"))
+@patch("cosmos.dataset.settings")
+def test_get_datasets_warns_uri_migration_once(mock_settings, caplog):
+    """get_datasets emits the Airflow 3 URI migration warning once, not once per dataset (#2778)."""
+    mock_settings.use_dataset_airflow3_uri_standard = False
+
+    class MockOutput:
+        def __init__(self, name):
+            self.namespace = "postgres://host:5432"
+            self.name = name
+
+    class MockEvent:
+        outputs = [MockOutput("db.public.t1"), MockOutput("db.public.t2"), MockOutput("db.public.t3")]
+
+    dbt_base_operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config,
+        task_id="my-task",
+        project_dir="my/dir",
+        should_store_compiled_sql=False,
+    )
+    dbt_base_operator.openlineage_events_completes = [MockEvent()]
+
+    with caplog.at_level(logging.WARNING):
+        assets = dbt_base_operator.get_datasets("outputs")
+
+    assert len(assets) == 3
+    assert caplog.text.count("Airflow 3.0.0 Asset (Dataset) URIs validation rules changed") == 1
+
+
 def _write_target_sql_fixture(tmp_path: Path) -> None:
     """Create a fake dbt ``target/`` tree with two .sql files and one non-SQL artefact."""
     compiled_dir = tmp_path / "target" / "compiled" / "pkg" / "models"

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -519,6 +519,52 @@ class TestStoreDbtStatusFromLog:
 
         assert "model__pkg__running_model_status" not in ti.store
 
+    @staticmethod
+    def _emitting_model_log_line() -> str:
+        return json.dumps(
+            {
+                "data": {
+                    "node_info": {
+                        "node_status": "success",
+                        "unique_id": "model.pkg.my_model",
+                        "resource_type": "model",
+                    }
+                }
+            }
+        )
+
+    def test_store_dbt_resource_status_from_log_skips_uri_generation_when_disabled(self):
+        """should_generate_model_uris=False skips outlet URI computation even with a namespace set."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+
+        with patch("cosmos.operators._watcher.base._ensure_subprocess_model_outlet_uris") as mock_ensure:
+            store_dbt_resource_status_from_log(
+                self._emitting_model_log_line(),
+                {"context": ctx, "project_dir": "/tmp/project"},
+                dataset_namespace="postgres://host:5432",
+                should_generate_model_uris=False,
+            )
+
+        mock_ensure.assert_not_called()
+        assert ti.store.get("model__pkg__my_model_status") == {"status": "success", "outlet_uris": []}
+
+    def test_store_dbt_resource_status_from_log_generates_uris_when_enabled(self):
+        """should_generate_model_uris=True triggers outlet URI computation for emitting resources."""
+        ti = _MockTI()
+        ctx = {"ti": ti}
+
+        with patch("cosmos.operators._watcher.base._ensure_subprocess_model_outlet_uris") as mock_ensure:
+            store_dbt_resource_status_from_log(
+                self._emitting_model_log_line(),
+                {"context": ctx, "project_dir": "/tmp/project"},
+                model_outlet_uris={},
+                dataset_namespace="postgres://host:5432",
+                should_generate_model_uris=True,
+            )
+
+        mock_ensure.assert_called_once_with({}, "postgres://host:5432", "/tmp/project")
+
     def test_store_dbt_resources_status_from_log_detects_passed_test_status(self):
         """Test that a passed test status is correctly parsed and stored in XCom."""
         ti = _MockTI()
@@ -920,6 +966,52 @@ def test_producer_respects_explicit_invocation_mode():
 
     op2 = DbtProducerWatcherOperator(project_dir=".", profile_config=None, invocation_mode=InvocationMode.DBT_RUNNER)
     assert op2.invocation_mode == InvocationMode.DBT_RUNNER
+
+
+@pytest.mark.parametrize(
+    "should_generate_model_uris, expected_namespace_calls",
+    [
+        (True, 1),
+        (False, 0),
+    ],
+)
+def test_producer_resolves_namespace_only_when_generating_model_uris(
+    should_generate_model_uris, expected_namespace_calls
+):
+    """With datasets disabled the producer does no dataset work: it must not resolve the namespace
+    (no profile parsing) and leaves _dataset_namespace as None. URI generation itself is gated by
+    the explicit should_generate_model_uris flag in the log parser (covered by the parser tests)."""
+    op = DbtProducerWatcherOperator(
+        project_dir=".",
+        profile_config=profile_config,
+        _should_generate_model_uris=should_generate_model_uris,
+    )
+    context = {"ti": _MockTI(), "run_id": "run-1"}
+
+    with (
+        patch("cosmos.operators.watcher.get_dataset_namespace", return_value="postgres://host:5432") as mock_namespace,
+        patch("cosmos.operators.local.DbtLocalBaseOperator.execute", return_value=None),
+        patch("cosmos.operators.watcher.safe_xcom_push"),
+        patch("cosmos.operators.watcher._delete_xcom_backup_variable"),
+    ):
+        op.execute(context)
+
+    assert mock_namespace.call_count == expected_namespace_calls
+    expected_namespace = "postgres://host:5432" if should_generate_model_uris else None
+    assert op._dataset_namespace == expected_namespace
+
+
+def test_make_parse_callable_forwards_should_generate_model_uris():
+    """The parser callable forwards the producer's _should_generate_model_uris control flag."""
+    op = DbtProducerWatcherOperator(
+        project_dir=".",
+        profile_config=profile_config,
+        _should_generate_model_uris=False,
+    )
+
+    callable_ = op._make_parse_callable()
+
+    assert callable_.keywords["should_generate_model_uris"] is False
 
 
 def test_run_subprocess_sets_process_log_line_callable():

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -1,4 +1,5 @@
 import json
+import logging
 from datetime import datetime
 from unittest.mock import MagicMock, patch
 
@@ -17,6 +18,7 @@ from cosmos.dataset import (
     construct_dataset_uri,
     get_dataset_alias_name,
     get_dataset_namespace,
+    make_dataset_uri_builder,
 )
 
 START_DATE = datetime(2024, 4, 16)
@@ -249,14 +251,84 @@ class TestConstructDatasetUri:
 
     @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
     def test_airflow3_uri(self):
-        uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
+        # warn_uri_migration=False: this test only asserts the returned URI, so suppress the
+        # migration warning to keep logs quiet and independent of the env's Cosmos settings.
+        uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers", warn_uri_migration=False)
         assert uri == "postgres://host:5432/mydb/public/customers"
+
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_airflow3_with_airflow3_standard_does_not_warn(self, mock_settings, caplog):
+        mock_settings.use_dataset_airflow3_uri_standard = True
+        with caplog.at_level(logging.WARNING):
+            uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers")
+
+        assert uri == "postgres://host:5432/mydb/public/customers"
+        assert "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed" not in caplog.text
+
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_airflow3_warning_can_be_suppressed_by_caller(self, mock_settings, caplog):
+        mock_settings.use_dataset_airflow3_uri_standard = False
+        with caplog.at_level(logging.WARNING):
+            uri = construct_dataset_uri("postgres://host:5432", "mydb.public.customers", warn_uri_migration=False)
+
+        assert uri == "postgres://host:5432/mydb/public/customers"
+        assert "Airflow 3.0.0 Asset (Dataset) URIs validation rules changed" not in caplog.text
+
+
+# --- Tests for make_dataset_uri_builder ---
+
+
+class TestMakeDatasetUriBuilder:
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_warns_once_across_many_builds(self, mock_settings, caplog):
+        mock_settings.use_dataset_airflow3_uri_standard = False
+        build_uri = make_dataset_uri_builder()
+
+        with caplog.at_level(logging.WARNING):
+            uris = [build_uri("postgres://host:5432", f"db.public.t{i}") for i in range(5)]
+
+        assert len(uris) == 5
+        assert caplog.text.count("Airflow 3.0.0 Asset (Dataset) URIs validation rules changed") == 1
+
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_each_builder_warns_again(self, mock_settings, caplog):
+        """State is per-builder, so a later builder (e.g. a later task run) warns once more."""
+        mock_settings.use_dataset_airflow3_uri_standard = False
+
+        with caplog.at_level(logging.WARNING):
+            make_dataset_uri_builder()("postgres://host:5432", "db.public.t1")
+            make_dataset_uri_builder()("postgres://host:5432", "db.public.t2")
+
+        assert caplog.text.count("Airflow 3.0.0 Asset (Dataset) URIs validation rules changed") == 2
 
 
 # --- Tests for compute_model_outlet_uris ---
 
 
 class TestComputeModelOutletUris:
+    @staticmethod
+    def _manifest_with_two_emitting_nodes():
+        return {
+            "nodes": {
+                "model.jaffle_shop.customers": {
+                    "resource_type": "model",
+                    "database": "postgres",
+                    "schema": "public",
+                    "alias": "customers",
+                },
+                "seed.jaffle_shop.raw_orders": {
+                    "resource_type": "seed",
+                    "database": "postgres",
+                    "schema": "public",
+                    "alias": "raw_orders",
+                },
+            }
+        }
+
     def test_reads_manifest_and_computes_uris(self, tmp_path):
         manifest = {
             "nodes": {
@@ -288,6 +360,19 @@ class TestComputeModelOutletUris:
         assert "model.jaffle_shop.customers" in result
         assert "seed.jaffle_shop.raw_orders" in result
         assert "test.jaffle_shop.not_null" not in result
+
+    @patch("cosmos.dataset.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("cosmos.dataset.settings")
+    def test_warns_once_per_manifest_computation_not_globally(self, mock_settings, tmp_path, caplog):
+        mock_settings.use_dataset_airflow3_uri_standard = False
+        manifest_path = tmp_path / "manifest.json"
+        manifest_path.write_text(json.dumps(self._manifest_with_two_emitting_nodes()))
+
+        with caplog.at_level(logging.WARNING):
+            result = compute_model_outlet_uris(str(manifest_path), "postgres://host:5432")
+            compute_model_outlet_uris(str(manifest_path), "postgres://host:5432")
+
+        assert caplog.text.count("Airflow 3.0.0 Asset (Dataset) URIs validation rules changed") == 2
         assert len(result) == 2
 
     def test_missing_manifest_returns_empty(self):


### PR DESCRIPTION
## Description

This PR makes two related changes in their own commits:

- WATCHER now preserves the original `RenderConfig.emit_datasets` value before forcing the producer task's own `emit_datasets=False`. When consumers have `emit_datasets=False`, the producer skips dataset namespace and outlet URI preparation entirely.
- When WATCHER does need to compute outlet URIs from `manifest.json`, Cosmos logs the Asset URI migration warning once per manifest computation instead of once per dbt node. This could be done in several other ways, wasn't sure if this is the most elegant way possible.

This fixes the reported problem where WATCHER producer logs could contain hundreds or thousands of repeated Asset URI warnings even when dataset emission was disabled.

## Related Issue(s)

Fixes #2778

## Breaking Change?

No.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works