### PR TITLE
Move test jobs that need no secrets to an unprivileged pull_request workflow

### DIFF
--- a/.github/workflows/test-unprivileged.yml
+++ b/.github/workflows/test-unprivileged.yml
@@ -106,6 +106,24 @@ jobs:
           done <<< "$FILES"
           echo "code_changed=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
 
+  Type-Check:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: "3.10"
+          architecture: "x64"
+
+      - run: pip3 install "hatch>=1.14.2"
+      - run: hatch run tests.py3.10-3.1-1.9:type-check
+
   Run-Unit-Tests:
     needs: Check-changed-files
     if: needs.Check-changed-files.outputs.code_changed == 'true'
@@ -156,7 +174,7 @@ jobs:
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-cov
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -205,7 +223,7 @@ jobs:
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-telemetry
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-telemetry-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -261,7 +279,7 @@ jobs:
           uv pip install --system "hatch>=1.14.2"
           hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
 
-      - name: Run performance tests against against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
+      - name: Run performance tests against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
         id: run-performance-tests
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-performance-setup
@@ -286,3 +304,84 @@ jobs:
       AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
       AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
       PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+
+  Run-Integration-Tests-dbt-Loom:
+    # Dedicated job for the cross-project example DAGs (cross_project_manifest_dag.py
+    # and cross_project_dbt_ls_dag.py), which exercise dbt-loom. Carved out of
+    # Run-Integration-Tests so the loom job's dbt + loom versions can move
+    # independently of the main matrix. It uses no secrets, so it runs here in the
+    # unprivileged workflow rather than under pull_request_target.
+    needs: Check-changed-files
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        airflow-version: ["3.2"]
+        dbt-version: ["1.11"]
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: integration-dbt-loom-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Test cross-project dbt-loom example DAGs (manifest + dbt ls)
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-loom
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-integration-dbt-loom-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
+          path: .coverage
+          include-hidden-files: true
+
+    env:
+      AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
+      PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+      AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+      AIRFLOW__COSMOS__ENABLE_CACHE: 0
+      DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+
+      # cross_project_manifest_dag's profiles.yml references these
+      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+      POSTGRES_HOST: localhost
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+      POSTGRES_DB: postgres
+      POSTGRES_SCHEMA: public
+      POSTGRES_PORT: 5432

--- a/.github/workflows/test-unprivileged.yml
+++ b/.github/workflows/test-unprivileged.yml
@@ -1,0 +1,288 @@
+name: test-unprivileged
+
+on:
+  push: # Run on pushes to the default branch so coverage on main stays current.
+    branches: [main]
+  # Unprivileged test jobs that execute untrusted PR code but require no secrets. Running them
+  # under `pull_request` (not `pull_request_target`) means fork PRs get a read-only token and no
+  # access to repository secrets, so checking out and running the PR's code is not a privileged
+  # operation. This preserves fast feedback for forks without a manual approval gate, while
+  # avoiding the privileged-checkout and cache-poisoning patterns that `pull_request_target`
+  # would introduce. Jobs that need secrets (integration, kubernetes, coverage upload) stay in
+  # test.yml, gated behind the Authorize environment.
+  pull_request:
+    branches: [main, 'release-*']
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
+env:
+  SCARF_NO_ANALYTICS: "true"
+
+jobs:
+  # Skip unit/telemetry/performance tests when only non-code files changed.
+  Check-changed-files:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      code_changed: ${{ steps.check.outputs.code_changed }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          persist-credentials: false
+
+      - id: check
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          if [ "${{ github.event_name }}" == "pull_request" ] || [ "${{ github.event_name }}" == "pull_request_target" ]; then
+            # Use GitHub API to list changed files — works reliably for fork PRs
+            # where git diff may fail because the fork's commits aren't in local history.
+            PR_NUMBER="${{ github.event.pull_request.number }}"
+            if ! FILES=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" --paginate --jq '.[].filename' 2>/tmp/gh_api_err); then
+              echo "::warning::Failed to list PR changed files via GitHub API, falling back to running all tests. Error: $(cat /tmp/gh_api_err)"
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          else
+            BASE="${{ github.event.before }}"
+            HEAD="${{ github.sha }}"
+            # Handle cases where BASE is missing or all zeros (e.g., first push, force push)
+            if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+            # Compute changed files; if git diff fails, assume code changed to be safe
+            if ! FILES=$(git diff --name-only "$BASE" "$HEAD" 2>/dev/null); then
+              echo "code_changed=true" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+          CODE_CHANGED=false
+          # If we can't determine changed files, run tests to be safe
+          if [ -z "$FILES" ]; then
+            CODE_CHANGED=true
+          fi
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              # Documentation and metadata
+              README.rst|README.md) ;;
+              CHANGELOG.rst) ;;
+              CODE_OF_CONDUCT.md) ;;
+              CONTRIBUTING.md) ;;
+              LICENSE) ;;
+              SECURITY.rst) ;;
+              PRIVACY_NOTICE.rst) ;;
+              CODEOWNERS) ;;
+              CLAUDE.md) ;;
+              AGENTS.md) ;;
+              docs/*) ;;
+              # GitHub and CI config unrelated to tests
+              .github/pull_request_template.md) ;;
+              .github/ISSUE_TEMPLATE/*) ;;
+              .github/dependabot.yml) ;;
+              .github/workflows/docs.yml) ;;
+              .github/workflows/docs-build.yml) ;;
+              .github/workflows/stale.yml) ;;
+              .github/workflows/actionlint.yml) ;;
+              .github/workflows/codeql.yml) ;;
+              .github/workflows/zizmor.yml) ;;
+              .github/workflows/deploy.yml) ;;
+              # Tooling config that does not affect test outcomes
+              .gitignore) ;;
+              .tiltignore) ;;
+              Tiltfile) ;;
+              .codespell-ignore-words) ;;
+              .pre-commit-config.yaml) ;;
+              .airflow-registry.yaml) ;;
+              *) CODE_CHANGED=true; break ;;
+            esac
+          done <<< "$FILES"
+          echo "code_changed=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
+
+  Run-Unit-Tests:
+    needs: Check-changed-files
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.11", "3.12", "3.13"]
+        airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
+        dbt-version: ["1.10"]
+        exclude:
+          # Apache Airflow versions prior to 3.1.0 have not been tested with Python 3.13.
+          - python-version: "3.13"
+            airflow-version: "2.9"
+          - python-version: "3.13"
+            airflow-version: "2.10"
+          - python-version: "3.13"
+            airflow-version: "2.11"
+          - python-version: "3.13"
+            airflow-version: "3.0"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-cov
+
+      - name: Upload coverage to Github
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
+          path: .coverage
+          include-hidden-files: true
+
+  Run-Telemetry-Tests:
+    needs: Check-changed-files
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        airflow-version: ["2.10"]
+        dbt-version: ["1.9"]
+    env:
+      SCARF_NO_ANALYTICS: "false"
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: telemetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Run telemetry tests
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-telemetry
+
+      - name: Upload coverage to Github
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-telemetry-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
+          path: .coverage
+          include-hidden-files: true
+
+  Run-Performance-Tests:
+    needs: Check-changed-files
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11"]
+        airflow-version: ["2.10", "3.0"]
+        dbt-version: ["1.9"]
+        num-models: [1, 10, 50, 100, 500]
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+        ports:
+          - 5432:5432
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+
+      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
+        with:
+          path: |
+            ~/.cache/pip
+            .local/share/hatch/
+          key: perf-test-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Run performance tests against against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
+        id: run-performance-tests
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-performance-setup
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-performance
+
+          # read the performance results and set them as an env var for the next step
+          # format: NUM_MODELS={num_models}\nTIME={end - start}\n
+          cat /tmp/performance_results.txt > "$GITHUB_STEP_SUMMARY"
+        env:
+          AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 180.0
+          PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+          POSTGRES_HOST: localhost
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+          MODEL_COUNT: ${{ matrix.num-models }}
+    env:
+      AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
+      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
+      PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,11 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
-  # Also run on pull requests originating from forks. Jobs that require sensitive secrets (integration tests,
-  # kubernetes, code coverage) depend on the Authorize job, which requires manually approving the workflow run for
-  # external PRs. Jobs that do not use sensitive secrets (type-check, unit tests, performance, telemetry) run
-  # without approval.
+    branches: [main, split-pr-test-workflow]
+  # Also run on pull requests originating from forks. Jobs here require sensitive secrets (integration tests,
+  # kubernetes, code coverage) and depend on the Authorize job, which requires manually approving the workflow run
+  # for external PRs. Jobs that do not use sensitive secrets (type-check still runs here; unit, telemetry and
+  # performance tests run in the unprivileged test-unprivileged.yml workflow) do not need that approval.
   pull_request_target:
     branches: [main, 'release-*'] # zizmor: ignore[dangerous-triggers]
 
@@ -130,63 +130,6 @@ jobs:
 
       - run: pip3 install "hatch>=1.14.2"
       - run: hatch run tests.py3.10-3.1-1.9:type-check
-
-  Run-Unit-Tests:
-    needs: Check-changed-files
-    if: needs.Check-changed-files.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.10", "3.11", "3.12", "3.13"]
-        airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2"]
-        dbt-version: ["1.10"]
-        exclude:
-          # Apache Airflow versions prior to 3.1.0 have not been tested with Python 3.13.
-          - python-version: "3.13"
-            airflow-version: "2.9"
-          - python-version: "3.13"
-            airflow-version: "2.10"
-          - python-version: "3.13"
-            airflow-version: "2.11"
-          - python-version: "3.13"
-            airflow-version: "3.0"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: unit-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install packages and dependencies
-        run: |
-          python -m pip install uv
-          uv pip install --system "hatch>=1.14.2"
-          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
-
-      - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
-        run: |
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-cov
-
-      - name: Upload coverage to Github
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-unit-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
-          path: .coverage
-          include-hidden-files: true
 
   Run-Integration-Tests:
     needs: [Authorize, Check-changed-files]
@@ -708,131 +651,6 @@ jobs:
           RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
 
 
-  Run-Telemetry-Tests:
-    needs: Check-changed-files
-    if: needs.Check-changed-files.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-        airflow-version: ["2.10"]
-        dbt-version: ["1.9"]
-    env:
-      SCARF_NO_ANALYTICS: "false"
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: telemetry-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install packages and dependencies
-        run: |
-          python -m pip install uv
-          uv pip install --system "hatch>=1.14.2"
-          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
-
-      - name: Run telemetry tests
-        run: |
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-telemetry
-
-      - name: Upload coverage to Github
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-telemetry-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
-          path: .coverage
-          include-hidden-files: true
-
-  Run-Performance-Tests:
-    needs: Check-changed-files
-    if: needs.Check-changed-files.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-        airflow-version: ["2.10", "3.0"]
-        dbt-version: ["1.9"]
-        num-models: [1, 10, 50, 100, 500]
-    services:
-      postgres:
-        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: perf-test-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install packages and dependencies
-        run: |
-          python -m pip install uv
-          uv pip install --system "hatch>=1.14.2"
-          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
-
-      - name: Run performance tests against against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt ${{ matrix.dbt-version }}
-        id: run-performance-tests
-        run: |
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-performance-setup
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-performance
-
-          # read the performance results and set them as an env var for the next step
-          # format: NUM_MODELS={num_models}\nTIME={end - start}\n
-          cat /tmp/performance_results.txt > "$GITHUB_STEP_SUMMARY"
-        env:
-          AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
-          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 180.0
-          PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
-          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
-          POSTGRES_HOST: localhost
-          POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: postgres
-          POSTGRES_DB: postgres
-          POSTGRES_SCHEMA: public
-          POSTGRES_PORT: 5432
-          MODEL_COUNT: ${{ matrix.num-models }}
-    env:
-      AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
-      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-      PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
-
   Run-Kubernetes-Tests:
     needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
@@ -905,15 +723,15 @@ jobs:
     if: github.event.action != 'labeled'
     needs:
       - Authorize
-      - Run-Unit-Tests
       - Run-Integration-Tests
       - Run-Integration-Tests-dbt-Loom
       - Run-Integration-Tests-Expensive
       - Run-Kubernetes-Tests
-      - Run-Telemetry-Tests
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      # Required to read artifacts from the sibling test-unprivileged.yml run.
+      actions: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -927,10 +745,63 @@ jobs:
       - name: Install coverage
         run: |
           pip3 install coverage
-      - name: Download all coverage artifacts
+      - name: Download coverage artifacts from this run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: ./coverage
+          pattern: coverage-*
+
+      # The unit and telemetry tests run in the unprivileged test-unprivileged.yml workflow, so
+      # their coverage lands in a separate workflow run for the same commit. Locate that run by
+      # head SHA and wait until its unit/telemetry coverage artifacts are available. (The
+      # performance tests run in that same workflow but upload no coverage, so they are irrelevant
+      # here — we only wait on the unit/telemetry artifacts, never on the whole run, so the
+      # longer-running performance matrix does not hold this step up.)
+      #
+      # By the time this job runs, those artifacts are expected to already exist: this job only
+      # starts after its `needs` (the integration and kubernetes jobs) complete, which take
+      # ~5-18 min, whereas the unit and telemetry tests run in parallel from the same commit and
+      # finish in ~2 min. So the first attempt below almost always finds the artifacts and breaks
+      # immediately. The retry loop is a safety gate for the rare race where this job somehow
+      # reaches this step before the unprivileged run has uploaded them; it waits up to 5 minutes
+      # (15 attempts x 20s) before failing rather than silently dropping coverage.
+      - name: Locate unprivileged test run for this commit
+        id: unprivileged-run
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
+          RUN_ID=""
+          for attempt in $(seq 1 15); do
+            RUN_ID=$(gh api \
+              "repos/${{ github.repository }}/actions/workflows/test-unprivileged.yml/runs?head_sha=${HEAD_SHA}&per_page=1" \
+              --jq '.workflow_runs[0].id // ""')
+            if [ -n "$RUN_ID" ]; then
+              COUNT=$(gh api \
+                "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
+                --jq '[.artifacts[].name | select(startswith("coverage-unit-test-") or startswith("coverage-telemetry-test-"))] | length')
+              if [ "${COUNT:-0}" -gt 0 ]; then
+                echo "Found ${COUNT} unit/telemetry coverage artifacts in run ${RUN_ID}."
+                break
+              fi
+            fi
+            echo "Waiting for test-unprivileged.yml coverage artifacts (attempt ${attempt}/15)…"
+            sleep 20
+          done
+          if [ -z "$RUN_ID" ]; then
+            echo "::error::No test-unprivileged.yml run found for ${HEAD_SHA}; unit/telemetry coverage would be missing."
+            exit 1
+          fi
+          echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
+
+      - name: Download unit and telemetry coverage from the unprivileged run
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
+        with:
+          path: ./coverage
+          pattern: coverage-*
+          run-id: ${{ steps.unprivileged-run.outputs.run_id }}
+          github-token: ${{ github.token }}
+
       - name: Combine coverage
         run: |
           coverage combine ./coverage/coverage*/.coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,11 +2,12 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
-  # Also run on pull requests originating from forks. Jobs here require sensitive secrets (integration tests,
-  # kubernetes, code coverage) and depend on the Authorize job, which requires manually approving the workflow run
-  # for external PRs. Jobs that do not use sensitive secrets (type-check still runs here; unit, telemetry and
-  # performance tests run in the unprivileged test-unprivileged.yml workflow) do not need that approval.
+    branches: [main, split-pr-test-workflow]
+  # Also run on pull requests originating from forks. Every test job here is secret-dependent
+  # (integration tests, kubernetes, code coverage) and depends on the Authorize job, which requires
+  # manually approving the workflow run for external PRs. Jobs that need no secrets (type-check,
+  # unit, telemetry and performance tests) run in the separate, unprivileged test-unprivileged.yml
+  # workflow without that approval; only Check-changed-files is duplicated across both.
   pull_request_target:
     branches: [main, 'release-*'] # zizmor: ignore[dangerous-triggers]
 
@@ -28,7 +29,7 @@ jobs:
     steps:
       - run: true
 
-  # Skip unit/integration tests when only non-code files changed (Type-Check still runs).
+  # Skip the integration and kubernetes tests when only non-code files changed.
   Check-changed-files:
     runs-on: ubuntu-latest
     permissions:
@@ -112,24 +113,6 @@ jobs:
             esac
           done <<< "$FILES"
           echo "code_changed=$CODE_CHANGED" >> "$GITHUB_OUTPUT"
-
-  Type-Check:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: "3.10"
-          architecture: "x64"
-
-      - run: pip3 install "hatch>=1.14.2"
-      - run: hatch run tests.py3.10-3.1-1.9:type-check
 
   Run-Integration-Tests:
     needs: [Authorize, Check-changed-files]
@@ -228,7 +211,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
           AIRFLOW_CONN_DUCKDB_DEFAULT: "duckdb:///?host=''"
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-split${{ matrix.split-group }}
@@ -308,7 +291,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-expensive-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -452,7 +435,7 @@ jobs:
         run: |
           hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-async
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-dbt-async-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -474,86 +457,6 @@ jobs:
       DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
 
       # The following are only required because the profiles.yml file references them. They are not used by the tests selected by this job.
-      AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
-      POSTGRES_HOST: localhost
-      POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: postgres
-      POSTGRES_SCHEMA: public
-      POSTGRES_PORT: 5432
-
-  Run-Integration-Tests-dbt-Loom:
-    # Dedicated job for the cross-project example DAGs (cross_project_manifest_dag.py
-    # and cross_project_dbt_ls_dag.py), which exercise dbt-loom. Carved out of
-    # Run-Integration-Tests so the loom job's dbt + loom versions can move
-    # independently of the main matrix.
-    needs: [Authorize, Check-changed-files]
-    if: needs.Check-changed-files.outputs.code_changed == 'true'
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        python-version: ["3.11"]
-        airflow-version: ["3.2"]
-        dbt-version: ["1.11"]
-    services:
-      postgres:
-        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494  # 14.18
-        env:
-          POSTGRES_PASSWORD: postgres
-        options: >-
-          --health-cmd pg_isready
-          --health-interval 10s
-          --health-timeout 5s
-          --health-retries 5
-        ports:
-          - 5432:5432
-
-    steps:
-      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
-        with:
-          ref: ${{ github.event.pull_request.head.sha || github.ref }}
-          persist-credentials: false
-
-      - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
-        with:
-          path: |
-            ~/.cache/pip
-            .local/share/hatch/
-          key: integration-dbt-loom-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}-${{ hashFiles('pyproject.toml') }}-${{ hashFiles('cosmos/__init__.py') }}
-
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      - name: Install packages and dependencies
-        run: |
-          python -m pip install uv
-          uv pip install --system "hatch>=1.14.2"
-          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
-
-      - name: Test cross-project dbt-loom example DAGs (manifest + dbt ls)
-        run: |
-          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-loom
-
-      - name: Upload coverage to Github
-        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
-        with:
-          name: coverage-integration-dbt-loom-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
-          path: .coverage
-          include-hidden-files: true
-
-    env:
-      AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
-      PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
-      AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
-      AIRFLOW__COSMOS__ENABLE_CACHE: 0
-      DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
-
-      # cross_project_manifest_dag's profiles.yml references these
       AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@0.0.0.0:5432/postgres
       POSTGRES_HOST: localhost
       POSTGRES_USER: postgres
@@ -628,7 +531,7 @@ jobs:
           AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
           RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -712,7 +615,7 @@ jobs:
           POSTGRES_SCHEMA: public
           POSTGRES_PORT: 5432
 
-      - name: Upload coverage to Github
+      - name: Upload coverage to GitHub
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-integration-kubernetes-test-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
@@ -724,7 +627,6 @@ jobs:
     needs:
       - Authorize
       - Run-Integration-Tests
-      - Run-Integration-Tests-dbt-Loom
       - Run-Integration-Tests-Expensive
       - Run-Kubernetes-Tests
     runs-on: ubuntu-latest
@@ -751,20 +653,21 @@ jobs:
           path: ./coverage
           pattern: coverage-*
 
-      # The unit and telemetry tests run in the unprivileged test-unprivileged.yml workflow, so
-      # their coverage lands in a separate workflow run for the same commit. Locate that run by
-      # head SHA and wait until its unit/telemetry coverage artifacts are available. (The
-      # performance tests run in that same workflow but upload no coverage, so they are irrelevant
-      # here — we only wait on the unit/telemetry artifacts, never on the whole run, so the
-      # longer-running performance matrix does not hold this step up.)
+      # The unit, telemetry and dbt-loom tests run in the unprivileged test-unprivileged.yml
+      # workflow, so their coverage lands in a separate workflow run for the same commit. Locate
+      # that run by head SHA and wait until those coverage artifacts are available. (The performance
+      # tests run in that same workflow but upload no coverage, so they are irrelevant here — we
+      # wait only on the coverage-producing artifacts, never on the whole run, so the longer-running
+      # performance matrix does not hold this step up.)
       #
       # By the time this job runs, those artifacts are expected to already exist: this job only
       # starts after its `needs` (the integration and kubernetes jobs) complete, which take
-      # ~5-18 min, whereas the unit and telemetry tests run in parallel from the same commit and
-      # finish in ~2 min. So the first attempt below almost always finds the artifacts and breaks
-      # immediately. The retry loop is a safety gate for the rare race where this job somehow
-      # reaches this step before the unprivileged run has uploaded them; it waits up to 5 minutes
-      # (15 attempts x 20s) before failing rather than silently dropping coverage.
+      # ~5-18 min, whereas the unprivileged unit/telemetry/dbt-loom tests run in parallel from the
+      # same commit and finish well within that window. So the first attempt below almost always
+      # finds the artifacts and breaks immediately. The retry loop is a safety gate for the rare
+      # race where this job reaches this step before the unprivileged run has uploaded them; it
+      # waits up to 5 minutes (15 attempts x 20s) before failing rather than silently dropping
+      # coverage.
       - name: Locate unprivileged test run for this commit
         id: unprivileged-run
         env:
@@ -772,16 +675,20 @@ jobs:
         run: |
           HEAD_SHA="${{ github.event.pull_request.head.sha || github.sha }}"
           RUN_ID=""
+          FOUND=""
           for attempt in $(seq 1 15); do
             RUN_ID=$(gh api \
               "repos/${{ github.repository }}/actions/workflows/test-unprivileged.yml/runs?head_sha=${HEAD_SHA}&per_page=1" \
               --jq '.workflow_runs[0].id // ""')
             if [ -n "$RUN_ID" ]; then
-              COUNT=$(gh api \
+              NAMES=$(gh api \
                 "repos/${{ github.repository }}/actions/runs/${RUN_ID}/artifacts?per_page=100" \
-                --jq '[.artifacts[].name | select(startswith("coverage-unit-test-") or startswith("coverage-telemetry-test-"))] | length')
-              if [ "${COUNT:-0}" -gt 0 ]; then
-                echo "Found ${COUNT} unit/telemetry coverage artifacts in run ${RUN_ID}."
+                --jq '.artifacts[].name')
+              if echo "$NAMES" | grep -q '^coverage-unit-test-' \
+                && echo "$NAMES" | grep -q '^coverage-telemetry-test-' \
+                && echo "$NAMES" | grep -q '^coverage-integration-dbt-loom-test-'; then
+                echo "Found unit, telemetry and dbt-loom coverage artifacts in run ${RUN_ID}."
+                FOUND=1
                 break
               fi
             fi
@@ -789,12 +696,16 @@ jobs:
             sleep 20
           done
           if [ -z "$RUN_ID" ]; then
-            echo "::error::No test-unprivileged.yml run found for ${HEAD_SHA}; unit/telemetry coverage would be missing."
+            echo "::error::No test-unprivileged.yml run found for ${HEAD_SHA}; its coverage would be missing."
+            exit 1
+          fi
+          if [ -z "$FOUND" ]; then
+            echo "::error::test-unprivileged.yml run ${RUN_ID} did not publish all expected coverage artifacts (unit, telemetry, dbt-loom) after waiting; refusing to upload partial coverage."
             exit 1
           fi
           echo "run_id=${RUN_ID}" >> "$GITHUB_OUTPUT"
 
-      - name: Download unit and telemetry coverage from the unprivileged run
+      - name: Download unit, telemetry and dbt-loom coverage from the unprivileged run
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8.0.1
         with:
           path: ./coverage

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, split-pr-test-workflow]
+    branches: [main]
   # Also run on pull requests originating from forks. Jobs here require sensitive secrets (integration tests,
   # kubernetes, code coverage) and depend on the Authorize job, which requires manually approving the workflow run
   # for external PRs. Jobs that do not use sensitive secrets (type-check still runs here; unit, telemetry and

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main, split-pr-test-workflow]
+    branches: [main]
   # Also run on pull requests originating from forks. Every test job here is secret-dependent
   # (integration tests, kubernetes, code coverage) and depends on the Authorize job, which requires
   # manually approving the workflow run for external PRs. Jobs that need no secrets (type-check,


### PR DESCRIPTION
CodeQL flagged three pre-existing [alerts](https://github.com/astronomer/astronomer-cosmos/runs/80263826909?pr=2789) in `test.yml` surfaced via PR #2789's CI run — one critical privileged checkout (`actions/untrusted-checkout`) and two cache-poisoning alerts (`actions/cache-poisoning`) — on the `Run-Unit-Tests`, `Run-Telemetry-Tests` and `Run-Performance-Tests` jobs. Those jobs run untrusted PR code under `pull_request_target` without the `Authorize` environment gate that the secret-dependent jobs use, so CodeQL treats them as privileged execution of untrusted code.

The fix moves every test job that needs no repository secrets into a new `test-unprivileged.yml` workflow triggered by `pull_request` and push-to-main: `Type-Check`, `Run-Unit-Tests`, `Run-Telemetry-Tests`, `Run-Performance-Tests` and `Run-Integration-Tests-dbt-Loom`. (The only secret any of them referenced, `COSMOS_CONN_POSTGRES_PASSWORD`, is set by the test itself.) Under `pull_request`, fork code runs with a read-only token and no secret access, which removes the privileged context the alerts depend on without adding any manual approval gate.

This leaves a clean split:
- `test.yml` (`pull_request_target`): only secret-dependent jobs (integration variants, kubernetes, code coverage), gated by `Authorize`, plus `Check-changed-files`.
- `test-unprivileged.yml` (`pull_request` + push-to-main): every job that needs no secrets.
- `Check-changed-files` is duplicated across both.

Coverage is preserved: the `Code-Coverage` job locates the sibling `test-unprivileged.yml` run by head SHA and downloads the unit, telemetry and dbt-loom coverage artifacts before combining and uploading to Codecov.

This is the root-cause fix for the CodeQL failure also seen on #2789; once merged, dependency bumps that touch those checkout steps will no longer re-surface the alerts.

🤖 Generated with Claude Code
