### PR TITLE
Set persist-credentials false for checkout in actionlint workflow

### DIFF
--- a/.github/workflows/actionlint.yml
+++ b/.github/workflows/actionlint.yml
@@ -18,6 +18,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Validate workflow files
         uses: reviewdog/action-actionlint@6fb7acc99f4a1008869fa8a0f09cfca740837d9d # v1.72.0


### PR DESCRIPTION
The `actions/checkout` step in `actionlint.yml` was the only checkout in the repository that did not set `persist-credentials: false`, so zizmor's `artipacked` audit flagged it as "credential persistence through GitHub Actions artifacts" (severity Low). Every other workflow already disables credential persistence right after checkout.

This sets `persist-credentials: false` on that step to match the rest of the workflows and clear the finding. The checkout in this job only validates workflow YAML and needs no persisted token.

Surfaced while reviewing the `actions/checkout` bump: https://github.com/astronomer/astronomer-cosmos/pull/2789#discussion_r3378455664.

🤖 Generated with [Claude Code](https://claude.com/claude-code)