### PR TITLE
Align WATCHER_KUBERNETES producer default task_id with PRODUCER_WATCHER_TASK_ID

### DIFF
--- a/cosmos/operators/watcher_kubernetes.py
+++ b/cosmos/operators/watcher_kubernetes.py
@@ -18,6 +18,7 @@ from airflow.providers.cncf.kubernetes.callbacks import KubernetesPodOperatorCal
 
 from cosmos.airflow._override import CosmosKubernetesPodManager
 from cosmos.airflow.compatibility import EmptyOperator
+from cosmos.constants import PRODUCER_WATCHER_TASK_ID
 from cosmos.log import get_logger
 from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
 from cosmos.operators._watcher.xcom import (
@@ -87,7 +88,7 @@ class DbtProducerWatcherKubernetesOperator(DbtBuildKubernetesOperator):
     _process_log_line_callable: Callable[[str, dict[str, Any]], None] | None = store_dbt_resource_status_from_log
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
-        task_id = kwargs.pop("task_id", "dbt_producer_watcher_operator")
+        task_id = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
 
         existing_callbacks = kwargs.get("callbacks")
         if existing_callbacks is None:

--- a/tests/operators/test_watcher_kubernetes_unit.py
+++ b/tests/operators/test_watcher_kubernetes_unit.py
@@ -9,7 +9,12 @@ from airflow.providers.cncf.kubernetes.secret import Secret
 from packaging.version import Version
 
 from cosmos.config import ProfileConfig, ProjectConfig, RenderConfig
-from cosmos.constants import LoadMode, TestBehavior, _K8s_WATCHER_MIN_K8S_PROVIDER_VERSION
+from cosmos.constants import (
+    PRODUCER_WATCHER_TASK_ID,
+    LoadMode,
+    TestBehavior,
+    _K8s_WATCHER_MIN_K8S_PROVIDER_VERSION,
+)
 
 if Version(airflow_k8s_provider_version) < _K8s_WATCHER_MIN_K8S_PROVIDER_VERSION:
     pytest.skip(
@@ -74,6 +79,33 @@ project_config = ProjectConfig(
 )
 
 render_config = RenderConfig(load_method=LoadMode.DBT_MANIFEST, test_behavior=TestBehavior.NONE)
+
+
+def test_producer_default_task_id_matches_watcher_task_id():
+    """The Kubernetes producer must default its ``task_id`` to ``PRODUCER_WATCHER_TASK_ID``.
+
+    Consumer sensors default ``producer_task_id`` to ``PRODUCER_WATCHER_TASK_ID``, so a
+    directly-instantiated producer with a different default would make consumers poll the
+    wrong task and hang. The Cosmos-rendered graph always sets ``task_id`` explicitly, but
+    this guards direct instantiation and keeps parity with ``DbtProducerWatcherOperator``.
+    """
+    op = DbtProducerWatcherKubernetesOperator(
+        project_dir=".",
+        profile_config=None,
+        image="dbt-image:latest",
+    )
+    assert op.task_id == PRODUCER_WATCHER_TASK_ID
+
+
+def test_producer_honours_explicit_task_id():
+    """An explicitly-provided ``task_id`` is still respected."""
+    op = DbtProducerWatcherKubernetesOperator(
+        task_id="custom_producer",
+        project_dir=".",
+        profile_config=None,
+        image="dbt-image:latest",
+    )
+    assert op.task_id == "custom_producer"
 
 
 @patch("cosmos.operators.watcher_kubernetes._restore_xcom_from_variable")


### PR DESCRIPTION
## Description

`DbtProducerWatcherKubernetesOperator` defaulted its `task_id` to `"dbt_producer_watcher_operator"`, while watcher consumer sensors default `producer_task_id` to `PRODUCER_WATCHER_TASK_ID` (`"dbt_producer_watcher"`) — the same constant the non-Kubernetes `DbtProducerWatcherOperator` already uses.

The Cosmos-rendered graph always sets the producer `task_id` explicitly (`cosmos/airflow/graph.py`), so generated DAGs are unaffected. The mismatch only surfaces on direct instantiation, where consumer sensors would poll the wrong producer task and hang. This aligns the default and adds regression tests.

Surfaced during review of #2543 (the open Copilot thread on this operator's default `task_id`); it is pre-existing on `main`, so it ships as its own small PR.

## Related Issue(s)

Related to #2543.

🤖 Generated with [Claude Code](https://claude.com/claude-code)