### PR TITLE
Avoid deprecated `airflow.exceptions.AirflowSkipException` import on Airflow 3.1+

### DIFF
--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -67,8 +67,8 @@ def delete_variable(key: str) -> None:
         Variable.delete(key)
 
 
-# ``airflow.exceptions.AirflowSkipException`` is deprecated on Airflow 3.1+; the Task SDK path does
-# not exist on Airflow 2 / 3.0 (hence the fallback; ignore is for the mypy env, pinned apache-airflow<3.1).
+# ``airflow.exceptions.AirflowSkipException`` is deprecated on Airflow 3.2+; the Task SDK path only
+# exposes it from 3.2 onwards, hence the fallback for Airflow 2 / 3.0 / 3.1.
 try:
     from airflow.sdk.exceptions import AirflowSkipException as AirflowSkipException  # type: ignore[attr-defined]
 except ImportError:

--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -65,3 +65,13 @@ def delete_variable(key: str) -> None:
         from airflow.models import Variable
 
         Variable.delete(key)
+
+
+# ``airflow.exceptions.AirflowSkipException`` is deprecated on Airflow 3.1+ in favour of the Task SDK
+# path, which does not exist on Airflow 2 / 3.0.
+try:
+    # attr-defined is ignored because the mypy env pins apache-airflow<3.1, where this path does not
+    # yet exist; at runtime the except branch handles Airflow 2 / 3.0.
+    from airflow.sdk.exceptions import AirflowSkipException as AirflowSkipException  # type: ignore[attr-defined]
+except ImportError:
+    from airflow.exceptions import AirflowSkipException as AirflowSkipException

--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -67,11 +67,9 @@ def delete_variable(key: str) -> None:
         Variable.delete(key)
 
 
-# ``airflow.exceptions.AirflowSkipException`` is deprecated on Airflow 3.1+ in favour of the Task SDK
-# path, which does not exist on Airflow 2 / 3.0.
+# ``airflow.exceptions.AirflowSkipException`` is deprecated on Airflow 3.1+; the Task SDK path does
+# not exist on Airflow 2 / 3.0 (hence the fallback; ignore is for the mypy env, pinned apache-airflow<3.1).
 try:
-    # attr-defined is ignored because the mypy env pins apache-airflow<3.1, where this path does not
-    # yet exist; at runtime the except branch handles Airflow 2 / 3.0.
     from airflow.sdk.exceptions import AirflowSkipException as AirflowSkipException  # type: ignore[attr-defined]
 except ImportError:
     from airflow.exceptions import AirflowSkipException as AirflowSkipException

--- a/cosmos/operators/_k8s_common.py
+++ b/cosmos/operators/_k8s_common.py
@@ -15,7 +15,7 @@ from os import PathLike
 from typing import TYPE_CHECKING, Any, Protocol
 
 import kubernetes.client as k8s
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import convert_env_vars
 from airflow.providers.cncf.kubernetes.callbacks import client_type
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
@@ -26,6 +26,7 @@ except ImportError:
     from airflow.utils.context import context_merge
 
 from cosmos.airflow._override import CosmosKubernetesPodManager
+from cosmos.airflow.compatibility import AirflowSkipException
 from cosmos.config import ProfileConfig
 from cosmos.operators._watcher.xcom import (
     _compose_backup_callback,

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -6,9 +6,10 @@ import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException
 
 from cosmos import settings
+from cosmos.airflow.compatibility import AirflowSkipException
 from cosmos.config import ProfileConfig
 from cosmos.constants import (
     _DATASET_EMITTING_RESOURCE_TYPES,

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -16,11 +16,12 @@ from typing import TYPE_CHECKING, Any, Literal
 from urllib.parse import urlparse
 
 import jinja2
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException
 from airflow.models.taskinstance import TaskInstance
 from airflow.utils.strings import to_boolean
 from packaging.version import Version
 
+from cosmos.airflow.compatibility import AirflowSkipException
 from cosmos.io import _construct_dest_file_path
 
 if TYPE_CHECKING:  # pragma: no cover

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -7,7 +7,7 @@ import sys
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
 
-from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.exceptions import AirflowException
 
 try:
     # Airflow 3.1 onwards
@@ -15,6 +15,7 @@ try:
 except ImportError:
     from airflow.utils.task_group import TaskGroup
 
+from cosmos.airflow.compatibility import AirflowSkipException
 from cosmos.config import ProfileConfig
 from cosmos.constants import (
     PRODUCER_WATCHER_DEFAULT_PRIORITY_WEIGHT,

--- a/tests/airflow/test_compatibility.py
+++ b/tests/airflow/test_compatibility.py
@@ -1,0 +1,29 @@
+import pytest
+from packaging.version import Version
+
+from cosmos.airflow.compatibility import AirflowSkipException
+from cosmos.constants import AIRFLOW_VERSION
+
+
+def test_airflow_skip_exception_is_a_skip_exception():
+    from airflow.exceptions import AirflowException
+
+    assert issubclass(AirflowSkipException, AirflowException)
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION < Version("3.2"),
+    reason="airflow.sdk.exceptions.AirflowSkipException only exists on Airflow 3.2+",
+)
+def test_airflow_skip_exception_resolves_to_task_sdk_on_3_2_plus():
+    """On Airflow 3.2+ the shim must resolve to the Task SDK, not the deprecated airflow.exceptions path."""
+    assert AirflowSkipException.__module__ == "airflow.sdk.exceptions"
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION >= Version("3.2"),
+    reason="airflow.sdk.exceptions.AirflowSkipException is absent before Airflow 3.2",
+)
+def test_airflow_skip_exception_falls_back_before_3_2():
+    """Before Airflow 3.2 the legacy import is not deprecated, so the shim falls back to it."""
+    assert AirflowSkipException.__module__ == "airflow.exceptions"


### PR DESCRIPTION
## Problem

On Airflow 3.2+, importing `AirflowSkipException` from `airflow.exceptions` is deprecated and emits a `UserWarning` at import time:

```
WARNING - airflow.exceptions.AirflowSkipException is deprecated and will be removed in a future
version. Use airflow.sdk.exceptions.AirflowSkipException instead. category=UserWarning
```

Cosmos imports it from `airflow.exceptions` in `local.py`, `watcher.py`, `_watcher/base.py`, and `_k8s_common.py`, so the warning shows up at DAG parse / task execution.

## Fix

`airflow.sdk.exceptions.AirflowSkipException` only exists on Airflow 3.2+ — the Task SDK does not expose it on Airflow 2 / 3.0 / 3.1, where `airflow.exceptions.AirflowSkipException` is **not** deprecated. So a plain switch would break older versions.

Add a version-tolerant re-export in the existing `cosmos/airflow/compatibility.py` (which already centralises Airflow 2/3 import differences) that prefers the Task SDK path and falls back to `airflow.exceptions`, and import `AirflowSkipException` from there in the operator modules. `AirflowException` is unaffected (not deprecated) and is left as-is.

## Verification

- **Airflow 3.2.0**: importing the Cosmos operators emits **no** `AirflowSkipException` deprecation warning; it resolves to `airflow.sdk.exceptions.AirflowSkipException`.
- **Airflow 3.0 / 3.1**: the Task SDK does not expose `AirflowSkipException`, so it falls back to `airflow.exceptions.AirflowSkipException` (which is not deprecated there, so no warning).
- New regression test (`tests/airflow/test_compatibility.py`) asserts the shim resolves to the Task SDK on Airflow ≥ 3.2 and to `airflow.exceptions` below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
