### PR TITLE
Treat concurrent cosmos_cache Variable insert IntegrityError as benign

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -615,6 +615,22 @@ class DbtGraph:
         logger.debug("Value of `dbt_yaml_selectors_cache_key` for <%s>: %s", self.cache_key, cache_args)
         return cache_args
 
+    def _log_concurrent_cache_write(self, cache_name: str) -> None:
+        """Log a benign duplicate-key race when concurrently writing the cache Variable.
+
+        When two schedulers or DAG processors parse the same DAG at once and neither finds an
+        existing ``cosmos_cache__*`` Variable, both attempt the INSERT. The unique constraint on
+        ``variable.key`` lets one win and makes the other raise an ``IntegrityError`` (Postgres
+        ``UniqueViolation``). The value we wanted to write is already present, so the loser treats
+        the duplicate-key error as a no-op and logs it at debug level rather than propagating it.
+        """
+        logger.debug(
+            "Cosmos %s cache for Airflow Variable '%s' was concurrently written by another "
+            "parser (duplicate key); treating as a no-op.",
+            cache_name,
+            self.cache_key,
+        )
+
     def _save_cache_to_variable(self, cache_dict: dict[str, Any], cache_name: str) -> None:
         """Write cache_dict to an Airflow Variable, warning on AirflowRuntimeError.
 
@@ -622,10 +638,15 @@ class DbtGraph:
         DAG processor does not have direct access to a usable Airflow metadata database
         (for example, when the ``variable`` table is unavailable).
         """
+        from sqlalchemy.exc import IntegrityError
+
         try:
             from airflow.sdk.exceptions import AirflowRuntimeError
         except ImportError:
-            Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            try:
+                Variable.set(self.cache_key, cache_dict, serialize_json=True)
+            except IntegrityError:
+                self._log_concurrent_cache_write(cache_name)
             return
 
         is_yaml_cache = "yaml" in cache_name.lower()
@@ -637,6 +658,8 @@ class DbtGraph:
         cache_specific_workaround = "" if is_yaml_cache else ", using LoadMode.DBT_MANIFEST"
         try:
             Variable.set(self.cache_key, cache_dict, serialize_json=True)
+        except IntegrityError:
+            self._log_concurrent_cache_write(cache_name)
         except AirflowRuntimeError as e:
             logger.warning(
                 "Failed to save Cosmos %s cache to Airflow Variable '%s': %s. "

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2502,6 +2502,36 @@ def test_save_yaml_selectors_cache_variable_set_failure(mock_variable_set, tmp_d
     assert "AIRFLOW__COSMOS__REMOTE_CACHE_DIR" in caplog.text
 
 
+@patch("cosmos.dbt.graph.Variable.set")
+def test_save_dbt_ls_cache_concurrent_integrity_error(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from sqlalchemy.exc import IntegrityError
+
+    mock_variable_set.side_effect = IntegrityError("INSERT INTO variable", {}, Exception("duplicate key"))
+    graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
+    with caplog.at_level(logging.DEBUG, logger="cosmos.dbt.graph"):
+        graph.save_dbt_ls_cache("some output")
+    assert "Failed to save Cosmos" not in caplog.text
+    assert "concurrently written by another parser" in caplog.text
+    assert "cosmos_cache__something" in caplog.text
+
+
+@patch("cosmos.dbt.graph.Variable.set")
+def test_save_yaml_selectors_cache_concurrent_integrity_error(mock_variable_set, tmp_dbt_project_dir, caplog):
+    from sqlalchemy.exc import IntegrityError
+
+    mock_variable_set.side_effect = IntegrityError("INSERT INTO variable", {}, Exception("duplicate key"))
+    graph = DbtGraph(cache_identifier="something", project=ProjectConfig(dbt_project_path=tmp_dbt_project_dir))
+    selectors = YamlSelectors(
+        {"staging_orders": {"name": "staging_orders", "definition": {"method": "tag", "value": "tag_a"}}},
+        {"select": ["tag:tag_a"], "exclude": None},
+    )
+    with caplog.at_level(logging.DEBUG, logger="cosmos.dbt.graph"):
+        graph.save_yaml_selectors_cache(selectors)
+    assert "Failed to save Cosmos" not in caplog.text
+    assert "concurrently written by another parser" in caplog.text
+    assert "cosmos_cache__something" in caplog.text
+
+
 @pytest.mark.integration
 def test_get_dbt_ls_cache_returns_empty_if_non_json_var(airflow_variable):
     graph = DbtGraph(project=ProjectConfig())


### PR DESCRIPTION
## Summary

Concurrent DAG parses that both miss the `cosmos_cache__*` Airflow Variable can race on the INSERT. The unique constraint on `variable.key` lets one writer win and makes the other raise a SQLAlchemy `IntegrityError` (Postgres `UniqueViolation`), which propagated as a noisy traceback in scheduler/DAG-processor logs even though the cache value was already written.

`_save_cache_to_variable` now treats this duplicate-key race as a benign no-op: the loser logs it at debug level instead of raising. This is handled on both the Airflow 2 path (direct metadata-DB write) and the Airflow 3 path (alongside the existing `AirflowRuntimeError` handling), so it also covers the YAML selectors cache, which shares the same write path.

- Add `_log_concurrent_cache_write` helper for the shared debug log.
- Catch `IntegrityError` in both branches of `_save_cache_to_variable`.
- Add tests asserting the duplicate-key error is swallowed with a debug log for both the dbt ls and YAML selectors caches.

## Related Issue(s)

closes #2723
closes BOSS-416

## Breaking Change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)