### PR TITLE
Fix watcher ORM ban on Airflow 3.0 by detecting the supervisor at runtime

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -9,6 +9,19 @@ from packaging.version import Version
 
 AIRFLOW_VERSION = Version(airflow.__version__)
 
+
+def airflow_supports_task_sdk_runtime(version: Version = AIRFLOW_VERSION) -> bool:
+    """Whether Airflow's task-SDK runtime XCom / task-state APIs are usable in the triggerer.
+
+    ``XCom.get_one`` and ``RuntimeTaskInstance.get_task_states`` import ``SUPERVISOR_COMMS``
+    from ``airflow.sdk.execution_time.task_runner`` -- a symbol that only exists on Airflow
+    3.1+. On Airflow 3.0 those APIs raise outside a task-SDK supervisor process (most notably
+    ``dag.test()``, which runs triggers/tasks inline), so callers must read XCom and producer
+    task state directly from the metadata DB instead. See apache/airflow#51816 and #59093.
+    """
+    return version >= Version("3.1.0")
+
+
 # dbt materialization for models that are inlined as a CTE into downstream models and never written to the warehouse.
 DBT_EPHEMERAL_MATERIALIZATION = "ephemeral"
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -10,18 +10,6 @@ from packaging.version import Version
 AIRFLOW_VERSION = Version(airflow.__version__)
 
 
-def airflow_supports_task_sdk_runtime(version: Version = AIRFLOW_VERSION) -> bool:
-    """Whether Airflow's task-SDK runtime XCom / task-state APIs are usable in the triggerer.
-
-    ``XCom.get_one`` and ``RuntimeTaskInstance.get_task_states`` import ``SUPERVISOR_COMMS``
-    from ``airflow.sdk.execution_time.task_runner`` -- a symbol that only exists on Airflow
-    3.1+. On Airflow 3.0 those APIs raise outside a task-SDK supervisor process (most notably
-    ``dag.test()``, which runs triggers/tasks inline), so callers must read XCom and producer
-    task state directly from the metadata DB instead. See apache/airflow#51816 and #59093.
-    """
-    return version >= Version("3.1.0")
-
-
 # dbt materialization for models that are inlined as a CTE into downstream models and never written to the warehouse.
 DBT_EPHEMERAL_MATERIALIZATION = "ephemeral"
 

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -155,9 +155,9 @@ def build_producer_state_fetcher(
       forbidden -- ``create_session`` raises ``RuntimeError: Direct database access via the
       ORM is not allowed in Airflow 3.0`` -- but ``RuntimeTaskInstance.get_task_states`` works
       because the worker binds ``SUPERVISOR_COMMS``.
-    * Outside a supervisor (``dag.test()`` running inline, or the Airflow 3.0 triggerer process
-      where ``SUPERVISOR_COMMS`` is never bound), ``get_task_states`` raises ``NameError`` while
-      ORM access *is* permitted.
+    * Outside a supervisor (``dag.test()`` running inline), ``SUPERVISOR_COMMS`` is unbound, so
+      ``get_task_states`` raises ``NameError`` while ORM access *is* permitted. (A real worker and a
+      real triggerer both bind ``SUPERVISOR_COMMS`` and take the task-SDK path above.)
 
     So on Airflow >= 3.0 we prefer ``get_task_states`` and fall back to the metadata DB only on
     ``NameError`` (no supervisor). See apache/airflow#51816, #59093.
@@ -208,9 +208,8 @@ def build_producer_state_fetcher(
                 run_ids=[run_id],
             )
         except NameError as exc:
-            # No task-SDK supervisor (e.g. dag.test() inline, or the Airflow 3.0 triggerer):
-            # SUPERVISOR_COMMS is unbound. Read producer state from the metadata DB, which is
-            # permitted in these non-supervisor contexts.
+            # No task-SDK supervisor (dag.test() running inline): SUPERVISOR_COMMS is unbound. Read
+            # producer state from the metadata DB, which is permitted in this non-supervisor context.
             logger.debug(
                 "RuntimeTaskInstance.get_task_states unavailable (no supervisor: %s); reading state from the metadata DB",
                 exc,

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -145,16 +145,25 @@ def build_producer_state_fetcher(
     producer_task_id: str,
     logger: logging.Logger,
 ) -> ProducerStateFetcher | None:
-    """Return a callable that fetches the producer task state for the given Airflow version."""
+    """Return a callable that fetches the producer task state for the given Airflow version.
 
-    # Imported lazily: a module-level import of cosmos.constants here triggers a circular import
-    # during Airflow plugin discovery (cosmos.plugin imports from a half-initialized constants).
-    from cosmos.constants import airflow_supports_task_sdk_runtime
+    On Airflow 3.x the same callable is used from two very different runtime contexts, and
+    the correct data source differs between them -- so the choice is made at call time, not
+    by version alone:
 
-    # Airflow < 3.1 reads producer task state directly from the metadata DB. The task-SDK
-    # ``RuntimeTaskInstance.get_task_states`` raises on Airflow 3.0 outside a supervisor
-    # (e.g. dag.test()), so it is only usable on 3.1+. See apache/airflow#51816, #59093.
-    if not airflow_supports_task_sdk_runtime(airflow_version):
+    * Inside a task-SDK worker (the sensor's synchronous ``poke()``), direct ORM access is
+      forbidden -- ``create_session`` raises ``RuntimeError: Direct database access via the
+      ORM is not allowed in Airflow 3.0`` -- but ``RuntimeTaskInstance.get_task_states`` works
+      because the worker binds ``SUPERVISOR_COMMS``.
+    * Outside a supervisor (``dag.test()`` running inline, or the Airflow 3.0 triggerer process
+      where ``SUPERVISOR_COMMS`` is never bound), ``get_task_states`` raises ``NameError`` while
+      ORM access *is* permitted.
+
+    So on Airflow >= 3.0 we prefer ``get_task_states`` and fall back to the metadata DB only on
+    ``NameError`` (no supervisor). See apache/airflow#51816, #59093.
+    """
+
+    def build_orm_fetcher() -> ProducerStateFetcher | None:
         try:
             TaskInstance, create_session = _load_airflow2_dependencies()
         except ImportError as exc:  # pragma: no cover - defensive guard for stripped test envs
@@ -178,11 +187,18 @@ def build_producer_state_fetcher(
 
         return fetch_state_orm
 
+    # Airflow < 3.0 has no task-SDK runtime: read producer task state directly from the
+    # metadata DB, which is always permitted there.
+    if airflow_version < Version("3.0.0"):
+        return build_orm_fetcher()
+
     try:
         RuntimeTaskInstance = _load_airflow3_dependencies()
     except (ImportError, NameError) as exc:  # pragma: no cover - Airflow 3 libs missing
-        logger.warning("Could not load Airflow 3 RuntimeTaskInstance: %s", exc)
-        return None
+        logger.warning("Could not load Airflow 3 RuntimeTaskInstance, falling back to ORM: %s", exc)
+        return build_orm_fetcher()
+
+    orm_fetcher = build_orm_fetcher()
 
     def fetch_state_airflow3() -> str | None:
         try:
@@ -191,9 +207,15 @@ def build_producer_state_fetcher(
                 task_ids=[producer_task_id],
                 run_ids=[run_id],
             )
-        except NameError as exc:  # pragma: no cover - Airflow 3.0 missing supervisor comms
-            logger.warning("RuntimeTaskInstance.get_task_states unavailable due to NameError: %s", exc)
-            return None
+        except NameError as exc:
+            # No task-SDK supervisor (e.g. dag.test() inline, or the Airflow 3.0 triggerer):
+            # SUPERVISOR_COMMS is unbound. Read producer state from the metadata DB, which is
+            # permitted in these non-supervisor contexts.
+            logger.debug(
+                "RuntimeTaskInstance.get_task_states unavailable (no supervisor: %s); reading state from the metadata DB",
+                exc,
+            )
+            return orm_fetcher() if orm_fetcher is not None else None
         state = task_states.get(run_id, {}).get(producer_task_id)
         if state is not None:
             return str(state)

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -147,14 +147,21 @@ def build_producer_state_fetcher(
 ) -> ProducerStateFetcher | None:
     """Return a callable that fetches the producer task state for the given Airflow version."""
 
-    if airflow_version < Version("3.0.0"):
+    # Imported lazily: a module-level import of cosmos.constants here triggers a circular import
+    # during Airflow plugin discovery (cosmos.plugin imports from a half-initialized constants).
+    from cosmos.constants import airflow_supports_task_sdk_runtime
+
+    # Airflow < 3.1 reads producer task state directly from the metadata DB. The task-SDK
+    # ``RuntimeTaskInstance.get_task_states`` raises on Airflow 3.0 outside a supervisor
+    # (e.g. dag.test()), so it is only usable on 3.1+. See apache/airflow#51816, #59093.
+    if not airflow_supports_task_sdk_runtime(airflow_version):
         try:
             TaskInstance, create_session = _load_airflow2_dependencies()
         except ImportError as exc:  # pragma: no cover - defensive guard for stripped test envs
-            logger.warning("Could not import Airflow 2 state dependencies: %s", exc)
+            logger.warning("Could not import ORM state dependencies: %s", exc)
             return None
 
-        def fetch_state_airflow2() -> str | None:
+        def fetch_state_orm() -> str | None:
             with create_session() as session:
                 ti = (
                     session.query(TaskInstance)
@@ -169,7 +176,7 @@ def build_producer_state_fetcher(
                     return str(ti.state)
                 return None
 
-        return fetch_state_airflow2
+        return fetch_state_orm
 
     try:
         RuntimeTaskInstance = _load_airflow3_dependencies()

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -7,9 +7,8 @@ from typing import Any
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from asgiref.sync import sync_to_async
-from packaging.version import Version
 
-from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, AIRFLOW_VERSION
+from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, AIRFLOW_VERSION, airflow_supports_task_sdk_runtime
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import (
@@ -79,25 +78,13 @@ class WatcherTrigger(BaseTrigger):
     async def get_xcom_val_af3(self, key: str) -> Any | None:
         from airflow.sdk.execution_time.xcom import XCom
 
-        try:
-            return await sync_to_async(XCom.get_one)(
-                run_id=self.run_id,
-                key=key,
-                task_id=self.producer_task_id,
-                dag_id=self.dag_id,
-                map_index=self.map_index,
-            )
-        except ImportError:
-            # On Airflow 3.0, ``XCom.get_one`` unconditionally imports ``SUPERVISOR_COMMS``
-            # from ``airflow.sdk.execution_time.task_runner`` -- a symbol that only exists on
-            # Airflow 3.1+. Outside a task-SDK supervisor process (most notably ``dag.test()``,
-            # which runs deferred triggers inline) that import raises, the deferred task is
-            # re-queued forever, and the DAG run hangs silently. A real triggerer process has the
-            # supervisor environment, so the SDK path works there and stays primary; only the
-            # non-supervisor case falls back to the direct-DB ORM path, which the ``ti.xcom_pull``
-            # implementation on AF 3.0 reads straight from ``XComModel`` (no supervisor needed).
-            # See apache/airflow#51816 and apache/airflow#59093.
-            return await self.get_xcom_val_af2(key)
+        return await sync_to_async(XCom.get_one)(
+            run_id=self.run_id,
+            key=key,
+            task_id=self.producer_task_id,
+            dag_id=self.dag_id,
+            map_index=self.map_index,
+        )
 
     async def get_xcom_val_af2(self, key: str) -> Any | None:
         from airflow.models import TaskInstance
@@ -129,10 +116,12 @@ class WatcherTrigger(BaseTrigger):
             self.run_id,
             self.map_index,
         )
-        if AIRFLOW_VERSION < Version("3.0.0"):
-            return await self.get_xcom_val_af2(key)
-        else:
+        # Airflow 3.0's task-SDK XCom API raises outside a supervisor (e.g. dag.test()), so only
+        # use it on 3.1+; Airflow < 3.1 reads XCom directly from the metadata DB. See #51816.
+        if airflow_supports_task_sdk_runtime(AIRFLOW_VERSION):
             return await self.get_xcom_val_af3(key)
+        else:
+            return await self.get_xcom_val_af2(key)
 
     async def _get_node_status(self) -> Any | None:
         """Return the dbt node status from XCom.

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -7,8 +7,9 @@ from typing import Any
 
 from airflow.triggers.base import BaseTrigger, TriggerEvent
 from asgiref.sync import sync_to_async
+from packaging.version import Version
 
-from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, AIRFLOW_VERSION, airflow_supports_task_sdk_runtime
+from cosmos.constants import _DBT_STARTUP_EVENTS_XCOM_KEY, AIRFLOW_VERSION
 from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import (
@@ -116,11 +117,19 @@ class WatcherTrigger(BaseTrigger):
             self.run_id,
             self.map_index,
         )
-        # Airflow 3.0's task-SDK XCom API raises outside a supervisor (e.g. dag.test()), so only
-        # use it on 3.1+; Airflow < 3.1 reads XCom directly from the metadata DB. See #51816.
-        if airflow_supports_task_sdk_runtime(AIRFLOW_VERSION):
+        # Airflow < 3.0 has no task-SDK runtime: read XCom directly from the metadata DB.
+        if AIRFLOW_VERSION < Version("3.0.0"):
+            return await self.get_xcom_val_af2(key)
+        # Airflow >= 3.0: prefer the task-SDK XCom API. A real triggerer binds SUPERVISOR_COMMS
+        # (TriggererJobRunner.init_comms) and forbids direct ORM access -- create_session raises
+        # "Direct database access via the ORM is not allowed in Airflow 3.0" -- so XCom.get_one
+        # is the only path that works there. Only outside a supervisor (dag.test() running
+        # inline) is SUPERVISOR_COMMS unbound, making XCom.get_one raise ImportError/NameError;
+        # there ORM access IS permitted, so fall back to the metadata DB. A version gate cannot
+        # tell these apart. See apache/airflow#51816, #59093.
+        try:
             return await self.get_xcom_val_af3(key)
-        else:
+        except (ImportError, NameError):
             return await self.get_xcom_val_af2(key)
 
     async def _get_node_status(self) -> Any | None:

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -79,13 +79,25 @@ class WatcherTrigger(BaseTrigger):
     async def get_xcom_val_af3(self, key: str) -> Any | None:
         from airflow.sdk.execution_time.xcom import XCom
 
-        return await sync_to_async(XCom.get_one)(
-            run_id=self.run_id,
-            key=key,
-            task_id=self.producer_task_id,
-            dag_id=self.dag_id,
-            map_index=self.map_index,
-        )
+        try:
+            return await sync_to_async(XCom.get_one)(
+                run_id=self.run_id,
+                key=key,
+                task_id=self.producer_task_id,
+                dag_id=self.dag_id,
+                map_index=self.map_index,
+            )
+        except ImportError:
+            # On Airflow 3.0, ``XCom.get_one`` unconditionally imports ``SUPERVISOR_COMMS``
+            # from ``airflow.sdk.execution_time.task_runner`` -- a symbol that only exists on
+            # Airflow 3.1+. Outside a task-SDK supervisor process (most notably ``dag.test()``,
+            # which runs deferred triggers inline) that import raises, the deferred task is
+            # re-queued forever, and the DAG run hangs silently. A real triggerer process has the
+            # supervisor environment, so the SDK path works there and stays primary; only the
+            # non-supervisor case falls back to the direct-DB ORM path, which the ``ti.xcom_pull``
+            # implementation on AF 3.0 reads straight from ``XComModel`` (no supervisor needed).
+            # See apache/airflow#51816 and apache/airflow#59093.
+            return await self.get_xcom_val_af2(key)
 
     async def get_xcom_val_af2(self, key: str) -> Any | None:
         from airflow.models import TaskInstance

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -52,24 +52,6 @@ class TestWatcherTrigger:
             )
             assert result == expected_value
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Require Airflow >= 3.0.0")
-    @pytest.mark.asyncio
-    async def test_get_xcom_val_af3_falls_back_to_af2_on_import_error(self):
-        # On Airflow 3.0, XCom.get_one imports SUPERVISOR_COMMS (3.1+ only) and raises
-        # ImportError outside a supervisor (e.g. dag.test()). The SDK path must fall back to
-        # the direct-DB ORM path instead of propagating the error. See apache/airflow#51816.
-        expected_value = {"foo": "bar"}
-
-        with patch("cosmos.operators._watcher.triggerer.sync_to_async") as mock_sync_to_async:
-            mock_get_one = AsyncMock(side_effect=ImportError("cannot import name 'SUPERVISOR_COMMS'"))
-            mock_sync_to_async.return_value = mock_get_one
-
-            with patch.object(self.trigger, "get_xcom_val_af2", AsyncMock(return_value=expected_value)) as mock_af2:
-                result = await self.trigger.get_xcom_val_af3("test_key")
-
-            mock_af2.assert_awaited_once_with("test_key")
-            assert result == expected_value
-
     @pytest.mark.skipif(AIRFLOW_VERSION >= Version("3.0.0"), reason="Require Airflow < 3.0.0")
     @pytest.mark.asyncio
     async def test_get_xcom_val_af2(self):
@@ -151,8 +133,8 @@ class TestWatcherTrigger:
     @pytest.mark.parametrize(
         "airflow_version, expected_val",
         [
-            (Version("2.11.0"), "af2"),  # Airflow < 3 uses get_xcom_val_af2
-            (Version("3.0.0"), "af3"),  # Airflow >= 3 uses get_xcom_val_af3
+            (Version("2.11.0"), "af2"),  # Airflow < 3.1 uses the direct-DB get_xcom_val_af2
+            (Version("3.1.0"), "af3"),  # Airflow >= 3.1 uses the task-SDK get_xcom_val_af3
         ],
     )
     async def test_get_xcom_val_branches(self, airflow_version, expected_val):
@@ -287,8 +269,11 @@ class TestWatcherTrigger:
                 raise ModuleNotFoundError("missing runtime")
             return _real_import(name, *args, **kwargs)
 
-        with patch("builtins.__import__", side_effect=_import_side_effect):
-            state = await self.trigger._get_producer_task_status()
+        # Pin to 3.1.0 so the task-SDK branch is taken; that is where the RuntimeTaskInstance
+        # import is attempted (and here blocked), which must degrade to None rather than raise.
+        with patch("cosmos.operators._watcher.triggerer.AIRFLOW_VERSION", Version("3.1.0")):
+            with patch("builtins.__import__", side_effect=_import_side_effect):
+                state = await self.trigger._get_producer_task_status()
 
         assert state is None
 

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -134,6 +134,7 @@ class TestWatcherTrigger:
         "airflow_version, expected_val",
         [
             (Version("2.11.0"), "af2"),  # Airflow < 3.1 uses the direct-DB get_xcom_val_af2
+            (Version("3.0.0"), "af2"),  # Airflow 3.0 lacks SUPERVISOR_COMMS, so also uses get_xcom_val_af2
             (Version("3.1.0"), "af3"),  # Airflow >= 3.1 uses the task-SDK get_xcom_val_af3
         ],
     )

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -52,6 +52,24 @@ class TestWatcherTrigger:
             )
             assert result == expected_value
 
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Require Airflow >= 3.0.0")
+    @pytest.mark.asyncio
+    async def test_get_xcom_val_af3_falls_back_to_af2_on_import_error(self):
+        # On Airflow 3.0, XCom.get_one imports SUPERVISOR_COMMS (3.1+ only) and raises
+        # ImportError outside a supervisor (e.g. dag.test()). The SDK path must fall back to
+        # the direct-DB ORM path instead of propagating the error. See apache/airflow#51816.
+        expected_value = {"foo": "bar"}
+
+        with patch("cosmos.operators._watcher.triggerer.sync_to_async") as mock_sync_to_async:
+            mock_get_one = AsyncMock(side_effect=ImportError("cannot import name 'SUPERVISOR_COMMS'"))
+            mock_sync_to_async.return_value = mock_get_one
+
+            with patch.object(self.trigger, "get_xcom_val_af2", AsyncMock(return_value=expected_value)) as mock_af2:
+                result = await self.trigger.get_xcom_val_af3("test_key")
+
+            mock_af2.assert_awaited_once_with("test_key")
+            assert result == expected_value
+
     @pytest.mark.skipif(AIRFLOW_VERSION >= Version("3.0.0"), reason="Require Airflow < 3.0.0")
     @pytest.mark.asyncio
     async def test_get_xcom_val_af2(self):

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -133,9 +133,12 @@ class TestWatcherTrigger:
     @pytest.mark.parametrize(
         "airflow_version, expected_val",
         [
-            (Version("2.11.0"), "af2"),  # Airflow < 3.1 uses the direct-DB get_xcom_val_af2
-            (Version("3.0.0"), "af2"),  # Airflow 3.0 lacks SUPERVISOR_COMMS, so also uses get_xcom_val_af2
-            (Version("3.1.0"), "af3"),  # Airflow >= 3.1 uses the task-SDK get_xcom_val_af3
+            (Version("2.11.0"), "af2"),  # Airflow < 3.0 reads XCom directly from the metadata DB
+            # Airflow >= 3.0 uses the task-SDK get_xcom_val_af3: a real triggerer binds
+            # SUPERVISOR_COMMS (init_comms) and forbids ORM access, so the SDK is the only path
+            # that works there.
+            (Version("3.0.0"), "af3"),
+            (Version("3.1.0"), "af3"),
         ],
     )
     async def test_get_xcom_val_branches(self, airflow_version, expected_val):
@@ -148,6 +151,19 @@ class TestWatcherTrigger:
                 with patch.object(self.trigger, "get_xcom_val_af3", AsyncMock(return_value="af3")):
                     val = await self.trigger.get_xcom_val("key")
                     assert val == "af3"
+
+    @pytest.mark.parametrize("raised", [ImportError("no SUPERVISOR_COMMS"), NameError("SUPERVISOR_COMMS")])
+    async def test_get_xcom_val_af3_falls_back_to_orm_without_supervisor(self, raised):
+        # On Airflow >= 3.0 the task-SDK XCom path is primary, but outside a supervisor
+        # (dag.test() running inline) SUPERVISOR_COMMS is unbound and XCom.get_one raises
+        # ImportError/NameError. There ORM access is permitted, so we must fall back to it.
+        with patch("cosmos.operators._watcher.triggerer.AIRFLOW_VERSION", Version("3.0.0")):
+            with patch.object(self.trigger, "get_xcom_val_af3", AsyncMock(side_effect=raised)):
+                with patch.object(self.trigger, "get_xcom_val_af2", AsyncMock(return_value="af2")) as mock_af2:
+                    val = await self.trigger.get_xcom_val("key")
+
+        assert val == "af2"
+        mock_af2.assert_awaited_once_with("key")
 
     @pytest.mark.parametrize(
         "xcom_status_val, producer_state, expected",
@@ -264,19 +280,30 @@ class TestWatcherTrigger:
         AIRFLOW_VERSION < Version("3.0.0"), reason="RuntimeTaskInstance import exists on Airflow >= 3.0"
     )
     @pytest.mark.asyncio
-    async def test_get_producer_task_status_airflow3_import_error(self):
+    async def test_get_producer_task_status_airflow3_import_error_falls_back_to_orm(self):
+        # If the task-SDK RuntimeTaskInstance cannot be imported (stripped env), the fetcher must
+        # fall back to the metadata-DB ORM path rather than degrade to None.
         def _import_side_effect(name: str, *args, **kwargs):
             if name == "airflow.sdk.execution_time.task_runner":
                 raise ModuleNotFoundError("missing runtime")
             return _real_import(name, *args, **kwargs)
 
-        # Pin to 3.1.0 so the task-SDK branch is taken; that is where the RuntimeTaskInstance
-        # import is attempted (and here blocked), which must degrade to None rather than raise.
-        with patch("cosmos.operators._watcher.triggerer.AIRFLOW_VERSION", Version("3.1.0")):
-            with patch("builtins.__import__", side_effect=_import_side_effect):
-                state = await self.trigger._get_producer_task_status()
+        orm_ti = MagicMock()
+        orm_ti.state = "success"
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.one_or_none.return_value = orm_ti
+        create_session_cm = MagicMock()
+        create_session_cm.return_value.__enter__.return_value = session
 
-        assert state is None
+        with patch("cosmos.operators._watcher.triggerer.AIRFLOW_VERSION", Version("3.1.0")):
+            with patch(
+                "cosmos.operators._watcher.state._load_airflow2_dependencies",
+                return_value=(MagicMock(), create_session_cm),
+            ):
+                with patch("builtins.__import__", side_effect=_import_side_effect):
+                    state = await self.trigger._get_producer_task_status()
+
+        assert state == "success"
 
     @pytest.mark.asyncio
     async def test_run_producer_success_model_not_run(self, caplog):

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1064,8 +1064,8 @@ class TestDbtConsumerWatcherSensor:
         fetcher.assert_called_once_with()
         assert status is None
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
-    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.1.0"), reason="task-SDK get_task_states path is Airflow >= 3.1")
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.1.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3(self, mock_get_task_states):
         sensor = self.make_sensor()
@@ -1085,8 +1085,8 @@ class TestDbtConsumerWatcherSensor:
             dag_id="example_dag", task_ids=[sensor.producer_task_id], run_ids=["run_3"]
         )
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
-    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.1.0"), reason="task-SDK get_task_states path is Airflow >= 3.1")
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.1.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3_missing_state(self, mock_get_task_states):
         sensor = self.make_sensor()

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -1064,8 +1064,8 @@ class TestDbtConsumerWatcherSensor:
         fetcher.assert_called_once_with()
         assert status is None
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.1.0"), reason="task-SDK get_task_states path is Airflow >= 3.1")
-    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.1.0"))
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="task-SDK get_task_states path is Airflow >= 3.0")
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3(self, mock_get_task_states):
         sensor = self.make_sensor()
@@ -1085,8 +1085,8 @@ class TestDbtConsumerWatcherSensor:
             dag_id="example_dag", task_ids=[sensor.producer_task_id], run_ids=["run_3"]
         )
 
-    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.1.0"), reason="task-SDK get_task_states path is Airflow >= 3.1")
-    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.1.0"))
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="task-SDK get_task_states path is Airflow >= 3.0")
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
     @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
     def test_get_producer_task_status_airflow3_missing_state(self, mock_get_task_states):
         sensor = self.make_sensor()
@@ -1105,6 +1105,40 @@ class TestDbtConsumerWatcherSensor:
         mock_get_task_states.assert_called_once_with(
             dag_id="example_dag", task_ids=[sensor.producer_task_id], run_ids=["run_3_missing"]
         )
+
+    @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="task-SDK get_task_states path is Airflow >= 3.0")
+    @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))
+    @patch("airflow.sdk.execution_time.task_runner.RuntimeTaskInstance.get_task_states")
+    def test_get_producer_task_status_airflow3_falls_back_to_orm_without_supervisor(self, mock_get_task_states):
+        # Regression for the Airflow 3.0 worker crash: inside a task-SDK worker get_task_states
+        # works, but with no supervisor (e.g. dag.test()) it raises NameError because
+        # SUPERVISOR_COMMS is unbound. There the metadata DB IS readable, so the fetcher must
+        # fall back to the ORM instead of propagating the NameError.
+        sensor = self.make_sensor()
+        sensor._get_producer_task_status = DbtConsumerWatcherSensor._get_producer_task_status.__get__(
+            sensor, DbtConsumerWatcherSensor
+        )
+        ti = MagicMock()
+        ti.dag_id = "example_dag"
+        context = self.make_context(ti, run_id="run_3_no_supervisor")
+
+        mock_get_task_states.side_effect = NameError("name 'SUPERVISOR_COMMS' is not defined")
+
+        orm_ti = MagicMock()
+        orm_ti.state = "success"
+        session = MagicMock()
+        session.query.return_value.filter_by.return_value.one_or_none.return_value = orm_ti
+        create_session_cm = MagicMock()
+        create_session_cm.return_value.__enter__.return_value = session
+
+        with patch(
+            "cosmos.operators._watcher.state._load_airflow2_dependencies",
+            return_value=(MagicMock(), create_session_cm),
+        ):
+            status = sensor._get_producer_task_status(context)
+
+        assert status == "success"
+        mock_get_task_states.assert_called_once()
 
     @pytest.mark.skipif(AIRFLOW_VERSION < Version("3.0.0"), reason="Database lookup path in Airflow < 3.0")
     @patch("cosmos.operators._watcher.base.AIRFLOW_VERSION", new=Version("3.0.0"))

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -70,17 +70,6 @@ def get_dag_bag() -> DagBag:  # noqa: C901
         if AIRFLOW_VERSION >= Version("3.0.0"):
             file.writelines("example_cosmos_cleanup_dag.py\n")
 
-        if Version("3.0.0") <= AIRFLOW_VERSION < Version("3.1.0"):
-            # `dag.test()` on Airflow 3.0 runs the WatcherTrigger inline. The trigger calls
-            # `airflow.sdk.execution_time.xcom.XCom.get_one`, which imports `SUPERVISOR_COMMS`
-            # from `airflow.sdk.execution_time.task_runner`. That symbol does not exist until
-            # Airflow 3.1, so the import fails, `dag.test()` re-queues the deferred task
-            # forever, and the integration job hangs until GH Actions kills it. The watcher
-            # path works on AF 3.0 in a real triggerer process; this skip only excludes the
-            # `dag.test()` exerciser. Drop once we either depend on AF >= 3.1 or rework the
-            # trigger's XCom fetch to not need `SUPERVISOR_COMMS`.
-            file.writelines("watcher_with_freshness_check.py\n")
-
         if AIRFLOW_VERSION == Version("2.9.0"):
             # aiobotocore can't be installed with all the other Cosmos test dependencies in Airflow 2.9
             file.writelines("cosmos_example_manifest_dag.py\n")


### PR DESCRIPTION
## Problem

In `WATCHER` mode on **Airflow 3.0**, the deferred triggerer's `get_xcom_val_af3` → `XCom.get_one` raises:

```
File "cosmos/operators/_watcher/triggerer.py", line 82, in get_xcom_val_af3
    return await sync_to_async(XCom.get_one)(...)
File "airflow/sdk/bases/xcom.py", line 242, in get_one
    from airflow.sdk.execution_time.task_runner import SUPERVISOR_COMMS
ImportError: cannot import name 'SUPERVISOR_COMMS' from 'airflow.sdk.execution_time.task_runner'
```

This was first hit under `dag.test()` (#2693). A prior revision worked around it by gating the task-SDK path at `>= 3.1` and routing **all** of AF 3.0 to the direct-DB ORM — which then crashed real 3.0 workers and triggerers with `RuntimeError: Direct database access via the ORM is not allowed in Airflow 3.0` (seen on `3.0.0+astro.2`).

## Root cause

The version gate rested on the premise that "a triggerer never binds `SUPERVISOR_COMMS` on 3.0." Inspecting the installed AF 3.0 source shows that premise is wrong:

- The worker (`task_runner.main()`) and the triggerer (`TriggererJobRunner.init_comms()`) **both bind `SUPERVISOR_COMMS` at runtime**, so the task-SDK APIs (`XCom.get_one`, `RuntimeTaskInstance.get_task_states`) **work** there — and the supervisor installs `BlockedDBSession`, so **ORM access is banned**.
- `SUPERVISOR_COMMS` is unbound **only** with no supervisor (`dag.test()` inline) — and there `XCom.get_one`/`get_task_states` raise `ImportError`/`NameError` while ORM access **is** permitted.

A single version gate can't tell "under a supervisor" from "not," so it caused the `ImportError` under `dag.test()` and the ORM `RuntimeError` on real workers/triggerers.

## Fix — detect the supervisor at call time

On AF ≥3.0, prefer the task-SDK and fall back to the ORM only when there is no supervisor:

- **`state.py`** `build_producer_state_fetcher` — try `RuntimeTaskInstance.get_task_states`; on `NameError` (no supervisor) → ORM.
- **`triggerer.py`** `get_xcom_val` — try `XCom.get_one`; on `ImportError`/`NameError` → ORM.

| Context | Path |
|---|---|
| Real 3.0 worker / triggerer (SDK ✅, ORM banned) | task-SDK |
| `dag.test()` inline, AF 3.0/3.1 (no supervisor) | ORM fallback |
| Airflow 2.x | ORM |

This targets AF 3.0 (3.1+ is unaffected — the CI skip was 3.0-only). A version gate is insufficient *within* 3.0: the same build runs as a real worker/triggerer (`SUPERVISOR_COMMS` bound → task-SDK works, ORM banned) and as `dag.test()` inline (no supervisor → task-SDK raises, ORM permitted), so the choice must be made at runtime, not by version.

## Testing

- **Worker/triggerer (task-SDK) path:** verified by source inspection (above) + unit tests — AF3 producer-state tests run at **3.0.0**; `test_get_xcom_val_branches` expects the task-SDK path on 3.0.
- **No-supervisor (ORM) path:** new `..._falls_back_to_orm_without_supervisor` (state) and parametrized `ImportError`/`NameError` fallback (triggerer) tests; the re-enabled `watcher_with_freshness_check.py` `dag.test()` integration cell.
- ✅ Full unit suite green on the AF 3.0 hatch env; ✅ mypy clean. AF 2.x ORM tests pass.

Refs: #2693, apache/airflow#51816, apache/airflow#59093

🤖 Generated with [Claude Code](https://claude.com/claude-code)



