### PR TITLE
Use SDK Variable in WATCHER XCom backup to reduce log noise

### DIFF
--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -8,6 +8,8 @@ Airflow 3 pre-releases (e.g. 3.0.0rc1) are treated as Airflow 3.
 
 from __future__ import annotations
 
+from typing import Any
+
 from cosmos.constants import _AIRFLOW3_MAJOR_VERSION, AIRFLOW_VERSION
 
 if AIRFLOW_VERSION.major >= _AIRFLOW3_MAJOR_VERSION:
@@ -26,3 +28,40 @@ else:
 # operator as a string for later dynamic import (e.g. ``Task.operator_class``) rather than
 # referencing the class. Derived from the class itself, so it always matches the imported one.
 EMPTY_OPERATOR_CLASS_PATH = f"{EmptyOperator.__module__}.{EmptyOperator.__name__}"
+
+
+# ``Variable`` moved to the Task SDK in Airflow 3. ``airflow.sdk.Variable`` avoids the
+# deprecation warning that ``airflow.models.Variable`` emits per access on Airflow 3, but it only
+# works inside the task supervisor; outside it (e.g. ``dag.test()``) it raises ImportError. These
+# helpers prefer the SDK and fall back to ``airflow.models.Variable`` when it is not usable.
+def get_variable(key: str, default: Any = None) -> Any:
+    try:
+        from airflow.sdk import Variable
+
+        return Variable.get(key, default=default)
+    except ImportError:
+        from airflow.models import Variable as LegacyVariable
+
+        return LegacyVariable.get(key, default_var=default)
+
+
+def set_variable(key: str, value: str) -> None:
+    try:
+        from airflow.sdk import Variable
+
+        Variable.set(key, value)
+    except ImportError:
+        from airflow.models import Variable
+
+        Variable.set(key, value)
+
+
+def delete_variable(key: str) -> None:
+    try:
+        from airflow.sdk import Variable
+
+        Variable.delete(key)
+    except ImportError:
+        from airflow.models import Variable
+
+        Variable.delete(key)

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -14,6 +14,7 @@ import re
 import zlib
 from typing import Any
 
+from cosmos.airflow.compatibility import delete_variable, get_variable, set_variable
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import safe_xcom_push
 
@@ -94,10 +95,8 @@ def _persist_backup(var_key: str, backup_buffer: dict[str, Any]) -> None:
     if not backup_buffer:
         return
 
-    from airflow.models import Variable
-
     compressed = base64.b64encode(zlib.compress(json.dumps(backup_buffer, default=str).encode("utf-8"))).decode("utf-8")
-    Variable.set(var_key, compressed)
+    set_variable(var_key, compressed)
     logger.debug("Persisted %d XCom entries to Variable '%s'", len(backup_buffer), var_key)
 
 
@@ -125,9 +124,7 @@ def _delete_xcom_backup_variable(context: Any) -> None:
     if not isinstance(var_key, str):
         return
     try:
-        from airflow.models import Variable
-
-        Variable.delete(var_key)
+        delete_variable(var_key)
         logger.debug("Deleted XCom backup Variable '%s'", var_key)
     except KeyError:
         pass
@@ -138,15 +135,13 @@ def _restore_xcom_from_variable(context: Any) -> bool:
 
     Returns True if the restore succeeded, False if no backup was found.
     """
-    from airflow.models import Variable
-
     ti = context["ti"]
     dag_id = ti.dag_id
     run_id = context["run_id"]
     task_group_id = _get_task_group_id(ti)
 
     var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
-    compressed = Variable.get(var_key, default_var=None)
+    compressed = get_variable(var_key, default=None)
     if compressed is None:
         logger.info("No XCom backup Variable found at '%s'", var_key)
         return False
@@ -157,7 +152,7 @@ def _restore_xcom_from_variable(context: Any) -> bool:
     logger.info("Restored %d XCom entries from Variable '%s'", len(backup), var_key)
 
     try:
-        Variable.delete(var_key)
+        delete_variable(var_key)
         logger.debug("Deleted XCom backup Variable '%s' after restore", var_key)
     except KeyError:
         logger.debug("XCom backup Variable '%s' already deleted", var_key)

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -231,21 +231,21 @@ class TestInitXcomBackup:
 
 
 class TestPersistBackup:
-    @patch("airflow.models.Variable")
-    def test_writes_compressed_data_to_variable(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.set_variable")
+    def test_writes_compressed_data_to_variable(self, mock_set_variable):
         _persist_backup("my_var_key", {"key1": "value1", "key2": "value2"})
 
-        mock_variable.set.assert_called_once()
-        var_key, compressed = mock_variable.set.call_args[0]
+        mock_set_variable.assert_called_once()
+        var_key, compressed = mock_set_variable.call_args[0]
         assert var_key == "my_var_key"
         data = json.loads(zlib.decompress(base64.b64decode(compressed.encode("utf-8"))).decode("utf-8"))
         assert data == {"key1": "value1", "key2": "value2"}
 
-    @patch("airflow.models.Variable")
-    def test_skips_empty_buffer(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.set_variable")
+    def test_skips_empty_buffer(self, mock_set_variable):
         _persist_backup("my_var_key", {})
 
-        mock_variable.set.assert_not_called()
+        mock_set_variable.assert_not_called()
 
 
 class TestSafeXcomPushBackup:
@@ -294,43 +294,44 @@ class TestBackupXcomToVariable:
 
 
 class TestDeleteXcomBackupVariable:
-    @patch("airflow.models.Variable")
-    def test_deletes_variable(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_deletes_variable(self, mock_delete_variable):
         ti = _MockTI()
         context = {"ti": ti, "run_id": "test_run"}
         _init_xcom_backup(context)
 
         _delete_xcom_backup_variable(context)
 
-        mock_variable.delete.assert_called_once_with(ti._cosmos_xcom_backup_var_key)
+        mock_delete_variable.assert_called_once_with(ti._cosmos_xcom_backup_var_key)
 
-    @patch("airflow.models.Variable")
-    def test_noop_without_init(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_noop_without_init(self, mock_delete_variable):
         ti = _MockTI()
         context = {"ti": ti}
 
         _delete_xcom_backup_variable(context)
 
-        mock_variable.delete.assert_not_called()
+        mock_delete_variable.assert_not_called()
 
-    @patch("airflow.models.Variable")
-    def test_ignores_key_error(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_ignores_key_error(self, mock_delete_variable):
         ti = _MockTI()
         context = {"ti": ti, "run_id": "test_run"}
         _init_xcom_backup(context)
-        mock_variable.delete.side_effect = KeyError("not found")
+        mock_delete_variable.side_effect = KeyError("not found")
 
         _delete_xcom_backup_variable(context)  # should not raise
 
 
 class TestRestoreXcomFromVariable:
     @patch("cosmos.operators._watcher.xcom._persist_backup")
-    @patch("airflow.models.Variable")
-    def test_restores_entries(self, mock_variable, mock_persist):
+    @patch("cosmos.operators._watcher.xcom.get_variable")
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_restores_entries(self, mock_delete_variable, mock_get_variable, mock_persist):
         ti = _MockTI()
         backup = {"key1": "val1", "key2": "val2"}
         compressed = base64.b64encode(zlib.compress(json.dumps(backup).encode("utf-8"))).decode("utf-8")
-        mock_variable.get.return_value = compressed
+        mock_get_variable.return_value = compressed
         context = {"ti": ti, "run_id": "test_run"}
 
         result = _restore_xcom_from_variable(context)
@@ -338,12 +339,12 @@ class TestRestoreXcomFromVariable:
         assert result is True
         assert ti.store["key1"] == "val1"
         assert ti.store["key2"] == "val2"
-        mock_variable.delete.assert_called_once()
+        mock_delete_variable.assert_called_once()
 
-    @patch("airflow.models.Variable")
-    def test_returns_false_when_no_backup(self, mock_variable):
+    @patch("cosmos.operators._watcher.xcom.get_variable")
+    def test_returns_false_when_no_backup(self, mock_get_variable):
         ti = _MockTI()
-        mock_variable.get.return_value = None
+        mock_get_variable.return_value = None
         context = {"ti": ti, "run_id": "test_run"}
 
         result = _restore_xcom_from_variable(context)

--- a/tests/operators/_watcher/test_xcom.py
+++ b/tests/operators/_watcher/test_xcom.py
@@ -1,0 +1,50 @@
+"""Unit tests for the Airflow Variable compatibility helpers used by the WATCHER XCom backup."""
+
+from __future__ import annotations
+
+import sys
+from unittest.mock import MagicMock, patch
+
+from cosmos.airflow import compatibility
+from cosmos.operators._watcher.xcom import _persist_backup
+
+
+@patch("cosmos.operators._watcher.xcom.set_variable")
+def test_persist_backup_uses_set_variable(mock_set_variable):
+    _persist_backup("cosmos_xcom_backup__key", {"foo": "bar"})
+
+    mock_set_variable.assert_called_once()
+
+
+def test_get_variable_prefers_sdk():
+    sdk_variable = MagicMock()
+    with patch.dict(sys.modules, {"airflow.sdk": MagicMock(Variable=sdk_variable)}):
+        compatibility.get_variable("k", default="x")
+
+    sdk_variable.get.assert_called_once_with("k", default="x")
+
+
+def test_set_variable_falls_back_to_models_outside_task_runner():
+    sdk_variable = MagicMock()
+    sdk_variable.set.side_effect = ImportError("SUPERVISOR_COMMS")
+    models_variable = MagicMock()
+    with (
+        patch.dict(sys.modules, {"airflow.sdk": MagicMock(Variable=sdk_variable)}),
+        patch("airflow.models.Variable", models_variable),
+    ):
+        compatibility.set_variable("k", "v")
+
+    models_variable.set.assert_called_once_with("k", "v")
+
+
+def test_get_variable_falls_back_to_models_outside_task_runner():
+    sdk_variable = MagicMock()
+    sdk_variable.get.side_effect = ImportError("SUPERVISOR_COMMS")
+    models_variable = MagicMock()
+    with (
+        patch.dict(sys.modules, {"airflow.sdk": MagicMock(Variable=sdk_variable)}),
+        patch("airflow.models.Variable", models_variable),
+    ):
+        compatibility.get_variable("k", default="x")
+
+    models_variable.get.assert_called_once_with("k", default_var="x")

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -197,10 +197,12 @@ def test_dbt_producer_log_format_always_json():
     assert op.log_format == "json"
 
 
-@patch("airflow.models.Variable")
+@patch("cosmos.operators._watcher.xcom.delete_variable")
 @patch("cosmos.operators._watcher.xcom._persist_backup")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.execute")
-def test_dbt_producer_watcher_operator_pushes_completion_status_on_success(mock_execute, mock_persist, mock_variable):
+def test_dbt_producer_watcher_operator_pushes_completion_status_on_success(
+    mock_execute, mock_persist, mock_delete_variable
+):
     """Test that operator pushes 'completed' status to XCom on success."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
     mock_ti = _MockTI()
@@ -212,10 +214,12 @@ def test_dbt_producer_watcher_operator_pushes_completion_status_on_success(mock_
     mock_execute.assert_called_once()
 
 
-@patch("airflow.models.Variable")
+@patch("cosmos.operators._watcher.xcom.delete_variable")
 @patch("cosmos.operators._watcher.xcom._persist_backup")
 @patch("cosmos.operators.local.DbtLocalBaseOperator.execute")
-def test_dbt_producer_watcher_operator_pushes_completion_status_on_failure(mock_execute, mock_persist, mock_variable):
+def test_dbt_producer_watcher_operator_pushes_completion_status_on_failure(
+    mock_execute, mock_persist, mock_delete_variable
+):
     """Test that operator pushes 'completed' status to XCom even when execution fails."""
     op = DbtProducerWatcherOperator(project_dir=".", profile_config=None)
     mock_ti = _MockTI()


### PR DESCRIPTION
## Environment

- astronomer-cosmos 1.14.2
- Apache Airflow 3.1.8
- ExecutionMode.WATCHER

## What happened

The WATCHER XCom backup imports `airflow.models.Variable` directly. On Airflow 3 that path emits a `Variable.set from airflow.models is deprecated` warning on every `safe_xcom_push`, which adds up to hundreds of warnings per producer run.

## Fix

- Add small Variable compatibility helpers to `cosmos/airflow/compatibility.py` (the existing home for Airflow 2/3 import differences, alongside `EmptyOperator`). They prefer `airflow.sdk.Variable` and fall back to `airflow.models.Variable` on Airflow 2.
- Route the WATCHER XCom backup get/set/delete through these helpers instead of importing `airflow.models.Variable` directly.

The helpers are thin wrapper functions rather than a bare class re-export like `EmptyOperator`, because the `get` signature differs across versions (`airflow.sdk.Variable.get(key, default=...)` vs `airflow.models.Variable.get(key, default_var=...)`), so a direct re-export would not give callers a stable interface.

## Scope

This PR focuses only on the deprecated `Variable` log noise. The related Airflow 3 Asset URI migration warning is addressed separately in #2788, which takes a broader approach (warn once per manifest computation and skip URI generation when consumers have `emit_datasets=False`).

## Tests

- Added `tests/operators/_watcher/test_xcom.py` for the Variable helpers.
- Updated `tests/operators/_watcher/test_state.py` and `tests/operators/test_watcher.py` to patch the helpers instead of `airflow.models.Variable`, so the mocks intercept the call on Airflow 3 as well.

## Validation

Tested on Airflow 3.1.8 with a WATCHER DAG (around 906 nodes, 225 dbt models per run): the deprecated `Variable` warnings dropped from hundreds per run to 0, with all models completing normally.
