### PR TITLE
Fix duplicate consumer logs in WATCHER mode

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -602,6 +602,14 @@ class BaseConsumerSensor(BaseSensorOperator):
         status = event.get("status")
         reason = event.get("reason")
 
+        # Log the node's dbt event once at terminal (poke() does the same for the non-deferrable path).
+        dbt_events = get_xcom_val(
+            task_instance=context["ti"],
+            key=get_dbt_event_xcom_key(self.model_unique_id),
+            task_ids=self.producer_task_id,
+        )
+        _log_dbt_event(dbt_events)
+
         if status == EventStatus.SKIPPED:
             raise AirflowSkipException(
                 f"{self._resource_label} '{self.model_unique_id}' was skipped by the dbt command."
@@ -624,12 +632,6 @@ class BaseConsumerSensor(BaseSensorOperator):
         if status != "failed":
             return
 
-        dbt_events = get_xcom_val(
-            task_instance=context["ti"],
-            key=get_dbt_event_xcom_key(self.model_unique_id),
-            task_ids=self.producer_task_id,
-        )
-        _log_dbt_event(dbt_events)
         if reason == WatcherEventReason.NODE_FAILED:
             raise AirflowException(
                 f"dbt {self._resource_label.lower()} '{self.model_unique_id}' failed. Review the producer task '{self.producer_task_id}' logs for details."

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -763,6 +763,11 @@ class BaseConsumerSensor(BaseSensorOperator):
         if status is not None:
             self._cache_compiled_sql(ti, context)
 
+        if status is None:
+            return self._handle_no_dbt_node_status(producer_task_state, try_number, context)
+
+        # Log the dbt event only once the node is terminal; poke runs every interval, so logging before
+        # this point would repeat the line on each poke.
         dbt_events = get_xcom_val(
             task_instance=context["ti"],
             key=get_dbt_event_xcom_key(self.model_unique_id),
@@ -770,9 +775,7 @@ class BaseConsumerSensor(BaseSensorOperator):
         )
         _log_dbt_event(dbt_events)
 
-        if status is None:
-            return self._handle_no_dbt_node_status(producer_task_state, try_number, context)
-        elif is_dbt_node_status_skipped(status):
+        if is_dbt_node_status_skipped(status):
             raise AirflowSkipException(
                 f"{self._resource_label} '{self.model_unique_id}' was skipped by the dbt command."
             )

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -14,10 +14,8 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import (
     PRODUCER_FINAL_STATES,
-    _log_dbt_event,
     build_producer_state_fetcher,
     get_compiled_sql_xcom_key,
-    get_dbt_event_xcom_key,
     get_status_xcom_key,
     is_dbt_node_status_failed,
     is_dbt_node_status_skipped,
@@ -230,8 +228,6 @@ class WatcherTrigger(BaseTrigger):
 
         while True:
             producer_task_state = await self._get_producer_task_status()
-            dbt_log_event = await self.get_xcom_val(get_dbt_event_xcom_key(self.model_unique_id))
-            _log_dbt_event(dbt_log_event)
             dbt_node_status, compiled_sql = await self._parse_dbt_node_status_and_compiled_sql()
             if is_dbt_node_status_success(dbt_node_status):
                 logger.debug("dbt node '%s' succeeded", self.model_unique_id)

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -331,6 +331,40 @@ class TestWatcherTrigger:
         assert events[0].payload["status"] == "success"
         assert events[0].payload["compiled_sql"] == "SELECT 1"
 
+    @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
+    @pytest.mark.asyncio
+    async def test_run_does_not_log_dbt_event_per_poll(self, mock_startup_events, caplog):
+        """Regression for #2456: the trigger must not log the per-node dbt event on each poll (the consumer
+        logs it once at terminal). Before the fix this line was emitted once per polling iteration, so with
+        three polls below it appeared three times, duplicating the consumer log."""
+        from cosmos.operators._watcher.state import get_dbt_event_xcom_key
+
+        caplog.set_level("INFO")
+        dbt_event = {"status": "running", "msg": "1 of 1 START model.test", "start_time": None, "finish_time": None}
+
+        async def get_xcom_val_side_effect(key):
+            if key == get_dbt_event_xcom_key(self.trigger.model_unique_id):
+                return dbt_event
+            return None
+
+        with (
+            patch.object(self.trigger, "get_xcom_val", AsyncMock(side_effect=get_xcom_val_side_effect)),
+            patch.object(
+                self.trigger, "_get_producer_task_status", AsyncMock(side_effect=["running", "running", "running"])
+            ),
+            patch.object(
+                self.trigger,
+                "_parse_dbt_node_status_and_compiled_sql",
+                AsyncMock(side_effect=[(None, None), (None, None), ("success", "SELECT 1")]),
+            ),
+            patch("asyncio.sleep", new_callable=AsyncMock),
+        ):
+            events = [event async for event in self.trigger.run()]
+
+        assert events[0].payload["status"] == "success"
+        # Across the three polls the per-node dbt event line must not be logged by the trigger.
+        assert "[RUNNING] Start:" not in caplog.text
+
     @pytest.mark.asyncio
     @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
     async def test_run_failed_model_includes_compiled_sql_in_event(self, mock_startup_events):

--- a/tests/operators/_watcher/test_triggerer.py
+++ b/tests/operators/_watcher/test_triggerer.py
@@ -167,11 +167,8 @@ class TestWatcherTrigger:
         ],
     )
     @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
-    @patch("cosmos.operators._watcher.triggerer._log_dbt_event")
     @pytest.mark.asyncio
-    async def test_run_various_outcomes(
-        self, mock_dbt_event, mock_startup_events, xcom_status_val, producer_state, expected
-    ):
+    async def test_run_various_outcomes(self, mock_startup_events, xcom_status_val, producer_state, expected):
         async def fake_get_xcom_val(key):
             if key == _DBT_STARTUP_EVENTS_XCOM_KEY:
                 return _STARTUP_EVENTS
@@ -189,9 +186,8 @@ class TestWatcherTrigger:
             assert events[0].payload == expected
 
     @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
-    @patch("cosmos.operators._watcher.triggerer._log_dbt_event")
     @pytest.mark.asyncio
-    async def test_run_success_with_outlet_uris(self, mock_dbt_event, mock_startup_events):
+    async def test_run_success_with_outlet_uris(self, mock_startup_events):
         """When model succeeds and outlet URIs are present, TriggerEvent includes them."""
         outlet_uris = ["postgres://host:5432/db/schema/table"]
         xcom_dict = {"status": "success", "outlet_uris": outlet_uris}
@@ -307,12 +303,10 @@ class TestWatcherTrigger:
         assert "The producer task 'task_1' succeeded" in caplog.text
         assert "There is no information about the node 'model.test' execution" in caplog.text
 
-    @patch("cosmos.operators._watcher.triggerer._log_dbt_event")
     @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
     @pytest.mark.asyncio
-    async def test_run_poke_interval_and_debug_log(self, mock_startup_events, mock_dbt_event, caplog):
+    async def test_run_poke_interval_and_debug_log(self, mock_startup_events, caplog):
         get_xcom_val_mock = AsyncMock(return_value=None)
-        mock_dbt_event.return_value = None
         get_producer_status_mock = AsyncMock(side_effect=["running", "running", "running"])
         parse_dbt_node_status_and_compiled_sql_mock = AsyncMock(
             side_effect=[(None, None), (None, None), ("success", "SELECT 1")]
@@ -446,12 +440,9 @@ class TestWatcherTriggerProducerSkipped:
             poke_interval=0.001,
         )
 
-    @patch("cosmos.operators._watcher.triggerer._log_dbt_event")
     @patch("cosmos.operators._watcher.triggerer.WatcherTrigger._log_startup_events")
     @pytest.mark.asyncio
-    async def test_run_producer_skipped_yields_producer_skipped_event(
-        self, mock_startup_events, mock_dbt_event, caplog
-    ):
+    async def test_run_producer_skipped_yields_producer_skipped_event(self, mock_startup_events, caplog):
         """Test that when producer is skipped, trigger yields failed with PRODUCER_SKIPPED reason."""
         get_xcom_val_mock = AsyncMock(return_value=None)
         get_producer_status_mock = AsyncMock(return_value="skipped")

--- a/tests/operators/_watcher/test_watcher_base.py
+++ b/tests/operators/_watcher/test_watcher_base.py
@@ -158,6 +158,44 @@ class TestBaseConsumerSensor:
             with pytest.raises(AirflowSkipException, match="was skipped by the dbt command"):
                 sensor.poke(context)
 
+    def test_poke_logs_dbt_event_only_at_terminal(self):
+        """poke must not log the per-node dbt event while the node is still running (status None); it logs
+        once the node is terminal. Regression for #2456 on the non-deferrable path."""
+
+        class SubclassBaseConsumerSensor(BaseConsumerSensor, DbtRunLocalOperator):
+            something_to_be_implemented = True
+
+        sensor = SubclassBaseConsumerSensor(
+            task_id="test_sensor",
+            producer_task_id="dbt_run_local",
+            profile_config=None,
+            project_dir="/tmp/sample_project",
+            extra_context={"dbt_node_config": {"unique_id": "model.pkg.my_model"}},
+        )
+        mock_ti = Mock()
+        mock_ti.try_number = 1
+        context = {"ti": mock_ti, "run_id": "run_123"}
+
+        with (
+            patch.object(sensor, "_get_producer_task_status", return_value="running"),
+            patch.object(sensor, "_log_startup_events"),
+            patch.object(sensor, "_cache_compiled_sql"),
+            patch("cosmos.operators._watcher.base.get_xcom_val", return_value={"status": "success", "msg": "ok"}),
+            patch("cosmos.operators._watcher.base._log_dbt_event") as mock_log,
+        ):
+            # Node still running: must not log (it would duplicate on each poke).
+            with (
+                patch.object(sensor, "_get_node_status", return_value=None),
+                patch.object(sensor, "_handle_no_dbt_node_status", return_value=False),
+            ):
+                assert sensor.poke(context) is False
+            mock_log.assert_not_called()
+
+            # Node terminal: logs exactly once.
+            with patch.object(sensor, "_get_node_status", return_value="success"):
+                assert sensor.poke(context) is True
+            mock_log.assert_called_once()
+
 
 class TestHandleNoDbtNodeStatus:
     """Tests for BaseConsumerSensor._handle_no_dbt_node_status."""

--- a/tests/operators/_watcher/test_watcher_base.py
+++ b/tests/operators/_watcher/test_watcher_base.py
@@ -129,9 +129,32 @@ class TestBaseConsumerSensor:
             project_dir="/tmp/sample_project",
             extra_context={"dbt_node_config": {"unique_id": "model.pkg.my_model"}},
         )
-        context = Mock()
+        context = {"ti": Mock()}
         with pytest.raises(AirflowSkipException, match="was skipped by the dbt command"):
             sensor.execute_complete(context, {"status": "skipped", "reason": "source_not_fresh"})
+
+    def test_execute_complete_logs_dbt_event_on_success(self):
+        """Deferrable path: execute_complete logs the per-node dbt event once on success, not only on failure.
+
+        Regression for #2456 - removing the per-poll trigger log must not drop the single terminal log line."""
+
+        class SubclassBaseConsumerSensor(BaseConsumerSensor, DbtRunLocalOperator):
+            something_to_be_implemented = True
+
+        sensor = SubclassBaseConsumerSensor(
+            task_id="test_sensor",
+            producer_task_id="dbt_run_local",
+            profile_config=None,
+            project_dir="/tmp/sample_project",
+            extra_context={"dbt_node_config": {"unique_id": "model.pkg.my_model"}},
+        )
+        context = {"ti": Mock()}
+        with (
+            patch("cosmos.operators._watcher.base.get_xcom_val", return_value={"status": "success", "msg": "ok"}),
+            patch("cosmos.operators._watcher.base._log_dbt_event") as mock_log,
+        ):
+            sensor.execute_complete(context, {"status": "success"})
+        mock_log.assert_called_once()
 
     def test_poke_raises_airflow_skip_exception_when_status_is_skipped(self):
         """poke raises AirflowSkipException when node status is 'skipped'."""

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -292,7 +292,7 @@ def test_dbt_consumer_watcher_sensor_execute_complete_model_not_run_logs_message
     )
     sensor.model_unique_id = "model.pkg.skipped_model"
 
-    context = {"dag_run": MagicMock()}
+    context = {"dag_run": MagicMock(), "ti": MagicMock()}
     event = {"status": "success", "reason": WatcherEventReason.NODE_NOT_RUN}
 
     with caplog.at_level(logging.INFO):
@@ -1585,7 +1585,7 @@ class TestDbtConsumerWatcherSensor:
     def test_execute_complete_extracts_compiled_sql(self, mock_override_rtif):
         """Test that execute_complete extracts compiled_sql from the event and sets it on the sensor."""
         sensor = self.make_sensor()
-        context = Mock()
+        context = {"ti": MagicMock()}
 
         assert sensor.compiled_sql == ""  # Initially empty
 
@@ -1598,7 +1598,7 @@ class TestDbtConsumerWatcherSensor:
     def test_execute_complete_handles_missing_compiled_sql(self):
         """Test that execute_complete handles events without compiled_sql gracefully."""
         sensor = self.make_sensor()
-        context = Mock()
+        context = {"ti": MagicMock()}
 
         assert sensor.compiled_sql == ""  # Initially empty
 


### PR DESCRIPTION
## Problem

In `ExecutionMode.WATCHER`, the consumer task log showed the same dbt event line repeated many times — the **#2456** symptom that looked like the dbt command had run twice.

**Cause:** the consumer logged the producer's per-node `_dbt_event` on **every poll** of its wait loop — in both the deferrable trigger (`WatcherTrigger.run()`) and the non-deferrable `poke()`. The loop polls until the node reaches a terminal state, so the same event was re-logged on each iteration.

## Fix

Log the per-node `_dbt_event` only once, at terminal, in **both** consumer paths:
- **Deferrable** (`WatcherTrigger.run()`): drop the per-poll fetch/log from the trigger loop. The consumer logs the event once in `execute_complete`.
- **Non-deferrable** (`poke()`): move `_log_dbt_event()` after the `status is None` early-return so it fires once the node is terminal instead of on every poke.

No information is lost — the event is still logged once at terminal.

## Scope

This is the first of three split PRs carved out of #2792 (per review feedback):
1. **this PR** — duplicate consumer logs
2. error-message capture (dbt-runner mode) — merged in #2806
3. per-node event buffering (the architectural change)

## Testing

- `test_run_does_not_log_dbt_event_per_poll`: runs the deferrable trigger over multiple polls and asserts the dbt event line is not logged per poll.
- `test_poke_logs_dbt_event_only_at_terminal`: asserts the non-deferrable `poke()` does not log while the node is running and logs exactly once at terminal.
- Both fail on the pre-fix code (the duplicated line) and pass now.
- Full `tests/operators/_watcher/` suite passes on the AF 3.0 hatch env; `pre-commit` (ruff/black/mypy) passes.

Before

<img width="1712" height="1025" alt="Screenshot 2026-06-29 at 1 24 57 AM" src="https://github.com/user-attachments/assets/9e15a0f3-8c4b-410e-9168-0912c2c0e21a" />


After
<img width="1698" height="1005" alt="Screenshot 2026-06-29 at 1 22 20 AM" src="https://github.com/user-attachments/assets/29aa50a7-0274-4dec-bcaf-2f10c2910bd5" />



Relates to #2456 #2777

🤖 Generated with [Claude Code](https://claude.com/claude-code)