### PR TITLE
Capture dbt-runner error message in WATCHER consumer logs

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -113,7 +113,12 @@ def _process_dbt_log_event(task_instance: Any, dbt_log: dict[str, Any]) -> None:
     unique_id = node_info.get("unique_id")
     start_time = node_info.get("node_started_at")
     finish_time = node_info.get("node_finished_at")
-    msg = data.get("msg") or info.get("msg")
+    # The error text lives in different places depending on the invocation mode: ``run_result.message`` on
+    # ``NodeFinished`` (dbt-runner mode) and ``data.msg`` on ``RunResultError`` (subprocess mode). The old code
+    # read only ``data.msg``/``info.msg``, which are empty on ``NodeFinished`` -- so a failed dbt-runner node
+    # reached the consumer with no error message. Read ``run_result.message`` first to capture it.
+    run_result = data.get("run_result") or {}
+    msg = run_result.get("message") or data.get("msg") or info.get("msg")
 
     if unique_id:
         dbt_event = {

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -114,9 +114,7 @@ def _process_dbt_log_event(task_instance: Any, dbt_log: dict[str, Any]) -> None:
     start_time = node_info.get("node_started_at")
     finish_time = node_info.get("node_finished_at")
     # The error text lives in different places depending on the invocation mode: ``run_result.message`` on
-    # ``NodeFinished`` (dbt-runner mode) and ``data.msg`` on ``RunResultError`` (subprocess mode). The old code
-    # read only ``data.msg``/``info.msg``, which are empty on ``NodeFinished`` -- so a failed dbt-runner node
-    # reached the consumer with no error message. Read ``run_result.message`` first to capture it.
+    # ``NodeFinished`` (dbt-runner mode) and ``data.msg`` on ``RunResultError`` (subprocess mode).
     run_result = data.get("run_result") or {}
     msg = run_result.get("message") or data.get("msg") or info.get("msg")
 

--- a/tests/operators/_watcher/test_watcher_base.py
+++ b/tests/operators/_watcher/test_watcher_base.py
@@ -91,6 +91,31 @@ class TestBaseConsumerSensor:
             _process_dbt_log_event(task_instance, dbt_log)
             mock_push.assert_not_called()
 
+    def test_process_dbt_log_event_captures_error_from_run_result_message(self):
+        """dbt-runner mode: the error text lives in NodeFinished.data.run_result.message (data.msg/info.msg
+        are empty there). It must reach the consumer's _dbt_event."""
+        task_instance = Mock()
+        dbt_log = {
+            "data": {
+                "node_info": {
+                    "unique_id": "model.test.bad_model",
+                    "node_status": "error",
+                    "node_started_at": "2024-01-01T00:00:00",
+                    "node_finished_at": "2024-01-01T00:01:00",
+                },
+                "run_result": {"status": "error", "message": "Runtime Error ... Catalog Error: Table does not exist!"},
+                "msg": "",
+            },
+            "info": {"name": "NodeFinished", "msg": ""},
+        }
+
+        with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
+            _process_dbt_log_event(task_instance, dbt_log)
+
+        value = mock_push.call_args.kwargs["value"]
+        assert value["status"] == "error"
+        assert value["msg"] == "Runtime Error ... Catalog Error: Table does not exist!"
+
     def test_execute_complete_raises_airflow_skip_exception_when_status_is_skipped(self):
         """execute_complete raises AirflowSkipException when the trigger sends status='skipped'."""
 

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -2437,7 +2437,7 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
 
 
 @pytest.mark.integration
-def test_process_dbt_log_event_surfaces_dbt_runner_error_from_real_event(tmp_path):
+def test_process_dbt_log_event_surfaces_dbt_runner_error_from_real_event(tmp_path, monkeypatch):
     """Functional check against the real dbt interface: a failed dbt-runner node carries its error only in
     ``NodeFinished.run_result.message`` (``data.msg``/``info.msg`` do not), so ``_process_dbt_log_event`` must
     read it for the WATCHER consumer to log the failure. Runs real dbt-runner against Postgres so the assertion
@@ -2449,19 +2449,27 @@ def test_process_dbt_log_event_surfaces_dbt_runner_error_from_real_event(tmp_pat
 
     project_dir = tmp_path / "watcher_failing_tests"
     shutil.copytree(DBT_WATCHER_FAILING_TESTS_PATH, project_dir)
-    profiles_dir = tmp_path / "profiles"
-    profiles_dir.mkdir()
-    (profiles_dir / "profiles.yml").write_text(
-        "default:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n      host: 0.0.0.0\n"
-        "      port: 5432\n      user: postgres\n      password: postgres\n      dbname: postgres\n"
-        "      schema: public\n      threads: 4\n"
-    )
 
     events: list[str] = []
     runner = dbtRunner(callbacks=[lambda event: events.append(MessageToJson(event, preserving_proto_field_name=True))])
-    runner.invoke(
-        ["run", "--project-dir", str(project_dir), "--profiles-dir", str(profiles_dir), "--profile", "default"]
-    )
+    # Generate profiles.yml from the same example_conn-based ProfileConfig the other watcher integration tests use,
+    # so connection details are not duplicated/hardcoded in the test.
+    with profile_config.ensure_profile() as (profiles_yml_path, env_vars):
+        for key, value in env_vars.items():
+            monkeypatch.setenv(key, value)
+        runner.invoke(
+            [
+                "run",
+                "--project-dir",
+                str(project_dir),
+                "--profiles-dir",
+                str(profiles_yml_path.parent),
+                "--profile",
+                profile_config.profile_name,
+                "--target",
+                profile_config.target_name,
+            ]
+        )
 
     node_finished = next(
         (

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import logging
+import shutil
 from datetime import datetime, timedelta
 from pathlib import Path
 from unittest.mock import ANY, MagicMock, Mock, patch
@@ -2433,6 +2434,54 @@ def test_dbt_dag_with_watcher_and_failing_model(caplog):
 
     dbt_error_message = """Database Error in model model_f (models/model_f.sql)\n  column "this_column_does_not_exist_at_all" does not exist\n  LINE 1"""
     assert dbt_error_message in caplog.text
+
+
+@pytest.mark.integration
+def test_process_dbt_log_event_surfaces_dbt_runner_error_from_real_event(tmp_path):
+    """Functional check against the real dbt interface: a failed dbt-runner node carries its error only in
+    ``NodeFinished.run_result.message`` (``data.msg``/``info.msg`` do not), so ``_process_dbt_log_event`` must
+    read it for the WATCHER consumer to log the failure. Runs real dbt-runner against Postgres so the assertion
+    cannot drift from dbt's event shape the way a hand-built mock can. Regression for #2456."""
+    from dbt.cli.main import dbtRunner
+    from google.protobuf.json_format import MessageToJson
+
+    from cosmos.operators._watcher.base import _process_dbt_log_event
+
+    project_dir = tmp_path / "watcher_failing_tests"
+    shutil.copytree(DBT_WATCHER_FAILING_TESTS_PATH, project_dir)
+    profiles_dir = tmp_path / "profiles"
+    profiles_dir.mkdir()
+    (profiles_dir / "profiles.yml").write_text(
+        "default:\n  target: dev\n  outputs:\n    dev:\n      type: postgres\n      host: 0.0.0.0\n"
+        "      port: 5432\n      user: postgres\n      password: postgres\n      dbname: postgres\n"
+        "      schema: public\n      threads: 4\n"
+    )
+
+    events: list[str] = []
+    runner = dbtRunner(callbacks=[lambda event: events.append(MessageToJson(event, preserving_proto_field_name=True))])
+    runner.invoke(
+        ["run", "--project-dir", str(project_dir), "--profiles-dir", str(profiles_dir), "--profile", "default"]
+    )
+
+    node_finished = next(
+        (
+            log
+            for event in events
+            if (log := json.loads(event)).get("info", {}).get("name") == "NodeFinished"
+            and "model_f" in (log.get("data", {}).get("node_info", {}).get("unique_id") or "")
+        ),
+        None,
+    )
+    assert node_finished is not None, "did not capture a NodeFinished event for the failing model"
+    # Premise of the fix: the error is absent from data.msg/info.msg and present only in run_result.message.
+    assert not node_finished["data"].get("msg")
+
+    with patch("cosmos.operators._watcher.base.safe_xcom_push") as mock_push:
+        _process_dbt_log_event(Mock(), node_finished)
+
+    pushed = mock_push.call_args.kwargs["value"]
+    assert pushed["status"] == "error"
+    assert "this_column_does_not_exist_at_all" in pushed["msg"]
 
 
 @pytest.mark.skipif(


### PR DESCRIPTION
## Problem

In `ExecutionMode.WATCHER` the producer ships each node's structured dbt event to the consumer via XCom. The error text lives in different places depending on invocation mode:

- **dbt-runner mode:** `NodeFinished.data.run_result.message`
- **subprocess mode:** `RunResultError.data.msg`

`_process_dbt_log_event` read only `data.msg` / `info.msg`, which are **empty on `NodeFinished`**. So a failed **dbt-runner** node reached the consumer with no error text — the consumer logged `[ERROR] Start.. Finish..` with no detail and pointed users at the producer log.

## Fix

Read `run_result.message` first when building the per-node `_dbt_event`, so the dbt-runner error reaches the consumer.

## Scope — read before reviewing

This is split PR 2 of 3 carved out of #2792 (per review feedback):
1. duplicate consumer logs → #2805
2. **this PR** — dbt-runner error capture, on the existing **per-event** write path
3. per-node event buffering (architectural change)

**Important:** this fixes the **dbt-runner** case cleanly and statelessly. The **subprocess** case is *not* fully fixed here: there the error arrives in a *later* `RunResultError` (after the terminal event) and must not be overwritten by a trailing empty message — which requires retained per-node state. That robustness lands with the **buffering** PR (3), where the `RunResultError` re-flush and "don't overwrite the error"/"ignore `\"None\"` status" guards live.

## Testing

- Unit test `test_process_dbt_log_event_captures_error_from_run_result_message`: a `NodeFinished` with `run_result.message` set and empty `data.msg`/`info.msg` pushes the error to `_dbt_event`.
- Integration test `test_process_dbt_log_event_surfaces_dbt_runner_error_from_real_event` (added per review feedback — aligned to dbt's real event interface, not a mock): runs real dbt-runner against the failing `watcher_failing_tests` project and asserts `_process_dbt_log_event` surfaces the error from the actual `NodeFinished.run_result.message`. It first asserts the premise (`data.msg` empty) and **fails without the fix** (the consumer would otherwise get the generic `Finished running node ...`).
- Full `tests/operators/_watcher/` suite passes on the AF 3.0 hatch env; `pre-commit` (ruff/black/mypy) passes.

Before/after consumer-log screenshots below.

AFTER

<img width="1700" height="981" alt="Screenshot 2026-06-27 at 7 15 04 PM" src="https://github.com/user-attachments/assets/8099216d-7097-493e-82d0-3d8e26aa6ebe" />

BEFORE

<img width="1708" height="1016" alt="Screenshot 2026-06-27 at 7 17 04 PM" src="https://github.com/user-attachments/assets/1793ce48-b04e-49b6-9e9e-79c6e243b38a" />

Reproduce: add a failing model and run a WATCHER DbtDag (dbt-runner mode); the error now appears in the failing node's **consumer** task log.
```sql
select this_column_does_not_exist_at_all
```
Relates to #2456.

🤖 Generated with [Claude Code](https://claude.com/claude-code)