### PR TITLE
Fix UnboundLocalError in build_airflow_graph with empty nodes

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from collections import OrderedDict, defaultdict
 from collections.abc import Callable
 from copy import deepcopy
+from pathlib import Path
 from typing import Any
 
 try:  # Airflow 3
@@ -1060,13 +1061,12 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             tests_per_model=tests_per_model,
         )
 
-    # Arguments shared by every node's task/group as well as the AFTER_ALL/detached test tasks below.
-    # Defined before the loop so it is always bound, even when ``nodes`` is empty
-    task_or_group_args: dict[str, Any] = {
+    # Immutable base args shared by every node's task/group as well as the AFTER_ALL/detached test tasks below.
+    # ``node`` and ``task_group`` are intentionally omitted so per-node dicts are built cleanly each iteration.
+    base_task_or_group_args: dict[str, Any] = {
         # Arguments to this method:
         "dag": dag,
         "task_group": parent_task_group,
-        "node": None,
         "task_args": task_args,
         "dbt_project_name": dbt_project_name,
         "render_config": render_config,
@@ -1080,6 +1080,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
         "node_converters": render_config.node_converters or {},
     }
 
+    last_node: DbtNode | None = None
     for node_id, node in nodes.items():
         task_group = (
             create_task_groups_based_on_folder(dag, node, parent_task_group, task_groups)
@@ -1087,7 +1088,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             else task_group
         )
         task_or_group_args = {
-            **task_or_group_args,
+            **base_task_or_group_args,
             "task_group": task_group,
             "node": node,
         }
@@ -1096,6 +1097,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
         if task_or_group is not None:
             tasks_map[node_id] = task_or_group
         task_group = parent_task_group
+        last_node = node
 
     # If test_behaviour=="after_all", there will be one test task, run by the end of the DAG
     # The end of a DAG is defined by the DAG leaf tasks (tasks which do not have downstream tasks)
@@ -1109,14 +1111,23 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             render_config=render_config,
             enable_owner_inheritance=render_config.enable_owner_inheritance,
         )
+        # When nodes is empty, create a minimal placeholder so node_converters for TEST don't crash on node.unique_id.
+        after_all_node: DbtNode = last_node or DbtNode(
+            unique_id=f"test.{dbt_project_name}",
+            resource_type=DbtResourceType.TEST,
+            depends_on=[],
+            path_base=Path("."),
+            original_file_path=Path("."),
+        )
         test_task_args = {
-            **task_or_group_args,
+            **base_task_or_group_args,
+            # AFTER_ALL test is a single DAG-level task: place it at root so task_id stays e.g. "astro_shop_test"
+            "task_group": parent_task_group,
             "task_meta": test_meta,
             "resource_type": DbtResourceType.TEST,
+            "node": after_all_node,
         }
-        # AFTER_ALL test is a single DAG-level task: place it at root so task_id stays e.g. "astro_shop_test"
-        test_task_args["task_group"] = parent_task_group
-        test_task = generate_or_convert_task(**test_task_args)
+        test_task = generate_or_convert_task(**test_task_args)  # type: ignore[arg-type]
         leaves_ids = calculate_leaves(tasks_ids=list(tasks_map.keys()), nodes=nodes)
         for leaf_node_id in leaves_ids:
             tasks_map[leaf_node_id] >> test_task
@@ -1136,11 +1147,12 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
                 enable_owner_inheritance=render_config.enable_owner_inheritance,
             )
             test_task_args = {
-                **task_or_group_args,
+                **base_task_or_group_args,
                 "task_meta": test_meta,
                 "resource_type": node.resource_type,
+                "node": node,
             }
-            test_task = generate_or_convert_task(**test_task_args)
+            test_task = generate_or_convert_task(**test_task_args)  # type: ignore[arg-type]
             tasks_map[node_id] = test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1061,8 +1061,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
         )
 
     # Arguments shared by every node's task/group as well as the AFTER_ALL/detached test tasks below.
-    # Defined before the loop so it is always bound, even when ``nodes`` is empty (e.g. an empty or
-    # mocked manifest), which would otherwise raise UnboundLocalError in the AFTER_ALL branch.
+    # Defined before the loop so it is always bound, even when ``nodes`` is empty
     task_or_group_args: dict[str, Any] = {
         # Arguments to this method:
         "dag": dag,

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1060,6 +1060,27 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             tests_per_model=tests_per_model,
         )
 
+    # Arguments shared by every node's task/group as well as the AFTER_ALL/detached test tasks below.
+    # Defined before the loop so it is always bound, even when ``nodes`` is empty (e.g. an empty or
+    # mocked manifest), which would otherwise raise UnboundLocalError in the AFTER_ALL branch.
+    task_or_group_args: dict[str, Any] = {
+        # Arguments to this method:
+        "dag": dag,
+        "task_group": parent_task_group,
+        "node": None,
+        "task_args": task_args,
+        "dbt_project_name": dbt_project_name,
+        "render_config": render_config,
+        # Properties from ExecutionConfig:
+        "execution_mode": execution_mode,
+        "test_indirect_selection": test_indirect_selection,
+        # Argument to DbtDag or DbtTaskGroup:
+        "on_warning_callback": on_warning_callback,
+        # Calculated in this method:
+        "detached_from_parent": detached_from_parent,
+        "node_converters": render_config.node_converters or {},
+    }
+
     for node_id, node in nodes.items():
         task_group = (
             create_task_groups_based_on_folder(dag, node, parent_task_group, task_groups)
@@ -1067,24 +1088,12 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             else task_group
         )
         task_or_group_args = {
-            # Arguments to this method:
-            "dag": dag,
+            **task_or_group_args,
             "task_group": task_group,
             "node": node,
-            "task_args": task_args,
-            "dbt_project_name": dbt_project_name,
-            "render_config": render_config,
-            # Properties from ExecutionConfig:
-            "execution_mode": execution_mode,
-            "test_indirect_selection": test_indirect_selection,
-            # Argument to DbtDag or DbtTaskGroup:
-            "on_warning_callback": on_warning_callback,
-            # Calculated in this method:
-            "detached_from_parent": detached_from_parent,
-            "node_converters": render_config.node_converters or {},
         }
 
-        task_or_group = generate_task_or_group(**task_or_group_args, filtered_nodes=nodes)  # type: ignore[arg-type]
+        task_or_group = generate_task_or_group(**task_or_group_args, filtered_nodes=nodes)
         if task_or_group is not None:
             tasks_map[node_id] = task_or_group
         task_group = parent_task_group
@@ -1108,7 +1117,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
         }
         # AFTER_ALL test is a single DAG-level task: place it at root so task_id stays e.g. "astro_shop_test"
         test_task_args["task_group"] = parent_task_group
-        test_task = generate_or_convert_task(**test_task_args)  # type: ignore[arg-type]
+        test_task = generate_or_convert_task(**test_task_args)
         leaves_ids = calculate_leaves(tasks_ids=list(tasks_map.keys()), nodes=nodes)
         for leaf_node_id in leaves_ids:
             tasks_map[leaf_node_id] >> test_task
@@ -1132,7 +1141,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
                 "task_meta": test_meta,
                 "resource_type": node.resource_type,
             }
-            test_task = generate_or_convert_task(**test_task_args)  # type: ignore[arg-type]
+            test_task = generate_or_convert_task(**test_task_args)
             tasks_map[node_id] = test_task
 
     create_airflow_task_dependencies(nodes, tasks_map)

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1092,7 +1092,7 @@ def build_airflow_graph(  # noqa: C901 TODO: https://github.com/astronomer/astro
             "node": node,
         }
 
-        task_or_group = generate_task_or_group(**task_or_group_args, filtered_nodes=nodes)
+        task_or_group = generate_task_or_group(**task_or_group_args, filtered_nodes=nodes)  # type: ignore[arg-type]
         if task_or_group is not None:
             tasks_map[node_id] = task_or_group
         task_group = parent_task_group

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -429,7 +429,7 @@ def test_build_airflow_graph_with_after_all_and_empty_nodes():
     # The AFTER_ALL test task is still created, but it has no upstream leaves to depend on.
     assert list(tasks_map.keys()) == ["astro_shop_test"]
     assert [task.task_id for task in dag.tasks] == ["astro_shop_test"]
-    assert isinstance(tasks_map["astro_shop_test"], EmptyOperator
+    assert isinstance(tasks_map["astro_shop_test"], EmptyOperator)
 
 
 @pytest.mark.integration

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -407,6 +407,7 @@ def test_build_airflow_graph_with_after_all_and_empty_nodes():
                 ),
             ),
         }
+
         def _convert_test(dag: DAG, task_group: TaskGroup | None, node: DbtNode, task_id: str, **kwargs):
             return EmptyOperator(dag=dag, task_group=task_group, task_id=task_id)
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -407,9 +407,14 @@ def test_build_airflow_graph_with_after_all_and_empty_nodes():
                 ),
             ),
         }
+        def _convert_test(dag: DAG, task_group: TaskGroup | None, node: DbtNode, task_id: str, **kwargs):
+            return EmptyOperator(dag=dag, task_group=task_group, task_id=task_id)
+
         render_config = RenderConfig(
             test_behavior=TestBehavior.AFTER_ALL,
             source_rendering_behavior=SOURCE_RENDERING_BEHAVIOR,
+            node_converters={DbtResourceType.TEST: _convert_test},
+            node_conversion_by_task_group=False,
         )
         tasks_map = build_airflow_graph(
             nodes={},
@@ -424,6 +429,7 @@ def test_build_airflow_graph_with_after_all_and_empty_nodes():
     # The AFTER_ALL test task is still created, but it has no upstream leaves to depend on.
     assert list(tasks_map.keys()) == ["astro_shop_test"]
     assert [task.task_id for task in dag.tasks] == ["astro_shop_test"]
+    assert isinstance(tasks_map["astro_shop_test"], EmptyOperator
 
 
 @pytest.mark.integration

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -387,6 +387,45 @@ def test_build_airflow_graph_with_after_all():
     assert dag.leaves[0].select == "tag:some"
 
 
+def test_build_airflow_graph_with_after_all_and_empty_nodes():
+    """Empty ``nodes`` (e.g. an empty or mocked manifest) must not raise UnboundLocalError.
+
+    Regression test for https://github.com/astronomer/astronomer-cosmos/issues/2813: with
+    ``TestBehavior.AFTER_ALL`` the per-node loop never runs when ``nodes`` is empty, so the
+    AFTER_ALL branch used to read an unbound ``task_or_group_args``.
+    """
+    with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:
+        task_args = {
+            "project_dir": SAMPLE_PROJ_PATH,
+            "conn_id": "fake_conn",
+            "profile_config": ProfileConfig(
+                profile_name="default",
+                target_name="default",
+                profile_mapping=PostgresUserPasswordProfileMapping(
+                    conn_id="fake_conn",
+                    profile_args={"schema": "public"},
+                ),
+            ),
+        }
+        render_config = RenderConfig(
+            test_behavior=TestBehavior.AFTER_ALL,
+            source_rendering_behavior=SOURCE_RENDERING_BEHAVIOR,
+        )
+        tasks_map = build_airflow_graph(
+            nodes={},
+            dag=dag,
+            execution_mode=ExecutionMode.LOCAL,
+            test_indirect_selection=TestIndirectSelection.EAGER,
+            task_args=task_args,
+            dbt_project_name="astro_shop",
+            render_config=render_config,
+        )
+
+    # The AFTER_ALL test task is still created, but it has no upstream leaves to depend on.
+    assert list(tasks_map.keys()) == ["astro_shop_test"]
+    assert [task.task_id for task in dag.tasks] == ["astro_shop_test"]
+
+
 @pytest.mark.integration
 def test_build_airflow_graph_with_build():
     with DAG("test-id", start_date=datetime(2022, 1, 1)) as dag:


### PR DESCRIPTION
## Description

`build_airflow_graph` raised `UnboundLocalError: cannot access local variable 'task_or_group_args'` when called with an empty `nodes` mapping (e.g. an empty or mocked dbt manifest) together with `RenderConfig(test_behavior=TestBehavior.AFTER_ALL)`, because `task_or_group_args` was only bound inside the per-node loop yet read afterwards in the `AFTER_ALL` branch. This moves the shared `task_or_group_args` to before the loop so it is always bound, merging in only the per-node `task_group`/`node` inside the loop. Behaviour for non-empty manifests is unchanged; an empty manifest now yields just the standalone project test task instead of crashing. A regression test covering the empty-nodes + `AFTER_ALL` scenario is included.

## Related Issue(s)

closes #2813

## Breaking Change?

No.

## Checklist

- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
