### PR TITLE
Fix `group_nodes_by_folder` collapsing folders that share a leaf name

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -927,12 +927,18 @@ def create_task_groups_based_on_folder(
     """
     task_group = None
     resource_file_path_parts = str(node.original_file_path).split("/")[:-1]
+    # Cache groups by their cumulative path rather than the bare folder name, so
+    # that folders sharing a leaf name under different parents (e.g.
+    # ``staging/aurora`` and ``marts/aurora``) become distinct task groups instead
+    # of collapsing into the first one created.
+    cumulative_path = ""
     for resource_file_path_part in resource_file_path_parts:
-        if resource_file_path_part in task_groups:
-            task_group = task_groups[resource_file_path_part]
+        cumulative_path = f"{cumulative_path}/{resource_file_path_part}" if cumulative_path else resource_file_path_part
+        if cumulative_path in task_groups:
+            task_group = task_groups[cumulative_path]
         else:
             task_group = TaskGroup(dag=dag, group_id=resource_file_path_part, parent_group=parent_task_group)
-            task_groups[resource_file_path_part] = task_group
+            task_groups[cumulative_path] = task_group
         parent_task_group = task_group
     return task_group
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -28,6 +28,7 @@ from cosmos.airflow.graph import (
     calculate_detached_node_name,
     calculate_leaves,
     calculate_operator_class,
+    create_task_groups_based_on_folder,
     create_task_metadata,
     create_test_task_metadata,
     exclude_detached_tests_if_needed,
@@ -178,13 +179,13 @@ def test_build_airflow_graph_with_after_each():
         "seed_parent_seed",
         "gen2.models.parent.run",
         "gen2.models.parent.test",
-        "gen2.models.child_run",
-        "gen2.models.child2_v2_run",
+        "gen3.models.child_run",
+        "gen3.models.child2_v2_run",
     ]
 
     assert topological_sort == expected_sort
     task_groups = dag.task_group_dict
-    assert len(task_groups) == 4
+    assert len(task_groups) == 5
 
     assert task_groups["gen2.models.parent"].upstream_task_ids == {"seed_parent_seed"}
     assert list(task_groups["gen2.models.parent"].children.keys()) == [
@@ -193,8 +194,8 @@ def test_build_airflow_graph_with_after_each():
     ]
 
     assert len(dag.leaves) == 2
-    assert dag.leaves[0].task_id == "gen2.models.child_run"
-    assert dag.leaves[1].task_id == "gen2.models.child2_v2_run"
+    assert dag.leaves[0].task_id == "gen3.models.child_run"
+    assert dag.leaves[1].task_id == "gen3.models.child2_v2_run"
 
     task_seed_parent_seed = dag.tasks[0]
     task_parent_run = dag.tasks[1]
@@ -373,14 +374,14 @@ def test_build_airflow_graph_with_after_all():
     expected_sort = [
         "seed_parent_seed",
         "gen2.models.parent_run",
-        "gen2.models.child_run",
-        "gen2.models.child2_v2_run",
+        "gen3.models.child_run",
+        "gen3.models.child2_v2_run",
         "astro_shop_test",
     ]
     assert topological_sort == expected_sort
 
     task_groups = dag.task_group_dict
-    assert len(task_groups) == 3
+    assert len(task_groups) == 4
 
     assert len(dag.leaves) == 1
     assert dag.leaves[0].task_id == "astro_shop_test"
@@ -419,17 +420,17 @@ def test_build_airflow_graph_with_build():
     expected_sort = [
         "seed_parent_seed_build",
         "gen2.models.parent_model_build",
-        "gen2.models.child_model_build",
-        "gen2.models.child2_v2_model_build",
+        "gen3.models.child_model_build",
+        "gen3.models.child2_v2_model_build",
     ]
     assert topological_sort == expected_sort
 
     task_groups = dag.task_group_dict
-    assert len(task_groups) == 3
+    assert len(task_groups) == 4
 
     assert len(dag.leaves) == 2
-    assert dag.leaves[0].task_id in ("gen2.models.child_model_build", "gen2.models.child2_v2_model_build")
-    assert dag.leaves[1].task_id in ("gen2.models.child_model_build", "gen2.models.child2_v2_model_build")
+    assert dag.leaves[0].task_id in ("gen3.models.child_model_build", "gen3.models.child2_v2_model_build")
+    assert dag.leaves[1].task_id in ("gen3.models.child_model_build", "gen3.models.child2_v2_model_build")
 
 
 @pytest.mark.integration
@@ -466,6 +467,50 @@ def test_build_airflow_graph_with_override_profile_config():
     generated_parent_profile_config = dag.task_dict["gen2.models.parent.run"].profile_config
     assert generated_parent_profile_config.profile_name == "default"
     assert generated_parent_profile_config.profile_mapping.profile_args["schema"] == "public"
+
+
+def test_create_task_groups_based_on_folder_distinguishes_same_leaf_name():
+    """Folders sharing a leaf name under different parents (e.g. ``staging/aurora``
+    and ``marts/aurora``) must map to distinct TaskGroups instead of collapsing
+    into the first one created."""
+    staging_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.staging_aurora_orders",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=SAMPLE_PROJ_PATH,
+        original_file_path=Path("models/staging/aurora/orders.sql"),
+    )
+    marts_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.marts_aurora_orders",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=SAMPLE_PROJ_PATH,
+        original_file_path=Path("models/marts/aurora/orders.sql"),
+    )
+
+    task_groups: dict = {}
+    with DAG("test-folder-collision", start_date=datetime(2022, 1, 1)) as dag:
+        staging_group = create_task_groups_based_on_folder(
+            dag=dag, node=staging_node, parent_task_group=None, task_groups=task_groups
+        )
+        marts_group = create_task_groups_based_on_folder(
+            dag=dag, node=marts_node, parent_task_group=None, task_groups=task_groups
+        )
+
+    assert staging_group is not None
+    assert marts_group is not None
+    assert staging_group is not marts_group
+    assert staging_group.group_id == "models.staging.aurora"
+    assert marts_group.group_id == "models.marts.aurora"
+    # Groups are cached by cumulative path; the shared ``models`` ancestor is
+    # reused, while the two ``aurora`` leaves stay distinct.
+    assert set(task_groups) == {
+        "models",
+        "models/staging",
+        "models/staging/aurora",
+        "models/marts",
+        "models/marts/aurora",
+    }
 
 
 def test_calculate_operator_class():
@@ -1463,12 +1508,12 @@ def test_custom_meta():
         )
         # test custom meta (queue, pool)
         for task in dag.tasks:
-            if task.task_id == "gen2.models.child2_v2_run":
+            if task.task_id == "gen3.models.child2_v2_run":
                 assert task.pool == "custom_pool"
             else:
                 assert task.pool == "default_pool"
 
-            if task.task_id == "gen2.models.child_run":
+            if task.task_id == "gen3.models.child_run":
                 assert task.queue == "custom_queue"
             else:
                 assert task.queue == "default"


### PR DESCRIPTION
## Description

When `RenderConfig.group_nodes_by_folder=True`, `create_task_groups_based_on_folder` cached the generated `TaskGroup`s by the **bare folder name**. As a result, folders that share a leaf name under different parents — e.g. `models/staging/aurora` and `models/marts/aurora` — collapsed into a single `TaskGroup`: the first `aurora` group created was reused for every later folder named `aurora`, so its models were placed under the wrong parent.

This re-keys the group cache by the **cumulative folder path** instead of the leaf name, so same-named folders under different parents render as distinct task groups (`models.staging.aurora` vs `models.marts.aurora`) while shared ancestors (e.g. `models/`) are still reused. The `group_id` shown in the UI is unchanged (still the leaf folder name, scoped under its parent).

### Before
```
models/
  aurora/          # contains BOTH staging/aurora and marts/aurora models
```

### After
```
models/
  staging/
    aurora/        # staging models only
  marts/
    aurora/        # marts models only
```

## Tests

- **Added** `test_create_task_groups_based_on_folder_distinguishes_same_leaf_name` — a regression test that builds two nodes under `staging/aurora` and `marts/aurora` and asserts they map to distinct task groups (`models.staging.aurora` vs `models.marts.aurora`) with the cache keyed by cumulative path.
- **Updated existing folder-grouping tests** in `tests/airflow/test_graph.py` that had encoded the old (buggy) behaviour. In the test fixtures, `child`/`child2_v2` live under `gen3/models/` while `parent` lives under `gen2/models/`; previously the `gen3/models` folder collapsed into `gen2.models`, so the tests asserted task ids like `gen2.models.child_run`. With the fix they are correctly `gen3.models.child_run`, and the `len(task_groups)` assertions increase by one because `gen3.models` is now its own group:
  - `test_build_airflow_graph_with_after_each`: task ids `gen2.models.child*` → `gen3.models.child*`; group count `4` → `5`.
  - `test_build_airflow_graph_with_after_all`: same id update; group count `3` → `4`.
  - `test_build_airflow_graph_with_build`: same id update; group count `3` → `4`.
  - `test_custom_meta`: the custom `pool`/`queue` assertions now key off `gen3.models.child*` ids.

  (`test_build_airflow_graph_with_override_profile_config` only references `parent`, which stays under `gen2.models`, so it is unchanged.)

## Related Issue(s)

<!-- No existing issue found. -->

## Breaking Change?

Yes, task groups will be rendered with a different name than PR - since their name will contain a hierarchy.

## Checklist

- [ ] I have made corresponding changes to the documentation (not required)
- [x] I have added tests that prove my fix is effective (`test_create_task_groups_based_on_folder_distinguishes_same_leaf_name`), and updated existing folder-grouping tests that encoded the previous behaviour

🤖 Generated with Claude Code (https://claude.com/claude-code)
