### PR TITLE
docs: add note and example for custom profile mapping

### DIFF
--- a/docs/guides/connect_database/use-profile-mapping.rst
+++ b/docs/guides/connect_database/use-profile-mapping.rst
@@ -8,7 +8,14 @@ you can use the same connection objects you use in Airflow to authenticate with 
 a class in Cosmos for each Airflow connection to dbt profile mapping.
 
 .. note::
-   Adapters without a built-in ProfileMapping (such as ``dbt-glue``, ``dbt-athena``, etc.) are still fully supported in Cosmos. In these cases, you can bypass ProfileMapping and use a user-provided ``profiles.yml`` file instead. See :ref:`use-your-profiles-yml` for more information.
+   Cosmos natively supports all adapters compatible with **dbt Core** and **dbt Fusion** without any reliance on dbt Platform. This includes both official `Trusted Adapters <https://docs.getdbt.com/docs/trusted-adapters>`_ and `Community Adapters <https://docs.getdbt.com/docs/community-adapters>`_.
+   While some of these adapters lack a built-in automated profile mapping class in Cosmos, including
+   `AWS Glue <https://docs.getdbt.com/docs/local/connect-data-platform/glue-setup?version=2.0&name=Fusion>`_,
+   `Dremio <https://docs.getdbt.com/docs/local/connect-data-platform/dremio-setup?version=2.0&name=Fusion>`_,
+   `Azure Synapse <https://docs.getdbt.com/docs/local/connect-data-platform/azuresynapse-setup?version=2.0&name=Fusion>`_, and
+   `IBM Netezza <https://docs.getdbt.com/docs/local/connect-data-platform/ibmnetezza-setup?version=2.0&name=Fusion>`_, among others,
+   they remain fully operational out of the box. In these scenarios, you can simply bypass automated connection mappings entirely and pass a user-provided ``profiles.yml`` file configuration instead.
+   For a detailed implementation guide, see :ref:`use-your-profiles-yml`.
 
 You can find the available profile mappings on the left-hand side of this page. Each profile mapping is imported from
 ``cosmos.profiles`` and takes two arguments:

--- a/docs/guides/connect_database/use-profile-mapping.rst
+++ b/docs/guides/connect_database/use-profile-mapping.rst
@@ -7,6 +7,9 @@ Profile mappings are utilities provided by Cosmos that translate `Apache Airflow
 you can use the same connection objects you use in Airflow to authenticate with your database in dbt. To do so, there's
 a class in Cosmos for each Airflow connection to dbt profile mapping.
 
+.. note::
+   Adapters without a built-in ProfileMapping (such as ``dbt-glue``, ``dbt-athena``, etc.) are still fully supported in Cosmos. In these cases, you can bypass ProfileMapping and use a user-provided ``profiles.yml`` file instead. See :ref:`use-your-profiles-yml` for more information.
+
 You can find the available profile mappings on the left-hand side of this page. Each profile mapping is imported from
 ``cosmos.profiles`` and takes two arguments:
 

--- a/docs/guides/connect_database/use-your-profiles-yml.rst
+++ b/docs/guides/connect_database/use-your-profiles-yml.rst
@@ -7,6 +7,9 @@ If you don't want to use `Apache Airflow® <https://airflow.apache.org/>`_ conne
 you can use your own dbt profiles.yml file. To do so, you'll need to pass the path to your profiles.yml file to the
 ``profiles_yml_filepath`` argument in ``ProfileConfig``.
 
+.. tip::
+   This approach works with any adapter compatible with **dbt Core** or **dbt Fusion**, including both official `Trusted Adapters <https://docs.getdbt.com/docs/trusted-adapters>`_ and `Community Adapters <https://docs.getdbt.com/docs/community-adapters>`_.
+
 For example, the code snippet below points Cosmos at a ``profiles.yml`` file and instructs Cosmos to use the
 ``my_snowflake_profile`` profile and ``dev`` target:
 
@@ -22,11 +25,10 @@ For example, the code snippet below points Cosmos at a ``profiles.yml`` file and
 
     dag = DbtDag(profile_config=profile_config, ...)
 
-
 Example: AWS Glue (dbt-glue)
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-AWS Glue is not natively supported by Cosmos' built-in profile mappings, but is fully supported when you provide your own ``profiles.yml`` file.
+`AWS Glue <https://docs.getdbt.com/docs/local/connect-data-platform/glue-setup?version=2.0&name=Fusion>`_ is not natively supported by Cosmos' built-in profile mappings, but is fully supported when you provide your own ``profiles.yml`` file.
 
 First, configure your ``profiles.yml`` file (for example, at ``/path/to/profiles.yml``):
 
@@ -37,10 +39,14 @@ First, configure your ``profiles.yml`` file (for example, at ``/path/to/profiles
       outputs:
         dev:
           type: glue
-          role_arn: arn:aws:iam::123456789012:role/GlueExecutionRoleExample
+          role_arn: arn:aws:iam::1234567890:role/GlueExecutionRoleExample
           region: us-east-1
-          schema: my_schema
-          database: my_database
+          workers: 2
+          worker_type: G.1X
+          idle_timeout: 10
+          schema: "dbt_demo"
+          session_provisioning_timeout_in_seconds: 120
+          location: "s3://dbt_demo_bucket/dbt_demo_data"
 
 Then, point Cosmos to your ``profiles.yml`` file using ``ProfileConfig``:
 

--- a/docs/guides/connect_database/use-your-profiles-yml.rst
+++ b/docs/guides/connect_database/use-your-profiles-yml.rst
@@ -21,3 +21,37 @@ For example, the code snippet below points Cosmos at a ``profiles.yml`` file and
     )
 
     dag = DbtDag(profile_config=profile_config, ...)
+
+
+Example: AWS Glue (dbt-glue)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+AWS Glue is not natively supported by Cosmos' built-in profile mappings, but is fully supported when you provide your own ``profiles.yml`` file.
+
+First, configure your ``profiles.yml`` file (for example, at ``/path/to/profiles.yml``):
+
+.. code-block:: yaml
+
+    my_glue_profile:
+      target: dev
+      outputs:
+        dev:
+          type: glue
+          role_arn: arn:aws:iam::123456789012:role/GlueExecutionRoleExample
+          region: us-east-1
+          schema: my_schema
+          database: my_database
+
+Then, point Cosmos to your ``profiles.yml`` file using ``ProfileConfig``:
+
+.. code-block:: python
+
+    from cosmos.config import ProfileConfig
+
+    profile_config = ProfileConfig(
+        profile_name="my_glue_profile",
+        target_name="dev",
+        profiles_yml_filepath="/path/to/profiles.yml",
+    )
+
+    dag = DbtDag(profile_config=profile_config, ...)


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
Add documentation clarifying that dbt adapters without a built-in Cosmos ProfileMapping (such as dbt-glue, dremio, etc.) are still fully supported by supplying a user-provided `profiles.yml` via `ProfileConfig(profiles_yml_filepath=...)`.

- Add a note on the "Use a profile mapping" guide page directing users to the bring-your-own-profiles.yml path when no built-in mapping exists.
- Add a concrete AWS Glue (dbt-glue) example on the "Use your own profiles.yml" guide page showing both the YAML configuration and the corresponding `ProfileConfig` usage.

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
closes #2821

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
