### PR TITLE
Docs: clarify Cosmos supports dbt-glue (and other adapters) via a user-provided profiles.yml

### DIFF
--- a/docs/guides/connect_database/index.rst
+++ b/docs/guides/connect_database/index.rst
@@ -13,7 +13,8 @@ to use a profile mapping to translate that Airflow connection to a dbt profile. 
 maintain a single connection object in Airflow than it is to maintain a connection object in Airflow and a dbt profile
 in your dbt project.
 
-If you don't already have an Airflow connection, or if there's no readily-available profile mapping for your database,
+If you don't already have an Airflow connection, or if there's no readily-available profile mapping for your database
+(e.g. `dbt-glue <https://github.com/aws-samples/dbt-glue>`_ or other community adapters),
 you can use your own dbt profiles.yml file.
 
 Regardless of which method you use, you'll need to tell Cosmos which profile and target name it should use. Profile config

--- a/docs/guides/connect_database/use-your-profiles-yml.rst
+++ b/docs/guides/connect_database/use-your-profiles-yml.rst
@@ -7,6 +7,14 @@ If you don't want to use `Apache Airflow® <https://airflow.apache.org/>`_ conne
 you can use your own dbt profiles.yml file. To do so, you'll need to pass the path to your profiles.yml file to the
 ``profiles_yml_filepath`` argument in ``ProfileConfig``.
 
+.. note::
+
+   This method supports **any dbt adapter**, including those without a built-in ``ProfileMapping``
+   in Cosmos (e.g. `dbt-glue <https://github.com/aws-samples/dbt-glue>`_). If your database is not
+   listed in the `available profile mappings <../use-profile-mapping.html>`_, using your own
+   ``profiles.yml`` is the recommended approach and retains all Cosmos features (task-group
+   rendering, OpenLineage lineage, etc.).
+
 For example, the code snippet below points Cosmos at a ``profiles.yml`` file and instructs Cosmos to use the
 ``my_snowflake_profile`` profile and ``dev`` target:
 
@@ -21,3 +29,24 @@ For example, the code snippet below points Cosmos at a ``profiles.yml`` file and
     )
 
     dag = DbtDag(profile_config=profile_config, ...)
+
+Using dbt-glue with a custom profiles.yml
+-----------------------------------------
+
+If you are using `dbt-glue <https://github.com/aws-samples/dbt-glue>`_ (or any other adapter without a built-in
+profile mapping), provide the adapter-specific ``profiles.yml`` via ``profiles_yml_filepath``:
+
+.. code-block:: python
+
+    from cosmos.config import ProfileConfig
+
+    profile_config = ProfileConfig(
+        profile_name="glue_profile",
+        target_name="dev",
+        profiles_yml_filepath="/path/to/glue/profiles.yml",
+    )
+
+    dag = DbtDag(profile_config=profile_config, ...)
+
+Your ``profiles.yml`` should follow the `dbt-glue profile configuration <https://github.com/aws-samples/dbt-glue#configuration>`_
+as documented by the adapter maintainer.


### PR DESCRIPTION
Closes #2821

Adds an explicit note and a dbt-glue example to the "Use your own profiles.yml" guide, so that users of adapters without a built-in `ProfileMapping` know Cosmos still fully supports them via `profiles_yml_filepath`.

Also updates the index page to mention dbt-glue as an example.