### PR TITLE
Ignore Claude Code user-local files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -176,3 +176,7 @@ webserver_config.py
 
 # VI
 *.sw[a-z]
+
+# Claude Code user-local files
+.claude/settings.local.json
+.claude/worktrees/


### PR DESCRIPTION
Adds two scoped entries to `.gitignore` for Claude Code user-local files that should never be committed:

- `.claude/settings.local.json` — personal local Claude Code settings
- `.claude/worktrees/` — nested git worktrees created under the repo

These are user-specific and were showing up as untracked. The `.claude/` directory itself remains trackable so shared config can be committed if desired in the future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)