### PR TITLE
Fix `on_warning_callback` skipping test warnings in subprocess mode

### DIFF
--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -11,10 +11,12 @@ if TYPE_CHECKING:
 from cosmos import __version__ as cosmos_version
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
-DBT_NO_TESTS_MSG = "Nothing to do"
-DBT_WARN_MSG = "WARN"
 DBT_FRESHNESS_WARN_MSG = "WARN freshness of"
-DBT_SUMMARY_WARN_RE = re.compile(r"WARN=(\d+)")
+# The dbt run summary line looks like "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=16".
+# Anchor on its shape (``Done.`` ... ``WARN=<count>`` ... ``TOTAL=<n>``) so that a later non-summary
+# line that happens to contain a "WARN=<digits>" token (e.g. a --debug resource/usage report printed
+# after the summary) is not mistaken for the warning count.
+DBT_SUMMARY_WARN_RE = re.compile(r"Done\..*\bWARN=(\d+)\b.*\bTOTAL=\d+")
 
 
 def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
@@ -22,10 +24,12 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     Parse the number of warnings from the output of a dbt command run via subprocess.
 
     Scans the full output (every stdout line) for the dbt run summary line
-    ``Done. PASS=.. WARN=N ..`` instead of only the last line. Newer dbt versions print a
+    ``Done. PASS=.. WARN=N .. TOTAL=N`` instead of only the last line. Newer dbt versions print a
     deprecation summary, a ``--debug`` resource report and a "Flushing usage events" line
     *after* the summary, so it is no longer guaranteed to be the final stdout line. Reading
-    only the last line silently misses warnings (issues #1951, #2492, #2014).
+    only the last line silently misses warnings (issues #1951, #2492, #2014). The summary is
+    matched by shape (``Done.`` ... ``TOTAL=N``) so a stray ``WARN=<digits>`` token on any other
+    line is not miscounted.
 
     :param result: The result of the dbt command run via subprocess.
     :return: The number of warnings reported by dbt, or 0 if no summary line is found.

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -17,33 +17,36 @@ logger = get_logger(__name__)
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"
 DBT_FRESHNESS_WARN_MSG = "WARN freshness of"
+# The dbt run summary line looks like "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=16".
+# It is the only dbt output line that carries a "WARN=<count>" token.
+DBT_SUMMARY_WARN_RE = re.compile(r"WARN=(\d+)")
 
 
 def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> int:
     """
-    Parses the dbt test output message and returns the number of warnings.
+    Parse the number of warnings from the output of a dbt command run via subprocess.
 
-    :param result: String containing the output to be parsed.
-    :return: An integer value associated with the keyword, or 0 if parsing fails.
+    Scans the full output (every stdout line) for the dbt run summary line
+    ``Done. PASS=.. WARN=N ..`` instead of only the last line. Newer dbt versions print a
+    deprecation summary, a ``--debug`` resource report and a "Flushing usage events" line
+    *after* the summary, so it is no longer guaranteed to be the final stdout line. Reading
+    only the last line silently misses warnings (issues #1951, #2492, #2014).
+
+    :param result: The result of the dbt command run via subprocess.
+    :return: The number of warnings reported by dbt, or 0 if no summary line is found.
 
     Usage:
     -----
-    output_str = "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16"
-    num_warns = parse_output(output_str)
+    full_output = ["...", "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16", "..."]
+    num_warns = parse_number_of_warnings_subprocess(result)
     print(num_warns)
     # Output: 1
     """
-    output = result.output
-    num = 0
-    if DBT_NO_TESTS_MSG not in result.output and DBT_WARN_MSG in result.output:
-        try:
-            num = int(output.split(f"{DBT_WARN_MSG}=")[1].split()[0])
-        except ValueError:
-            logger.error(
-                "Could not parse number of %ss. Check your dbt/airflow version or if --quiet is not being used",
-                DBT_WARN_MSG,
-            )
-    return num
+    for line in reversed(result.full_output):
+        match = DBT_SUMMARY_WARN_RE.search(line)
+        if match:
+            return int(match.group(1))
+    return 0
 
 
 # Python 3.13 exposes a deprecated operator, we can replace it in the future

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -14,8 +14,6 @@ from cosmos.hooks.subprocess import FullOutputSubprocessResult
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"
 DBT_FRESHNESS_WARN_MSG = "WARN freshness of"
-# The dbt run summary line looks like "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=16".
-# It is the only dbt output line that carries a "WARN=<count>" token.
 DBT_SUMMARY_WARN_RE = re.compile(r"WARN=(\d+)")
 
 

--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -10,9 +10,6 @@ if TYPE_CHECKING:
 
 from cosmos import __version__ as cosmos_version
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
-from cosmos.log import get_logger
-
-logger = get_logger(__name__)
 
 DBT_NO_TESTS_MSG = "Nothing to do"
 DBT_WARN_MSG = "WARN"
@@ -38,6 +35,7 @@ def parse_number_of_warnings_subprocess(result: FullOutputSubprocessResult) -> i
     Usage:
     -----
     full_output = ["...", "Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16", "..."]
+    result = FullOutputSubprocessResult(exit_code=0, output=full_output[-1], full_output=full_output)
     num_warns = parse_number_of_warnings_subprocess(result)
     print(num_warns)
     # Output: 1

--- a/tests/dbt/parser/test_output.py
+++ b/tests/dbt/parser/test_output.py
@@ -1,12 +1,6 @@
-import logging
 from unittest.mock import MagicMock
 
 import pytest
-
-try:  # For Airflow 3
-    from airflow.providers.standard.hooks.subprocess import SubprocessResult
-except ImportError:  # For Airflow 2
-    from airflow.hooks.subprocess import SubprocessResult
 
 from cosmos.dbt.parser.output import (
     extract_dbt_runner_issues,
@@ -18,30 +12,52 @@ from cosmos.dbt.parser.output import (
 from cosmos.hooks.subprocess import FullOutputSubprocessResult
 
 
+def _subprocess_result(full_output: list[str]) -> FullOutputSubprocessResult:
+    """Build a FullOutputSubprocessResult whose ``output`` is the last line, mirroring how
+    FullOutputSubprocessHook.run_command populates it in production."""
+    return FullOutputSubprocessResult(exit_code=0, output=full_output[-1], full_output=full_output)
+
+
 @pytest.mark.parametrize(
-    "output_str, expected_warnings",
+    "full_output, expected_warnings",
     [
-        ("Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16", 1),
-        ("Done. PASS=15 WARN=0 ERROR=0 SKIP=0 TOTAL=16", 0),
-        ("Done. PASS=15 WARN=2 ERROR=0 SKIP=0 TOTAL=16", 2),
-        ("Nothing to do. Exiting without running tests.", 0),
+        (["Done. PASS=15 WARN=1 ERROR=0 SKIP=0 TOTAL=16"], 1),
+        (["Done. PASS=15 WARN=0 ERROR=0 SKIP=0 TOTAL=16"], 0),
+        (["Done. PASS=15 WARN=2 ERROR=0 SKIP=0 TOTAL=16"], 2),
+        (["Nothing to do. Exiting without running tests."], 0),
     ],
 )
-def test_parse_number_of_warnings_subprocess(output_str: str, expected_warnings):
-    result = SubprocessResult(exit_code=0, output=output_str)
-    num_warns = parse_number_of_warnings_subprocess(result)
+def test_parse_number_of_warnings_subprocess(full_output: list[str], expected_warnings: int):
+    num_warns = parse_number_of_warnings_subprocess(_subprocess_result(full_output))
     assert num_warns == expected_warnings
 
 
-def test_parse_number_of_warnings_subprocess_error_logged(caplog):
-    output_str = "WARN= should log an error."
-    with caplog.at_level(logging.ERROR):
-        result = SubprocessResult(exit_code=0, output=output_str)
-        parse_number_of_warnings_subprocess(result)
-    expected_error_log = (
-        "Could not parse number of WARNs. Check your dbt/airflow version or if --quiet is not being used"
-    )
-    assert expected_error_log in caplog.text
+def test_parse_number_of_warnings_subprocess_summary_not_last_line():
+    """Regression for issues #1951, #2492 and #2014.
+
+    Newer dbt versions print a deprecation summary, a ``--debug`` resource report and a
+    "Flushing usage events" line *after* the ``Done. ... WARN=N ...`` summary, so the summary is
+    no longer the last stdout line. The previous implementation inspected only the last line and
+    silently returned 0, so on_warning_callback was never invoked.
+    """
+    full_output = [
+        "13:52:42  1 of 1 WARN 1 not_null_my_model_my_column .................. [WARN 1 in 2.53s]",
+        "13:52:44  Done. PASS=0 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1",
+        "13:52:44  [WARNING][DeprecationsSummary]: Deprecated functionality",
+        "Summary of encountered deprecations:",
+        "- PropertyMovedToConfigDeprecation: 12 occurrences",
+        '13:52:44  Resource report: {"command_name": "test", "command_success": true}',
+        "13:52:44  Command `dbt test` succeeded at 13:52:44 after 39.75 seconds",
+        "13:52:44  Flushing usage events",
+    ]
+    assert parse_number_of_warnings_subprocess(_subprocess_result(full_output)) == 1
+
+
+def test_parse_number_of_warnings_subprocess_without_summary_returns_zero():
+    """A run without a ``WARN=<count>`` summary line (e.g. dbt ``--quiet``) parses as 0 and does
+    not raise, even when a line contains the bare substring ``WARN=``."""
+    full_output = ["Running with dbt=1.11.8", "WARN= is not a valid summary token"]
+    assert parse_number_of_warnings_subprocess(_subprocess_result(full_output)) == 0
 
 
 def test_parse_number_of_warnings_dbt_runner_with_warnings():

--- a/tests/dbt/parser/test_output.py
+++ b/tests/dbt/parser/test_output.py
@@ -60,6 +60,27 @@ def test_parse_number_of_warnings_subprocess_without_summary_returns_zero():
     assert parse_number_of_warnings_subprocess(_subprocess_result(full_output)) == 0
 
 
+def test_parse_number_of_warnings_subprocess_only_counts_summary_line():
+    """Only the ``Done. ... WARN=N ... TOTAL=N`` summary line is counted. Because the full output is
+    scanned in reverse, a later non-summary line that happens to contain a ``WARN=<digits>`` token
+    (e.g. a ``--debug`` resource/usage report printed after the summary) must not override the real
+    summary, nor be counted when there is no summary line at all (PR #2832 review)."""
+    # A trailing WARN=<digits> emitted after the real summary is ignored; the summary's count wins.
+    after_summary = [
+        "13:52:44  Done. PASS=0 WARN=1 ERROR=0 SKIP=0 NO-OP=0 TOTAL=1",
+        "13:52:45  Resource report: emitted WARN=99 internal-metric events",
+        "13:52:45  Flushing usage events",
+    ]
+    assert parse_number_of_warnings_subprocess(_subprocess_result(after_summary)) == 1
+
+    # A stray WARN=<digits> with no Done./TOTAL= summary line counts as 0 (callback not triggered).
+    no_summary = [
+        "Running with dbt=1.11.8",
+        "13:52:45  Resource report: emitted WARN=99 internal-metric events",
+    ]
+    assert parse_number_of_warnings_subprocess(_subprocess_result(no_summary)) == 0
+
+
 def test_parse_number_of_warnings_dbt_runner_with_warnings():
     runner_result = MagicMock()
     runner_result.result.results = [

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1127,6 +1127,44 @@ def test_run_test_operator_without_callback(invocation_mode):
 
 
 @pytest.mark.integration
+def test_run_test_operator_with_callback_and_trailing_dbt_output(failing_test_dbt_project):
+    """Regression for issues #1951, #2492 and #2014.
+
+    In SUBPROCESS invocation mode the dbt warning count used to be parsed from only the last
+    stdout line. Running dbt with ``--debug`` makes it print a resource report and a
+    "Command ... succeeded" line *after* the ``Done. ... WARN=N ...`` summary, so the summary is
+    no longer the last line. Before the fix on_warning_callback was silently skipped; now it must
+    fire with the warning details in the context.
+    """
+    on_warning_callback = MagicMock()
+
+    with DAG("test-warning-trailing-output", start_date=datetime(2022, 1, 1)) as dag:
+        seed_operator = DbtSeedLocalOperator(
+            profile_config=mini_profile_config,
+            project_dir=failing_test_dbt_project,
+            task_id="seed",
+            append_env=True,
+            invocation_mode=InvocationMode.SUBPROCESS,
+        )
+        test_operator = DbtTestLocalOperator(
+            profile_config=mini_profile_config,
+            project_dir=failing_test_dbt_project,
+            task_id="test",
+            append_env=True,
+            on_warning_callback=on_warning_callback,
+            invocation_mode=InvocationMode.SUBPROCESS,
+            dbt_cmd_global_flags=["--debug"],
+        )
+        seed_operator >> test_operator
+    run_test_dag(dag)
+
+    assert on_warning_callback.called
+    context = on_warning_callback.call_args.args[0]
+    assert context.get("test_names")
+    assert context.get("test_results")
+
+
+@pytest.mark.integration
 def test_run_operator_emits_events():
     class MockRun:
         facets = {"c": 3}


### PR DESCRIPTION
## Description

In `ExecutionMode.LOCAL` running in subprocess invocation mode, `on_warning_callback` was never invoked for dbt **test** warnings.

`DbtTestLocalOperator.execute()` only calls the callback when `parse_number_of_warnings_subprocess()` reports a positive count. That function inspected **only the last line** of dbt's stdout (`FullOutputSubprocessResult.output`), assuming the `Done. PASS=.. WARN=N ..` summary is always the final line.

Newer dbt versions (1.10+, since https://github.com/dbt-labs/dbt-core/pull/11540 was merged - discussion in https://github.com/dbt-labs/dbt-core/discussions/11493) no longer guarantee that. After the summary, dbt prints a deprecation summary, a `--debug` resource report, a `Command ... succeeded` line and a `Flushing usage events` line. The parser therefore found no `WARN=` token on the last line, returned `0`, the `number_of_warnings > 0` gate was `False`, and the callback was silently skipped - even though the run reported `WARN=1`.

The dbt-runner invocation path is unaffected (it counts result statuses directly), and
`DbtSourceLocalOperator` / `DbtBuildLocalOperator` are unaffected (they fire the callback
unconditionally).

## Fix

`parse_number_of_warnings_subprocess()` now scans the **full** subprocess output for the summary line and extracts the count with a regex capture group (`WARN=(\d+)`). This:

- detects warnings regardless of what dbt prints after the summary, and
- removes a latent uncaught `IndexError` that occurred when a trailing line contained the
  substring `WARN` (e.g. `[WARNING]`) but not `WARN=`.

## Related issues

Closes #2014
Closes #2492
Closes: #1951

🤖 Generated with Claude Code (https://claude.com/claude-code)
