### PR TITLE
docs: Move GCP GKE execution modes to a dedicated page

### DIFF
--- a/docs/guides/run_dbt/container/gcp-gke.rst
+++ b/docs/guides/run_dbt/container/gcp-gke.rst
@@ -1,0 +1,99 @@
+.. _gcp-gke:
+
+
+GCP GKE execution modes (experimental)
+======================================
+
+.. versionadded:: 1.15.0
+
+.. warning::
+
+   This feature is **experimental** and may change without a deprecation period.
+
+Cosmos provides two execution modes to run dbt in `Google Managed Airflow Gen 3 <https://cloud.google.com/products/managed-service-for-apache-airflow>`_ (formerly Cloud Composer 3) with a self-managed custom GKE cluster:
+
+- ``ExecutionMode.GCP_GKE``: the GKE variant of :ref:`kubernetes`.
+- ``ExecutionMode.WATCHER_GCP_GKE``: the GKE variant of :ref:`watcher-kubernetes-execution-mode`.
+
+Both modes work the same way as their Kubernetes counterparts but use the
+`GKEStartPodOperator <https://airflow.apache.org/docs/apache-airflow-providers-google/stable/_api/airflow/providers/google/cloud/operators/kubernetes_engine/index.html#airflow.providers.google.cloud.operators.kubernetes_engine.GKEStartPodOperator>`_
+instead of ``KubernetesPodOperator``, which handles GKE authentication automatically and lets you select the cluster to use.
+
+To use either mode, install the Google Cloud provider:
+
+.. code-block:: bash
+
+    pip install "astronomer-cosmos[google]"
+
+Both modes require three additional parameters in ``operator_args``:
+
+- ``project_id``: Your GCP project ID
+- ``location``: The GKE cluster location (e.g. ``us-central1``)
+- ``cluster_name``: The GKE cluster name
+
+
+.. _gcp-gke-execution-mode:
+
+GCP GKE execution mode
+~~~~~~~~~~~~~~~~~~~~~~~
+
+``ExecutionMode.GCP_GKE`` is the GCP GKE variant of ``ExecutionMode.KUBERNETES``.
+
+.. code-block:: python
+
+    from cosmos import DbtDag
+    from cosmos.config import ExecutionConfig
+    from cosmos.constants import ExecutionMode
+
+    dag = DbtDag(
+        dag_id="jaffle_shop_gcp_gke",
+        # ... other DAG parameters ...
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.GCP_GKE,
+            dbt_project_path="dags/dbt/jaffle_shop",
+        ),
+        operator_args={
+            "image": "dbt-jaffle-shop:1.0.0",
+            "get_logs": True,
+            "project_id": "my-gcp-project",
+            "location": "us-central1",
+            "cluster_name": "my-gke-cluster",
+        },
+    )
+
+All other configuration (Docker image, secrets, profiles) and the :ref:`limitations <kubernetes-known-limitations>`
+are the same as ``ExecutionMode.KUBERNETES``. For detailed setup instructions, refer to the
+:ref:`kubernetes` documentation.
+
+
+.. _watcher-gcp-gke-execution-mode:
+
+Watcher GCP GKE execution mode
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``ExecutionMode.WATCHER_GCP_GKE`` is the GCP GKE variant of ``ExecutionMode.WATCHER_KUBERNETES``.
+
+.. code-block:: python
+
+    from cosmos import DbtDag
+    from cosmos.config import ExecutionConfig
+    from cosmos.constants import ExecutionMode
+
+    dag = DbtDag(
+        dag_id="jaffle_shop_watcher_gcp_gke",
+        # ... other DAG parameters ...
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.WATCHER_GCP_GKE,
+            dbt_project_path="dags/dbt/jaffle_shop",
+        ),
+        operator_args={
+            "image": "dbt-jaffle-shop:1.0.0",
+            "get_logs": True,
+            "project_id": "my-gcp-project",
+            "location": "us-central1",
+            "cluster_name": "my-gke-cluster",
+        },
+    )
+
+All limitations and configuration from ``ExecutionMode.WATCHER_KUBERNETES`` apply. For more details, refer to
+the :ref:`watcher-kubernetes-execution-mode` documentation.

--- a/docs/guides/run_dbt/container/index.rst
+++ b/docs/guides/run_dbt/container/index.rst
@@ -12,3 +12,4 @@ Run dbt in a container
    aws-eks
    azure-container-instance
    gcp-cloud-run-job
+   gcp-gke

--- a/docs/guides/run_dbt/container/kubernetes.rst
+++ b/docs/guides/run_dbt/container/kubernetes.rst
@@ -1,13 +1,10 @@
 .. _kubernetes:
 
 
-Kubernetes and GCP GKE execution modes
-======================================
+Kubernetes execution mode
+=========================
 
-The ``ExecutionMode.KUBERNETES`` provides a very isolated method to run ``dbt`` from within a Kubernetes Pod, usually in a separate host.
-
-
-A GCP GKE variant is also available as ``ExecutionMode.GCP_GKE``, which uses ``GKEStartPodOperator`` instead of ``KubernetesPodOperator``. See :ref:`gcp-gke-execution-mode` below.
+The ``kubernetes`` execution mode provides a very isolated method to run ``dbt`` from within a Kubernetes Pod, usually in a separate host.
 
 Performance and maintenance considerations
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -172,60 +169,12 @@ Enable and trigger a run of the `jaffle_shop_k8s <https://github.com/astronomer/
 .. figure:: https://github.com/astronomer/astronomer-cosmos/raw/main/docs/_static/jaffle_shop_k8s_dag_run.png
     :width: 800
 
-.. _gcp-gke-execution-mode:
-
-GCP GKE execution mode
-+++++++++++++++++++++++
-
-.. versionadded:: 1.15.0
-
-``ExecutionMode.GCP_GKE`` works the same way as ``ExecutionMode.KUBERNETES`` but uses the
-`GKEStartPodOperator <https://airflow.apache.org/docs/apache-airflow-providers-google/stable/_api/airflow/providers/google/cloud/operators/kubernetes_engine/index.html>`_
-instead of ``KubernetesPodOperator``. This is the recommended mode for users running
-dbt on Google Kubernetes Engine, as it handles GKE authentication automatically and lets you select the cluster to use.
-
-The ``GKEStartPodOperator`` requires three additional parameters in ``operator_args``:
-
-- ``project_id``: Your GCP project ID
-- ``location``: The GKE cluster location (e.g. ``us-central1``)
-- ``cluster_name``: The GKE cluster name
-
-.. code-block:: python
-
-    from cosmos import DbtDag
-    from cosmos.config import ExecutionConfig
-    from cosmos.constants import ExecutionMode
-
-    dag = DbtDag(
-        dag_id="jaffle_shop_gcp_gke",
-        # ... other DAG parameters ...
-        execution_config=ExecutionConfig(
-            execution_mode=ExecutionMode.GCP_GKE,
-            dbt_project_path="dags/dbt/jaffle_shop",
-        ),
-        operator_args={
-            "image": "dbt-jaffle-shop:1.0.0",
-            "get_logs": True,
-            "project_id": "my-gcp-project",
-            "location": "us-central1",
-            "cluster_name": "my-gke-cluster",
-        },
-    )
-
-All other configuration (Docker image, secrets, profiles) is the same as ``ExecutionMode.KUBERNETES``.
-
-To use this mode, install the Google Cloud provider:
-
-.. code-block:: bash
-
-    pip install "astronomer-cosmos[google]"
-
 .. _kubernetes-known-limitations:
 
 Known limitations
 ~~~~~~~~~~~~~~~~~
 
-The Kubernetes and GCP GKE execution modes share the following limitations:
+The Kubernetes execution mode has the following limitations:
 
 - Does not emit OpenLineage events (there is an `open ticket #496 <https://github.com/astronomer/astronomer-cosmos/issues/496>`__ to address this)
 - Does not emit Airflow datasets, assets, and dataset aliases (there is an `open ticket #2329 <https://github.com/astronomer/astronomer-cosmos/issues/2329>`__ to address this)

--- a/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
@@ -1,8 +1,8 @@
 .. _watcher-kubernetes-execution-mode:
 
 
-Watcher Kubernetes and GCP GKE execution modes (experimental)
-=============================================================
+Watcher Kubernetes execution mode (experimental)
+================================================
 
 .. versionadded:: 1.13.0
 
@@ -13,9 +13,6 @@ This execution mode is ideal for users who:
 - Want to leverage the performance benefits of the watcher execution mode
 - Need to run dbt in isolated Kubernetes pods
 - Prefer not to install dbt in their `Apache Airflow® <https://airflow.apache.org/>`_ deployment
-
-A GCP GKE variant is also available as ``ExecutionMode.WATCHER_GCP_GKE``, which uses
-``GKEStartPodOperator`` instead of ``KubernetesPodOperator``. See :ref:`watcher-gcp-gke-execution-mode` below.
 
 
 Background
@@ -206,51 +203,10 @@ Before using ``ExecutionMode.WATCHER_KUBERNETES``, ensure you have:
 For detailed setup instructions, refer to the :ref:`kubernetes` documentation.
 
 
-.. _watcher-gcp-gke-execution-mode:
-
-Watcher GCP GKE execution mode
-++++++++++++++++++++++++++++++
-
-.. versionadded:: 1.15.0
-
-``ExecutionMode.WATCHER_GCP_GKE`` is the GCP GKE variant of ``ExecutionMode.WATCHER_KUBERNETES``.
-It uses ``GKEStartPodOperator`` instead of ``KubernetesPodOperator`` and requires the same
-additional parameters as :ref:`gcp-gke-execution-mode` (``project_id``, ``location``, ``cluster_name``).
-
-.. code-block:: python
-
-    from cosmos import DbtDag
-    from cosmos.config import ExecutionConfig
-    from cosmos.constants import ExecutionMode
-
-    dag = DbtDag(
-        dag_id="jaffle_shop_watcher_gcp_gke",
-        # ... other DAG parameters ...
-        execution_config=ExecutionConfig(
-            execution_mode=ExecutionMode.WATCHER_GCP_GKE,
-            dbt_project_path="dags/dbt/jaffle_shop",
-        ),
-        operator_args={
-            "image": "dbt-jaffle-shop:1.0.0",
-            "get_logs": True,
-            "project_id": "my-gcp-project",
-            "location": "us-central1",
-            "cluster_name": "my-gke-cluster",
-        },
-    )
-
-All limitations and configuration from ``ExecutionMode.WATCHER_KUBERNETES`` apply.
-
-To use this mode, install the Google Cloud provider:
-
-.. code-block:: bash
-
-    pip install "astronomer-cosmos[google]"
-
 Summary
 ~~~~~~~
 
-``ExecutionMode.WATCHER_KUBERNETES`` (and ``ExecutionMode.WATCHER_GCP_GKE``) provides:
+``ExecutionMode.WATCHER_KUBERNETES`` provides:
 
 - ✅ **~63% faster** dbt DAG runs compared to ``ExecutionMode.KUBERNETES``
 - ✅ **Isolation** between dbt and Airflow dependencies

--- a/docs/guides/run_dbt/execution-modes.rst
+++ b/docs/guides/run_dbt/execution-modes.rst
@@ -180,9 +180,13 @@ If you want to use a container execution mode, use the following decision tree t
     M[ExecutionMode.AZURE_CONTAINER_INSTANCE]
 
     N[Are you a GCP user?]
-    O[ExecutionMode.GCP_CLOUD_RUN_JOB]
+    O[Use GKE Kubernetes cluster?]
+    P[Try experimental high-performance GKE mode?]
+    Q[ExecutionMode.WATCHER_GCP_GKE]
+    R[ExecutionMode.GCP_GKE]
+    S[ExecutionMode.GCP_CLOUD_RUN_JOB]
 
-    P[Review container execution options]
+    T[Review container execution options]
 
     A --> B
     B -->|Yes| C
@@ -204,15 +208,21 @@ If you want to use a container execution mode, use the following decision tree t
     L -->|No| N
 
     N -->|Yes| O
-    N -->|No| P
+    N -->|No| T
+
+    O -->|Yes| P
+    O -->|No| S
+
+    P -->|Yes| Q
+    P -->|No| R
 
     classDef decision fill:#fff3cd,stroke:#b58900,color:#333
     classDef action fill:#e8f5e9,stroke:#2e7d32,color:#333
     classDef result fill:#e3f2fd,stroke:#1565c0,color:#333
 
-    class B,D,E,H,I,L,N decision
-    class J,K,M,O action
-    class C,F,G,P result
+    class B,D,E,H,I,L,N,O,P decision
+    class J,K,M,R,S action
+    class C,F,G,Q,T result
 
 .. _execution-modes-comparison:
 

--- a/docs/guides/run_dbt/execution-modes.rst
+++ b/docs/guides/run_dbt/execution-modes.rst
@@ -141,12 +141,13 @@ In a container
 You can also execute dbt commands in a container. Choosing these kinds of execution modes provides a high degree of isolation. However, they come with limitations where you can only create Airflow connections with the dbt ``profiles.yml`` file and it has slower run times because of container provisioning. They all also require a pre-existing Docker image.
 
 - :ref:`docker <docker>` : Run ``dbt`` commands via Docker containers inside the Airflow worker node.
-- :ref:`kubernetes <kubernetes>`: Run ``dbt`` commands within Kubernetes Pods managed by Cosmos. Also supports GCP GKE via ``ExecutionMode.GCP_GKE``.
-- :ref:`watcher_kubernetes <watcher-kubernetes-execution-mode>`: (experimental since Cosmos 1.13.0) Combines the speed of the watcher execution mode with the isolation of Kubernetes. Also supports GCP GKE via ``ExecutionMode.WATCHER_GCP_GKE``.
+- :ref:`kubernetes <kubernetes>`: Run ``dbt`` commands within Kubernetes Pods managed by Cosmos.
+- :ref:`watcher_kubernetes <watcher-kubernetes-execution-mode>`: (experimental since Cosmos 1.13.0) Combines the speed of the watcher execution mode with the isolation of Kubernetes.
 - :ref:`aws_ecs <aws-container-run-job>`: Run ``dbt`` commands in containers via AWS ECS.
 - :ref:`aws_eks <aws-eks>`: Run ``dbt`` commands via Kubernetes Pods in AWS EKS.
 - :ref:`azure_container_instance <azure-container-instance>`: Run ``dbt`` commands in Azure Container Instances.
 - :ref:`gcp_cloud_run_job <gcp-cloud-run-job>`: Run ``dbt`` commands via a container managed by GCP Cloud Run Job.
+- :ref:`gcp_gke <gcp-gke>`: (experimental since Cosmos 1.15.0) Run ``dbt`` commands via Kubernetes Pods on GCP GKE using ``GKEStartPodOperator``. Includes a watcher variant, ``ExecutionMode.WATCHER_GCP_GKE``.
 
 Choose your container execution mode type
 +++++++++++++++++++++++++++++++++++++++++
@@ -179,13 +180,9 @@ If you want to use a container execution mode, use the following decision tree t
     M[ExecutionMode.AZURE_CONTAINER_INSTANCE]
 
     N[Are you a GCP user?]
-    O[Use GKE Kubernetes cluster?]
-    P[Try experimental high-performance GKE mode?]
-    Q[ExecutionMode.WATCHER_GCP_GKE]
-    R[ExecutionMode.GCP_GKE]
-    S[ExecutionMode.GCP_CLOUD_RUN_JOB]
+    O[ExecutionMode.GCP_CLOUD_RUN_JOB]
 
-    T[Review container execution options]
+    P[Review container execution options]
 
     A --> B
     B -->|Yes| C
@@ -207,21 +204,15 @@ If you want to use a container execution mode, use the following decision tree t
     L -->|No| N
 
     N -->|Yes| O
-    N -->|No| T
-
-    O -->|Yes| P
-    O -->|No| S
-
-    P -->|Yes| Q
-    P -->|No| R
+    N -->|No| P
 
     classDef decision fill:#fff3cd,stroke:#b58900,color:#333
     classDef action fill:#e8f5e9,stroke:#2e7d32,color:#333
     classDef result fill:#e3f2fd,stroke:#1565c0,color:#333
 
-    class B,D,E,H,I,L,N,O,P decision
-    class J,K,M,R,S action
-    class C,F,G,Q,T result
+    class B,D,E,H,I,L,N decision
+    class J,K,M,O action
+    class C,F,G,P result
 
 .. _execution-modes-comparison:
 
@@ -266,14 +257,6 @@ The type of execution mode that you choose directly affects how fast your Cosmos
      - Fast
      - High
      - No
-   * - GCP GKE
-     - Slow
-     - High
-     - No
-   * - Watcher GCP GKE
-     - Fast
-     - High
-     - No
    * - AWS ECS
      - Slow
      - High
@@ -288,5 +271,13 @@ The type of execution mode that you choose directly affects how fast your Cosmos
      - No
    * - GCP Cloud Run Job Instance
      - Slow
+     - High
+     - No
+   * - GCP GKE
+     - Slow
+     - High
+     - No
+   * - Watcher GCP GKE
+     - Fast
      - High
      - No


### PR DESCRIPTION
## Description

Added dedicated docs page for GCP GKE modes (single page for both)

Answers to comment https://github.com/astronomer/astronomer-cosmos/pull/2488#pullrequestreview-4552776640

## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works
