### PR TITLE
docs: Document retrying models but not tests

### DIFF
--- a/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
+++ b/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
@@ -49,6 +49,41 @@ Finally, an example DAG and how it is rendered in the `Apache Airflow® <https:/
 
 .. image:: ../../_static/test_behavior_build.png
 
+Retrying models but not tests
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+A common requirement is to retry failing model runs while never retrying tests, for example when tests are slow and
+retrying them would delay or block subsequent DAG runs.
+
+With the default ``TestBehavior.AFTER_EACH``, this is done by setting ``retries`` on the models and a different
+``retries`` on their dbt tests: see :ref:`operator-args-test-nodes`.
+
+If you use ``TestBehavior.AFTER_ALL`` instead, tests run as a single task at the end of the DAG that is independent
+of any model node, so it keeps the DAG-level ``retries`` default while per-node ``retries`` apply only to the model
+(run) tasks. Set ``retries=0`` as the DAG-wide default and override ``retries`` for the models in your
+``dbt_project.yml``:
+
+.. code-block:: python
+
+    from cosmos import DbtDag, RenderConfig
+    from cosmos.constants import TestBehavior
+
+    DbtDag(
+        # ...
+        operator_args={"retries": 0},
+        render_config=RenderConfig(test_behavior=TestBehavior.AFTER_ALL),
+    )
+
+.. code-block:: yaml
+
+    # dbt_project.yml — retry every model run twice, leaving the final test task at retries=0
+    models:
+      my_dbt_project:
+        +meta:
+          cosmos:
+            operator_kwargs:
+              retries: 2
+
 Warning behavior
 ~~~~~~~~~~~~~~~~
 

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2933,6 +2933,54 @@ def test_create_task_metadata_seed_rendering_always_no_flag():
     assert "should_run_if_seed_changed" not in metadata.extra_context
 
 
+def _model_with_node_retries(retries):
+    return DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.proj.my_model",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=Path("."),
+        original_file_path=Path("models/my_model.sql"),
+        tags=[],
+        config={"materialized": "table", "meta": {"cosmos": {"operator_kwargs": {"retries": retries}}}},
+        has_test=True,
+    )
+
+
+def test_retries_after_all_separates_model_and_test():
+    """Per-node ``retries`` reaches the model task, while the AFTER_ALL test task (node=None) keeps the DAG default.
+
+    This is the supported way to retry model runs but not tests (issue #2130).
+    """
+    node = _model_with_node_retries(2)
+    model_meta = create_task_metadata(
+        node, execution_mode=ExecutionMode.LOCAL, args={"retries": 0}, dbt_dag_task_group_identifier="dag"
+    )
+    test_meta = create_test_task_metadata(
+        "proj_test",
+        ExecutionMode.LOCAL,
+        TestIndirectSelection.EAGER,
+        task_args={"retries": 0},
+        render_config=RenderConfig(test_behavior=TestBehavior.AFTER_ALL, select=[], exclude=[]),
+    )
+    assert model_meta.arguments["retries"] == 2
+    assert test_meta.arguments["retries"] == 0
+
+
+def test_retries_after_each_test_inherits_model_operator_kwargs():
+    """AFTER_EACH builds the test task from the model node, so per-node ``retries`` also applies to the test,
+    unless the test itself declares an override (see ``test_test_node_operator_kwargs_override_the_ones_inherited_from_the_model``).
+    """
+    node = _model_with_node_retries(2)
+    test_meta = create_test_task_metadata(
+        "test",
+        ExecutionMode.LOCAL,
+        TestIndirectSelection.EAGER,
+        task_args={"retries": 0},
+        node=node,
+    )
+    assert test_meta.arguments["retries"] == 2
+
+
 def _model_and_test_nodes(model_kwargs, test_kwargs, second_test_kwargs=None):
     model = DbtNode(
         unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.my_model",


### PR DESCRIPTION
## Problem

Issue #2130: users want to retry **model runs** but **not tests** — slow tests (e.g. 30 min) would otherwise be retried and block subsequent DAG runs.

## Solution

Documents how to retry models without retrying tests in the testing-behavior guide:

- **`TestBehavior.AFTER_EACH` (default)**: since #2936, a test's own `operator_kwargs` (e.g. `retries: 0`) overrides what it would otherwise inherit from the model it tests. This is the primary recipe — see `overriding-operator-args.rst`.
- **`TestBehavior.AFTER_ALL`**: documented here as an alternative. The single end-of-DAG test task has no associated node, so it keeps the DAG-level `retries` default while per-node `retries` apply only to model tasks.

This PR originally proposed `AFTER_ALL` as the only way to solve this, since `AFTER_EACH` unconditionally inherited the model's `retries` at the time and ignored any `operator_kwargs` set on the test itself. #2936 has since merged and fixed that directly, so this PR was rebased on top: the stale "`AFTER_EACH` ignores test kwargs" note and the regression test asserting that now-fixed behavior were removed, and the section now points to #2936's docs first.

## Verification

- `test_retries_after_all_separates_model_and_test` and `test_retries_after_each_test_inherits_model_operator_kwargs` pass, alongside the full `tests/airflow/test_graph.py` suite (166 passed).
- `sphinx-build` is clean; the `:ref:operator-args-test-nodes` cross-reference resolves.

Closes #2130

🤖 Generated with Claude Code (https://claude.com/claude-code)
