### PR TITLE
Declare AssetAlias outlets at parse time on Airflow 3

### DIFF
--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -416,9 +416,21 @@ def register_dataset_on_task(
         logger.info("Assigning outlets with DatasetAlias in Airflow 3")
         from airflow.sdk.definitions.asset import AssetAlias
 
-        # AssetAlias is registered on the task outlets as well as the
-        # outlet_events. This was required in Airflow 3.0.0; later releases
-        # may make it automatic, at which point this line becomes a no-op.
-        task.outlets.append(AssetAlias(dataset_alias_name))
+        _ensure_asset_alias_outlet(task, dataset_alias_name)
+        asset_alias = AssetAlias(dataset_alias_name)
         for outlet in new_outlets:
-            context["outlet_events"][AssetAlias(dataset_alias_name)].add(outlet)
+            context["outlet_events"][asset_alias].add(outlet)
+
+
+def _ensure_asset_alias_outlet(task: Any, dataset_alias_name: str) -> None:
+    """Append the AssetAlias outlet at runtime only if it is missing (Airflow 3).
+
+    The alias is normally declared as a static outlet at parse time (see
+    ``DbtLocalBaseOperator.__init__``, issue-2417). This keeps emission working when outlets
+    were not set at parse time, while avoiding a duplicate alias.
+    """
+    from airflow.sdk.definitions.asset import AssetAlias
+
+    existing_alias_names = {outlet.name for outlet in task.outlets if isinstance(outlet, AssetAlias)}
+    if dataset_alias_name not in existing_alias_names:
+        task.outlets.append(AssetAlias(dataset_alias_name))

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -1011,6 +1011,23 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
                 operator_kwargs["outlets"] = outlets + [
                     DatasetAlias(name=get_dataset_alias_name(dag_id, task_group_id, self.task_id))
                 ]
+        elif (
+            kwargs.get("emit_datasets", True)
+            and settings.enable_dataset_alias
+            and AIRFLOW_VERSION.major == _AIRFLOW3_MAJOR_VERSION
+        ):
+            # issue-2417: On Airflow 3, declare the AssetAlias as a static (parse-time) outlet so the producing
+            # task is serialized with an asset reference; otherwise it is only attached at runtime (register_dataset).
+            from airflow.sdk.definitions.asset import AssetAlias
+
+            dag = kwargs.get("dag")
+            task_group = kwargs.get("task_group")
+
+            # Keep user outlets as-is so concrete Assets keep emitting/scheduling; only append the Cosmos alias.
+            user_outlets = list(kwargs.get("outlets", []))
+            operator_kwargs["outlets"] = user_outlets + [
+                AssetAlias(name=get_dataset_alias_name(dag, task_group, self.task_id))
+            ]
 
         if "task_id" in operator_kwargs:
             operator_kwargs.pop("task_id")

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -824,6 +824,102 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_3_onwards(caplog):
     )
 
 
+@pytest.mark.skipif(
+    version.parse(airflow_version).major < 3,
+    reason="From Airflow 3.0 onwards, outlets are declared via AssetAlias at parse time.",
+)
+def test_run_operator_declares_asset_alias_outlet_at_parse_time_airflow_3():
+    """issue-2417: on Airflow 3 the AssetAlias must be a static (parse-time) outlet, otherwise emitted assets
+    never show up in the Airflow "Assets" graph."""
+    from airflow.sdk.definitions.asset import AssetAlias
+
+    with DAG("test_id_4", start_date=datetime(2022, 1, 1)) as dag:
+        seed_operator = DbtSeedLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="seed",
+            dag=dag,
+            emit_datasets=False,
+            install_deps=False,
+        )
+        run_operator = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run",
+            dag=dag,
+            install_deps=False,
+        )
+        test_operator = DbtTestLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="test",
+            dag=dag,
+            install_deps=False,
+        )
+        seed_operator >> run_operator >> test_operator
+
+    assert seed_operator.outlets == []  # because emit_datasets=False
+    assert run_operator.outlets == [AssetAlias(name="test_id_4__run")]
+    assert test_operator.outlets == [AssetAlias(name="test_id_4__test")]
+
+
+@pytest.mark.skipif(
+    version.parse(airflow_version).major < 3,
+    reason="From Airflow 3.0 onwards, outlets are declared via AssetAlias at parse time (issue-2417).",
+)
+def test_run_operator_manual_outlets_airflow_3(caplog):
+    """issue-2417: user-supplied outlets are preserved as-is on Airflow 3; Cosmos only appends its AssetAlias.
+
+    A concrete ``Asset`` must not be rewritten into an ``AssetAlias``, which would silently stop it emitting and
+    scheduling downstream DAGs.
+    """
+    from airflow.sdk.definitions.asset import Asset, AssetAlias
+
+    manual_asset = Asset(uri="manual_asset")
+    manual_alias = AssetAlias(name="manual_alias")
+    with DAG("test_id_5", start_date=datetime(2022, 1, 1)) as dag:
+        run_operator = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run",
+            dag=dag,
+            install_deps=False,
+            outlets=[manual_asset, manual_alias],
+        )
+
+    assert run_operator.outlets == [manual_asset, manual_alias, AssetAlias(name="test_id_5__run")]
+    assert isinstance(run_operator.outlets[0], Asset)
+
+
+@pytest.mark.skipif(
+    version.parse(airflow_version).major < 3,
+    reason="_ensure_asset_alias_outlet only applies on Airflow 3 (issue-2417).",
+)
+def test_ensure_asset_alias_outlet_airflow_3():
+    """The runtime helper appends the alias only when it is missing, avoiding a duplicate of the parse-time outlet."""
+    from airflow.sdk.definitions.asset import AssetAlias
+
+    from cosmos.dataset import _ensure_asset_alias_outlet
+
+    with DAG("test_id_6", start_date=datetime(2022, 1, 1)) as dag:
+        run_operator = DbtRunLocalOperator(
+            profile_config=real_profile_config,
+            project_dir=DBT_PROJ_DIR,
+            task_id="run",
+            dag=dag,
+            install_deps=False,
+        )
+
+    # The alias is already declared at parse time, so re-ensuring it is a no-op (dedup branch).
+    assert run_operator.outlets == [AssetAlias(name="test_id_6__run")]
+    _ensure_asset_alias_outlet(run_operator, "test_id_6__run")
+    assert run_operator.outlets == [AssetAlias(name="test_id_6__run")]
+
+    # A new alias name is appended (append branch).
+    _ensure_asset_alias_outlet(run_operator, "another_alias")
+    assert run_operator.outlets == [AssetAlias(name="test_id_6__run"), AssetAlias(name="another_alias")]
+
+
 @pytest.mark.integration
 def test_dbt_dag_with_group_nodes_by_folder():
     """

--- a/tests/operators/test_watcher.py
+++ b/tests/operators/test_watcher.py
@@ -3534,3 +3534,27 @@ class TestStoreDbtResourceStatusFromLogNonJson:
         with caplog.at_level(logging.INFO, logger="cosmos.operators._watcher.base"):
             store_dbt_resource_status_from_log("", {"context": ctx}, tests_per_model={}, test_results_per_model={})
         assert caplog.text == ""
+
+
+@pytest.mark.skipif(
+    AIRFLOW_VERSION.major < 3,
+    reason="From Airflow 3.0 onwards, outlets are declared via AssetAlias at parse time (issue-2417).",
+)
+def test_consumer_sensor_declares_asset_alias_outlet_at_parse_time_airflow_3():
+    """issue-2417: WATCHER consumer sensors must declare the AssetAlias as a static (parse-time) outlet on
+    Airflow 3, otherwise emitted model assets never appear in the Airflow "Assets" graph."""
+    from airflow import DAG
+    from airflow.sdk.definitions.asset import AssetAlias
+
+    with DAG("watcher_assets_dag", start_date=datetime(2022, 1, 1)):
+        consumer = DbtConsumerWatcherSensor(
+            project_dir=".",
+            profiles_dir=".",
+            profile_config=profile_config,
+            model_unique_id="model.pkg.m",
+            poke_interval=1,
+            producer_task_id="dbt_producer_watcher_operator",
+            task_id="consumer_sensor",
+        )
+
+    assert consumer.outlets == [AssetAlias(name="watcher_assets_dag__consumer_sensor")]


### PR DESCRIPTION
## Problem

Related to #2417. On Airflow 3, dbt assets emit as events (Overview tab / `airflow asset list`) but the producing task is serialized with **no** asset reference. Cause: the block in `DbtLocalBaseOperator.__init__` that declares the alias as a parse-time outlet is gated to Airflow < 3, so on Airflow 3 the `AssetAlias` is only attached at runtime in `register_dataset`.

## Solution

- Declare the `AssetAlias` as a parse-time outlet on Airflow 3 too (previously it was only attached at runtime in `register_dataset`); guard the runtime append so it isn't duplicated.
- Preserve any user-supplied outlets as-is: a user-declared concrete `Asset` is kept unchanged so it keeps emitting and scheduling downstream DAGs, and Cosmos only appends its own `AssetAlias` alongside it. (Earlier revisions rewrote concrete `Asset` outlets into `AssetAlias`, which silently disabled their emission/scheduling — see review feedback.)
- Covers `ExecutionMode.WATCHER` as well, since watcher consumer sensors inherit from `DbtRunLocalOperator`.

**Scope:** restores the parse-time task↔alias parity with Airflow 2.x. It does **not** make per-model assets show in the Airflow 3 Assets list (`/assets`), which only lists "active" concrete `Asset` outlets — alias-resolved assets stay orphaned. Concrete outlets are tracked in #2001.

## Verification

On Airflow 3.1.7 (`tests.py3.11-3.1-1.9`) and 2.10.5:
- New regression tests (local + watcher) pass; they fail without the change. The manual-outlets test asserts a user-supplied `Asset` survives unchanged alongside the appended Cosmos `AssetAlias`.
- Airflow 2 path untouched; unit subset passes (one pre-existing, unrelated failure).
- `pre-commit` passes.

Assets in AF UI

<img width="1691" height="1037" alt="Screenshot 2026-06-25 at 8 50 36 PM" src="https://github.com/user-attachments/assets/c3a74750-03b2-4452-8fde-0b00ffe0a61b" />


Related to #2417, #2001

🤖 Generated with Claude Code (https://claude.com/claude-code)
