### PR TITLE
refactor: avoid hard-coded status strings in watcher

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -23,6 +23,7 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
 from cosmos.operators._watcher.state import (
+    DbtNodeStatus,
     ProducerTaskState,
     _iso_to_string,
     _log_dbt_event,
@@ -282,7 +283,7 @@ def _rewrite_upstream_failure_skip_status(
     if is_dbt_upstream_failure_skip_event(log_line.get("info", {}).get("name")):
         upstream_failure_skipped_ids.add(unique_id)
     if is_dbt_node_status_skipped(dbt_node_status) and unique_id in upstream_failure_skipped_ids:
-        return "failed"
+        return DbtNodeStatus.FAILED
     return dbt_node_status
 
 

--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -23,6 +23,7 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.aggregation import get_tests_status_xcom_key, push_test_result_or_aggregate
 from cosmos.operators._watcher.state import (
+    ProducerTaskState,
     _iso_to_string,
     _log_dbt_event,
     build_producer_state_fetcher,
@@ -280,7 +281,7 @@ def _rewrite_upstream_failure_skip_status(
         return dbt_node_status
     if is_dbt_upstream_failure_skip_event(log_line.get("info", {}).get("name")):
         upstream_failure_skipped_ids.add(unique_id)
-    if dbt_node_status == "skipped" and unique_id in upstream_failure_skipped_ids:
+    if is_dbt_node_status_skipped(dbt_node_status) and unique_id in upstream_failure_skipped_ids:
         return "failed"
     return dbt_node_status
 
@@ -615,7 +616,7 @@ class BaseConsumerSensor(BaseSensorOperator):
                 f"{self._resource_label} '{self.model_unique_id}' was skipped by the dbt command."
             )
 
-        if status == "success" and reason == WatcherEventReason.NODE_NOT_RUN:
+        if status == EventStatus.SUCCESS and reason == WatcherEventReason.NODE_NOT_RUN:
             logger.info(
                 "%s '%s' was skipped by the dbt command. This may happen if it is an ephemeral model or if the model sql file is empty.",
                 self._resource_label,
@@ -629,7 +630,7 @@ class BaseConsumerSensor(BaseSensorOperator):
             if hasattr(self, "_override_rtif"):
                 self._override_rtif(context)
 
-        if status != "failed":
+        if status != EventStatus.FAILED:
             return
 
         if reason == WatcherEventReason.NODE_FAILED:
@@ -712,7 +713,7 @@ class BaseConsumerSensor(BaseSensorOperator):
 
     def _handle_no_dbt_node_status(self, producer_task_state: str | None, try_number: int, context: Context) -> bool:
         """Handle the case where no dbt node status has been reported yet."""
-        if producer_task_state == "failed":
+        if producer_task_state == ProducerTaskState.FAILED:
             if self.poke_retry_number > 0:
                 raise AirflowException(
                     f"The dbt build command failed in producer task. Please check the log of task {self.producer_task_id} for details."
@@ -721,7 +722,7 @@ class BaseConsumerSensor(BaseSensorOperator):
                 # This handles the scenario of tasks that failed with `State.UPSTREAM_FAILED`
                 return self._fallback_to_non_watcher_run(try_number, context)
 
-        if producer_task_state == "skipped":
+        if producer_task_state == ProducerTaskState.SKIPPED:
             return self._fallback_to_non_watcher_run(try_number, context)
 
         self.poke_retry_number += 1

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -20,12 +20,31 @@ from packaging.version import Version
 
 ProducerStateFetcher = Callable[[], str | None]
 
-DBT_NODE_STATUS_SKIPPED = "skipped"
 
-# dbt uses different status values for different node types (models/tests):"
-DBT_SUCCESS_STATUSES = frozenset({"success", "pass", "warn"})
-DBT_FAILED_STATUSES = frozenset({"failed", "fail", "error", "runtime error"})
-DBT_SKIPPED_STATUSES = frozenset({DBT_NODE_STATUS_SKIPPED})
+class DbtNodeStatus(str, Enum):
+    """Raw dbt node status values the watcher inspects. dbt uses different values per node type
+    (e.g. models report ``success``/``error``, tests ``pass``/``fail``/``warn``), so the watcher
+    groups them into the ``DBT_*_STATUSES`` sets below rather than checking a single value."""
+
+    SUCCESS = "success"
+    PASS = "pass"
+    WARN = "warn"
+    FAILED = "failed"
+    FAIL = "fail"
+    ERROR = "error"
+    RUNTIME_ERROR = "runtime error"
+    SKIPPED = "skipped"
+
+    def __str__(self) -> str:
+        # Render as the raw dbt value (e.g. "skipped") in logs/XCom rather than "DbtNodeStatus.SKIPPED".
+        return self.value
+
+
+DBT_SUCCESS_STATUSES = frozenset({DbtNodeStatus.SUCCESS, DbtNodeStatus.PASS, DbtNodeStatus.WARN})
+DBT_FAILED_STATUSES = frozenset(
+    {DbtNodeStatus.FAILED, DbtNodeStatus.FAIL, DbtNodeStatus.ERROR, DbtNodeStatus.RUNTIME_ERROR}
+)
+DBT_SKIPPED_STATUSES = frozenset({DbtNodeStatus.SKIPPED})
 
 # dbt event names that signal a node was skipped because an upstream node failed.
 # dbt fires SkippingDetails (non-ephemeral upstream) or LogSkipBecauseError

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -20,10 +20,12 @@ from packaging.version import Version
 
 ProducerStateFetcher = Callable[[], str | None]
 
+DBT_NODE_STATUS_SKIPPED = "skipped"
+
 # dbt uses different status values for different node types (models/tests):"
 DBT_SUCCESS_STATUSES = frozenset({"success", "pass", "warn"})
 DBT_FAILED_STATUSES = frozenset({"failed", "fail", "error", "runtime error"})
-DBT_SKIPPED_STATUSES = frozenset({"skipped"})
+DBT_SKIPPED_STATUSES = frozenset({DBT_NODE_STATUS_SKIPPED})
 
 # dbt event names that signal a node was skipped because an upstream node failed.
 # dbt fires SkippingDetails (non-ephemeral upstream) or LogSkipBecauseError
@@ -34,13 +36,38 @@ DBT_UPSTREAM_FAILURE_SKIP_EVENT_NAMES = frozenset({"SkippingDetails", "LogSkipBe
 # dbt source freshness statuses that mark a source as stale and propagate skips downstream.
 DBT_SOURCE_FRESHNESS_STALE_STATUSES = frozenset({"error", "warn"})
 
+
+class ProducerTaskState(str, Enum):
+    """Airflow producer task states the watcher inspects (mirrors ``TaskInstanceState`` values)."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    SKIPPED = "skipped"
+    UPSTREAM_FAILED = "upstream_failed"
+    REMOVED = "removed"
+
+
 # Airflow task states that indicate the producer has finished and will not deliver any more XCom updates.
 # Used to decide whether a sensor retry should fall back to a non-watcher run or keep polling.
-PRODUCER_TERMINAL_STATES = frozenset({"success", "failed", "skipped", "upstream_failed", "removed"})
+PRODUCER_TERMINAL_STATES = frozenset(
+    {
+        ProducerTaskState.SUCCESS,
+        ProducerTaskState.FAILED,
+        ProducerTaskState.SKIPPED,
+        ProducerTaskState.UPSTREAM_FAILED,
+        ProducerTaskState.REMOVED,
+    }
+)
 
 # Airflow task states checked by the watcher trigger to know the producer task has reached its
 # final outcome and the trigger can exit early. Subset of PRODUCER_TERMINAL_STATES.
-PRODUCER_FINAL_STATES = frozenset({"failed", "success", "skipped"})
+PRODUCER_FINAL_STATES = frozenset(
+    {
+        ProducerTaskState.FAILED,
+        ProducerTaskState.SUCCESS,
+        ProducerTaskState.SKIPPED,
+    }
+)
 
 
 class DbtTestStatus(str, Enum):

--- a/cosmos/operators/_watcher/triggerer.py
+++ b/cosmos/operators/_watcher/triggerer.py
@@ -14,6 +14,7 @@ from cosmos.listeners.dag_run_listener import EventStatus
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import (
     PRODUCER_FINAL_STATES,
+    ProducerTaskState,
     build_producer_state_fetcher,
     get_compiled_sql_xcom_key,
     get_status_xcom_key,
@@ -244,7 +245,7 @@ class WatcherTrigger(BaseTrigger):
                     event_data["compiled_sql"] = compiled_sql
                 yield TriggerEvent(event_data)  # type: ignore[no-untyped-call]
                 return
-            elif producer_task_state == "failed":
+            elif producer_task_state == ProducerTaskState.FAILED:
                 logger.error(
                     "Watcher producer task '%s' failed before delivering results for node '%s'",
                     self.producer_task_id,
@@ -252,7 +253,7 @@ class WatcherTrigger(BaseTrigger):
                 )
                 yield TriggerEvent({"status": EventStatus.FAILED, "reason": WatcherEventReason.PRODUCER_FAILED})  # type: ignore[no-untyped-call]
                 return
-            elif producer_task_state == "skipped":
+            elif producer_task_state == ProducerTaskState.SKIPPED:
                 logger.info(
                     "Watcher producer task '%s' was skipped (e.g. retry). "
                     "Consumer will fall back to running dbt for node '%s'.",
@@ -261,7 +262,7 @@ class WatcherTrigger(BaseTrigger):
                 )
                 yield TriggerEvent({"status": EventStatus.FAILED, "reason": WatcherEventReason.PRODUCER_SKIPPED})  # type: ignore[no-untyped-call]
                 return
-            elif producer_task_state == "success" and dbt_node_status is None:
+            elif producer_task_state == ProducerTaskState.SUCCESS and dbt_node_status is None:
                 logger.info(
                     "The producer task '%s' succeeded. There is no information about the node '%s' execution.",
                     self.producer_task_id,

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -30,7 +30,11 @@ from cosmos.operators._watcher.base import (
     BaseConsumerSensor,
     store_dbt_resource_status_from_log,
 )
-from cosmos.operators._watcher.state import DBT_SOURCE_FRESHNESS_STALE_STATUSES, DBT_SUCCESS_STATUSES
+from cosmos.operators._watcher.state import (
+    DBT_NODE_STATUS_SKIPPED,
+    DBT_SOURCE_FRESHNESS_STALE_STATUSES,
+    DBT_SUCCESS_STATUSES,
+)
 from cosmos.operators._watcher.xcom import (
     _compose_backup_callback,
     _delete_xcom_backup_variable,
@@ -123,7 +127,7 @@ def _default_freshness_callback(
     # and test hash-suffixed unique_ids are not valid dbt --exclude selectors.
     excludable = [uid for uid in visited if nodes.get(uid) and nodes[uid].resource_type in _excludable_resource_types]
     logger.info("Nodes to skip due to stale sources: %s", excludable)
-    return [(uid, "skipped") for uid in excludable]
+    return [(uid, DBT_NODE_STATUS_SKIPPED) for uid in excludable]
 
 
 class _StdoutFilter:

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -31,9 +31,9 @@ from cosmos.operators._watcher.base import (
     store_dbt_resource_status_from_log,
 )
 from cosmos.operators._watcher.state import (
-    DBT_NODE_STATUS_SKIPPED,
     DBT_SOURCE_FRESHNESS_STALE_STATUSES,
     DBT_SUCCESS_STATUSES,
+    DbtNodeStatus,
 )
 from cosmos.operators._watcher.xcom import (
     _compose_backup_callback,
@@ -127,7 +127,7 @@ def _default_freshness_callback(
     # and test hash-suffixed unique_ids are not valid dbt --exclude selectors.
     excludable = [uid for uid in visited if nodes.get(uid) and nodes[uid].resource_type in _excludable_resource_types]
     logger.info("Nodes to skip due to stale sources: %s", excludable)
-    return [(uid, DBT_NODE_STATUS_SKIPPED) for uid in excludable]
+    return [(uid, DbtNodeStatus.SKIPPED) for uid in excludable]
 
 
 class _StdoutFilter:


### PR DESCRIPTION
## Description

Addresses #2585. The watcher used a mixed approach for the same status values — sometimes a typed constant/enum, sometimes a bare string literal (e.g. the literal `"skipped"`/`"failed"` vs `WatcherEventReason.PRODUCER_SKIPPED`). This normalises the status vocabularies and removes the remaining hard-coded literals.

### Changes

**`_watcher/state.py`** (single source of truth):
- Add `ProducerTaskState(str, Enum)` for Airflow producer task states, which previously had **no** enum at all — only membership frozensets. As a `str` subclass its members compare equal to the raw state strings, so `==` and set membership are unchanged.
- Rebuild `PRODUCER_TERMINAL_STATES` / `PRODUCER_FINAL_STATES` from the enum instead of duplicating literals.
- Add `DbtNodeStatus(str, Enum)` holding every raw dbt node status value (`success`/`pass`/`warn`/`failed`/`fail`/`error`/`runtime error`/`skipped`), and rebuild the `DBT_SUCCESS_STATUSES` / `DBT_FAILED_STATUSES` / `DBT_SKIPPED_STATUSES` frozensets from its members. A `__str__` override returns the raw value so logs/XCom render `skipped`/`failed` rather than `DbtNodeStatus.SKIPPED`.

**`_watcher/triggerer.py`**: replace `producer_task_state == "failed"/"skipped"/"success"` with `ProducerTaskState.*`.

**`_watcher/base.py`**: replace `dbt_node_status == "skipped"` → `is_dbt_node_status_skipped(...)`; the upstream-failure rewrite `return "failed"` → `DbtNodeStatus.FAILED`; `status == "success"` / `status != "failed"` → `EventStatus.SUCCESS`/`EventStatus.FAILED`; two `producer_task_state` literals → `ProducerTaskState.*`.

**`operators/watcher.py`**: the freshness callback's `(uid, "skipped")` → `(uid, DbtNodeStatus.SKIPPED)`.

This is **behaviour-neutral** — enum members are `str` subclasses carrying the identical string values, and the `__str__` override keeps their rendered/serialised form unchanged.

## Testing

- `ruff`, `black`, `mypy` pass (full pre-commit suite green on the commit).
- Watcher unit tests pass: `tests/operators/_watcher/` (163 passed, 1 skipped).

Closes #2585

🤖 Generated with [Claude Code](https://claude.com/claude-code)
