### PR TITLE
Wait for all coverage jobs before combining coverage

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -628,6 +628,8 @@ jobs:
       - Authorize
       - Run-Integration-Tests
       - Run-Integration-Tests-Expensive
+      - Run-Integration-Tests-DBT-Async
+      - Run-Integration-dbt-fusion-Tests
       - Run-Kubernetes-Tests
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
## Description

`Code-Coverage` only lists 3 of the 5 coverage-producing jobs in its `needs`. This is about dependency correctness, not job timing: when one of the two missing jobs (`Run-Integration-Tests-DBT-Async`, `Run-Integration-dbt-fusion-Tests`) fails and we "Re-run failed jobs", `Code-Coverage` isn't a dependent so it's never re-triggered, leaving under-reported coverage on Codecov. This adds both jobs to `needs` so coverage combines only after every coverage job has finished.

## Breaking Change?

No.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
