### PR TITLE
Surface failing dbt nodes in subprocess exception for on_failure_callback

### DIFF
--- a/cosmos/dbt/parser/output.py
+++ b/cosmos/dbt/parser/output.py
@@ -125,6 +125,31 @@ def extract_log_issues(log_list: list[str]) -> tuple[list[str], list[str]]:
     return test_names, test_results
 
 
+def extract_dbt_failure_details(log_list: list[str]) -> list[str]:
+    """
+    Extract dbt failure/error messages from subprocess output.
+
+    Counterpart of :func:`extract_log_issues` (which handles warnings). dbt prints failures as
+    ``<Failure|Error> in <resource_type> <name> (<path>)`` followed by a detail line.
+
+    :param log_list: List of strings, where each string is a log line from a dbt command.
+    :return: A list of formatted ``"<failure line> <detail>"`` strings, one per failing node.
+    """
+
+    def clean_line(line: str) -> str:
+        return line.replace("\x1b[33m", "").replace("\x1b[31m", "").replace("\x1b[0m", "").strip()
+
+    timestamp = re.compile(r"^\d{2}:\d{2}:\d{2}\s+")
+    cleaned = [clean_line(line) for line in log_list]
+    details: list[str] = []
+    for index, line in enumerate(cleaned):
+        if "Failure in " in line or "Error in " in line:
+            failure = timestamp.sub("", line)
+            detail = timestamp.sub("", cleaned[index + 1]) if index + 1 < len(cleaned) else ""
+            details.append(f"{failure} {detail}".strip())
+    return details
+
+
 # Python 3.13 exposes a deprecated operator, we can replace it in the future
 @deprecation.deprecated(
     deprecated_in="1.9",

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -95,6 +95,7 @@ from cosmos.constants import (
     OPENLINEAGE_PRODUCER,
 )
 from cosmos.dbt.parser.output import (
+    extract_dbt_failure_details,
     extract_freshness_warn_msg,
     extract_log_issues,
     parse_number_of_warnings_subprocess,
@@ -303,7 +304,12 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             raise AirflowSkipException(f"dbt command returned exit code {self.skip_exit_code}. Skipping.")
         elif result.exit_code != 0:
             self.log.error("\n".join(result.full_output))
-            raise AirflowException(f"dbt command failed. The command returned a non-zero exit code {result.exit_code}.")
+            message = f"dbt command failed. The command returned a non-zero exit code {result.exit_code}."
+            # Surface failing nodes via context["exception"] for on_failure_callback (issue-1806)
+            failure_details = extract_dbt_failure_details(result.full_output)
+            if failure_details:
+                message += " Errors:\n" + "\n".join(failure_details)
+            raise AirflowException(message)
 
     def handle_exception_dbt_runner(self, result: dbtRunnerResult) -> None:
         """dbtRunnerResult has an attribute `success` that is False if the command failed."""

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -308,7 +308,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             # Surface failing nodes via context["exception"] for on_failure_callback (issue-1806)
             failure_details = extract_dbt_failure_details(result.full_output)
             if failure_details:
-                message += " Errors:\n" + "\n".join(failure_details)
+                message += " Details:\n" + "\n".join(failure_details)
             raise AirflowException(message)
 
     def handle_exception_dbt_runner(self, result: dbtRunnerResult) -> None:

--- a/tests/dbt/parser/test_output.py
+++ b/tests/dbt/parser/test_output.py
@@ -3,6 +3,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from cosmos.dbt.parser.output import (
+    extract_dbt_failure_details,
     extract_dbt_runner_issues,
     extract_freshness_warn_msg,
     extract_log_issues,
@@ -131,6 +132,23 @@ def test_extract_log_issues_dbt_1_12_format() -> None:
     test_names, test_results = extract_log_issues(log_list)
     assert test_names == ["accepted_values_mini_orders_status__placed"]
     assert test_results == ["Got 4 results, configured to warn if >1"]
+
+
+def test_extract_dbt_failure_details() -> None:
+    log_list = [
+        "20:30:01  \x1b[31mRunning with dbt=1.3.0\x1b[0m",
+        "20:30:02  \x1b[31mFailure in test not_null_my_model_id (models/schema.yml)\x1b[0m",
+        "20:30:02  \x1b[31m  Got 5 results, configured to fail if != 0\x1b[0m",
+        "20:30:03  \x1b[31mError in model my_model (models/my_model.sql)\x1b[0m",
+        "20:30:03  \x1b[31m  Database Error: relation does not exist\x1b[0m",
+    ]
+    details = extract_dbt_failure_details(log_list)
+    assert details == [
+        "Failure in test not_null_my_model_id (models/schema.yml) Got 5 results, configured to fail if != 0",
+        "Error in model my_model (models/my_model.sql) Database Error: relation does not exist",
+    ]
+
+    assert extract_dbt_failure_details(["20:30:01  Running with dbt=1.3.0", "20:30:02  Completed successfully"]) == []
 
 
 def test_extract_dbt_runner_issues():

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -1888,6 +1888,28 @@ def test_handle_exception_subprocess(caplog):
     assert "\n".join(full_output) in caplog.text
 
 
+def test_handle_exception_subprocess_surfaces_failing_tests():
+    """Failing dbt nodes are included in the raised exception (reachable via context["exception"]). issue-1806."""
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=None,
+        task_id="my-task",
+        project_dir="my/dir",
+    )
+    full_output = [
+        "20:30:02  Failure in test not_null_my_model_id (models/schema.yml)",
+        "20:30:02    Got 5 results, configured to fail if != 0",
+    ]
+    result = FullOutputSubprocessResult(exit_code=1, output="test", full_output=full_output)
+
+    with pytest.raises(AirflowException) as err_context:
+        operator.handle_exception_subprocess(result)
+
+    message = str(err_context.value)
+    assert "non-zero exit code 1" in message
+    assert "not_null_my_model_id" in message
+    assert "Got 5 results, configured to fail if != 0" in message
+
+
 @pytest.fixture
 def mock_context():
     return MagicMock()


### PR DESCRIPTION
## Problem

Related to #1806. On `InvocationMode.SUBPROCESS`, a failed dbt command raised a generic exception (`dbt command failed. The command returned a non-zero exit code N`), so an `on_failure_callback` — which receives the exception via `context["exception"]` — had no detail about *which* tests/models failed. The `InvocationMode.DBT_RUNNER` path already includes the failing node names and messages in its exception.

This forced users to duplicate tests (a `warn` copy for notifications + an `error` copy for failures) to get failure details into a notification.

## Solution

- Add `extract_dbt_failure_details()` in `cosmos/dbt/parser/output.py` (counterpart to `extract_log_issues`, which handles warnings) to pull dbt `Failure in …` / `Error in …` lines from the subprocess output.
- In `handle_exception_subprocess`, append those failing nodes to the raised `AirflowException`, bringing `subprocess` to parity with `dbt_runner`.

The failing test names/messages are now reachable via `context["exception"]` in a standard `on_failure_callback` — **no new configuration and no XCom**. When the output has no failure markers, the message is unchanged.

## Verification

On the Airflow 2.10.5 hatch env:
- `test_extract_dbt_failure_details` — parser extracts failure + detail lines.
- `test_handle_exception_subprocess_surfaces_failing_tests` — the raised exception contains the failing test name and message.
- Existing `test_handle_exception_subprocess` still passes (no markers → generic short message preserved).
- `pre-commit` (ruff/black/mypy) green.

DAG

```python
from datetime import datetime

from cosmos import DbtDag, ProjectConfig
from airflow.sdk import Param

from include.profiles import airflow_db
from include.constants import jaffle_shop_path, venv_execution_config

def failure_callback_func(context):
    exception = context.get("exception")
    print("Exception:: ", exception)

simple_dag = DbtDag(
    project_config=ProjectConfig(jaffle_shop_path),
    profile_config=airflow_db,
    execution_config=venv_execution_config,
    schedule="@daily",
    start_date=datetime(2023, 1, 1),
    catchup=False,
    dag_id="simple_dag",
    default_args={"on_failure_callback": failure_callback_func}
)
```
<img width="1358" height="405" alt="Screenshot 2026-06-27 at 5 47 21 AM" src="https://github.com/user-attachments/assets/2f66de73-b9bc-4c5b-b96b-a638989fb01a" />
<img width="1706" height="970" alt="Screenshot 2026-06-27 at 5 47 45 AM" src="https://github.com/user-attachments/assets/cb67b5fd-e5ea-44fd-8cc1-51a54f0fcd67" />


Related to #1806

🤖 Generated with Claude Code (https://claude.com/claude-code)