### PR TITLE
Document `on_failure_callback` access to dbt test failures

### DIFF
--- a/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
+++ b/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
@@ -124,13 +124,23 @@ Failure notifications
 ~~~~~~~~~~~~~~~~~~~~~~~
 
 Tests configured with ``severity: error`` fail the task when they fail. To send notifications on failure, use
-Airflow's standard ``on_failure_callback``. Cosmos includes the failing dbt nodes (test names and messages) in the
-raised exception, which Airflow exposes to the callback as ``context["exception"]``:
+Airflow's standard ``on_failure_callback``. Airflow exposes the raised exception to the callback as
+``context["exception"]``.
+
+With ``InvocationMode.DBT_RUNNER`` (the default), Cosmos includes the failing dbt nodes (test names and messages) in
+that exception. With ``InvocationMode.SUBPROCESS``, the exception currently only includes the dbt command's exit
+code.
 
 .. code-block:: python
 
-    def failure_callback_func(context):
-        exception = context.get("exception")
+    from airflow.providers.slack.hooks.slack_webhook import SlackWebhookHook
+    from airflow.utils.context import Context
+
+    from cosmos import DbtDag
+
+
+    def failure_callback_func(context: Context):
+        exception = context["exception"]
         slack_hook = SlackWebhookHook(slack_webhook_conn_id="slack_conn_id")
         slack_hook.send(text=f":red_circle: dbt failed:\n{exception}")
 

--- a/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
+++ b/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
@@ -120,6 +120,25 @@ When at least one WARN message is present, the function passed to ``on_warning_c
     In Cosmos 1.15.0 and earlier, a callback passed only through ``operator_args`` was silently dropped, so the
     top-level argument remains the recommended form.
 
+Failure notifications
+~~~~~~~~~~~~~~~~~~~~~~~
+
+Tests configured with ``severity: error`` fail the task when they fail. To send notifications on failure, use
+Airflow's standard ``on_failure_callback``. Cosmos includes the failing dbt nodes (test names and messages) in the
+raised exception, which Airflow exposes to the callback as ``context["exception"]``:
+
+.. code-block:: python
+
+    def failure_callback_func(context):
+        exception = context.get("exception")
+        slack_hook = SlackWebhookHook(slack_webhook_conn_id="slack_conn_id")
+        slack_hook.send(text=f":red_circle: dbt failed:\n{exception}")
+
+
+    my_dag = DbtDag(
+        # ...
+        default_args={"on_failure_callback": failure_callback_func},
+    )
 
 Tests with multiple parents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
## Problem

Related to #1806. There was no documentation explaining how to send notifications when a dbt test with `severity: error` fails. Users assumed only `on_warning_callback` could surface test details.

## Solution

Add a "Failure notifications" section to the testing-behavior guide explaining that:
- `severity: error` tests fail the task, so Airflow's standard `on_failure_callback` applies.
- Cosmos includes the failing dbt nodes (test names and messages) in the raised exception, reachable via `context["exception"]` — no extra configuration or XCom.

Includes a short Slack-notification example.


The behavior this documents is implemented in #2845 (`dbt_runner` already surfaced these details; #2845 brings `subprocess` to parity).

Related to #1806, #2845

🤖 Generated with Claude Code (https://claude.com/claude-code)