### PR TITLE
ci: Restore being able to run integration tests on external committers PRs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,10 +38,15 @@ jobs:
     outputs:
       code_changed: ${{ steps.check.outputs.code_changed }}
     steps:
+      # Only the `push` branch below uses the working tree (`git diff`). For pull_request /
+      # pull_request_target the changed-file list comes from the GitHub API, so we must NOT
+      # check out untrusted fork code in this ungated job — that is the pull_request_target
+      # "pwn request" risk actions/checkout v7 refuses by default.
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        if: github.event_name == 'push'
         with:
           fetch-depth: 0
-          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+          ref: ${{ github.sha }}
           persist-credentials: false
 
       - id: check
@@ -157,6 +162,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -248,6 +256,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -335,6 +346,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -412,6 +426,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -483,6 +500,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -571,6 +591,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
@@ -639,6 +662,9 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
           persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
 
       - name: Set up Python 3.11
         uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0


### PR DESCRIPTION
## Description

The recently adopted [`actions/checkout` v7.0.0](https://github.com/astronomer/astronomer-cosmos/pull/2833) refuses to check out fork PR code in a `pull_request_target` workflow unless `allow-unsafe-pr-checkout: true` is set on the step (it guards against "pwn request" attacks). This broke `test.yml` for fork PRs: the `Check-changed-files` job failed outright, and the secret-dependent jobs (integration, kubernetes, coverage) were skipped behind it. Surfaced by the CI failure on #2826.

The fix follows the repo's existing safe-`pull_request_target` model — the `Authorize` owner-review environment gate:
Validated locally: full pre-commit suite passes (incl. `check-yaml`); `zizmor` reports no findings.

> Note: `pull_request_target` loads the workflow from the base branch, so this only takes effect once merged to `main` — re-running an open fork PR's CI beforehand still uses the old workflow.

## Related Issue(s)

Surfaced by the CI failure on #2826 (does not close it).

## Breaking Change?

No — CI configuration only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required) — N/A (CI config only)
- [x] I have added tests that prove my fix is effective or that my feature works — N/A; validated via `zizmor` + pre-commit, and verifiable once a fork PR's CI runs against the merged workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)
