### PR TITLE
reject output-only template fields on the async BigQuery path

### DIFF
--- a/cosmos/operators/_asynchronous/bigquery.py
+++ b/cosmos/operators/_asynchronous/bigquery.py
@@ -95,6 +95,10 @@ class DbtRunAirflowAsyncBigqueryOperator(BigQueryInsertJobOperator, AbstractDbtL
         task_id = self.dbt_kwargs.pop("task_id")
         self.full_refresh = self.dbt_kwargs.pop("full_refresh", False)
 
+        # This path forwards dbt_kwargs raw and never routes through
+        # DbtLocalBaseOperator.__init__, so apply the same output-only guard here.
+        self._reject_output_only_template_fields(self.dbt_kwargs)
+
         AbstractDbtLocalBase.__init__(
             self, task_id=task_id, project_dir=project_dir, profile_config=profile_config, **self.dbt_kwargs
         )

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -191,6 +191,17 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     _OUTPUT_ONLY_TEMPLATE_FIELDS: tuple[str, ...] = ("compiled_sql", "freshness")
     _process_log_line_callable: Callable[[str, Any], None] | None = None
 
+    @classmethod
+    def _reject_output_only_template_fields(cls, kwargs: dict[str, Any]) -> None:
+        forbidden = [f for f in cls._OUTPUT_ONLY_TEMPLATE_FIELDS if f in kwargs]
+        if forbidden:
+            names = ", ".join(repr(f) for f in forbidden)
+            raise CosmosValueError(
+                f"{names} {'is' if len(forbidden) == 1 else 'are'} output-only "
+                "template field(s) populated by Cosmos at runtime; "
+                "remove them from operator_args."
+            )
+
     def __init__(
         self,
         task_id: str,
@@ -985,17 +996,9 @@ class DbtLocalBaseOperator(AbstractDbtLocalBase, BaseOperator):
         # ``compiled_sql`` and ``freshness`` are template fields populated by
         # Cosmos at runtime, not constructor arguments. They are not part of any
         # __init__ signature, so the argspec-based segregation below silently
-        # drops them — a user who sets them via ``operator_args`` would get no
-        # error and no effect. Reject them up front, before that split, so the
-        # misuse fails fast with a clear message.
-        forbidden = [f for f in self._OUTPUT_ONLY_TEMPLATE_FIELDS if f in kwargs]
-        if forbidden:
-            names = ", ".join(repr(f) for f in forbidden)
-            raise CosmosValueError(
-                f"{names} {'is' if len(forbidden) == 1 else 'are'} output-only "
-                "template field(s) populated by Cosmos at runtime; "
-                "remove them from operator_args."
-            )
+        # drops them. Reject them up front, before that split, so the misuse
+        # fails fast with a clear message.
+        self._reject_output_only_template_fields(kwargs)
 
         base_kwargs = {}
         operator_kwargs = {}

--- a/tests/operators/_asynchronous/test_bigquery.py
+++ b/tests/operators/_asynchronous/test_bigquery.py
@@ -76,6 +76,19 @@ def test_dbt_run_airflow_async_bigquery_operator_init_deferrable_defaults_true(p
     assert operator.deferrable is True
 
 
+@pytest.mark.parametrize("field", ["compiled_sql", "freshness"])
+def test_dbt_run_airflow_async_bigquery_operator_rejects_output_only_template_fields(profile_config_mock, field):
+    """The async BigQuery path forwards ``dbt_kwargs`` raw and bypasses the sync
+    guard, so it must reject output-only template fields on its own."""
+    with pytest.raises(CosmosValueError, match=field):
+        DbtRunAirflowAsyncBigqueryOperator(
+            task_id="test_task",
+            project_dir="/path/to/project",
+            profile_config=profile_config_mock,
+            dbt_kwargs={"task_id": "test_task", field: "value-the-user-tried-to-set"},
+        )
+
+
 def test_dbt_run_airflow_async_bigquery_operator_base_cmd(profile_config_mock):
     """Test base_cmd property returns the correct dbt command."""
     operator = DbtRunAirflowAsyncBigqueryOperator(


### PR DESCRIPTION
Follow-up to #2726. `DbtRunAirflowAsyncBigqueryOperator` inherits `AbstractDbtLocalBase` directly and forwards `dbt_kwargs` raw, so it never hit the guard in `DbtLocalBaseOperator.__init__` and still silently dropped `compiled_sql`/`freshness` on the async path.

Pulled the check into a small shared helper on `AbstractDbtLocalBase` and call it from both entry points, with a test mirroring the sync-path ones.

closes #2851
