### PR TITLE
ci(linkcheck): exclude flaky external links from the docs link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -33,6 +33,9 @@ exclude = [
     'https://ossrank\.com',
     # Bot-blocked — the Bitnami Helm chart repo returns 403 to non-Helm clients.
     'https://charts\.bitnami\.com',
+    # Bot-blocked / rate-limited from CI — AWS docs intermittently return 403 to
+    # automated requests (they resolve fine in a browser), causing flaky linkcheck failures.
+    'https://docs\.aws\.amazon\.com',
     # Intentional placeholder in example snippets, not a real repository.
     'https://github\.com/your-org/',
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -36,6 +36,9 @@ exclude = [
     # Bot-blocked / rate-limited from CI — AWS docs intermittently return 403 to
     # automated requests (they resolve fine in a browser), causing flaky linkcheck failures.
     'https://docs\.aws\.amazon\.com',
+    # Flaky from CI — this astronomer.io docs page intermittently drops the connection
+    # ("Connection reset by peer") during link checking, though it resolves fine in a browser.
+    'https://www\.astronomer\.io/docs/learn/airflow-ui',
     # Intentional placeholder in example snippets, not a real repository.
     'https://github\.com/your-org/',
 ]


### PR DESCRIPTION
The `linkcheck` job runs lychee over `docs/**/*.rst` across the whole repo, so a transient failure on *any* external link fails the check on unrelated PRs. This adds the links/hosts that flake from CI to the `lychee.toml` exclude list, next to the existing `ossrank.com` / `charts.bitnami.com` entries:

- `https://docs.aws.amazon.com` — intermittently returns `403` to automated requests (bot-blocking), while resolving fine in a browser. It's referenced from `mwaa.rst`, `generating-docs.rst` and `aws-container-run-job.rst`.
- `https://www.astronomer.io/docs/learn/airflow-ui` — intermittently drops the connection (`Connection reset by peer`), also fine in a browser. This one just failed the `linkcheck` job on an unrelated PR: [run 28440446117 / job 84276791488](https://github.com/astronomer/astronomer-cosmos/actions/runs/28440446117/job/84276791488).

Genuinely broken links should still be fixed in the docs, not excluded — these are specifically the ones that flake under automated checking.

Verified locally: `lychee --config lychee.toml 'docs/**/*.rst'` → 0 errors.