### PR TITLE
Add dbt-core 2.0 (alpha) to the integration test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,10 @@ name: test
 
 on:
   push: # Run on pushes to the default branch
-    branches: [main]
+    # TEMP — REVERT BEFORE MERGE. Also run on this bump branch so the new dbt-core 2.0
+    # matrix cells are exercised pre-merge: test.yml is pull_request_target, so PR runs read
+    # the matrix from `main`; a push event runs the branch's own workflow (and 2.0 matrix).
+    branches: [main, bump/dbt-core-2.0.0a3]
   # Also run on pull requests originating from forks. Every test job here is secret-dependent
   # (integration tests, kubernetes, code coverage) and depends on the Authorize job, which requires
   # manually approving the workflow run for external PRs. Jobs that need no secrets (type-check,

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -133,7 +133,10 @@ jobs:
       matrix:
         python-version: ["3.10", "3.11", "3.12", "3.13"]
         airflow-version: ["2.9", "2.10", "2.11", "3.0", "3.1", "3.2", "3.3"]
-        dbt-version: [ "1.11" ]
+        # "2.0" = dbt Core 2.0, the open-source build of the dbt Fusion engine
+        # (https://docs.getdbt.com/blog/dbt-core-v2-is-here). Installed with pre-releases
+        # allowed via integration-setup.sh (alpha-only today).
+        dbt-version: [ "1.11", "2.0" ]
         split-group: [1, 2, 3]
         exclude:
           # Apache Airflow versions prior to 3.1.0 have not been tested with Python 3.13.

--- a/cosmos/dbt/executable.py
+++ b/cosmos/dbt/executable.py
@@ -1,5 +1,11 @@
+from __future__ import annotations
+
 import shutil
+from functools import cache
+from importlib.metadata import PackageNotFoundError, version
 from importlib.util import find_spec
+
+from packaging.version import Version
 
 
 def get_system_dbt() -> str:
@@ -7,6 +13,22 @@ def get_system_dbt() -> str:
     Tries to identify which is the path to the dbt executable, return "dbt" otherwise.
     """
     return shutil.which("dbt") or "dbt"
+
+
+@cache
+def get_dbt_version() -> Version | None:
+    """
+    Return the installed dbt-core version, or None if dbt-core is not installed.
+
+    Reads the version from the installed package metadata rather than the ``dbt.version``
+    module: dbt-core 2.0 is CLI-only and no longer ships an importable ``dbt`` package, so
+    ``from dbt.version import __version__`` raises there. Package metadata works for both
+    dbt 1.x and 2.x. Cached for the process lifetime since the installed version is fixed.
+    """
+    try:
+        return Version(version("dbt-core"))
+    except PackageNotFoundError:
+        return None
 
 
 def is_dbt_installed_in_same_environment() -> bool:

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -551,7 +551,11 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.profile_config.target_name,
         ]
         if self.invocation_mode == InvocationMode.DBT_RUNNER:
-            from dbt.version import __version__ as dbt_version
+            from importlib.metadata import version as _installed_version
+
+            # dbt-core 2.0 removed the importable `dbt.version` module (it is CLI-only); read the
+            # installed version from package metadata instead, which works on both dbt 1.x and 2.x.
+            dbt_version = _installed_version("dbt-core")
 
             if Version(dbt_version) >= Version("1.5.6"):
                 # PR #1484 introduced the use of dbtRunner during DAG parsing. As a result, invoking dbtRunner again

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -551,13 +551,10 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.profile_config.target_name,
         ]
         if self.invocation_mode == InvocationMode.DBT_RUNNER:
-            from importlib.metadata import version as _installed_version
+            from cosmos.dbt.executable import get_dbt_version
 
-            # dbt-core 2.0 removed the importable `dbt.version` module (it is CLI-only); read the
-            # installed version from package metadata instead, which works on both dbt 1.x and 2.x.
-            dbt_version = _installed_version("dbt-core")
-
-            if Version(dbt_version) >= Version("1.5.6"):
+            dbt_version = get_dbt_version()
+            if dbt_version is not None and dbt_version >= Version("1.5.6"):
                 # PR #1484 introduced the use of dbtRunner during DAG parsing. As a result, invoking dbtRunner again
                 # during task execution can lead to task hangs—especially on Airflow 2.x. Investigation revealed that
                 # the issue stems from how dbtRunner handles static parsing. Cosmos copies the dbt project to temporary

--- a/dev/Dockerfile.postgres_profile_docker_k8s
+++ b/dev/Dockerfile.postgres_profile_docker_k8s
@@ -1,6 +1,6 @@
 FROM python:3.12
 
-RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<2.0'
+RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<3.0'
 RUN pip install --force-reinstall dbt-adapters
 RUN pip install --force-reinstall awscli
 

--- a/dev/Dockerfile.watcher_failing_tests_k8s
+++ b/dev/Dockerfile.watcher_failing_tests_k8s
@@ -1,6 +1,6 @@
 FROM python:3.12
 
-RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<2.0'
+RUN pip install --force-reinstall 'dbt-postgres>=1.8' 'dbt-core<3.0'
 RUN pip install --force-reinstall dbt-adapters
 RUN pip install --force-reinstall awscli
 

--- a/dev/dags/dbt/altered_jaffle_shop/dbt_project.yml
+++ b/dev/dags/dbt/altered_jaffle_shop/dbt_project.yml
@@ -17,7 +17,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   altered_jaffle_shop:

--- a/dev/dags/dbt/jaffle_shop_python/dbt_project.yml
+++ b/dev/dags/dbt/jaffle_shop_python/dbt_project.yml
@@ -17,4 +17,4 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]

--- a/dev/dags/dbt/model_version/dbt_project.yml
+++ b/dev/dags/dbt/model_version/dbt_project.yml
@@ -17,7 +17,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   jaffle_shop:

--- a/dev/dags/dbt/multi_folder/dbt_project.yml
+++ b/dev/dags/dbt/multi_folder/dbt_project.yml
@@ -13,7 +13,7 @@ clean-targets:
   - "target"
   - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   multi_folder:

--- a/dev/dags/dbt/multi_folder_failing/dbt_project.yml
+++ b/dev/dags/dbt/multi_folder_failing/dbt_project.yml
@@ -13,7 +13,7 @@ clean-targets:
   - "target"
   - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   multi_folder_failing:

--- a/dev/dags/dbt/simple/dbt_packages/dbt_date/dbt_project.yml
+++ b/dev/dags/dbt/simple/dbt_packages/dbt_date/dbt_project.yml
@@ -8,7 +8,7 @@ clean-targets: ["target", "dbt_packages"]
 macro-paths: ["macros"]
 log-path: "logs"
 
-require-dbt-version: [">=1.2.0", "<2.0.0"]
+require-dbt-version: [">=1.2.0", "<3.0.0"]
 profile: integration_tests
 
 quoting:

--- a/dev/dags/dbt/watcher_downstream_not_skipped/dbt_project.yml
+++ b/dev/dags/dbt/watcher_downstream_not_skipped/dbt_project.yml
@@ -16,7 +16,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 on-run-start:
   - "CREATE SEQUENCE IF NOT EXISTS {{ target.schema }}._cosmos_fail_once_seq"

--- a/dev/dags/dbt/watcher_failing_tests/dbt_project.yml
+++ b/dev/dags/dbt/watcher_failing_tests/dbt_project.yml
@@ -16,7 +16,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 models:
   watcher_failing_tests:

--- a/dev/dags/dbt/watcher_upstream_failure_recovery/dbt_project.yml
+++ b/dev/dags/dbt/watcher_upstream_failure_recovery/dbt_project.yml
@@ -16,7 +16,7 @@ clean-targets:
     - "dbt_modules"
     - "logs"
 
-require-dbt-version: [">=1.0.0", "<2.0.0"]
+require-dbt-version: [">=1.0.0", "<3.0.0"]
 
 # Sequence used by model_flaky.sql to fail on first run and succeed on subsequent
 # runs (see #2698 regression test). Using a project-specific sequence name

--- a/dev/dags/example_virtualenv.py
+++ b/dev/dags/example_virtualenv.py
@@ -57,7 +57,7 @@ def example_virtualenv() -> None:
         ),
         operator_args={
             "py_system_site_packages": False,
-            "py_requirements": ["dbt-postgres", "dbt-core<2.0"],
+            "py_requirements": ["dbt-postgres", "dbt-core<3.0"],
             "install_deps": True,
             "emit_datasets": False,  # Example of how to not set inlets and outlets
             # --------------------------------------------------------------------------
@@ -91,7 +91,7 @@ def example_virtualenv() -> None:
         ),
         operator_args={
             "py_system_site_packages": False,
-            "py_requirements": ["dbt-postgres", "dbt-core<2.0"],
+            "py_requirements": ["dbt-postgres", "dbt-core<3.0"],
             "install_deps": True,
         },
     )

--- a/dev/dags/example_virtualenv_mini.py
+++ b/dev/dags/example_virtualenv_mini.py
@@ -29,7 +29,7 @@ with DAG("example_virtualenv_mini", start_date=datetime(2022, 1, 1)) as dag:
         install_deps=True,
         append_env=True,
         py_system_site_packages=False,
-        py_requirements=["dbt-postgres", "dbt-core<2.0"],
+        py_requirements=["dbt-postgres", "dbt-core<3.0"],
         virtualenv_dir=Path("/tmp/persistent-venv2"),
     )
     seed_operator

--- a/scripts/test/integration-setup.sh
+++ b/scripts/test/integration-setup.sh
@@ -7,6 +7,18 @@ set -e
 DBT_VERSION="$1"
 NEXT_MINOR_VERSION=$(echo "$DBT_VERSION" | awk -F. '{print $1"."$2+1}')
 
+# dbt Core 2.0 (the open-source build of the dbt Fusion engine) is alpha-only today and is
+# NOT installed by pre-install-airflow.sh, which pins the dbt 1.11 baseline. For 2.x matrix
+# cells, (re)install dbt-core to the 2.x line allowing pre-releases. The lower bound uses an
+# explicit "a1" pre-release tag because PEP 440 sorts 2.0.0a3 < 2.0.0, so a bare ">=2.0" would
+# exclude the alpha. Postgres is the integration adapter; only its 1.11 beta resolves with 2.0.
+case "$DBT_VERSION" in
+  2.*)
+    uv pip uninstall dbt-core dbt-postgres dbt-adapters dbt-common dbt-extractor dbt-semantic-interfaces || true
+    uv pip install -U --prerelease=allow "dbt-core>=${DBT_VERSION}a1,<$NEXT_MINOR_VERSION" dbt-postgres
+    ;;
+esac
+
 # we install using the following workaround to overcome installation conflicts, such as:
 # apache-airflow 2.3.0 and dbt-core [0.13.0 - 1.5.2] and jinja2>=3.0.0 because these package versions have conflicting dependencies
 rm -f $AIRFLOW_HOME/airflow.cfg

--- a/scripts/test/pre-install-airflow.sh
+++ b/scripts/test/pre-install-airflow.sh
@@ -136,10 +136,10 @@ else
     exit 1
 fi
 
-# Installation of dbt in a separate Python virtual environment:
-# Cap dbt-core below 2.0. Previously dbt-loom (installed here) held dbt-core in
-# the 1.x range; with dbt-loom moved to the dedicated loom job, the bound is
-# explicit so `pip install -U` doesn't pull dbt-core 2.0 (Fusion), which lacks
-# the postgres adapter the subprocess tests rely on.
+# Installation of dbt in a separate Python virtual environment.
+# Cap dbt-core below 3.0 (raised from <2.0 to allow the dbt Core 2.0 / Fusion line).
+# Note: without --prerelease this resolves to the latest stable below 3.0 (1.11.x today),
+# since dbt-core 2.0 is alpha-only; the 2.x line is exercised via the matrix install path
+# in integration-setup.sh.
 python -m venv venv-subprocess
-venv-subprocess/bin/pip install -U "dbt-core<2.0" dbt-postgres
+venv-subprocess/bin/pip install -U "dbt-core<3.0" dbt-postgres

--- a/tests/perf/test_performance.py
+++ b/tests/perf/test_performance.py
@@ -9,12 +9,12 @@ from pathlib import Path
 
 import pytest
 from airflow.models.dagbag import DagBag
-from dbt.version import get_installed_version as get_dbt_version
-from packaging.version import Version
+
+from cosmos.dbt.executable import get_dbt_version
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
-DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
+DBT_VERSION = get_dbt_version()
 
 
 @cache

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -10,16 +10,16 @@ import pytest
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
-from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION, PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
+from cosmos.dbt.executable import get_dbt_version
 
 from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
-DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
+DBT_VERSION = get_dbt_version()
 KUBERNETES_DAGS = ["jaffle_shop_kubernetes", "jaffle_shop_watcher_kubernetes"]
 # DAGs that require seeds to be loaded first (run via dedicated ordered tests below)
 DAGS_WITH_SEED_DEPENDENCY = ["watcher_source_rendering_dag"]

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -5,16 +5,16 @@ from pathlib import Path
 
 import pytest
 from airflow.models.dagbag import DagBag
-from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION
+from cosmos.dbt.executable import get_dbt_version
 
 from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
-DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
+DBT_VERSION = get_dbt_version()
 
 IGNORED_DAG_FILES = [
     "performance_dag.py",


### PR DESCRIPTION
This started as a simple "add dbt-core 2.0 to the test matrix" and turned into a useful probe of what dbt Core 2.0 actually *is* — so I'm keeping it as a draft to capture the finding and agree on next steps before we commit to anything.

## What

**dbt Core 2.0** is dbt Labs' ground-up **Rust rewrite** of the dbt engine — Apache-2.0 licensed, currently in alpha (`2.0.0a3`). It's built on the **same foundations as the dbt Fusion engine**: dbt Labs open-sourced much of the Fusion code and shipped it as dbt Core v2 (see their [announcement](https://docs.getdbt.com/blog/dbt-core-v2-is-here)). The two are close cousins:

- **dbt Core 2.0** — the open-source (Apache-2.0) Rust core. CLI-first.
- **dbt Fusion** — the ELv2-licensed **superset binary** on the same Rust foundation, with extra capabilities ("can do more out of the box"). So Fusion ⊋ dbt Core 2.0.

The catch we ran into: the 2.0 alpha is **CLI-only** — it ships **no importable Python `dbt` package** at all (`import dbt` → `ModuleNotFoundError`; only `importlib.metadata.version("dbt-core")` resolves). That breaks the way we talk to dbt from Python today — `from dbt.version import __version__` and `InvocationMode.DBT_RUNNER` (which needs `dbt.cli.main.dbtRunner`) can't work against a binary that has no Python surface. dbt Labs' [v2 roadmap](https://github.com/dbt-labs/dbt-core/blob/main/docs/roadmap/2026-06-announcing-v2.md) lists "a programmatic (Python) interface for invoking dbt Core v2.0" as a parity gap they intend to close before GA, so this should ease over time.

This PR wires dbt Core 2.0 into the integration matrix to see how far we get, while leaving the existing dbt-Fusion job in place — that one drives the Fusion *binary* via subprocess, touches no Python API, and stays green. The contrast is the whole story: the Python-integrated cells fail 72/72, the subprocess Fusion cells pass 4/4 (full detail in the [findings comment](https://github.com/astronomer/astronomer-cosmos/pull/2860#issuecomment-4842205861), CI run [28435105169](https://github.com/astronomer/astronomer-cosmos/actions/runs/28435105169)).

## What we're doing in this PR

- Switch dbt-version detection to `importlib.metadata.version("dbt-core")` (`operators/local.py`) so it no longer imports the removed `dbt.version` module — works on dbt 1.x and 2.x.

## Next steps

- [ ] Revert the temporary CI-trigger commit (`7652a4a8`) before this is marked ready / merged — it only exists so the new 2.0 cells run on the branch (`test.yml` is `pull_request_target`).
- [ ] Drop the Postgres `2.0` cells and instead add a **duckdb-based** 2.0 cell: dbt 2.0's Fusion engine doesn't support the Postgres adapter our suite uses ([`dbt1005`](https://github.com/astronomer/astronomer-cosmos/pull/2860#issuecomment-4843703981)), but duckdb is in Fusion's supported set, runs locally, and we already ship `dbt-duckdb`. That's the real way to exercise dbt-core 2.0.

## Pending — on us (cosmos)

- [ ] Raise a clear, actionable error when `InvocationMode.DBT_RUNNER` is explicitly requested but the Python dbt API is unavailable (dbt-core 2.0 / Fusion), pointing users at `InvocationMode.SUBPROCESS` — instead of today's opaque `ImportError` from `dbt.cli.main`. (Auto-detect already falls back to subprocess; this covers the *explicit* case.)
- [ ] Gate dbt-core 2.0 to `ExecutionMode.LOCAL` + `InvocationMode.SUBPROCESS` in `config.py` validation, with a clear message for unsupported combos.
- [ ] Audit the remaining `dbt.*` import sites for a no-Python-dbt environment — `operators/virtualenv.py`, `dbt/parser/output.py`, and `operators/_asynchronous/bigquery.py` (the async path) — and guard any that aren't already (`dbt/runner.py` and `local.py:80` are already guarded via `is_available()` / `TYPE_CHECKING`).
- [ ] Decide whether the `dbt-core<2.0` → `<3.0` cap raises and the `require-dbt-version` fixture bumps land here or in a separate PR.

## Depends on dbt Labs (not us)

- A programmatic Python interface for dbt Core 2.0 is on their GA roadmap. If/when it lands, `DBT_RUNNER` mode could work again and we'd revisit the gating above.
