### PR TITLE
Mark `ExecutionMode.WATCHER` and `WATCHER_KUBERNETES` stable in Cosmos 1.15.0

### DIFF
--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -1,9 +1,9 @@
 .. _watcher-execution-mode:
 
-Watcher execution mode (experimental)
-=====================================
+Watcher execution mode
+======================
 
-With the release of **Cosmos 1.11.0**, we are introducing a powerful new experimental execution mode — ``ExecutionMode.WATCHER`` — designed to drastically reduce dbt pipeline run times in `Apache Airflow® <https://airflow.apache.org/>`_.
+Introduced as experimental in **Cosmos 1.11.0** and marked **stable starting with Cosmos 1.15.0**, ``ExecutionMode.WATCHER`` is a powerful execution mode designed to drastically reduce dbt pipeline run times in `Apache Airflow® <https://airflow.apache.org/>`_.
 
 Early benchmarks show that ``ExecutionMode.WATCHER`` can cut total DAG runtime **by up to 80%**, bringing performance **on par with running dbt CLI locally**. Since this execution mode improves the performance by leveraging `dbt threading <https://docs.getdbt.com/docs/running-a-dbt-project/using-threads>`_ and Airflow deferrable sensors, the performance gains will depend on three major factors:
 
@@ -678,6 +678,6 @@ Summary
 - ✅ Enables **smarter resource allocation**
 - ✅ Built on proven Cosmos rendering techniques
 
-This is an experimental feature, and we are looking for feedback from the community.
+``ExecutionMode.WATCHER`` was introduced as experimental in Cosmos 1.11.0 and is marked stable starting with Cosmos 1.15.0. We continue to welcome feedback from the community.
 
 Stay tuned for further documentation and base image support for the ``ExecutionMode.WATCHER`` in upcoming releases.

--- a/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-retry-history.rst
@@ -8,9 +8,10 @@ Watcher retry behavior history
 While ``ExecutionMode.WATCHER`` can significantly improve DAG run times, it is based on
 non-idempotent `Apache Airflow® <https://airflow.apache.org/>`_ tasks and relies on a complex retry
 mechanism in which one task's status can affect another task's status. This is the reason
-``ExecutionMode.WATCHER`` has remained marked as experimental for several months — until we can get
-this right. This document aims to present how each aspect of retries has evolved within the Cosmos
-watcher implementation across Cosmos releases.
+``ExecutionMode.WATCHER`` remained marked as experimental for several months — until this retry
+behavior was hardened. With Cosmos 1.15.0, ``ExecutionMode.WATCHER`` is marked stable. This document
+aims to present how each aspect of retries has evolved within the Cosmos watcher implementation
+across Cosmos releases.
 
 Goals
 +++++

--- a/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-kubernetes-execution-mode.rst
@@ -1,10 +1,14 @@
 .. _watcher-kubernetes-execution-mode:
 
 
-Watcher Kubernetes execution mode (experimental)
-================================================
+Watcher Kubernetes execution mode
+=================================
 
 .. versionadded:: 1.13.0
+
+.. note::
+   ``ExecutionMode.WATCHER_KUBERNETES`` was introduced as experimental in Cosmos 1.13.0 and is marked
+   stable starting with Cosmos 1.15.0.
 
 The ``ExecutionMode.WATCHER_KUBERNETES`` combines the **speed of the** :ref:`watcher-execution-mode` **with the isolation of** :ref:`kubernetes`.
 

--- a/docs/guides/run_dbt/execution-modes.rst
+++ b/docs/guides/run_dbt/execution-modes.rst
@@ -71,7 +71,7 @@ There are four execution mode options that run on the Airflow worker:
   - **No isolation**: dbt is installed in the same Python virtual environment as Airflow. In this case, Cosmos can invoke dbt commands as a library rather than as a subprocess, leading to performance gains.
   - **Partial isolation**: Create a dedicated Python virtual environment in the Airflow deployment, install dbt there, and configure Cosmos to use it by setting ``ExecutionConfig.dbt_executable_path``. This provides a good solution for dependency conflicts.
 
-- :ref:`watcher <watcher-execution-mode>`: (Experimental since Cosmos 1.11.0) Optimized for execution speed. Run a single ``dbt build`` command from a producer task and have sensor tasks to watch the progress of the producer, with improved DAG run time while maintaining the tasks lineage in the Airflow UI, and ability to retry failed tasks.
+- :ref:`watcher <watcher-execution-mode>`: (Stable since Cosmos 1.15.0) Optimized for execution speed. Run a single ``dbt build`` command from a producer task and have sensor tasks to watch the progress of the producer, with improved DAG run time while maintaining the tasks lineage in the Airflow UI, and ability to retry failed tasks.
 - :ref:`virtualenv <cosmos-managed-venv>`: Runs dbt commands from Python virtual environments created and managed by Cosmos. This mode removes the need to create a virtual environment at build time, unlike ``ExecutionMode.LOCAL``, while avoiding package conflicts. It is intended for cases where:
 
   - **Can't install dbt directly**: If you can't install dbt in the Airflow environment (either in the same environment or a dedicated one).
@@ -93,7 +93,7 @@ If you want to use an execution mode that can run in the Airflow worker node, us
 
       A([Execution on Airflow Worker Node])
 
-      B[Try experimental high-performance mode?]
+      B[Try high-performance mode?]
       C[ExecutionMode.WATCHER]
 
       D[Long running dbt commands and BigQuery?]
@@ -142,7 +142,7 @@ You can also execute dbt commands in a container. Choosing these kinds of execut
 
 - :ref:`docker <docker>` : Run ``dbt`` commands via Docker containers inside the Airflow worker node.
 - :ref:`kubernetes <kubernetes>`: Run ``dbt`` commands within Kubernetes Pods managed by Cosmos.
-- :ref:`watcher_kubernetes <watcher-kubernetes-execution-mode>`: (experimental since Cosmos 1.13.0) Combines the speed of the watcher execution mode with the isolation of Kubernetes.
+- :ref:`watcher_kubernetes <watcher-kubernetes-execution-mode>`: (Stable since Cosmos 1.15.0) Combines the speed of the watcher execution mode with the isolation of Kubernetes.
 - :ref:`aws_ecs <aws-container-run-job>`: Run ``dbt`` commands in containers via AWS ECS.
 - :ref:`aws_eks <aws-eks>`: Run ``dbt`` commands via Kubernetes Pods in AWS EKS.
 - :ref:`azure_container_instance <azure-container-instance>`: Run ``dbt`` commands in Azure Container Instances.
@@ -166,7 +166,7 @@ If you want to use a container execution mode, use the following decision tree t
 
     D[Do you have a Kubernetes cluster?]
 
-    E[Try experimental high-performance mode?]
+    E[Try high-performance mode?]
     F[ExecutionMode.WATCHER_KUBERNETES]
 
     G[ExecutionMode.KUBERNETES]

--- a/docs/optimize_performance/optimize_execution.rst
+++ b/docs/optimize_performance/optimize_execution.rst
@@ -25,7 +25,7 @@ See :ref:`watcher-execution-mode` for setup instructions and detailed benchmarks
 
 .. note::
 
-   ``ExecutionMode.WATCHER`` is currently experimental. Review its
+   ``ExecutionMode.WATCHER`` is stable starting with Cosmos 1.15.0. Review its
    `known limitations <https://astronomer.github.io/astronomer-cosmos/guides/run_dbt/airflow-worker/watcher-execution-mode.html#known-limitations>`_
    before adopting it in production.
 


### PR DESCRIPTION
## Description

Promotes the `ExecutionMode.WATCHER` (Airflow-worker) and `ExecutionMode.WATCHER_KUBERNETES` execution modes from **experimental** to **stable**, effective Cosmos 1.15.0.

The wording is explicit that these modes are stable *starting with* 1.15.0 (experimental through 1.14.x).

## Changes

- **`watcher-execution-mode.rst`** — drop "(experimental)" from the title; reword the intro and summary to state stable since 1.15.0.
- **`watcher-kubernetes-execution-mode.rst`** — drop "(experimental)" from the title; add a note that it is stable starting with 1.15.0.
- **`execution-modes.rst`** — `watcher` and `watcher_kubernetes` list entries now read "(Stable since Cosmos 1.15.0)"; remove "experimental" from the two decision-tree nodes that route to these modes.
- **`watcher-retry-history.rst`** — update the historical note to reflect that the retry behavior is hardened and the mode is now stable.
- **`optimize_execution.rst`** — update the note from "currently experimental" to "stable starting with Cosmos 1.15.0".

🤖 Generated with [Claude Code](https://claude.com/claude-code)