### PR TITLE
Reject output-only template fields on the async operator_args path

### DIFF
--- a/cosmos/operators/airflow_async.py
+++ b/cosmos/operators/airflow_async.py
@@ -54,6 +54,10 @@ class DbtRunAirflowAsyncOperator(DbtRunAirflowAsyncFactoryOperator):
         **kwargs: Any,
     ) -> None:
 
+        # Reject output-only template fields up front: the split below routes them into
+        # clean_kwargs, bypassing the inner operator's dbt_kwargs guard.
+        AbstractDbtLocalBase._reject_output_only_template_fields(kwargs)
+
         # Cosmos attempts to pass many kwargs that async operator simply does not accept.
         # We need to pop them.
         clean_kwargs = {}

--- a/tests/operators/test_airflow_async.py
+++ b/tests/operators/test_airflow_async.py
@@ -130,3 +130,31 @@ def test_dbt_run_airflow_async_operator_rejects_output_only_template_fields(fiel
             profile_config=profile_config,
             **{field: "value-the-user-tried-to-set"},
         )
+
+
+@pytest.mark.integration
+@pytest.mark.parametrize("field", ["compiled_sql", "freshness"])
+def test_airflow_async_operator_args_rejects_output_only_template_fields(mock_bigquery_conn, field):
+    """End-to-end: an output-only template field in ``operator_args`` fails DAG parsing."""
+    profile_mapping = get_automatic_profile_mapping(mock_bigquery_conn.conn_id, {})
+
+    profile_config = ProfileConfig(
+        profile_name="airflow_db",
+        target_name="bq",
+        profile_mapping=profile_mapping,
+    )
+
+    with pytest.raises(CosmosValueError, match=field):
+        DbtDag(
+            project_config=ProjectConfig(dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME),
+            profile_config=profile_config,
+            execution_config=ExecutionConfig(
+                execution_mode=ExecutionMode.AIRFLOW_ASYNC,
+                async_py_requirements=["dbt-bigquery"],
+            ),
+            schedule=None,
+            start_date=datetime(2023, 1, 1),
+            catchup=False,
+            dag_id="simple_dag_async",
+            operator_args={field: "value-the-user-tried-to-set"},
+        )

--- a/tests/operators/test_airflow_async.py
+++ b/tests/operators/test_airflow_async.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from pathlib import Path
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -9,6 +10,7 @@ from cosmos.operators.airflow_async import (
     DbtBuildAirflowAsyncOperator,
     DbtCompileAirflowAsyncOperator,
     DbtLSAirflowAsyncOperator,
+    DbtRunAirflowAsyncOperator,
     DbtRunOperationAirflowAsyncOperator,
     DbtSeedAirflowAsyncOperator,
     DbtSnapshotAirflowAsyncOperator,
@@ -113,3 +115,18 @@ def test_dbt_run_operation_airflow_async_operator_inheritance():
 
 def test_dbt_compile_airflow_async_operator_inheritance():
     assert issubclass(DbtCompileAirflowAsyncOperator, DbtCompileLocalOperator)
+
+
+@pytest.mark.parametrize("field", ["compiled_sql", "freshness"])
+def test_dbt_run_airflow_async_operator_rejects_output_only_template_fields(field):
+    """Output-only template fields (passed as top-level kwargs, e.g. via ``operator_args``)
+    bypass the inner ``dbt_kwargs`` guard and must be rejected up front with a clear error."""
+    profile_config = MagicMock(spec=ProfileConfig)
+
+    with pytest.raises(CosmosValueError, match=field):
+        DbtRunAirflowAsyncOperator(
+            task_id="run_model",
+            project_dir="/tmp/project",
+            profile_config=profile_config,
+            **{field: "value-the-user-tried-to-set"},
+        )


### PR DESCRIPTION
## Description

Follow-up to #2852.

#2852 added a guard on `DbtRunAirflowAsyncBigqueryOperator` that rejects output-only template fields (`compiled_sql`, `freshness`) passed via `dbt_kwargs`. However, the user-facing path is still unprotected.

`compiled_sql`/`freshness` are **template fields, not `__init__` parameters**. When a user sets them via `operator_args`, they arrive at `DbtRunAirflowAsyncOperator` as top-level kwargs (`operator_args` flow verbatim as `**task_kwargs` in `cosmos/core/airflow.py`). The kwarg split in `DbtRunAirflowAsyncOperator.__init__` routes anything that isn't a recognized init param into `clean_kwargs`, so these fields never land in `dbt_kwargs` and the #2852 guard never sees them.

Result today: the user gets an opaque `TypeError: Invalid arguments were passed ...` from the underlying async operator instead of the intended `CosmosValueError`.

## Fix

Reject the output-only fields against the raw `kwargs` at the top of `DbtRunAirflowAsyncOperator.__init__`, before the split. Reuses the existing `AbstractDbtLocalBase._reject_output_only_template_fields` helper.

After the fix, `operator_args={"compiled_sql": ...}` (or `freshness`) raises:

```
'compiled_sql' is output-only template field(s) populated by Cosmos at runtime; remove them from operator_args.
```

## Tests

Adds a parametrized unit test on `DbtRunAirflowAsyncOperator` (which had no prior coverage) for both `compiled_sql` and `freshness`. Top-level kwargs are exactly how `operator_args` reach the operator, so this covers the user path without needing a metadata DB.

Closes #2851

🤖 Generated with [Claude Code](https://claude.com/claude-code)