### PR TITLE
Add a `retries` param to `gcs_upload` callback

### DIFF
--- a/cosmos/io.py
+++ b/cosmos/io.py
@@ -81,6 +81,7 @@ def upload_to_gcp_gs(
     gcp_conn_id: str | None = None,
     source_subpath: str = DEFAULT_TARGET_PATH,
     use_tarball: bool = False,
+    num_max_attempts: int = 1,
     **kwargs: Any,
 ) -> None:
     """
@@ -91,6 +92,7 @@ def upload_to_gcp_gs(
     :param gcp_conn_id: GCP connection ID to use when uploading files.
     :param source_subpath: Path of the source directory sub-path to upload files from.
     :param use_tarball: If True, uploads a single tar.gz archive instead of individual files.
+    :param num_max_attempts: Number of upload attempts. Defaults to 1.
     """
     from airflow.providers.google.cloud.hooks.gcs import GCSHook
 
@@ -116,6 +118,7 @@ def upload_to_gcp_gs(
             object_name=f"{run_prefix}/{source_subpath}.tar.gz",
             data=buf.read(),
             mime_type="application/gzip",
+            num_max_attempts=num_max_attempts,
         )
     else:
         # Iterate over the files in the target dir and upload them to GCP GS
@@ -126,6 +129,7 @@ def upload_to_gcp_gs(
                     filename=f"{dirpath}/{filename}",
                     bucket_name=bucket_name,
                     object_name=object_name,
+                    num_max_attempts=num_max_attempts,
                 )
 
 

--- a/tests/test_io.py
+++ b/tests/test_io.py
@@ -111,6 +111,20 @@ def test_upload_artifacts_to_gcp_gs_tarball(dummy_kwargs):
         assert "filename" not in call_kwargs
 
 
+def test_upload_artifacts_to_gcp_gs_forwards_num_max_attempts(dummy_kwargs):
+    """Test upload_to_gcp_gs forwards num_max_attempts to every GCSHook.upload call."""
+    with (
+        patch("airflow.providers.google.cloud.hooks.gcs.GCSHook") as mock_hook,
+        patch("os.walk") as mock_walk,
+    ):
+        mock_walk.return_value = [("/project_dir/target", [], ["file1.txt", "file2.txt"])]
+
+        upload_to_gcp_gs("/project_dir", use_tarball=False, num_max_attempts=3, **dummy_kwargs)
+
+        upload_calls = mock_hook.return_value.upload.call_args_list
+        assert [call.kwargs["num_max_attempts"] for call in upload_calls] == [3, 3]
+
+
 def test_upload_artifacts_to_azure_wasb_no_tarball(dummy_kwargs):
     """Test upload_to_azure_wasb with use_tarball=False."""
     with (


### PR DESCRIPTION
## Description

<!-- Add a brief but complete description of the change. -->
This adds retries into GCS uploads. Transient errors during artifact uploads can result in failing DAG tasks unnecessarily. This uses the built in `num_max_attempts` param in `GCSHook.upload()` (which relies on exponential backoff) to retry uploads.

https://airflow.apache.org/docs/apache-airflow-providers-google/stable/_api/airflow/providers/google/cloud/hooks/gcs/index.html#airflow.providers.google.cloud.hooks.gcs.GCSHook.upload


## Related Issue(s)

<!-- If this PR closes an issue, you can use a keyword to auto-close. -->
<!-- i.e. "closes #0000" -->
Closes #2870.

## Breaking Change?

<!-- If this introduces a breaking change, specify that here. -->
No. This leaves present invocations untouched. Should function tidily in place.


## Checklist

- [X] I have made corresponding changes to the documentation (if required)
- [X] I have added tests that prove my fix is effective or that my feature works
