### PR TITLE
Support lists of paths for ProjectConfig relative-path args

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -334,6 +334,7 @@ class ProjectConfig:
             "ProjectConfig.seeds_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
             "Use ProjectConfig.seeds_paths instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self.seeds_paths[0] if self.seeds_paths else None
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -257,6 +257,7 @@ class ProjectConfig:
         dbt_project_path: str | Path | None = None,
         install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
+        *,
         models_relative_paths: str | Path | list[str | Path] = "models",
         seeds_relative_paths: str | Path | list[str | Path] = "seeds",
         snapshots_relative_paths: str | Path | list[str | Path] = "snapshots",

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -203,6 +203,7 @@ def _resolve_deprecated_relative_path(
         f"ProjectConfig.{singular_name} is deprecated since Cosmos 1.16 and will be removed in "
         f"Cosmos 2.0. Use ProjectConfig.{plural_name} instead.",
         DeprecationWarning,
+        stacklevel=2,
     )
     return singular_value
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -343,6 +343,7 @@ class ProjectConfig:
             "ProjectConfig.snapshots_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
             "Use ProjectConfig.snapshots_paths instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self.snapshots_paths[0] if self.snapshots_paths else None
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -183,6 +183,30 @@ class RenderConfig:
         return self.dbt_ls_path.exists()
 
 
+def _as_path_list(value: str | Path | list[str | Path]) -> list[str | Path]:
+    """Normalizes a single path or a list of paths into a list of paths."""
+    if isinstance(value, (str, Path)):
+        return [value]
+    return list(value)
+
+
+def _resolve_deprecated_relative_path(
+    plural_value: str | Path | list[str | Path],
+    singular_value: str | Path | None,
+    singular_name: str,
+    plural_name: str,
+) -> str | Path | list[str | Path]:
+    """Returns singular_value (with a DeprecationWarning) if set, otherwise plural_value unchanged."""
+    if singular_value is None:
+        return plural_value
+    warnings.warn(
+        f"ProjectConfig.{singular_name} is deprecated since Cosmos 1.16 and will be removed in "
+        f"Cosmos 2.0. Use ProjectConfig.{plural_name} instead.",
+        DeprecationWarning,
+    )
+    return singular_value
+
+
 class ProjectConfig:
     """
     Class for setting project config.
@@ -192,9 +216,18 @@ class ProjectConfig:
         ``dbt deps`` per DAG run via an Airflow template (e.g. ``"{{ params.install_deps }}"``), set
         ``ExecutionConfig.install_dbt_deps`` instead, which overrides this value at task execution time only.
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
-    :param models_relative_path: The relative path to the dbt models directory within the project. Defaults to models
-    :param seeds_relative_path: The relative path to the dbt seeds directory within the project. Defaults to seeds
-    :param snapshots_relative_path: The relative path to the dbt snapshots directory within the project. Defaults to snapshots
+    :param models_relative_paths: The relative path(s) to the dbt models directories within the project. Accepts a single
+        path or a list of paths. Defaults to ``["models"]``
+    :param seeds_relative_paths: The relative path(s) to the dbt seeds directories within the project. Accepts a single
+        path or a list of paths. Defaults to ``["seeds"]``
+    :param snapshots_relative_paths: The relative path(s) to the dbt snapshots directories within the project. Accepts a
+        single path or a list of paths. Defaults to ``["snapshots"]``
+    :param models_relative_path: Deprecated since Cosmos 1.16, use ``models_relative_paths`` instead. Will be removed in
+        Cosmos 2.0.
+    :param seeds_relative_path: Deprecated since Cosmos 1.16, use ``seeds_relative_paths`` instead. Will be removed in
+        Cosmos 2.0.
+    :param snapshots_relative_path: Deprecated since Cosmos 1.16, use ``snapshots_relative_paths`` instead. Will be
+        removed in Cosmos 2.0.
     :param manifest_path: The absolute path to the dbt manifest file. Defaults to None
     :param manifest_conn_id: Name of the Airflow connection used to access the manifest file if it is not stored locally. Defaults to None
     :param project_name: Allows the user to define the project name.
@@ -213,9 +246,9 @@ class ProjectConfig:
     install_dbt_deps: bool = True
     copy_dbt_packages: bool = settings.default_copy_dbt_packages
     manifest_path: Path | ObjectStoragePath | None = None
-    models_path: Path | None = None
-    seeds_path: Path | None = None
-    snapshots_path: Path | None = None
+    models_paths: list[Path] = []
+    seeds_paths: list[Path] = []
+    snapshots_paths: list[Path] = []
     project_name: str
 
     def __init__(
@@ -223,9 +256,12 @@ class ProjectConfig:
         dbt_project_path: str | Path | None = None,
         install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
-        models_relative_path: str | Path = "models",
-        seeds_relative_path: str | Path = "seeds",
-        snapshots_relative_path: str | Path = "snapshots",
+        models_relative_paths: str | Path | list[str | Path] = "models",
+        seeds_relative_paths: str | Path | list[str | Path] = "seeds",
+        snapshots_relative_paths: str | Path | list[str | Path] = "snapshots",
+        models_relative_path: str | Path | None = None,
+        seeds_relative_path: str | Path | None = None,
+        snapshots_relative_path: str | Path | None = None,
         manifest_path: str | Path | None = None,
         manifest_conn_id: str | None = None,
         project_name: str | None = None,
@@ -233,6 +269,15 @@ class ProjectConfig:
         dbt_vars: dict[str, str] | None = None,
         partial_parse: bool = True,
     ):
+        models_relative_paths = _resolve_deprecated_relative_path(
+            models_relative_paths, models_relative_path, "models_relative_path", "models_relative_paths"
+        )
+        seeds_relative_paths = _resolve_deprecated_relative_path(
+            seeds_relative_paths, seeds_relative_path, "seeds_relative_path", "seeds_relative_paths"
+        )
+        snapshots_relative_paths = _resolve_deprecated_relative_path(
+            snapshots_relative_paths, snapshots_relative_path, "snapshots_relative_path", "snapshots_relative_paths"
+        )
         # Since we allow dbt_project_path to be defined in ExecutionConfig and RenderConfig
         #   dbt_project_path may not always be defined here.
         # We do, however, still require that both manifest_path and project_name be defined, or neither be defined.
@@ -246,9 +291,9 @@ class ProjectConfig:
 
         if dbt_project_path:
             self.dbt_project_path = Path(dbt_project_path)
-            self.models_path = self.dbt_project_path / Path(models_relative_path)
-            self.seeds_path = self.dbt_project_path / Path(seeds_relative_path)
-            self.snapshots_path = self.dbt_project_path / Path(snapshots_relative_path)
+            self.models_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(models_relative_paths)]
+            self.seeds_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(seeds_relative_paths)]
+            self.snapshots_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(snapshots_relative_paths)]
             if not project_name:
                 self.project_name = self.dbt_project_path.stem
 
@@ -266,6 +311,36 @@ class ProjectConfig:
         self.partial_parse = partial_parse
         self.install_dbt_deps = install_dbt_deps
         self.copy_dbt_packages = copy_dbt_packages
+
+    @property
+    def models_path(self) -> Path | None:
+        """Deprecated since Cosmos 1.16, use ``models_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.models_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.models_paths instead.",
+            DeprecationWarning,
+        )
+        return self.models_paths[0] if self.models_paths else None
+
+    @property
+    def seeds_path(self) -> Path | None:
+        """Deprecated since Cosmos 1.16, use ``seeds_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.seeds_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.seeds_paths instead.",
+            DeprecationWarning,
+        )
+        return self.seeds_paths[0] if self.seeds_paths else None
+
+    @property
+    def snapshots_path(self) -> Path | None:
+        """Deprecated since Cosmos 1.16, use ``snapshots_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.snapshots_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.snapshots_paths instead.",
+            DeprecationWarning,
+        )
+        return self.snapshots_paths[0] if self.snapshots_paths else None
 
     def validate_project(self) -> None:
         """
@@ -285,12 +360,9 @@ class ProjectConfig:
         # while iterating on the `mandatory_paths` map works correctly for all paths, thereby validating the project.
         if self.dbt_project_path:
             project_yml_path = self.dbt_project_path / "dbt_project.yml"
-            mandatory_paths.update(
-                {
-                    "dbt_project.yml": Path(project_yml_path) if project_yml_path else None,
-                    "models directory ": Path(self.models_path) if self.models_path else None,
-                }
-            )
+            mandatory_paths["dbt_project.yml"] = Path(project_yml_path) if project_yml_path else None
+            for models_path in self.models_paths:
+                mandatory_paths[f"models directory {models_path}"] = Path(models_path)
         if self.manifest_path:
             mandatory_paths["manifest"] = self.manifest_path
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -246,9 +246,9 @@ class ProjectConfig:
     install_dbt_deps: bool = True
     copy_dbt_packages: bool = settings.default_copy_dbt_packages
     manifest_path: Path | ObjectStoragePath | None = None
-    models_paths: list[Path] = []
-    seeds_paths: list[Path] = []
-    snapshots_paths: list[Path] = []
+    models_paths: list[Path]
+    seeds_paths: list[Path]
+    snapshots_paths: list[Path]
     project_name: str
 
     def __init__(
@@ -278,6 +278,10 @@ class ProjectConfig:
         snapshots_relative_paths = _resolve_deprecated_relative_path(
             snapshots_relative_paths, snapshots_relative_path, "snapshots_relative_path", "snapshots_relative_paths"
         )
+        # Assigned here, not as a class-level default, so instances don't share one mutable list.
+        self.models_paths = []
+        self.seeds_paths = []
+        self.snapshots_paths = []
         # Since we allow dbt_project_path to be defined in ExecutionConfig and RenderConfig
         #   dbt_project_path may not always be defined here.
         # We do, however, still require that both manifest_path and project_name be defined, or neither be defined.

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -191,21 +191,35 @@ def _as_path_list(value: str | Path | list[str | Path]) -> list[str | Path]:
 
 
 def _resolve_deprecated_relative_path(
-    plural_value: str | Path | list[str | Path],
+    plural_value: str | Path | list[str | Path] | None,
     singular_value: str | Path | None,
+    default: str,
     singular_name: str,
     plural_name: str,
 ) -> str | Path | list[str | Path]:
-    """Returns singular_value (with a DeprecationWarning) if set, otherwise plural_value unchanged."""
-    if singular_value is None:
+    """Resolves a plural relative-path arg and its deprecated singular counterpart into one value.
+
+    Raises if both are explicitly set, since it would otherwise be unclear (and was previously
+    silently resolved by preferring the deprecated singular value) which one should win. Returns
+    singular_value (with a DeprecationWarning) if only it is set, plural_value if only it is set,
+    and `default` if neither is set.
+    """
+    if plural_value is not None and singular_value is not None:
+        raise CosmosValueError(
+            f"ProjectConfig.{plural_name} and the deprecated ProjectConfig.{singular_name} were both "
+            f"set. Remove ProjectConfig.{singular_name} and use only ProjectConfig.{plural_name}."
+        )
+    if singular_value is not None:
+        warnings.warn(
+            f"ProjectConfig.{singular_name} is deprecated since Cosmos 1.16 and will be removed in "
+            f"Cosmos 2.0. Use ProjectConfig.{plural_name} instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        return singular_value
+    if plural_value is not None:
         return plural_value
-    warnings.warn(
-        f"ProjectConfig.{singular_name} is deprecated since Cosmos 1.16 and will be removed in "
-        f"Cosmos 2.0. Use ProjectConfig.{plural_name} instead.",
-        DeprecationWarning,
-        stacklevel=2,
-    )
-    return singular_value
+    return default
 
 
 class ProjectConfig:
@@ -258,9 +272,9 @@ class ProjectConfig:
         install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
         *,
-        models_relative_paths: str | Path | list[str | Path] = "models",
-        seeds_relative_paths: str | Path | list[str | Path] = "seeds",
-        snapshots_relative_paths: str | Path | list[str | Path] = "snapshots",
+        models_relative_paths: str | Path | list[str | Path] | None = None,
+        seeds_relative_paths: str | Path | list[str | Path] | None = None,
+        snapshots_relative_paths: str | Path | list[str | Path] | None = None,
         models_relative_path: str | Path | None = None,
         seeds_relative_path: str | Path | None = None,
         snapshots_relative_path: str | Path | None = None,
@@ -272,13 +286,17 @@ class ProjectConfig:
         partial_parse: bool = True,
     ):
         models_relative_paths = _resolve_deprecated_relative_path(
-            models_relative_paths, models_relative_path, "models_relative_path", "models_relative_paths"
+            models_relative_paths, models_relative_path, "models", "models_relative_path", "models_relative_paths"
         )
         seeds_relative_paths = _resolve_deprecated_relative_path(
-            seeds_relative_paths, seeds_relative_path, "seeds_relative_path", "seeds_relative_paths"
+            seeds_relative_paths, seeds_relative_path, "seeds", "seeds_relative_path", "seeds_relative_paths"
         )
         snapshots_relative_paths = _resolve_deprecated_relative_path(
-            snapshots_relative_paths, snapshots_relative_path, "snapshots_relative_path", "snapshots_relative_paths"
+            snapshots_relative_paths,
+            snapshots_relative_path,
+            "snapshots",
+            "snapshots_relative_path",
+            "snapshots_relative_paths",
         )
         # Assigned here, not as a class-level default, so instances don't share one mutable list.
         self.models_paths = []
@@ -329,6 +347,17 @@ class ProjectConfig:
         )
         return self.models_paths[0] if self.models_paths else None
 
+    @models_path.setter
+    def models_path(self, value: Path | None) -> None:
+        """Deprecated since Cosmos 1.16, use ``models_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.models_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.models_paths instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.models_paths = [value] if value is not None else []
+
     @property
     def seeds_path(self) -> Path | None:
         """Deprecated since Cosmos 1.16, use ``seeds_paths`` instead. Will be removed in Cosmos 2.0."""
@@ -340,6 +369,17 @@ class ProjectConfig:
         )
         return self.seeds_paths[0] if self.seeds_paths else None
 
+    @seeds_path.setter
+    def seeds_path(self, value: Path | None) -> None:
+        """Deprecated since Cosmos 1.16, use ``seeds_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.seeds_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.seeds_paths instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.seeds_paths = [value] if value is not None else []
+
     @property
     def snapshots_path(self) -> Path | None:
         """Deprecated since Cosmos 1.16, use ``snapshots_paths`` instead. Will be removed in Cosmos 2.0."""
@@ -350,6 +390,17 @@ class ProjectConfig:
             stacklevel=2,
         )
         return self.snapshots_paths[0] if self.snapshots_paths else None
+
+    @snapshots_path.setter
+    def snapshots_path(self, value: Path | None) -> None:
+        """Deprecated since Cosmos 1.16, use ``snapshots_paths`` instead. Will be removed in Cosmos 2.0."""
+        warnings.warn(
+            "ProjectConfig.snapshots_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
+            "Use ProjectConfig.snapshots_paths instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        self.snapshots_paths = [value] if value is not None else []
 
     def validate_project(self) -> None:
         """

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -214,7 +214,9 @@ def _resolve_deprecated_relative_path(
             f"ProjectConfig.{singular_name} is deprecated since Cosmos 1.16 and will be removed in "
             f"Cosmos 2.0. Use ProjectConfig.{plural_name} instead.",
             DeprecationWarning,
-            stacklevel=2,
+            # stacklevel=3: skip this frame and _resolve_deprecated_relative_path's caller
+            # (ProjectConfig.__init__) to point at the user's own ProjectConfig(...) call site.
+            stacklevel=3,
         )
         return singular_value
     if plural_value is not None:
@@ -231,12 +233,6 @@ class ProjectConfig:
         ``dbt deps`` per DAG run via an Airflow template (e.g. ``"{{ params.install_deps }}"``), set
         ``ExecutionConfig.install_dbt_deps`` instead, which overrides this value at task execution time only.
     :param copy_dbt_packages: Copy dbt_packages directory, if it exists, instead of creating a symbolic link. If not set, fetches the value from [cosmos]default_copy_dbt_packages (False by default).
-    :param models_relative_paths: The relative path(s) to the dbt models directories within the project. Accepts a single
-        path or a list of paths. Defaults to ``["models"]``
-    :param seeds_relative_paths: The relative path(s) to the dbt seeds directories within the project. Accepts a single
-        path or a list of paths. Defaults to ``["seeds"]``
-    :param snapshots_relative_paths: The relative path(s) to the dbt snapshots directories within the project. Accepts a
-        single path or a list of paths. Defaults to ``["snapshots"]``
     :param models_relative_path: Deprecated since Cosmos 1.16, use ``models_relative_paths`` instead. Will be removed in
         Cosmos 2.0.
     :param seeds_relative_path: Deprecated since Cosmos 1.16, use ``seeds_relative_paths`` instead. Will be removed in
@@ -255,6 +251,12 @@ class ProjectConfig:
     :param partial_parse: If True, then attempt to use the ``partial_parse.msgpack`` if it exists. This is only used
         for the ``LoadMode.DBT_LS`` load mode, and for the ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``
         execution modes.
+    :param models_relative_paths: The relative path(s) to the dbt models directories within the project. Accepts a single
+        path or a list of paths. Keyword-only. Defaults to ``["models"]``
+    :param seeds_relative_paths: The relative path(s) to the dbt seeds directories within the project. Accepts a single
+        path or a list of paths. Keyword-only. Defaults to ``["seeds"]``
+    :param snapshots_relative_paths: The relative path(s) to the dbt snapshots directories within the project. Accepts a
+        single path or a list of paths. Keyword-only. Defaults to ``["snapshots"]``
     """
 
     dbt_project_path: Path | None = None
@@ -271,10 +273,6 @@ class ProjectConfig:
         dbt_project_path: str | Path | None = None,
         install_dbt_deps: bool = True,
         copy_dbt_packages: bool = settings.default_copy_dbt_packages,
-        *,
-        models_relative_paths: str | Path | list[str | Path] | None = None,
-        seeds_relative_paths: str | Path | list[str | Path] | None = None,
-        snapshots_relative_paths: str | Path | list[str | Path] | None = None,
         models_relative_path: str | Path | None = None,
         seeds_relative_path: str | Path | None = None,
         snapshots_relative_path: str | Path | None = None,
@@ -284,6 +282,10 @@ class ProjectConfig:
         env_vars: dict[str, str] | None = None,
         dbt_vars: dict[str, str] | None = None,
         partial_parse: bool = True,
+        *,
+        models_relative_paths: str | Path | list[str | Path] | None = None,
+        seeds_relative_paths: str | Path | list[str | Path] | None = None,
+        snapshots_relative_paths: str | Path | list[str | Path] | None = None,
     ):
         models_relative_paths = _resolve_deprecated_relative_path(
             models_relative_paths, models_relative_path, "models", "models_relative_path", "models_relative_paths"

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -323,6 +323,7 @@ class ProjectConfig:
             "ProjectConfig.models_path is deprecated since Cosmos 1.16 and will be removed in Cosmos 2.0. "
             "Use ProjectConfig.models_paths instead.",
             DeprecationWarning,
+            stacklevel=2,
         )
         return self.models_paths[0] if self.models_paths else None
 

--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -369,8 +369,8 @@ class ProjectConfig:
         if self.dbt_project_path:
             project_yml_path = self.dbt_project_path / "dbt_project.yml"
             mandatory_paths["dbt_project.yml"] = Path(project_yml_path) if project_yml_path else None
-            for models_path in self.models_paths:
-                mandatory_paths[f"models directory {models_path}"] = Path(models_path)
+            for i, models_path in enumerate(self.models_paths):
+                mandatory_paths[f"models directory[{i}]"] = Path(models_path)
         if self.manifest_path:
             mandatory_paths["manifest"] = self.manifest_path
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -91,7 +91,7 @@ def _relative_dirs(paths: list[Path], project_path: Path | None) -> list[str] | 
     result = []
     for p in paths:
         try:
-            result.append(str(p.relative_to(project_path)))
+            result.append(p.relative_to(project_path).as_posix())
         except ValueError:
             # p falls outside project_path (e.g. an absolute models_relative_paths entry).
             result.append(p.stem)

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -86,9 +86,14 @@ def _relative_dirs(paths: list[Path], project_path: Path | None) -> list[str] | 
     """Returns each path's location relative to project_path, preserving nested subdirectories."""
     if not paths:
         return None
-    if project_path is None:
-        return [p.stem for p in paths]
-    return [str(p.relative_to(project_path)) for p in paths]
+    result = []
+    for p in paths:
+        try:
+            result.append(str(p.relative_to(project_path)) if project_path else p.stem)
+        except ValueError:
+            # p falls outside project_path (e.g. an absolute models_relative_paths entry).
+            result.append(p.stem)
+    return result
 
 
 class CosmosLoadDbtException(Exception):

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -82,6 +82,15 @@ def _normalize_path(path: str | None) -> str:
         return Path(path.replace("\\", "/")).as_posix()
 
 
+def _relative_dirs(paths: list[Path], project_path: Path | None) -> list[str] | None:
+    """Returns each path's location relative to project_path, preserving nested subdirectories."""
+    if not paths:
+        return None
+    if project_path is None:
+        return [p.stem for p in paths]
+    return [str(p.relative_to(project_path)) for p in paths]
+
+
 class CosmosLoadDbtException(Exception):
     """
     Exception raised while trying to load a `dbt` project as a `DbtGraph` instance.
@@ -1107,9 +1116,9 @@ class DbtGraph:
         project = LegacyDbtProject(
             project_name=self.render_config.project_path.stem,
             dbt_root_path=self.render_config.project_path.parent.as_posix(),
-            dbt_models_dir=[p.stem for p in self.project.models_paths] or None,
-            dbt_seeds_dir=[p.stem for p in self.project.seeds_paths] or None,
-            dbt_snapshots_dir=[p.stem for p in self.project.snapshots_paths] or None,
+            dbt_models_dir=_relative_dirs(self.project.models_paths, self.project.dbt_project_path),
+            dbt_seeds_dir=_relative_dirs(self.project.seeds_paths, self.project.dbt_project_path),
+            dbt_snapshots_dir=_relative_dirs(self.project.snapshots_paths, self.project.dbt_project_path),
             dbt_vars=self.dbt_vars,
         )
         nodes = {}

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -84,12 +84,14 @@ def _normalize_path(path: str | None) -> str:
 
 def _relative_dirs(paths: list[Path], project_path: Path | None) -> list[str] | None:
     """Returns each path's location relative to project_path, preserving nested subdirectories."""
-    if not paths:
+    # None (not []) triggers LegacyDbtProject's own default; only do that when project_path is unset,
+    # so an explicitly empty `paths` list isn't confused with "unspecified".
+    if project_path is None:
         return None
     result = []
     for p in paths:
         try:
-            result.append(str(p.relative_to(project_path)) if project_path else p.stem)
+            result.append(str(p.relative_to(project_path)))
         except ValueError:
             # p falls outside project_path (e.g. an absolute models_relative_paths entry).
             result.append(p.stem)

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -1107,8 +1107,9 @@ class DbtGraph:
         project = LegacyDbtProject(
             project_name=self.render_config.project_path.stem,
             dbt_root_path=self.render_config.project_path.parent.as_posix(),
-            dbt_models_dir=self.project.models_path.stem if self.project.models_path else "models",
-            dbt_seeds_dir=self.project.seeds_path.stem if self.project.seeds_path else "seeds",
+            dbt_models_dir=[p.stem for p in self.project.models_paths] or None,
+            dbt_seeds_dir=[p.stem for p in self.project.seeds_paths] or None,
+            dbt_snapshots_dir=[p.stem for p in self.project.snapshots_paths] or None,
             dbt_vars=self.dbt_vars,
         )
         nodes = {}

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -337,6 +337,16 @@ class LegacyDbtProject:
         # add the model to the project
         self.seeds[model_name] = model
 
+    def _classify_dir(self, path: Path) -> DbtModelType | None:
+        """Returns whether path lives under a configured models or snapshots dir; most specific dir wins."""
+        candidates = [(models_dir, DbtModelType.DBT_MODEL) for models_dir in self.models_dir]
+        candidates += [(snapshots_dir, DbtModelType.DBT_SNAPSHOT) for snapshots_dir in self.snapshots_dir]
+        matches = [(dbt_dir, dbt_type) for dbt_dir, dbt_type in candidates if path.is_relative_to(dbt_dir)]
+        if not matches:
+            return None
+        _, dbt_type = max(matches, key=lambda match: len(match[0].parts))
+        return dbt_type
+
     def _handle_sql_file(self, path: Path) -> None:
         """
         Handles a single sql file.
@@ -345,7 +355,8 @@ class LegacyDbtProject:
         model_name = path.stem
 
         # construct the model object, which we'll use to store metadata
-        if any(str(models_dir) in str(path) for models_dir in self.models_dir):
+        resource_type = self._classify_dir(path)
+        if resource_type == DbtModelType.DBT_MODEL:
             model = DbtModel(
                 name=model_name,
                 type=DbtModelType.DBT_MODEL,
@@ -355,7 +366,7 @@ class LegacyDbtProject:
             # add the model to the project
             self.models[model.name] = model
 
-        elif any(str(snapshots_dir) in str(path) for snapshots_dir in self.snapshots_dir):
+        elif resource_type == DbtModelType.DBT_SNAPSHOT:
             model = DbtModel(
                 name=model_name,
                 type=DbtModelType.DBT_SNAPSHOT,

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -257,9 +257,9 @@ class LegacyDbtProject:
 
     # optional, user-specified instance variables
     dbt_root_path: str | None = None
-    dbt_models_dir: str | None = None
-    dbt_snapshots_dir: str | None = None
-    dbt_seeds_dir: str | None = None
+    dbt_models_dir: str | list[str] | None = None
+    dbt_snapshots_dir: str | list[str] | None = None
+    dbt_seeds_dir: str | list[str] | None = None
 
     # private instance variables for managing state
     models: dict[str, DbtModel] = field(default_factory=dict)
@@ -267,9 +267,9 @@ class LegacyDbtProject:
     seeds: dict[str, DbtModel] = field(default_factory=dict)
     tests: dict[str, DbtModel] = field(default_factory=dict)
     project_dir: Path = field(init=False)
-    models_dir: Path = field(init=False)
-    snapshots_dir: Path = field(init=False)
-    seeds_dir: Path = field(init=False)
+    models_dir: list[Path] = field(init=False)
+    snapshots_dir: list[Path] = field(init=False)
+    seeds_dir: list[Path] = field(init=False)
 
     dbt_vars: dict[str, str] = field(default_factory=dict)
 
@@ -278,35 +278,47 @@ class LegacyDbtProject:
         Initializes the parser.
         """
         self.dbt_root_path = self.dbt_root_path or "/usr/local/airflow/dags/dbt"
-        self.dbt_models_dir = self.dbt_models_dir or "models"
-        self.dbt_snapshots_dir = self.dbt_snapshots_dir or "snapshots"
-        self.dbt_seeds_dir = self.dbt_seeds_dir or "seeds"
+        dbt_models_dirs = self._as_dir_list(self.dbt_models_dir) or ["models"]
+        dbt_snapshots_dirs = self._as_dir_list(self.dbt_snapshots_dir) or ["snapshots"]
+        dbt_seeds_dirs = self._as_dir_list(self.dbt_seeds_dir) or ["seeds"]
 
         # set the project and model dirs
         self.project_dir = Path(os.path.join(self.dbt_root_path, self.project_name))
-        self.models_dir = self.project_dir / self.dbt_models_dir
-        self.snapshots_dir = self.project_dir / self.dbt_snapshots_dir
-        self.seeds_dir = self.project_dir / self.dbt_seeds_dir
+        self.models_dir = [self.project_dir / dbt_dir for dbt_dir in dbt_models_dirs]
+        self.snapshots_dir = [self.project_dir / dbt_dir for dbt_dir in dbt_snapshots_dirs]
+        self.seeds_dir = [self.project_dir / dbt_dir for dbt_dir in dbt_seeds_dirs]
 
-        # crawl the models in the project
-        for file_name in self.models_dir.rglob("*.sql"):
-            self._handle_sql_file(file_name)
+        for models_dir in self.models_dir:
+            # crawl the models in the project
+            for file_name in models_dir.rglob("*.sql"):
+                self._handle_sql_file(file_name)
 
-        # crawl the models in the project
-        for file_name in self.models_dir.rglob("*.py"):
-            self._handle_sql_file(file_name)
+            # crawl the models in the project
+            for file_name in models_dir.rglob("*.py"):
+                self._handle_sql_file(file_name)
+
+            # crawl the config files in the project
+            for file_name in models_dir.rglob("*.yml"):
+                self._handle_config_file(file_name)
 
         # crawl the snapshots in the project
-        for file_name in self.snapshots_dir.rglob("*.sql"):
-            self._handle_sql_file(file_name)
+        for snapshots_dir in self.snapshots_dir:
+            for file_name in snapshots_dir.rglob("*.sql"):
+                self._handle_sql_file(file_name)
 
         # crawl the seeds in the project
-        for file_name in self.seeds_dir.rglob("*.csv"):
-            self._handle_csv_file(file_name)
+        for seeds_dir in self.seeds_dir:
+            for file_name in seeds_dir.rglob("*.csv"):
+                self._handle_csv_file(file_name)
 
-        # crawl the config files in the project
-        for file_name in self.models_dir.rglob("*.yml"):
-            self._handle_config_file(file_name)
+    @staticmethod
+    def _as_dir_list(value: str | list[str] | None) -> list[str]:
+        """Normalizes a single directory name or a list of directory names into a list."""
+        if value is None:
+            return []
+        if isinstance(value, str):
+            return [value]
+        return list(value)
 
     def _handle_csv_file(self, path: Path) -> None:
         """
@@ -333,7 +345,7 @@ class LegacyDbtProject:
         model_name = path.stem
 
         # construct the model object, which we'll use to store metadata
-        if str(self.models_dir) in str(path):
+        if any(str(models_dir) in str(path) for models_dir in self.models_dir):
             model = DbtModel(
                 name=model_name,
                 type=DbtModelType.DBT_MODEL,
@@ -343,7 +355,7 @@ class LegacyDbtProject:
             # add the model to the project
             self.models[model.name] = model
 
-        elif str(self.snapshots_dir) in str(path):
+        elif any(str(snapshots_dir) in str(path) for snapshots_dir in self.snapshots_dir):
             model = DbtModel(
                 name=model_name,
                 type=DbtModelType.DBT_SNAPSHOT,

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -292,15 +292,12 @@ class LegacyDbtProject:
         self.seeds_dir = [self.project_dir / dbt_dir for dbt_dir in dbt_seeds_dirs]
 
         for models_dir in self.models_dir:
-            for file_name in models_dir.rglob("*.sql"):
-                if self._classify_dir(file_name) == DbtModelType.DBT_MODEL:
-                    self._handle_sql_file(file_name)
+            self._crawl_models_dir(models_dir)
 
-            # crawl the models in the project
-            for file_name in models_dir.rglob("*.py"):
-                self._handle_sql_file(file_name)
-
-            # crawl the config files in the project
+        # crawl the config files in the project. This runs as its own pass, after every models_dir
+        # has been crawled above, so a schema.yml in one dir can apply config to a model that lives
+        # in another dir — _handle_config_file only affects models that have already been parsed.
+        for models_dir in self.models_dir:
             for file_name in models_dir.rglob("*.yml"):
                 self._handle_config_file(file_name)
 
@@ -313,6 +310,16 @@ class LegacyDbtProject:
         for seeds_dir in self.seeds_dir:
             for file_name in seeds_dir.rglob("*.csv"):
                 self._handle_csv_file(file_name)
+
+    def _crawl_models_dir(self, models_dir: Path) -> None:
+        """Crawls a single models directory for .sql and .py model files."""
+        for file_name in models_dir.rglob("*.sql"):
+            if self._classify_dir(file_name) == DbtModelType.DBT_MODEL:
+                self._handle_sql_file(file_name)
+
+        # crawl the models in the project
+        for file_name in models_dir.rglob("*.py"):
+            self._handle_sql_file(file_name)
 
     @staticmethod
     def _as_dir_list(value: str | list[str] | None) -> list[str]:

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -292,9 +292,9 @@ class LegacyDbtProject:
         self.seeds_dir = [self.project_dir / dbt_dir for dbt_dir in dbt_seeds_dirs]
 
         for models_dir in self.models_dir:
-            # crawl the models in the project
             for file_name in models_dir.rglob("*.sql"):
-                self._handle_sql_file(file_name)
+                if self._classify_dir(file_name) == DbtModelType.DBT_MODEL:
+                    self._handle_sql_file(file_name)
 
             # crawl the models in the project
             for file_name in models_dir.rglob("*.py"):

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -14,6 +14,7 @@ from typing import Any, ClassVar
 import jinja2
 import yaml
 
+from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
 
 logger = get_logger(__name__)
@@ -319,7 +320,8 @@ class LegacyDbtProject:
 
         # crawl the models in the project
         for file_name in models_dir.rglob("*.py"):
-            self._handle_sql_file(file_name)
+            if self._classify_dir(file_name) == DbtModelType.DBT_MODEL:
+                self._handle_sql_file(file_name)
 
     @staticmethod
     def _as_dir_list(value: str | list[str] | None) -> list[str]:
@@ -328,7 +330,11 @@ class LegacyDbtProject:
             return []
         if isinstance(value, str):
             return [value]
-        return list(value)
+        if isinstance(value, list):
+            return list(value)
+        raise CosmosValueError(
+            f"Expected a directory name (str) or a list of directory names, got {type(value).__name__}: {value!r}."
+        )
 
     def _handle_csv_file(self, path: Path) -> None:
         """

--- a/cosmos/dbt/parser/project.py
+++ b/cosmos/dbt/parser/project.py
@@ -278,9 +278,12 @@ class LegacyDbtProject:
         Initializes the parser.
         """
         self.dbt_root_path = self.dbt_root_path or "/usr/local/airflow/dags/dbt"
-        dbt_models_dirs = self._as_dir_list(self.dbt_models_dir) or ["models"]
-        dbt_snapshots_dirs = self._as_dir_list(self.dbt_snapshots_dir) or ["snapshots"]
-        dbt_seeds_dirs = self._as_dir_list(self.dbt_seeds_dir) or ["seeds"]
+        # `is None` (not `or`) so an explicitly empty list (crawl nothing) isn't confused with "unset".
+        dbt_models_dirs = ["models"] if self.dbt_models_dir is None else self._as_dir_list(self.dbt_models_dir)
+        dbt_snapshots_dirs = (
+            ["snapshots"] if self.dbt_snapshots_dir is None else self._as_dir_list(self.dbt_snapshots_dir)
+        )
+        dbt_seeds_dirs = ["seeds"] if self.dbt_seeds_dir is None else self._as_dir_list(self.dbt_seeds_dir)
 
         # set the project and model dirs
         self.project_dir = Path(os.path.join(self.dbt_root_path, self.project_name))

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -128,6 +128,37 @@ def test_LegacyDbtProject__handle_config_file_with_selector(input_tags, expected
         assert dbt_project.models["orders"].config.config_selectors == expected_config_selectors
 
 
+def test_LegacyDbtProject_crawls_multiple_dirs(tmp_path):
+    """
+    LegacyDbtProject should support a list of directories for dbt_models_dir/dbt_seeds_dir/dbt_snapshots_dir,
+    crawling files from every directory in each list.
+    """
+    project_dir = tmp_path / "multi_dir_project"
+    for relative_dir in ("models", "models_v2", "seeds", "seeds_v2", "snapshots", "snapshots_v2"):
+        (project_dir / relative_dir).mkdir(parents=True)
+
+    (project_dir / "models" / "model_a.sql").write_text("select 1")
+    (project_dir / "models_v2" / "model_b.sql").write_text("select 2")
+    (project_dir / "seeds" / "seed_a.csv").write_text("id\n1")
+    (project_dir / "seeds_v2" / "seed_b.csv").write_text("id\n2")
+    (project_dir / "snapshots" / "snapshot_a.sql").write_text("{% snapshot snapshot_a %}\nselect 1\n{% endsnapshot %}")
+    (project_dir / "snapshots_v2" / "snapshot_b.sql").write_text(
+        "{% snapshot snapshot_b %}\nselect 2\n{% endsnapshot %}"
+    )
+
+    dbt_project = LegacyDbtProject(
+        project_name="multi_dir_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir=["models", "models_v2"],
+        dbt_seeds_dir=["seeds", "seeds_v2"],
+        dbt_snapshots_dir=["snapshots", "snapshots_v2"],
+    )
+
+    assert set(dbt_project.models.keys()) == {"model_a", "model_b"}
+    assert set(dbt_project.seeds.keys()) == {"seed_a", "seed_b"}
+    assert set(dbt_project.snapshots.keys()) == {"snapshot_a", "snapshot_b"}
+
+
 def test_dbtmodelconfig___repr__():
     dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=SAMPLE_MODEL_SQL_PATH)
     expected_start = (

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -10,6 +10,7 @@ import pytest
 import yaml
 
 from cosmos.dbt.parser.project import DbtModel, DbtModelType, LegacyDbtProject
+from cosmos.exceptions import CosmosValueError
 
 DBT_PROJECT_PATH = Path(__name__).parent.parent.parent.parent.parent / "dev/dags/dbt/"
 SAMPLE_CSV_PATH = DBT_PROJECT_PATH / "jaffle_shop/seeds/raw_customers.csv"
@@ -230,6 +231,37 @@ def test_LegacyDbtProject_explicit_empty_dir_list_crawls_nothing(tmp_path):
     )
 
     assert dbt_project.models == {}
+
+
+def test_LegacyDbtProject_rejects_invalid_dir_type():
+    """
+    dbt_models_dir/dbt_seeds_dir/dbt_snapshots_dir should raise a clear error for a misconfigured value
+    that is neither a string nor a list of strings, instead of failing obscurely downstream.
+    """
+    with pytest.raises(CosmosValueError, match="Expected a directory name"):
+        LegacyDbtProject(project_name="bad_config_project", dbt_models_dir=123)
+
+
+def test_LegacyDbtProject_py_file_in_nested_snapshots_dir_is_skipped(tmp_path):
+    """
+    A .py file living inside a snapshots dir nested under a models dir must not be picked up by the
+    unfiltered *.py crawl: the nested snapshots dir is more specific than the models dir, so it would
+    be classified as a snapshot and crash in DbtModel.__post_init__, which expects a
+    "{% snapshot ... %}" jinja block - not a bare .py file.
+    """
+    project_dir = tmp_path / "nested_py_project"
+    (project_dir / "models" / "snapshots").mkdir(parents=True)
+    (project_dir / "models" / "model_a.sql").write_text("select 1")
+    (project_dir / "models" / "snapshots" / "__init__.py").write_text("")
+
+    dbt_project = LegacyDbtProject(
+        project_name="nested_py_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir="models",
+        dbt_snapshots_dir="models/snapshots",
+    )
+
+    assert set(dbt_project.models.keys()) == {"model_a"}
 
 
 def test_LegacyDbtProject_classifies_nested_snapshots_dir_correctly(tmp_path):

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -242,6 +242,30 @@ def test_LegacyDbtProject_rejects_invalid_dir_type():
         LegacyDbtProject(project_name="bad_config_project", dbt_models_dir=123)
 
 
+def test_LegacyDbtProject__as_dir_list_returns_empty_for_none():
+    """
+    _as_dir_list(None) should return [] directly. __post_init__ already substitutes the
+    "models"/"seeds"/"snapshots" default via its own `is None` check before ever calling this method,
+    so this branch is otherwise unreachable through normal usage - covering it directly documents the
+    intended behavior in case _as_dir_list is ever called on its own (it's a @staticmethod).
+    """
+    assert LegacyDbtProject._as_dir_list(None) == []
+
+
+def test_LegacyDbtProject__classify_dir_returns_none_for_unmatched_path(tmp_path):
+    """
+    _classify_dir should return None for a path that isn't under any configured models or snapshots
+    dir. In practice _handle_sql_file only ever receives paths from rglob() over a configured dir, so
+    this branch is otherwise unreachable - covering it directly documents the fallback behavior.
+    """
+    dbt_project = LegacyDbtProject(
+        project_name="jaffle_shop",
+        dbt_root_path=DBT_PROJECT_PATH,
+    )
+    outside_path = tmp_path / "not_a_configured_dir" / "some_file.sql"
+    assert dbt_project._classify_dir(outside_path) is None
+
+
 def test_LegacyDbtProject_py_file_in_nested_snapshots_dir_is_skipped(tmp_path):
     """
     A .py file living inside a snapshots dir nested under a models dir must not be picked up by the

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -185,6 +185,30 @@ def test_LegacyDbtProject_accepts_single_dir_as_string(tmp_path):
     assert set(dbt_project.snapshots.keys()) == {"snapshot_a"}
 
 
+def test_LegacyDbtProject_classifies_nested_snapshots_dir_correctly(tmp_path):
+    """
+    A snapshots dir nested inside a models dir should still be classified as snapshots, not models -
+    a substring check on the path string would misclassify it since "models" is a substring of
+    ".../models/snapshots/snapshot_a.sql".
+    """
+    project_dir = tmp_path / "nested_dirs_project"
+    (project_dir / "models" / "snapshots").mkdir(parents=True)
+    (project_dir / "models" / "model_a.sql").write_text("select 1")
+    (project_dir / "models" / "snapshots" / "snapshot_a.sql").write_text(
+        "{% snapshot snapshot_a %}\nselect 1\n{% endsnapshot %}"
+    )
+
+    dbt_project = LegacyDbtProject(
+        project_name="nested_dirs_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir="models",
+        dbt_snapshots_dir="models/snapshots",
+    )
+
+    assert set(dbt_project.models.keys()) == {"model_a"}
+    assert set(dbt_project.snapshots.keys()) == {"snapshot_a"}
+
+
 def test_dbtmodelconfig___repr__():
     dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=SAMPLE_MODEL_SQL_PATH)
     expected_start = (

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -159,6 +159,35 @@ def test_LegacyDbtProject_crawls_multiple_dirs(tmp_path):
     assert set(dbt_project.snapshots.keys()) == {"snapshot_a", "snapshot_b"}
 
 
+def test_LegacyDbtProject_yml_config_applies_across_dirs(tmp_path):
+    """
+    A schema.yml in one models dir should be able to configure a model that lives in a different
+    models dir, regardless of dbt_models_dir list order. Regression test for a bug where the yml
+    pass ran per-dir (interleaved with the sql/py crawl) instead of once after every models dir was
+    crawled, so a yml processed before the dir holding its target model would silently drop the
+    config - `marts` is listed (and thus crawled) before `staging`, and `model_b` lives in `staging`.
+    """
+    project_dir = tmp_path / "cross_dir_config_project"
+    (project_dir / "marts").mkdir(parents=True)
+    (project_dir / "staging").mkdir(parents=True)
+
+    (project_dir / "marts" / "model_a.sql").write_text("select 1")
+    (project_dir / "staging" / "model_b.sql").write_text("select 2")
+
+    yaml_data = {"models": [{"name": "model_b", "config": {"tags": ["from_marts_yml"]}}]}
+    with open(project_dir / "marts" / "schema.yml", "w") as fp:
+        yaml.dump(yaml_data, fp)
+
+    dbt_project = LegacyDbtProject(
+        project_name="cross_dir_config_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir=["marts", "staging"],
+    )
+
+    assert set(dbt_project.models.keys()) == {"model_a", "model_b"}
+    assert "tags:from_marts_yml" in dbt_project.models["model_b"].config.config_selectors
+
+
 def test_LegacyDbtProject_accepts_single_dir_as_string(tmp_path):
     """
     dbt_models_dir/dbt_seeds_dir/dbt_snapshots_dir should still accept a plain string (not just a list),

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -185,6 +185,24 @@ def test_LegacyDbtProject_accepts_single_dir_as_string(tmp_path):
     assert set(dbt_project.snapshots.keys()) == {"snapshot_a"}
 
 
+def test_LegacyDbtProject_explicit_empty_dir_list_crawls_nothing(tmp_path):
+    """
+    dbt_models_dir=[] means "crawl no model directories" and must not fall back to the "models"
+    default - that default should only apply when dbt_models_dir is left unset (None).
+    """
+    project_dir = tmp_path / "empty_list_project"
+    (project_dir / "models").mkdir(parents=True)
+    (project_dir / "models" / "model_a.sql").write_text("select 1")
+
+    dbt_project = LegacyDbtProject(
+        project_name="empty_list_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir=[],
+    )
+
+    assert dbt_project.models == {}
+
+
 def test_LegacyDbtProject_classifies_nested_snapshots_dir_correctly(tmp_path):
     """
     A snapshots dir nested inside a models dir should still be classified as snapshots, not models -

--- a/tests/dbt/parser/test_project.py
+++ b/tests/dbt/parser/test_project.py
@@ -159,6 +159,32 @@ def test_LegacyDbtProject_crawls_multiple_dirs(tmp_path):
     assert set(dbt_project.snapshots.keys()) == {"snapshot_a", "snapshot_b"}
 
 
+def test_LegacyDbtProject_accepts_single_dir_as_string(tmp_path):
+    """
+    dbt_models_dir/dbt_seeds_dir/dbt_snapshots_dir should still accept a plain string (not just a list),
+    normalizing it into a single-item list.
+    """
+    project_dir = tmp_path / "single_dir_project"
+    for relative_dir in ("models", "seeds", "snapshots"):
+        (project_dir / relative_dir).mkdir(parents=True)
+
+    (project_dir / "models" / "model_a.sql").write_text("select 1")
+    (project_dir / "seeds" / "seed_a.csv").write_text("id\n1")
+    (project_dir / "snapshots" / "snapshot_a.sql").write_text("{% snapshot snapshot_a %}\nselect 1\n{% endsnapshot %}")
+
+    dbt_project = LegacyDbtProject(
+        project_name="single_dir_project",
+        dbt_root_path=str(tmp_path),
+        dbt_models_dir="models",
+        dbt_seeds_dir="seeds",
+        dbt_snapshots_dir="snapshots",
+    )
+
+    assert set(dbt_project.models.keys()) == {"model_a"}
+    assert set(dbt_project.seeds.keys()) == {"seed_a"}
+    assert set(dbt_project.snapshots.keys()) == {"snapshot_a"}
+
+
 def test_dbtmodelconfig___repr__():
     dbt_model = DbtModel(name="some_name", type=DbtModelType.DBT_MODEL, path=SAMPLE_MODEL_SQL_PATH)
     expected_start = (

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1517,6 +1517,49 @@ def test_load_via_custom_parser_with_nested_model_dir(tmp_path):
     assert dbt_graph.nodes["my_model"].unique_id == "model.nested_project.my_model"
 
 
+def test_load_via_custom_parser_with_explicit_empty_models_relative_paths(tmp_path):
+    """
+    models_relative_paths=[] means "no model directories" and must not fall back to crawling the
+    default "models" dir under LoadMode.CUSTOM, even if one happens to exist on disk.
+    """
+    project_dir = tmp_path / "empty_list_project"
+    (project_dir / "models").mkdir(parents=True)
+    (project_dir / "models" / "should_not_be_found.sql").write_text("select 1")
+    (project_dir / "profiles.yml").write_text(
+        "test:\n"
+        "  target: test\n"
+        "  outputs:\n"
+        "    test:\n"
+        "      type: postgres\n"
+        "      host: localhost\n"
+        "      user: user\n"
+        "      password: pass\n"
+        "      port: 5432\n"
+        "      dbname: db\n"
+        "      schema: public\n"
+        "      threads: 1\n"
+    )
+
+    project_config = ProjectConfig(dbt_project_path=project_dir, models_relative_paths=[])
+    execution_config = ExecutionConfig(dbt_project_path=project_dir)
+    render_config = RenderConfig(dbt_project_path=project_dir, source_rendering_behavior=SOURCE_RENDERING_BEHAVIOR)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profiles_yml_filepath=project_dir / "profiles.yml",
+    )
+    dbt_graph = DbtGraph(
+        project=project_config,
+        profile_config=profile_config,
+        render_config=render_config,
+        execution_config=execution_config,
+    )
+
+    dbt_graph.load_via_custom_parser()
+
+    assert dbt_graph.nodes == {}
+
+
 @pytest.mark.parametrize("project_name", [("altered_jaffle_shop"), ("jaffle_shop_python")])
 def test_validate_load_via_load_via_custom_parser_deprecated(project_name):
     """Deprecating warnings should be raised when using load_mode CUSTOM."""
@@ -3149,8 +3192,13 @@ def test__relative_dirs_preserves_nested_subdirectories():
 
 
 def test__relative_dirs_empty_and_no_project_path():
-    assert _relative_dirs([], Path("/some/project")) is None
-    assert _relative_dirs([Path("/some/project/custom/models")], None) == ["models"]
+    """
+    An explicitly empty paths list (project_path set) must stay [] rather than falling back to
+    LegacyDbtProject's default - only an unset project_path itself should trigger that fallback (via
+    None), since ProjectConfig always pairs a set project_path with a non-empty paths list otherwise.
+    """
+    assert _relative_dirs([], Path("/some/project")) == []
+    assert _relative_dirs([Path("/some/project/custom/models")], None) is None
 
 
 def test__relative_dirs_falls_back_when_path_outside_project():

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -3153,6 +3153,17 @@ def test__relative_dirs_empty_and_no_project_path():
     assert _relative_dirs([Path("/some/project/custom/models")], None) == ["models"]
 
 
+def test__relative_dirs_falls_back_when_path_outside_project():
+    """
+    A path outside project_path (e.g. an absolute models_relative_paths entry) should fall back to
+    Path.stem instead of raising ValueError from Path.relative_to.
+    """
+    project_path = Path("/some/project")
+    outside_path = Path("/some/other/models")
+
+    assert _relative_dirs([outside_path], project_path) == ["models"]
+
+
 @pytest.mark.parametrize(
     "pre_dbt_fusion_value,source_rendering_behaviour_value,expected_args_count",
     [

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -33,6 +33,7 @@ from cosmos.dbt.graph import (
     DbtNode,
     LoadMode,
     _normalize_path,
+    _relative_dirs,
     parse_dbt_ls_output,
     run_command,
     run_command_with_subprocess,
@@ -1470,6 +1471,50 @@ def test_load_via_load_via_custom_parser(project_name, nodes_count):
 
     assert dbt_graph.nodes == dbt_graph.filtered_nodes
     assert len(dbt_graph.nodes) == nodes_count
+
+
+def test_load_via_custom_parser_with_nested_model_dir(tmp_path):
+    """
+    A nested models_relative_paths dir (e.g. "custom/models") should still be crawled under
+    LoadMode.CUSTOM, not silently dropped by truncating the configured path to its last component.
+    """
+    project_dir = tmp_path / "nested_project"
+    (project_dir / "custom" / "models").mkdir(parents=True)
+    (project_dir / "custom" / "models" / "my_model.sql").write_text("select 1")
+    (project_dir / "profiles.yml").write_text(
+        "test:\n"
+        "  target: test\n"
+        "  outputs:\n"
+        "    test:\n"
+        "      type: postgres\n"
+        "      host: localhost\n"
+        "      user: user\n"
+        "      password: pass\n"
+        "      port: 5432\n"
+        "      dbname: db\n"
+        "      schema: public\n"
+        "      threads: 1\n"
+    )
+
+    project_config = ProjectConfig(dbt_project_path=project_dir, models_relative_paths="custom/models")
+    execution_config = ExecutionConfig(dbt_project_path=project_dir)
+    render_config = RenderConfig(dbt_project_path=project_dir, source_rendering_behavior=SOURCE_RENDERING_BEHAVIOR)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profiles_yml_filepath=project_dir / "profiles.yml",
+    )
+    dbt_graph = DbtGraph(
+        project=project_config,
+        profile_config=profile_config,
+        render_config=render_config,
+        execution_config=execution_config,
+    )
+
+    dbt_graph.load_via_custom_parser()
+
+    assert "my_model" in dbt_graph.nodes
+    assert dbt_graph.nodes["my_model"].unique_id == "model.nested_project.my_model"
 
 
 @pytest.mark.parametrize("project_name", [("altered_jaffle_shop"), ("jaffle_shop_python")])
@@ -3089,6 +3134,23 @@ def test__normalize_path():
     original_value = "seeds\\seed_ifs_util_manual_event_id.csv"
     expected_value = "seeds/seed_ifs_util_manual_event_id.csv"
     assert _normalize_path(original_value) == expected_value
+
+
+def test__relative_dirs_preserves_nested_subdirectories():
+    """
+    _relative_dirs should return each path's location relative to project_path, not just Path.stem -
+    otherwise a nested dir like "custom/models" collapses to "models" and LegacyDbtProject crawls the
+    wrong directory.
+    """
+    project_path = Path("/usr/local/airflow/dags/dbt/my_project")
+    paths = [project_path / "custom" / "models", project_path / "models_v2"]
+
+    assert _relative_dirs(paths, project_path) == ["custom/models", "models_v2"]
+
+
+def test__relative_dirs_empty_and_no_project_path():
+    assert _relative_dirs([], Path("/some/project")) is None
+    assert _relative_dirs([Path("/some/project/custom/models")], None) == ["models"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -102,6 +102,48 @@ def test_deprecated_singular_path_property_still_works(deprecated_attr, expected
         assert getattr(project_config, deprecated_attr) == expected
 
 
+@pytest.mark.parametrize(
+    "plural_kwarg,deprecated_kwarg",
+    [
+        ("models_relative_paths", "models_relative_path"),
+        ("seeds_relative_paths", "seeds_relative_path"),
+        ("snapshots_relative_paths", "snapshots_relative_path"),
+    ],
+)
+def test_init_with_both_plural_and_deprecated_singular_relative_path_raises(plural_kwarg, deprecated_kwarg):
+    """
+    Passing both a plural *_relative_paths kwarg and its deprecated singular counterpart is ambiguous -
+    it should raise instead of silently preferring the deprecated one and discarding the plural value.
+    """
+    kwargs = {
+        "dbt_project_path": "path/to/dbt/project",
+        plural_kwarg: ["custom"],
+        deprecated_kwarg: "custom",
+    }
+    with pytest.raises(CosmosValueError, match=deprecated_kwarg):
+        ProjectConfig(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "deprecated_attr,plural_attr",
+    [
+        ("models_path", "models_paths"),
+        ("seeds_path", "seeds_paths"),
+        ("snapshots_path", "snapshots_paths"),
+    ],
+)
+def test_deprecated_singular_path_property_setter_still_works(deprecated_attr, plural_attr):
+    """
+    Setting the deprecated singular *_path property - previously a plain writable attribute - should
+    still work: it must raise a DeprecationWarning and replace the plural *_paths list with a
+    single-item list, rather than raising AttributeError now that *_path is a property.
+    """
+    project_config = ProjectConfig(dbt_project_path="path/to/dbt/project")
+    with pytest.deprecated_call():
+        setattr(project_config, deprecated_attr, Path("elsewhere"))
+    assert getattr(project_config, plural_attr) == [Path("elsewhere")]
+
+
 def test_init_with_project_path_and_install_dbt_deps_succeeds():
     """
     Passing only dbt_project_path and install_dbt_deps should succeed and set install_dbt_deps to the value defined

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -22,12 +22,71 @@ def test_init_with_project_path_only():
     """
     project_config = ProjectConfig(dbt_project_path="path/to/dbt/project")
     assert project_config.dbt_project_path == Path("path/to/dbt/project")
-    assert project_config.models_path == Path("path/to/dbt/project/models")
-    assert project_config.seeds_path == Path("path/to/dbt/project/seeds")
-    assert project_config.snapshots_path == Path("path/to/dbt/project/snapshots")
+    assert project_config.models_paths == [Path("path/to/dbt/project/models")]
+    assert project_config.seeds_paths == [Path("path/to/dbt/project/seeds")]
+    assert project_config.snapshots_paths == [Path("path/to/dbt/project/snapshots")]
     assert project_config.project_name == "project"
     assert project_config.manifest_path is None
     assert project_config.install_dbt_deps is True
+
+
+def test_init_with_project_path_and_list_relative_paths():
+    """
+    Passing a list of paths to models_relative_paths/seeds_relative_paths/snapshots_relative_paths should
+    populate the corresponding *_paths list with one entry per item.
+    """
+    project_config = ProjectConfig(
+        dbt_project_path="path/to/dbt/project",
+        models_relative_paths=["models", "models_v2"],
+        seeds_relative_paths=["seeds"],
+        snapshots_relative_paths=["snapshots", "snapshots_v2"],
+    )
+    assert project_config.models_paths == [
+        Path("path/to/dbt/project/models"),
+        Path("path/to/dbt/project/models_v2"),
+    ]
+    assert project_config.seeds_paths == [Path("path/to/dbt/project/seeds")]
+    assert project_config.snapshots_paths == [
+        Path("path/to/dbt/project/snapshots"),
+        Path("path/to/dbt/project/snapshots_v2"),
+    ]
+
+
+@pytest.mark.parametrize(
+    "deprecated_kwarg,plural_attr,expected",
+    [
+        ("models_relative_path", "models_paths", [Path("path/to/dbt/project/custom_models")]),
+        ("seeds_relative_path", "seeds_paths", [Path("path/to/dbt/project/custom_seeds")]),
+        ("snapshots_relative_path", "snapshots_paths", [Path("path/to/dbt/project/custom_snapshots")]),
+    ],
+)
+def test_init_with_deprecated_singular_relative_path_still_works(deprecated_kwarg, plural_attr, expected):
+    """
+    The deprecated singular *_relative_path kwargs should still work, but should raise a DeprecationWarning
+    and populate the plural *_paths attribute with a single-item list.
+    """
+    kwargs = {"dbt_project_path": "path/to/dbt/project", deprecated_kwarg: f"custom_{deprecated_kwarg.split('_')[0]}"}
+    with pytest.deprecated_call():
+        project_config = ProjectConfig(**kwargs)
+    assert getattr(project_config, plural_attr) == expected
+
+
+@pytest.mark.parametrize(
+    "deprecated_attr,expected",
+    [
+        ("models_path", Path("path/to/dbt/project/models")),
+        ("seeds_path", Path("path/to/dbt/project/seeds")),
+        ("snapshots_path", Path("path/to/dbt/project/snapshots")),
+    ],
+)
+def test_deprecated_singular_path_property_still_works(deprecated_attr, expected):
+    """
+    Accessing the deprecated singular *_path property should raise a DeprecationWarning and return the
+    first entry of the corresponding plural *_paths list.
+    """
+    project_config = ProjectConfig(dbt_project_path="path/to/dbt/project")
+    with pytest.deprecated_call():
+        assert getattr(project_config, deprecated_attr) == expected
 
 
 def test_init_with_project_path_and_install_dbt_deps_succeeds():
@@ -107,6 +166,20 @@ def test_validate_project_missing_fails():
     with pytest.raises(CosmosValueError) as err_info:
         assert project_config.validate_project() is None
     assert err_info.value.args[0] == "Could not find dbt_project.yml at /tmp/dbt_project.yml"
+
+
+def test_validate_project_one_of_multiple_models_paths_missing_fails():
+    """
+    When multiple models_relative_paths are configured, validate_project should fail if any one of them
+    does not exist, naming the specific missing directory.
+    """
+    project_config = ProjectConfig(
+        dbt_project_path=DBT_PROJECTS_ROOT_DIR,
+        models_relative_paths=["models", "does_not_exist"],
+    )
+    with pytest.raises(CosmosValueError) as err_info:
+        project_config.validate_project()
+    assert "does_not_exist" in err_info.value.args[0]
 
 
 def test_is_manifest_available_is_true():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -52,6 +52,19 @@ def test_init_with_project_path_and_list_relative_paths():
     ]
 
 
+def test_models_paths_not_shared_across_instances():
+    """
+    models_paths/seeds_paths/snapshots_paths must not be a shared mutable default - mutating one
+    ProjectConfig instance's list should not affect another's.
+    """
+    config_a = ProjectConfig(manifest_path="a/manifest.json", project_name="a")
+    config_b = ProjectConfig(manifest_path="b/manifest.json", project_name="b")
+
+    config_a.models_paths.append(Path("unexpected"))
+
+    assert config_b.models_paths == []
+
+
 @pytest.mark.parametrize(
     "deprecated_kwarg,plural_attr,expected",
     [


### PR DESCRIPTION
## Summary
- `ProjectConfig` now accepts `models_relative_paths`/`seeds_relative_paths`/`snapshots_relative_paths` (a single path or a list), mirroring dbt's own support for multiple `model-paths`/`seed-paths`/`snapshot-paths`.
- The old singular `models_relative_path`/`seeds_relative_path`/`snapshots_relative_path` args and the derived `models_path`/`seeds_path`/`snapshots_path` attributes still work but now raise a `DeprecationWarning` and will be removed in Cosmos 2.0.
- Extended the deprecated `LoadMode.CUSTOM` legacy parser (`LegacyDbtProject`) to crawl multiple model/seed/snapshot directories instead of assuming a single one; also fixed a pre-existing gap where `dbt_snapshots_dir` was never passed through to it.
- `ProjectConfig.validate_project()` now validates every configured model directory instead of just the first one.

Follow-up fixes from review:
- Fixed a shared mutable list default on `ProjectConfig.models_paths`/`seeds_paths`/`snapshots_paths` that could leak state across instances created without `dbt_project_path`.
- Fixed `LoadMode.CUSTOM` silently dropping models under nested `models_relative_paths` (e.g. `"custom/models"`) by preserving the full relative path instead of just `Path.stem`.
- Fixed `LegacyDbtProject` misclassifying (and crashing on) a snapshots dir nested inside a models dir, by using proper path containment instead of a substring check.

closes: https://github.com/astronomer/astronomer-cosmos/issues/2100
closes: BOSS-197

## Test plan
- [x] `hatch run tests.py3.11-2.10-1.9:test tests/test_config.py tests/dbt/parser/test_project.py tests/dbt/test_graph.py`
- [x] `pre-commit run --all-files` (ruff, black, mypy)
- [x] CI

DagRun
<img width="1620" height="843" alt="Screenshot 2026-07-08 at 12 40 38 PM" src="https://github.com/user-attachments/assets/f952dea3-7236-417f-9f37-10abd7e33e0a" />
