### PR TITLE
Render `env_var()` Jinja when deriving WATCHER dataset namespace

### DIFF
--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -11,6 +11,7 @@ from packaging.version import Version
 
 from cosmos import settings
 from cosmos.constants import _DATASET_EMITTING_RESOURCE_TYPES, AIRFLOW_VERSION
+from cosmos.dbt.project import _resolve_env_var
 from cosmos.log import get_logger
 
 if TYPE_CHECKING:
@@ -145,6 +146,8 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
         with open(profile_config.profiles_yml_filepath) as f:
             profiles = yaml.safe_load(f)
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
+        # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
+        target = {key: _resolve_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
         adapter_type = target.get("type", "")
         return adapter_type, target
 

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
 import json
+import os
+import re
 import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
@@ -11,7 +13,6 @@ from packaging.version import Version
 
 from cosmos import settings
 from cosmos.constants import _DATASET_EMITTING_RESOURCE_TYPES, AIRFLOW_VERSION
-from cosmos.dbt.project import _resolve_env_var
 from cosmos.log import get_logger
 
 if TYPE_CHECKING:
@@ -129,6 +130,23 @@ def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_i
     return "__".join(identifiers_list)
 
 
+# Matches dbt's `{{ env_var('NAME') }}` / `{{ env_var('NAME', 'default') }}` Jinja calls only.
+# Deliberately narrower than a general Jinja renderer: profiles.yml values are only ever
+# substituted for this specific dbt construct, so no other Jinja syntax is evaluated.
+_ENV_VAR_PATTERN = re.compile(
+    r"""\{\{\s*env_var\(\s*(['"])(?P<name>.*?)\1\s*(?:,\s*(['"])(?P<default>.*?)\3\s*)?\)\s*\}\}"""
+)
+
+
+def _render_env_var(value: str) -> str:
+    """Substitute dbt-style ``env_var('NAME'[, 'default'])`` Jinja calls with the environment value."""
+
+    def _replace(match: re.Match[str]) -> str:
+        return os.getenv(match.group("name"), match.group("default") or "")
+
+    return _ENV_VAR_PATTERN.sub(_replace, value)
+
+
 def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any]]:
     """
     Extract the adapter type and profile dict from a ProfileConfig.
@@ -147,7 +165,7 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
             profiles = yaml.safe_load(f)
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
-        target = {key: _resolve_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
+        target = {key: _render_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
         adapter_type = target.get("type", "")
         return adapter_type, target
 

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -1,18 +1,18 @@
 from __future__ import annotations
 
 import json
-import os
-import re
 import urllib.parse
 from collections.abc import Callable
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 import yaml
+from jinja2.exceptions import TemplateError
 from packaging.version import Version
 
 from cosmos import settings
 from cosmos.constants import _DATASET_EMITTING_RESOURCE_TYPES, AIRFLOW_VERSION
+from cosmos.dbt.project import _resolve_env_var
 from cosmos.log import get_logger
 
 if TYPE_CHECKING:
@@ -130,23 +130,6 @@ def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_i
     return "__".join(identifiers_list)
 
 
-# Matches dbt's `{{ env_var('NAME') }}` / `{{ env_var('NAME', 'default') }}` Jinja calls only.
-# Deliberately narrower than a general Jinja renderer: profiles.yml values are only ever
-# substituted for this specific dbt construct, so no other Jinja syntax is evaluated.
-_ENV_VAR_PATTERN = re.compile(
-    r"""\{\{\s*env_var\(\s*(['"])(?P<name>.*?)\1\s*(?:,\s*(['"])(?P<default>.*?)\3\s*)?\)\s*\}\}"""
-)
-
-
-def _render_env_var(value: str) -> str:
-    """Substitute dbt-style ``env_var('NAME'[, 'default'])`` Jinja calls with the environment value."""
-
-    def _replace(match: re.Match[str]) -> str:
-        return os.getenv(match.group("name"), match.group("default") or "")
-
-    return _ENV_VAR_PATTERN.sub(_replace, value)
-
-
 def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any]]:
     """
     Extract the adapter type and profile dict from a ProfileConfig.
@@ -165,7 +148,7 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
             profiles = yaml.safe_load(f)
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
-        target = {key: _render_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
+        target = {key: _resolve_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
         adapter_type = target.get("type", "")
         return adapter_type, target
 
@@ -189,7 +172,7 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
     """
     try:
         adapter_type, profile_dict = _get_profile_dict(profile_config)
-    except (AttributeError, KeyError, TypeError, OSError, yaml.YAMLError):
+    except (AttributeError, KeyError, TypeError, OSError, yaml.YAMLError, TemplateError):
         logger.debug("Unable to extract profile info for dataset namespace derivation", exc_info=True)
         return None
 

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -151,6 +151,43 @@ my_profile:
         profile_config.target_name = "dev"
         assert get_dataset_namespace(profile_config) == "postgres://dbhost:5433"
 
+    def test_profiles_yml_filepath_env_var_default(self, tmp_path, monkeypatch):
+        """env_var()'s dbt-style default argument is honored when the variable is unset."""
+        monkeypatch.delenv("DB_HOST", raising=False)
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DB_HOST', 'db.prod.internal') }}"
+      port: 5433
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://db.prod.internal:5433"
+
+    def test_profiles_yml_filepath_other_jinja_untouched(self, tmp_path):
+        """Only the env_var() form is substituted; other Jinja syntax is left as-is (not evaluated)."""
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "db-{{ this.is_not_env_var }}.prod.internal"
+      port: 5433
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://db-{{ this.is_not_env_var }}.prod.internal:5433"
+
     def test_returns_none_on_error(self):
         profile_config = MagicMock()
         profile_config.profile_mapping = None

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -128,6 +128,29 @@ my_profile:
         profile_config.target_name = "dev"
         assert get_dataset_namespace(profile_config) == "postgres://dbhost:5433"
 
+    def test_profiles_yml_filepath_renders_env_var(self, tmp_path, monkeypatch):
+        """profiles.yml may use dbt's env_var() Jinja; it must be rendered, not passed through literally."""
+        monkeypatch.setenv("DB_HOST", "dbhost")
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DB_HOST') }}"
+      port: 5433
+      user: user
+      pass: pass
+      dbname: mydb
+      schema: public
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://dbhost:5433"
+
     def test_returns_none_on_error(self):
         profile_config = MagicMock()
         profile_config.profile_mapping = None

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -170,8 +170,29 @@ my_profile:
         profile_config.target_name = "dev"
         assert get_dataset_namespace(profile_config) == "postgres://db.prod.internal:5433"
 
-    def test_profiles_yml_filepath_other_jinja_untouched(self, tmp_path):
-        """Only the env_var() form is substituted; other Jinja syntax is left as-is (not evaluated)."""
+    def test_profiles_yml_filepath_env_var_with_jinja_filters(self, tmp_path, monkeypatch):
+        """env_var() used inside other Jinja constructs (concatenation, filters) renders correctly,
+        matching dbt's own rendering semantics rather than a bare env_var(...) substitution."""
+        monkeypatch.setenv("DB_HOST", "dbhost")
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DB_HOST') ~ '.internal' }}"
+      port: 5433
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://dbhost.internal:5433"
+
+    def test_profiles_yml_filepath_undefined_jinja_returns_none(self, tmp_path):
+        """profiles.yml referencing an undefined Jinja name (not env_var) fails to render; the caller's
+        catch-all returns None instead of propagating the Jinja error and breaking DAG parsing."""
         profiles_yml = tmp_path / "profiles.yml"
         profiles_yml.write_text("""
 my_profile:
@@ -186,7 +207,7 @@ my_profile:
         profile_config.profiles_yml_filepath = str(profiles_yml)
         profile_config.profile_name = "my_profile"
         profile_config.target_name = "dev"
-        assert get_dataset_namespace(profile_config) == "postgres://db-{{ this.is_not_env_var }}.prod.internal:5433"
+        assert get_dataset_namespace(profile_config) is None
 
     def test_returns_none_on_error(self):
         profile_config = MagicMock()


### PR DESCRIPTION
## Summary
- `ProfileConfig.profiles_yml_filepath` targets are read directly with `yaml.safe_load`, so any field using dbt's `env_var()` Jinja (e.g. `host: "{{ env_var('STARBURST_HOST') }}"`) was passed through literally into the WATCHER dataset-namespace resolvers, producing invalid Asset/Dataset URIs like `trino://{{ env_var('STARBURST_HOST') }}:443/...`.
- `_get_profile_dict` now renders `env_var()` Jinja on string values before returning the target dict, reusing the existing `_resolve_env_var` helper from `cosmos/dbt/project.py` — the same rendering dbt itself performs on `profiles.yml` at run time.
- The `profile_mapping` (Airflow-connection based) path is untouched, since those values already come from a resolved connection rather than a raw `profiles.yml`.

Fixes #2843

## Test plan
- [x] Added a regression test (`test_profiles_yml_filepath_renders_env_var`) reproducing the exact scenario from #2843.
- [x] `TestGetDatasetNamespace` (17/17) and the full `test_dataset.py` (35/35) pass.
- [x] `pre-commit run --all-files` (ruff, black, mypy, etc.) passes.
- [x] Manually reproduced the bug against pre-fix code (unrendered `trino://{{ env_var('STARBURST_HOST') }}:443`) and confirmed the fix resolves it end-to-end through the real `ProfileConfig` + `get_dataset_namespace` path (no mocks), with a real profiles.yml on disk and a real env var.