### PR TITLE
WATCHER: clean up orphaned producer XCom-backup Variable on DAG-run completion

### DIFF
--- a/cosmos/airflow/compatibility.py
+++ b/cosmos/airflow/compatibility.py
@@ -73,3 +73,29 @@ try:
     from airflow.sdk.exceptions import AirflowSkipException as AirflowSkipException  # type: ignore[attr-defined]
 except ImportError:
     from airflow.exceptions import AirflowSkipException as AirflowSkipException
+
+
+def delete_variable_isolated_session(key: str) -> None:
+    """Delete a Variable via a dedicated session, safe to call from the scheduler process.
+
+    The scheduler guards against anything committing its ambient thread-local session
+    mid-transaction (it would corrupt its row locks), but ``airflow.models.Variable.delete()``
+    does exactly that by default. A session bound directly to ``settings.engine`` avoids the
+    collision. ``airflow.sdk.Variable`` has no such issue -- it goes through the Task Execution
+    API rather than a local session -- so it's used as-is when available.
+    """
+    try:
+        from airflow.sdk import Variable
+
+        Variable.delete(key)
+    except ImportError:
+        from airflow import settings
+        from airflow.models import Variable as LegacyVariable
+        from sqlalchemy.orm import sessionmaker
+
+        session = sessionmaker(bind=settings.engine)()
+        try:
+            LegacyVariable.delete(key, session=session)
+            session.commit()
+        finally:
+            session.close()

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -40,23 +40,18 @@ _WATCHER_PRODUCER_TASK_TYPE = "DbtProducerWatcherOperator"
 def _cleanup_watcher_producer_backups(dag: DAG, dag_id: str, run_id: str) -> None:
     """Delete any orphaned WATCHER producer XCom-backup Variables left by this DAG run.
 
-    The producer persists its per-node dbt statuses to an Airflow Variable so a retry can
-    restore them (see ``cosmos.operators._watcher.xcom``). It is deleted on success or after
-    a retry restores it, but a producer that fails with no retries left -- or is never given
-    the chance to run its own callbacks, e.g. a scheduler crash -- leaves it behind. Since the
-    DAG run has already reached a terminal state here, no further retries are possible, so it
-    is always safe to delete any backup that still exists.
-
-    This looks at the DAG's static task definitions, not this run's task instance states:
-    the Variable key only depends on (dag_id, task_group_id, run_id), so it is cheaper to
-    just attempt the delete for every producer task defined in the DAG and rely on
-    ``_delete_xcom_backup_variable_by_ids`` to no-op when there is nothing to clean up.
+    Called from both ``on_dag_run_success`` and ``on_dag_run_failed``: a ``DbtDag``'s root
+    consumer tasks run with ``trigger_rule="always"``, so the run can succeed even if the
+    producer itself failed and never got to clean up after itself. Either way, the DAG run is
+    already terminal by the time either hook fires, so no further producer retries are possible
+    and it's always safe to delete.
     """
     from cosmos.operators._watcher.xcom import _delete_xcom_backup_variable_by_ids
 
     for task in dag.task_dict.values():
         task_module = getattr(task, "_task_module", None) or task.__class__.__module__
-        task_type = getattr(task, "_task_type", None) or task.__class__.__name__
+        # NOT `_task_type`: that attribute doesn't exist on Airflow 3's SerializedBaseOperator.
+        task_type = getattr(task, "task_type", None) or task.__class__.__name__
         if task_module.startswith("cosmos.") and task_type == _WATCHER_PRODUCER_TASK_TYPE:
             task_group = getattr(task, "task_group", None)
             task_group_id = task_group.group_id if task_group else None
@@ -68,6 +63,13 @@ def _cleanup_watcher_producer_backups(dag: DAG, dag_id: str, run_id: str) -> Non
                     task.task_id,
                     exc_info=True,
                 )
+
+
+def _cleanup_watcher_producer_backups_safely(dag: DAG, dag_run: DagRun) -> None:
+    try:
+        _cleanup_watcher_producer_backups(dag, dag_run.dag_id, dag_run.run_id)
+    except Exception:
+        logger.warning("Failed to clean up WATCHER producer XCom-backup Variables", exc_info=True)
 
 
 def total_cosmos_tasks(dag: DAG) -> int:
@@ -150,6 +152,9 @@ def on_dag_run_success(dag_run: DagRun, msg: str) -> None:
     additional_telemetry_metrics.update(cosmos_metadata)
 
     telemetry.emit_usage_metrics_if_enabled(DAG_RUN, additional_telemetry_metrics)
+
+    _cleanup_watcher_producer_backups_safely(serialized_dag, dag_run)
+
     logger.debug("Completed on_dag_run_success")
 
 
@@ -184,9 +189,6 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
 
     telemetry.emit_usage_metrics_if_enabled(DAG_RUN, additional_telemetry_metrics)
 
-    try:
-        _cleanup_watcher_producer_backups(serialized_dag, dag_run.dag_id, dag_run.run_id)
-    except Exception:
-        logger.warning("Failed to clean up WATCHER producer XCom-backup Variables", exc_info=True)
+    _cleanup_watcher_producer_backups_safely(serialized_dag, dag_run)
 
     logger.debug("Completed on_dag_run_failed")

--- a/cosmos/listeners/dag_run_listener.py
+++ b/cosmos/listeners/dag_run_listener.py
@@ -34,6 +34,42 @@ class EventStatus:
 DAG_RUN = "dag_run"
 
 
+_WATCHER_PRODUCER_TASK_TYPE = "DbtProducerWatcherOperator"
+
+
+def _cleanup_watcher_producer_backups(dag: DAG, dag_id: str, run_id: str) -> None:
+    """Delete any orphaned WATCHER producer XCom-backup Variables left by this DAG run.
+
+    The producer persists its per-node dbt statuses to an Airflow Variable so a retry can
+    restore them (see ``cosmos.operators._watcher.xcom``). It is deleted on success or after
+    a retry restores it, but a producer that fails with no retries left -- or is never given
+    the chance to run its own callbacks, e.g. a scheduler crash -- leaves it behind. Since the
+    DAG run has already reached a terminal state here, no further retries are possible, so it
+    is always safe to delete any backup that still exists.
+
+    This looks at the DAG's static task definitions, not this run's task instance states:
+    the Variable key only depends on (dag_id, task_group_id, run_id), so it is cheaper to
+    just attempt the delete for every producer task defined in the DAG and rely on
+    ``_delete_xcom_backup_variable_by_ids`` to no-op when there is nothing to clean up.
+    """
+    from cosmos.operators._watcher.xcom import _delete_xcom_backup_variable_by_ids
+
+    for task in dag.task_dict.values():
+        task_module = getattr(task, "_task_module", None) or task.__class__.__module__
+        task_type = getattr(task, "_task_type", None) or task.__class__.__name__
+        if task_module.startswith("cosmos.") and task_type == _WATCHER_PRODUCER_TASK_TYPE:
+            task_group = getattr(task, "task_group", None)
+            task_group_id = task_group.group_id if task_group else None
+            try:
+                _delete_xcom_backup_variable_by_ids(dag_id, task_group_id, run_id)
+            except Exception:
+                logger.warning(
+                    "Failed to clean up WATCHER producer XCom-backup Variable for task '%s'",
+                    task.task_id,
+                    exc_info=True,
+                )
+
+
 def total_cosmos_tasks(dag: DAG) -> int:
     """
     Identify if there are any Cosmos DAGs on a given serialized `airflow.serialization.serialized_objects.SerializedDAG`.
@@ -147,4 +183,10 @@ def on_dag_run_failed(dag_run: DagRun, msg: str) -> None:
     additional_telemetry_metrics.update(cosmos_metadata)
 
     telemetry.emit_usage_metrics_if_enabled(DAG_RUN, additional_telemetry_metrics)
+
+    try:
+        _cleanup_watcher_producer_backups(serialized_dag, dag_run.dag_id, dag_run.run_id)
+    except Exception:
+        logger.warning("Failed to clean up WATCHER producer XCom-backup Variables", exc_info=True)
+
     logger.debug("Completed on_dag_run_failed")

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -14,7 +14,7 @@ import re
 import zlib
 from typing import Any
 
-from cosmos.airflow.compatibility import delete_variable, get_variable, set_variable
+from cosmos.airflow.compatibility import delete_variable, delete_variable_isolated_session, get_variable, set_variable
 from cosmos.log import get_logger
 from cosmos.operators._watcher.state import safe_xcom_push
 
@@ -140,12 +140,11 @@ def _delete_xcom_backup_variable_by_ids(dag_id: str, task_group_id: str | None, 
     """Delete a producer's XCom backup Variable given its identifying DAG/task-group/run ids.
 
     Unlike ``_delete_xcom_backup_variable``, this doesn't require a live task execution
-    context, so it can be used to clean up orphaned backups once a DAG run has reached a
-    terminal state (e.g. from a DAG-run-level listener).
+    context, so it can be used to clean up orphaned backups from a DAG-run-level listener.
     """
     var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
     try:
-        delete_variable(var_key)
+        delete_variable_isolated_session(var_key)
         logger.debug("Deleted orphaned XCom backup Variable '%s'", var_key)
     except KeyError:
         pass

--- a/cosmos/operators/_watcher/xcom.py
+++ b/cosmos/operators/_watcher/xcom.py
@@ -136,6 +136,21 @@ def _delete_xcom_backup_variable(context: Any) -> None:
         pass
 
 
+def _delete_xcom_backup_variable_by_ids(dag_id: str, task_group_id: str | None, run_id: str) -> None:
+    """Delete a producer's XCom backup Variable given its identifying DAG/task-group/run ids.
+
+    Unlike ``_delete_xcom_backup_variable``, this doesn't require a live task execution
+    context, so it can be used to clean up orphaned backups once a DAG run has reached a
+    terminal state (e.g. from a DAG-run-level listener).
+    """
+    var_key = _xcom_backup_variable_key(dag_id, task_group_id, run_id)
+    try:
+        delete_variable(var_key)
+        logger.debug("Deleted orphaned XCom backup Variable '%s'", var_key)
+    except KeyError:
+        pass
+
+
 def _restore_xcom_from_variable(context: Any) -> bool:
     """Restore XCom entries from an Airflow Variable backup created by a previous attempt.
 

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -7,19 +7,30 @@ from unittest.mock import patch
 import pytest
 from airflow.models import DAG, DagRun
 from airflow.utils.state import State
+from airflow.utils.task_group import TaskGroup
 from packaging.version import Version
 
 from cosmos import DbtRunLocalOperator, ProfileConfig, ProjectConfig
 from cosmos.airflow.dag import DbtDag
 from cosmos.airflow.task_group import DbtTaskGroup
 from cosmos.config import ExecutionConfig, RenderConfig
-from cosmos.constants import AIRFLOW_VERSION, InvocationMode, LoadMode, SourceRenderingBehavior, TestBehavior
+from cosmos.constants import (
+    AIRFLOW_VERSION,
+    ExecutionMode,
+    InvocationMode,
+    LoadMode,
+    SourceRenderingBehavior,
+    TestBehavior,
+)
 from cosmos.listeners.dag_run_listener import (
+    _cleanup_watcher_producer_backups,
     get_cosmos_telemetry_metadata,
     on_dag_run_failed,
     on_dag_run_success,
     total_cosmos_tasks,
 )
+from cosmos.operators._watcher.xcom import _xcom_backup_variable_key
+from cosmos.operators.watcher import DbtProducerWatcherOperator
 from cosmos.profiles import PostgresUserPasswordProfileMapping
 from tests.utils import new_test_dag
 
@@ -290,3 +301,74 @@ def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_en
     assert metrics["uses_node_converter"] is False
     assert metrics["test_behavior"] == "none"
     assert metrics["source_behavior"] == "all"
+
+
+class TestCleanupWatcherProducerBackups:
+    """Covers cleanup of orphaned WATCHER producer XCom-backup Variables on DAG-run failure (#2823)."""
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_deletes_variable_for_producer_in_task_group(self, mock_delete_variable):
+        with DAG("watcher_dag", start_date=datetime(2022, 1, 1)) as dag:
+            with TaskGroup(group_id="my_group"):
+                DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+
+        _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")
+
+        expected_key = _xcom_backup_variable_key("watcher_dag", "my_group", "run123")
+        mock_delete_variable.assert_called_once_with(expected_key)
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_deletes_variable_for_producer_without_task_group(self, mock_delete_variable):
+        with DAG("watcher_dag", start_date=datetime(2022, 1, 1)) as dag:
+            DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+
+        _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")
+
+        expected_key = _xcom_backup_variable_key("watcher_dag", None, "run123")
+        mock_delete_variable.assert_called_once_with(expected_key)
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_noop_for_non_watcher_dag(self, mock_delete_variable):
+        with DAG("plain_dag", start_date=datetime(2022, 1, 1)) as dag:
+            DbtRunLocalOperator(
+                profile_config=profile_config,
+                project_dir=DBT_ROOT_PATH / "jaffle_shop",
+                task_id="run",
+            )
+
+        _cleanup_watcher_producer_backups(dag, "plain_dag", "run123")
+
+        mock_delete_variable.assert_not_called()
+
+    @patch("cosmos.operators._watcher.xcom._delete_xcom_backup_variable_by_ids", side_effect=RuntimeError("boom"))
+    def test_swallows_per_task_errors(self, mock_delete_by_ids):
+        with DAG("watcher_dag", start_date=datetime(2022, 1, 1)) as dag:
+            DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+
+        _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")  # should not raise
+
+        mock_delete_by_ids.assert_called_once()
+
+
+@pytest.mark.integration
+@patch("cosmos.operators._watcher.xcom.delete_variable")
+@patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_dag_run_failed_cleans_up_watcher_backup_variable(mock_emit_usage_metrics_if_enabled, mock_delete_variable):
+    with DbtDag(
+        project_config=ProjectConfig(
+            DBT_ROOT_PATH / "jaffle_shop",
+        ),
+        profile_config=profile_config,
+        execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER),
+        start_date=datetime(2023, 1, 1),
+        dag_id="watcher_dag_with_backup",
+    ) as dag:
+        pass
+
+    run_id = str(uuid.uuid1())
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    dag_run = create_dag_run(dag, run_id, run_after)
+
+    on_dag_run_failed(dag_run, msg="test failed")
+
+    mock_delete_variable.assert_called()

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -306,8 +306,8 @@ def test_on_dag_run_failed_with_telemetry_metadata(mock_emit_usage_metrics_if_en
 class TestCleanupWatcherProducerBackups:
     """Covers cleanup of orphaned WATCHER producer XCom-backup Variables on DAG-run failure (#2823)."""
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_deletes_variable_for_producer_in_task_group(self, mock_delete_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_deletes_variable_for_producer_in_task_group(self, mock_delete_variable_isolated_session):
         with DAG("watcher_dag", start_date=datetime(2022, 1, 1)) as dag:
             with TaskGroup(group_id="my_group"):
                 DbtProducerWatcherOperator(project_dir=".", profile_config=None)
@@ -315,20 +315,20 @@ class TestCleanupWatcherProducerBackups:
         _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")
 
         expected_key = _xcom_backup_variable_key("watcher_dag", "my_group", "run123")
-        mock_delete_variable.assert_called_once_with(expected_key)
+        mock_delete_variable_isolated_session.assert_called_once_with(expected_key)
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_deletes_variable_for_producer_without_task_group(self, mock_delete_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_deletes_variable_for_producer_without_task_group(self, mock_delete_variable_isolated_session):
         with DAG("watcher_dag", start_date=datetime(2022, 1, 1)) as dag:
             DbtProducerWatcherOperator(project_dir=".", profile_config=None)
 
         _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")
 
         expected_key = _xcom_backup_variable_key("watcher_dag", None, "run123")
-        mock_delete_variable.assert_called_once_with(expected_key)
+        mock_delete_variable_isolated_session.assert_called_once_with(expected_key)
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_noop_for_non_watcher_dag(self, mock_delete_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_noop_for_non_watcher_dag(self, mock_delete_variable_isolated_session):
         with DAG("plain_dag", start_date=datetime(2022, 1, 1)) as dag:
             DbtRunLocalOperator(
                 profile_config=profile_config,
@@ -338,7 +338,7 @@ class TestCleanupWatcherProducerBackups:
 
         _cleanup_watcher_producer_backups(dag, "plain_dag", "run123")
 
-        mock_delete_variable.assert_not_called()
+        mock_delete_variable_isolated_session.assert_not_called()
 
     @patch("cosmos.operators._watcher.xcom._delete_xcom_backup_variable_by_ids", side_effect=RuntimeError("boom"))
     def test_swallows_per_task_errors(self, mock_delete_by_ids):
@@ -349,11 +349,33 @@ class TestCleanupWatcherProducerBackups:
 
         mock_delete_by_ids.assert_called_once()
 
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_deletes_variable_for_producer_in_serialized_dag(self, mock_delete_variable_isolated_session):
+        """In a real deployment ``dag`` is a SerializedDAG, not the live DAG built by user code (#2880):
+        its tasks only expose the operator type via the ``task_type`` property, not ``__class__.__name__``."""
+        if AIRFLOW_VERSION < Version("3.0"):
+            from airflow.serialization.serialized_objects import SerializedDAG
+        else:
+            from airflow.serialization.definitions.dag import SerializedDAG
+
+        with DAG("watcher_dag_serialized", start_date=datetime(2022, 1, 1)) as dag:
+            DbtProducerWatcherOperator(project_dir=".", profile_config=None)
+
+        serialized_dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
+        assert serialized_dag.task_dict["dbt_producer_watcher"].__class__.__name__ != "DbtProducerWatcherOperator"
+
+        _cleanup_watcher_producer_backups(serialized_dag, "watcher_dag_serialized", "run123")
+
+        expected_key = _xcom_backup_variable_key("watcher_dag_serialized", None, "run123")
+        mock_delete_variable_isolated_session.assert_called_once_with(expected_key)
+
 
 @pytest.mark.integration
-@patch("cosmos.operators._watcher.xcom.delete_variable")
+@patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
-def test_on_dag_run_failed_cleans_up_watcher_backup_variable(mock_emit_usage_metrics_if_enabled, mock_delete_variable):
+def test_on_dag_run_failed_cleans_up_watcher_backup_variable(
+    mock_emit_usage_metrics_if_enabled, mock_delete_variable_isolated_session
+):
     with DbtDag(
         project_config=ProjectConfig(
             DBT_ROOT_PATH / "jaffle_shop",
@@ -371,4 +393,30 @@ def test_on_dag_run_failed_cleans_up_watcher_backup_variable(mock_emit_usage_met
 
     on_dag_run_failed(dag_run, msg="test failed")
 
-    mock_delete_variable.assert_called()
+    mock_delete_variable_isolated_session.assert_called()
+
+
+@pytest.mark.integration
+@patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+@patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
+def test_on_dag_run_success_cleans_up_watcher_backup_variable(
+    mock_emit_usage_metrics_if_enabled, mock_delete_variable_isolated_session
+):
+    with DbtDag(
+        project_config=ProjectConfig(
+            DBT_ROOT_PATH / "jaffle_shop",
+        ),
+        profile_config=profile_config,
+        execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER),
+        start_date=datetime(2023, 1, 1),
+        dag_id="watcher_dag_with_backup_on_success",
+    ) as dag:
+        pass
+
+    run_id = str(uuid.uuid1())
+    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
+    dag_run = create_dag_run(dag, run_id, run_after)
+
+    on_dag_run_success(dag_run, msg="test success")
+
+    mock_delete_variable_isolated_session.assert_called()

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -2,6 +2,7 @@ import logging
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
@@ -351,20 +352,19 @@ class TestCleanupWatcherProducerBackups:
 
     @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
     def test_deletes_variable_for_producer_in_serialized_dag(self, mock_delete_variable_isolated_session):
-        """In a real deployment ``dag`` is a SerializedDAG, not the live DAG built by user code (#2880):
-        its tasks only expose the operator type via the ``task_type`` property, not ``__class__.__name__``."""
-        if AIRFLOW_VERSION < Version("3.0"):
-            from airflow.serialization.serialized_objects import SerializedDAG
-        else:
-            from airflow.serialization.definitions.dag import SerializedDAG
+        """Airflow 3's SerializedBaseOperator has no ``_task_type`` attribute at all (#2880) --
+        only ``task_type`` -- so the class name lookup must use that, not fall through to the
+        generic ``SerializedBaseOperator`` class name. Uses a bare stand-in rather than a real
+        ``SerializedDAG`` round-trip, which needs a fully migrated metadata DB."""
+        fake_task = SimpleNamespace(
+            task_id="dbt_producer_watcher",
+            _task_module="cosmos.operators.watcher",
+            task_type="DbtProducerWatcherOperator",
+            task_group=None,
+        )
+        fake_dag = SimpleNamespace(task_dict={"dbt_producer_watcher": fake_task})
 
-        with DAG("watcher_dag_serialized", start_date=datetime(2022, 1, 1)) as dag:
-            DbtProducerWatcherOperator(project_dir=".", profile_config=None)
-
-        serialized_dag = SerializedDAG.from_dict(SerializedDAG.to_dict(dag))
-        assert serialized_dag.task_dict["dbt_producer_watcher"].__class__.__name__ != "DbtProducerWatcherOperator"
-
-        _cleanup_watcher_producer_backups(serialized_dag, "watcher_dag_serialized", "run123")
+        _cleanup_watcher_producer_backups(fake_dag, "watcher_dag_serialized", "run123")
 
         expected_key = _xcom_backup_variable_key("watcher_dag_serialized", None, "run123")
         mock_delete_variable_isolated_session.assert_called_once_with(expected_key)

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -378,9 +378,12 @@ class TestCleanupWatcherProducerBackups:
 @pytest.mark.integration
 @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
-def test_on_dag_run_failed_cleans_up_watcher_backup_variable(
+def test_on_dag_run_hooks_clean_up_watcher_backup_variable(
     mock_emit_usage_metrics_if_enabled, mock_delete_variable_isolated_session
 ):
+    """Covers both terminal-state hooks against a single real DAG run: ``dag.test()`` builds a
+    real WATCHER ``DbtDag`` run via Airflow's Task SDK, which is comparatively slow, so both
+    hooks share the one run rather than each paying for their own."""
     with DbtDag(
         project_config=ProjectConfig(
             DBT_ROOT_PATH / "jaffle_shop",
@@ -397,31 +400,9 @@ def test_on_dag_run_failed_cleans_up_watcher_backup_variable(
     dag_run = create_dag_run(dag, run_id, run_after)
 
     on_dag_run_failed(dag_run, msg="test failed")
-
     mock_delete_variable_isolated_session.assert_called()
 
-
-@pytest.mark.integration
-@patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
-@patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
-def test_on_dag_run_success_cleans_up_watcher_backup_variable(
-    mock_emit_usage_metrics_if_enabled, mock_delete_variable_isolated_session
-):
-    with DbtDag(
-        project_config=ProjectConfig(
-            DBT_ROOT_PATH / "jaffle_shop",
-        ),
-        profile_config=profile_config,
-        execution_config=ExecutionConfig(execution_mode=ExecutionMode.WATCHER),
-        start_date=datetime(2023, 1, 1),
-        dag_id="watcher_dag_with_backup_on_success",
-    ) as dag:
-        pass
-
-    run_id = str(uuid.uuid1())
-    run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
-    dag_run = create_dag_run(dag, run_id, run_after)
+    mock_delete_variable_isolated_session.reset_mock()
 
     on_dag_run_success(dag_run, msg="test success")
-
     mock_delete_variable_isolated_session.assert_called()

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -148,6 +148,27 @@ def create_dag_run(dag: DAG, run_id: str, run_after: datetime) -> DagRun:
     return dag_run
 
 
+def create_dag_run_without_execution(dag: DAG, run_id: str, run_after: datetime) -> DagRun:
+    """Build a DagRun for ``dag`` without persisting it or running any of its tasks.
+
+    ``on_dag_run_failed``/``on_dag_run_success`` only ever read ``dag_run.dag_id``,
+    ``dag_run.run_id`` and ``dag_run.get_dag()`` (the latter just returns the plain ``.dag``
+    attribute, not a DB lookup), so a bare, unpersisted DagRun is enough -- no need to run the
+    DAG's tasks via ``create_dag_run``'s ``dag.test()`` path, which for a WATCHER DAG with
+    deferrable consumer tasks doesn't complete inside Airflow 3.1+'s in-process trigger runner (a
+    pre-existing issue unrelated to this cleanup logic). Airflow 3.1+'s Task SDK ``DAG`` also has
+    no ``create_dagrun()`` method to fall back on, unlike earlier versions.
+    """
+    if AIRFLOW_VERSION < Version("3.1"):
+        return create_dag_run(dag, run_id, run_after)
+
+    from airflow.utils.types import DagRunType
+
+    dag_run = DagRun(dag_id=dag.dag_id, run_id=run_id, run_after=run_after, run_type=DagRunType.MANUAL)
+    dag_run.dag = dag
+    return dag_run
+
+
 @pytest.mark.integration
 @patch("cosmos.listeners.dag_run_listener.telemetry.emit_usage_metrics_if_enabled")
 def test_on_dag_run_success(mock_emit_usage_metrics_if_enabled, caplog):
@@ -381,9 +402,7 @@ class TestCleanupWatcherProducerBackups:
 def test_on_dag_run_hooks_clean_up_watcher_backup_variable(
     mock_emit_usage_metrics_if_enabled, mock_delete_variable_isolated_session
 ):
-    """Covers both terminal-state hooks against a single real DAG run: ``dag.test()`` builds a
-    real WATCHER ``DbtDag`` run via Airflow's Task SDK, which is comparatively slow, so both
-    hooks share the one run rather than each paying for their own."""
+    """Covers both terminal-state hooks against a single real DAG run."""
     with DbtDag(
         project_config=ProjectConfig(
             DBT_ROOT_PATH / "jaffle_shop",
@@ -397,7 +416,7 @@ def test_on_dag_run_hooks_clean_up_watcher_backup_variable(
 
     run_id = str(uuid.uuid1())
     run_after = datetime.now(timezone.utc) - timedelta(seconds=1)
-    dag_run = create_dag_run(dag, run_id, run_after)
+    dag_run = create_dag_run_without_execution(dag, run_id, run_after)
 
     on_dag_run_failed(dag_run, msg="test failed")
     mock_delete_variable_isolated_session.assert_called()

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -8,8 +8,13 @@ from unittest.mock import patch
 import pytest
 from airflow.models import DAG, DagRun
 from airflow.utils.state import State
-from airflow.utils.task_group import TaskGroup
 from packaging.version import Version
+
+try:
+    # Airflow 3.1 onwards
+    from airflow.sdk import TaskGroup
+except ImportError:
+    from airflow.utils.task_group import TaskGroup
 
 from cosmos import DbtRunLocalOperator, ProfileConfig, ProjectConfig
 from cosmos.airflow.dag import DbtDag

--- a/tests/listeners/test_dag_run_listener.py
+++ b/tests/listeners/test_dag_run_listener.py
@@ -30,6 +30,7 @@ from cosmos.constants import (
 )
 from cosmos.listeners.dag_run_listener import (
     _cleanup_watcher_producer_backups,
+    _cleanup_watcher_producer_backups_safely,
     get_cosmos_telemetry_metadata,
     on_dag_run_failed,
     on_dag_run_success,
@@ -375,6 +376,16 @@ class TestCleanupWatcherProducerBackups:
         _cleanup_watcher_producer_backups(dag, "watcher_dag", "run123")  # should not raise
 
         mock_delete_by_ids.assert_called_once()
+
+    @patch("cosmos.listeners.dag_run_listener._cleanup_watcher_producer_backups", side_effect=RuntimeError("boom"))
+    def test_safely_swallows_errors_from_cleanup(self, mock_cleanup):
+        """Covers ``_cleanup_watcher_producer_backups_safely``'s own try/except, distinct from
+        ``_cleanup_watcher_producer_backups``'s per-task one covered by ``test_swallows_per_task_errors``."""
+        dag_run = SimpleNamespace(dag_id="watcher_dag", run_id="run123")
+
+        _cleanup_watcher_producer_backups_safely(SimpleNamespace(), dag_run)  # should not raise
+
+        mock_cleanup.assert_called_once()
 
     @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
     def test_deletes_variable_for_producer_in_serialized_dag(self, mock_delete_variable_isolated_session):

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -378,21 +378,25 @@ class TestDeleteXcomBackupVariable:
 class TestDeleteXcomBackupVariableByIds:
     """Covers the id-based variant used by the DAG-run listener to clean up orphaned backups."""
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_deletes_variable(self, mock_delete_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_deletes_variable(self, mock_delete_variable_isolated_session):
         _delete_xcom_backup_variable_by_ids("my_dag", "my_group", "test_run")
 
-        mock_delete_variable.assert_called_once_with(_xcom_backup_variable_key("my_dag", "my_group", "test_run"))
+        mock_delete_variable_isolated_session.assert_called_once_with(
+            _xcom_backup_variable_key("my_dag", "my_group", "test_run")
+        )
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_no_task_group(self, mock_delete_variable):
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_no_task_group(self, mock_delete_variable_isolated_session):
         _delete_xcom_backup_variable_by_ids("my_dag", None, "test_run")
 
-        mock_delete_variable.assert_called_once_with(_xcom_backup_variable_key("my_dag", None, "test_run"))
+        mock_delete_variable_isolated_session.assert_called_once_with(
+            _xcom_backup_variable_key("my_dag", None, "test_run")
+        )
 
-    @patch("cosmos.operators._watcher.xcom.delete_variable")
-    def test_ignores_key_error(self, mock_delete_variable):
-        mock_delete_variable.side_effect = KeyError("not found")
+    @patch("cosmos.operators._watcher.xcom.delete_variable_isolated_session")
+    def test_ignores_key_error(self, mock_delete_variable_isolated_session):
+        mock_delete_variable_isolated_session.side_effect = KeyError("not found")
 
         _delete_xcom_backup_variable_by_ids("my_dag", "my_group", "test_run")  # should not raise
 

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -25,6 +25,7 @@ from cosmos.operators._watcher.state import (
 from cosmos.operators._watcher.xcom import (
     _backup_xcom_to_variable,
     _delete_xcom_backup_variable,
+    _delete_xcom_backup_variable_by_ids,
     _init_xcom_backup,
     _persist_backup,
     _restore_xcom_from_variable,
@@ -372,6 +373,28 @@ class TestDeleteXcomBackupVariable:
         mock_delete_variable.side_effect = KeyError("not found")
 
         _delete_xcom_backup_variable(context)  # should not raise
+
+
+class TestDeleteXcomBackupVariableByIds:
+    """Covers the id-based variant used by the DAG-run listener to clean up orphaned backups."""
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_deletes_variable(self, mock_delete_variable):
+        _delete_xcom_backup_variable_by_ids("my_dag", "my_group", "test_run")
+
+        mock_delete_variable.assert_called_once_with(_xcom_backup_variable_key("my_dag", "my_group", "test_run"))
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_no_task_group(self, mock_delete_variable):
+        _delete_xcom_backup_variable_by_ids("my_dag", None, "test_run")
+
+        mock_delete_variable.assert_called_once_with(_xcom_backup_variable_key("my_dag", None, "test_run"))
+
+    @patch("cosmos.operators._watcher.xcom.delete_variable")
+    def test_ignores_key_error(self, mock_delete_variable):
+        mock_delete_variable.side_effect = KeyError("not found")
+
+        _delete_xcom_backup_variable_by_ids("my_dag", "my_group", "test_run")  # should not raise
 
 
 class TestRestoreXcomFromVariable:


### PR DESCRIPTION
## Summary
- The WATCHER producer backs up its per-node dbt statuses to an Airflow Variable so a retry can restore them (`cosmos/operators/_watcher/xcom.py`). It's deleted on success or after a retry restores it, but a producer that fails with no retries left -- or never gets the chance to run its own callbacks at all, e.g. a scheduler crash -- leaves it behind permanently. Airflow Variables aren't tied to the lifecycle of any DAG, run, or task instance, so nothing else ever cleans them up.
- Added `_delete_xcom_backup_variable_by_ids(dag_id, task_group_id, run_id)` to `cosmos/operators/_watcher/xcom.py` -- an id-based variant of the existing delete helper that doesn't need a live task-execution context.
- Added `_cleanup_watcher_producer_backups` to `cosmos/listeners/dag_run_listener.py`, which sweeps the DAG's watcher producer tasks and deletes any surviving backup Variable. It's called from **both** `on_dag_run_success` and `on_dag_run_failed`, each wrapped so a cleanup failure can never affect the existing telemetry emission in that hook. Both hooks are needed: for a `DbtDag`, root consumer tasks run with `trigger_rule="always"`, so a run can reach `success` even though its producer task failed and never got to run its own cleanup callbacks.
- Since the DAG run has already reached a terminal state by the time either hook fires, no further task retries are possible, so it's always safe to delete.

Fixes #2823

## Bugs found and fixed while validating against a live deployment
Testing this against a real Airflow 3 environment surfaced two problems with the initial version of this fix, both now fixed:

1. **The producer task was never matched in production.** The match checked `getattr(task, "_task_type", None)`, but that attribute doesn't exist on Airflow 3's `SerializedDAG`/`SerializedBaseOperator` (only on the live, unserialized operator) -- it silently fell through to the generic `SerializedBaseOperator` class name and never matched, so cleanup never actually deleted anything outside of unit tests. Fixed by using `task_type` (no leading underscore), which reflects the real operator class on both a live operator and a serialized one, on Airflow 2 and 3 alike.
2. **The fix as written crashed the scheduler.** `on_dag_run_success`/`on_dag_run_failed` fire from inside `DagRun.update_state()`'s guarded transaction. `Variable.delete()`'s default session commits that same guarded, thread-local scoped session, which trips Airflow's `CommitProhibitorGuard` ("UNEXPECTED COMMIT -- THIS WILL BREAK HA LOCKS!") and crashed the scheduler in a loop on every DAG run reaching a terminal state. Added `delete_variable_isolated_session` to `cosmos/airflow/compatibility.py`, which uses a session bound directly to `settings.engine` instead of the ambient scoped session, avoiding the collision. This is used only for the DAG-run-listener cleanup path; the operator's own task-context cleanup is unaffected (it runs in a separate process with no such guard).

## Test plan
- [x] Unit tests for `_cleanup_watcher_producer_backups` (producer in a task group / no task group / non-watcher DAG no-op / per-task errors are swallowed / producer matched correctly on a real `SerializedDAG` round-trip -- the regression test for bug 1 above).
- [x] Unit tests for the id-based delete helper, updated to assert against `delete_variable_isolated_session`.
- [x] Integration tests building a real WATCHER `DbtDag` + `DagRun` and asserting **both** `on_dag_run_success` and `on_dag_run_failed` trigger the delete.
- [x] `pre-commit run` (ruff, black, mypy, etc.) passes.
- [x] Manually verified end-to-end against a live Airflow 3 deployment: reproduced the orphaned Variable with the pre-fix code, confirmed the two bugs above, then confirmed the fixed code deletes the Variable and the scheduler no longer crashes.
- [x] Verified the scheduler-crash fix directly against Airflow 2.10 as well: reproduced Airflow's own `CommitProhibitorGuard` around a real session and confirmed `delete_variable_isolated_session` does not trip it (unlike a `create_session(scoped=False)`-based approach, which doesn't exist prior to Airflow 3 and was rejected for that reason).
