### PR TITLE
docs: clarify callback support under ExecutionMode.WATCHER

### DIFF
--- a/docs/getting_started/astro-cli-quickstart.rst
+++ b/docs/getting_started/astro-cli-quickstart.rst
@@ -20,7 +20,7 @@ Prerequisites
 
 - `Python <https://www.python.org/downloads/>`_
 - Install `git <https://git-scm.com/install/>`_
-- Install the `Astro CLI <https://docs.astronomer.io/astro/cli/install-cli>`__
+- Install the `Astro CLI <https://www.astronomer.io/docs/astro/cli/install-cli>`__
 - A container manager such as Podman, Docker, or Orbstack. When you install the Astro CLI, it automatically installs Airflow and Podman, so you can immediately start working with Dags after installing the CLI. If you need to use Docker instead of Podman, see `Switch between Docker and Podman <https://www.astronomer.io/docs/astro/cli/switch-container-management>`__.
 - (Optional) Install a database viewer. This guide uses `dBeaver <https://dbeaver.io/download/>`_
 

--- a/docs/getting_started/astro.rst
+++ b/docs/getting_started/astro.rst
@@ -14,7 +14,7 @@ Pre-requisites
 
 To get started, you should have:
 
-- The Astro CLI installed. You can find installation instructions `here <https://docs.astronomer.io/astro/cli/install-cli>`_.
+- The Astro CLI installed. You can find installation instructions `here <https://www.astronomer.io/docs/astro/cli/install-cli>`_.
 - An Astro CLI project. You can initialize a new project with ``astro dev init``.
 - A dbt project. The `jaffle shop example <https://github.com/dbt-labs/jaffle-shop-classic>`_ is a good example.
 

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -510,6 +510,13 @@ Callback support
 
 The ``DbtProducerWatcherOperator`` and ``DbtConsumerWatcherSensor`` will use the user-defined callback function similar to ``ExecutionMode.LOCAL`` mode.
 
+A ``callback`` set via ``operator_args`` (or on ``DbtDag``/``DbtTaskGroup``) fires once per DAG run, on the
+producer task (``dbt_producer_watcher``), since that is the task that actually runs ``dbt build``. The callback
+receives the ``run_results.json`` for the whole project rather than a single model, because the per-model consumer
+sensor tasks do not invoke dbt in their normal execution path. Note that on a consumer sensor retry or manual task
+clear, the consumer falls back to running that single model's dbt command directly and the callback fires again at
+that point, with the retried model's own ``run_results.json``.
+
 You can define different ``callback`` behaviors for producer and consumer nodes by using ``operator_args`` to configure the consumer callback and ``setup_operator_args`` to override the callback for the producer, as described below.
 
 .. _watcher-source-freshness:

--- a/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
+++ b/docs/guides/run_dbt/airflow-worker/watcher-execution-mode.rst
@@ -508,14 +508,20 @@ Advanced config
 Callback support
 ++++++++++++++++
 
-The ``DbtProducerWatcherOperator`` and ``DbtConsumerWatcherSensor`` will use the user-defined callback function similar to ``ExecutionMode.LOCAL`` mode.
+.. note::
+   This section covers the Cosmos ``callback`` parameter described in :ref:`callbacks` (for post-execution actions
+   such as uploading dbt artifacts). It is unrelated to Airflow's native ``on_retry_callback``/``on_failure_callback``
+   task callbacks used elsewhere on this page (see :ref:`producer-status-backup`), and to the ``freshness_callback``
+   described below in :ref:`watcher-source-freshness`.
+
+The ``DbtProducerWatcherOperator`` uses the user-defined ``callback`` function similar to ``ExecutionMode.LOCAL`` mode.
 
 A ``callback`` set via ``operator_args`` (or on ``DbtDag``/``DbtTaskGroup``) fires once per DAG run, on the
 producer task (``dbt_producer_watcher``), since that is the task that actually runs ``dbt build``. The callback
-receives the ``run_results.json`` for the whole project rather than a single model, because the per-model consumer
-sensor tasks do not invoke dbt in their normal execution path. Note that on a consumer sensor retry or manual task
-clear, the consumer falls back to running that single model's dbt command directly and the callback fires again at
-that point, with the retried model's own ``run_results.json``.
+receives the ``run_results.json`` for the whole project rather than a single model, because the per-model
+``DbtConsumerWatcherSensor`` tasks do not invoke dbt in their normal execution path. Note that on a consumer sensor
+retry or manual task clear, the consumer falls back to running that single model's dbt command directly and the
+callback fires again at that point, with the retried model's own ``run_results.json``.
 
 You can define different ``callback`` behaviors for producer and consumer nodes by using ``operator_args`` to configure the consumer callback and ``setup_operator_args`` to override the callback for the producer, as described below.
 

--- a/docs/guides/run_dbt/callbacks/callbacks.rst
+++ b/docs/guides/run_dbt/callbacks/callbacks.rst
@@ -4,14 +4,13 @@ Callbacks
 =========
 
 .. note::
-    Feature available when using ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``.
+    Feature available when using ``ExecutionMode.LOCAL``, ``ExecutionMode.VIRTUALENV``, and ``ExecutionMode.WATCHER``.
 
-    Callbacks are also supported under ``ExecutionMode.WATCHER``, with one important difference: a callback set
-    via ``operator_args`` (or on ``DbtDag``/``DbtTaskGroup``) fires once per DAG run, on the producer task
-    (``dbt_producer_watcher``), which is the task that actually runs ``dbt build``. The per-model consumer sensor
-    tasks do not invoke dbt in their normal execution path, so the callback receives the ``run_results.json`` for
-    the whole project rather than a single model. See :ref:`watcher-execution-mode` for details on configuring
-    separate callbacks for producer and consumer tasks.
+    Under ``ExecutionMode.WATCHER``, a callback set via ``operator_args`` (or on ``DbtDag``/``DbtTaskGroup``) fires
+    once per DAG run, on the producer task (``dbt_producer_watcher``), which is the task that actually runs
+    ``dbt build``. The per-model consumer sensor tasks do not invoke dbt in their normal execution path, so the
+    callback receives the ``run_results.json`` for the whole project rather than a single model. See
+    :ref:`watcher-execution-mode` for details on configuring separate callbacks for producer and consumer tasks.
 
 .. note::
     Since Cosmos v1.15.0, ephemeral dbt models are rendered as ``EmptyOperator`` tasks by default (``RenderConfig.ephemeral_models_as_empty_operator=True``). Because no dbt command runs for these tasks, callbacks are not invoked for ephemeral models. Set ``ephemeral_models_as_empty_operator=False`` to render them as regular dbt run tasks if you rely on callbacks for them.

--- a/docs/guides/run_dbt/callbacks/callbacks.rst
+++ b/docs/guides/run_dbt/callbacks/callbacks.rst
@@ -6,6 +6,13 @@ Callbacks
 .. note::
     Feature available when using ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``.
 
+    Callbacks are also supported under ``ExecutionMode.WATCHER``, with one important difference: a callback set
+    via ``operator_args`` (or on ``DbtDag``/``DbtTaskGroup``) fires once per DAG run, on the producer task
+    (``dbt_producer_watcher``), which is the task that actually runs ``dbt build``. The per-model consumer sensor
+    tasks do not invoke dbt in their normal execution path, so the callback receives the ``run_results.json`` for
+    the whole project rather than a single model. See :ref:`watcher-execution-mode` for details on configuring
+    separate callbacks for producer and consumer tasks.
+
 .. note::
     Since Cosmos v1.15.0, ephemeral dbt models are rendered as ``EmptyOperator`` tasks by default (``RenderConfig.ephemeral_models_as_empty_operator=True``). Because no dbt command runs for these tasks, callbacks are not invoked for ephemeral models. Set ``ephemeral_models_as_empty_operator=False`` to render them as regular dbt run tasks if you rely on callbacks for them.
 
@@ -205,6 +212,7 @@ Users can use the same approach to call the data observability platform `monteca
 Limitations and Contributions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Callback support is available only when using ``ExecutionMode.LOCAL`` and ``ExecutionMode.VIRTUALENV``.
+Callback support is available when using ``ExecutionMode.LOCAL``, ``ExecutionMode.VIRTUALENV``, and
+``ExecutionMode.WATCHER`` (see the note above for the granularity difference under ``ExecutionMode.WATCHER``).
 Contributions to extend this functionality to other execution modes are welcome and encouraged. You can reference the
 implementation for ``ExecutionMode.LOCAL`` to add support for other modes.


### PR DESCRIPTION
## Summary
- The callbacks guide said callback support was limited to `ExecutionMode.LOCAL` and `ExecutionMode.VIRTUALENV`, which was stale and contradicted the watcher execution mode guide, which already documents callback support for `ExecutionMode.WATCHER`.
- Adds a note explaining that under `WATCHER`, a callback set via `operator_args` (or `DbtDag`/`DbtTaskGroup`) fires once per DAG run on the producer task (`dbt_producer_watcher`), with the whole-project `run_results.json`, rather than per-model — since the per-model consumer sensor tasks don't invoke dbt in their normal execution path.
- Also expands the existing "Callback support" section in the watcher execution mode guide with the same granularity detail, plus a note on the consumer retry/fallback path (which does invoke dbt per-model and re-fires the callback).
- Prompted by a customer question in Slack about whether callbacks work under `WATCHER`; verified the behavior against `cosmos/operators/watcher.py` and `cosmos/operators/local.py` before writing the docs.

## Test plan
- [x] `hatch run docs:build` — succeeds with no new warnings
- [x] `scripts/check_docs_style.py` on both edited files — clean
- [x] pre-commit hooks passed on commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)