### PR TITLE
docs: link AGENTS.md's test matrix to pyproject.toml instead of hardcoding versions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,7 +37,7 @@ hatch run tests.py3.10-3.1-1.9:type-check
 pre-commit run mypy --all-files
 ```
 
-Other available matrix versions: Python `3.10`, `3.11`, `3.12`, `3.13`, `3.14` × Airflow `2.9`, `2.10`, `2.11`, `3.0`, `3.1`, `3.2`, `3.3` × dbt `1.5`–`2.0`. Python `3.14` is only wired into CI for Airflow `3.2`/`3.3` with dbt `1.12` (see the pinned lockfiles).
+Other available matrix versions: see [`[[tool.hatch.envs.tests.matrix]]`](https://github.com/astronomer/astronomer-cosmos/blob/main/pyproject.toml#L180-L183) in `pyproject.toml` for the full, current Python × Airflow × dbt matrix.
 
 ### Building and Serving Docs
 


### PR DESCRIPTION
## Summary
- AGENTS.md's test-matrix line hardcoded the Python × Airflow × dbt version list, which meant every matrix change required a manual update here too — this PR originally existed because that line had gone stale (missing Airflow 3.3).
- Since opening this PR, `main` independently added Airflow 3.3 (and Python 3.14) to that same line via #2903, which made the original one-line fix a no-op once this branch was rebased.
- Per review feedback, replaced the hardcoded list with a link to `pyproject.toml`'s `[[tool.hatch.envs.tests.matrix]]` section instead, so this line can't go stale again.

## Test plan
- [x] Verified the linked lines (`pyproject.toml#L180-L183`) match the current matrix on `main`.
- [x] No code changes; docs-only diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)