### PR TITLE
Fix watcher multi-parent test aggregation: credit all parent models

### DIFF
--- a/cosmos/operators/_watcher/aggregation.py
+++ b/cosmos/operators/_watcher/aggregation.py
@@ -23,20 +23,25 @@ def accumulate_test_result(
     status: str,
     tests_per_model: dict[str, list[str]],
     test_results_per_model: dict[str, dict[str, str]],
-) -> str | None:
-    """Record a test's terminal status into test_results_per_model for its parent model.
+) -> list[str]:
+    """Record a test's terminal status into test_results_per_model for every parent model.
+
+    A test can belong to more than one model (e.g. a ``relationships`` test depends on
+    both the model it is defined on and the model it references), so it may appear under
+    several keys in ``tests_per_model``; its status is recorded under each.
 
     Results are keyed by ``test_unique_id`` so that a duplicated or replayed log line for
     the same test (the Kubernetes log reader can replay recent lines after an interruption)
     overwrites its entry instead of being counted as another distinct test.
 
-    Returns the parent model's unique_id if found, else None.
+    Returns the unique_ids of all parent models the test was recorded for (empty if none).
     """
+    matched_model_uids: list[str] = []
     for model_uid, test_uids in tests_per_model.items():
         if test_unique_id in test_uids:
             test_results_per_model.setdefault(model_uid, {})[test_unique_id] = status
-            return model_uid
-    return None
+            matched_model_uids.append(model_uid)
+    return matched_model_uids
 
 
 def get_aggregated_test_status(
@@ -86,8 +91,8 @@ def push_test_result_or_aggregate(
     :param task_instance: The Airflow task instance used for XCom push.
     """
     with _test_results_lock:
-        model_uid = accumulate_test_result(test_unique_id, status, tests_per_model, test_results_per_model)
-        if model_uid is not None:
+        model_uids = accumulate_test_result(test_unique_id, status, tests_per_model, test_results_per_model)
+        for model_uid in model_uids:
             aggregated = get_aggregated_test_status(model_uid, tests_per_model, test_results_per_model)
             if aggregated is not None:
                 safe_xcom_push(

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1625,6 +1625,39 @@ def test_tests_per_model_populated():
     assert any("unique_customers_customer_id" in t for t in customers_tests)
 
 
+def test_tests_per_model_lists_multi_parent_test_under_every_parent():
+    """A test with multiple parents (e.g. a relationships test) is listed under each parent.
+
+    This is the graph-level fact the watcher test-aggregation logic relies on: a shared
+    test must be recorded/aggregated for every parent model, not just one. Asserting it
+    against a real loaded graph keeps the aggregation unit tests honest — they hand-build
+    ``tests_per_model``, and this guards that the builder actually produces that shape.
+    """
+    project_config = ProjectConfig(
+        dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, manifest_path=SAMPLE_MANIFEST
+    )
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profiles_yml_filepath=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME / "profiles.yml",
+    )
+    execution_config = ExecutionConfig(dbt_project_path=project_config.dbt_project_path)
+    dbt_graph = DbtGraph(
+        project=project_config,
+        execution_config=execution_config,
+        profile_config=profile_config,
+    )
+    dbt_graph.load()
+
+    # jaffle_shop's relationships test on orders.customer_id depends on both orders and
+    # customers, so it must appear in tests_per_model under BOTH.
+    shared_test_id = "test.jaffle_shop.relationships_orders_customer_id__customer_id__ref_customers_.c6ec7f58f2"
+    orders_id = "model.jaffle_shop.orders"
+    customers_id = "model.jaffle_shop.customers"
+    assert shared_test_id in dbt_graph.tests_per_model[orders_id]
+    assert shared_test_id in dbt_graph.tests_per_model[customers_id]
+
+
 def test_tests_per_model_empty_when_no_tests():
     project_config = ProjectConfig(
         dbt_project_path=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME, manifest_path=SAMPLE_MANIFEST

--- a/tests/operators/_watcher/test_aggregation.py
+++ b/tests/operators/_watcher/test_aggregation.py
@@ -18,6 +18,16 @@ TESTS_PER_MODEL = {
     "model.pkg.customers": ["test.pkg.not_null_customers_id"],
 }
 
+# A shared test (e.g. a relationships test) belongs to more than one model: it is defined
+# on ``orders`` and references ``customers``, so it appears under both. ``products`` does
+# not depend on it — it is the negative case that pins down "credited to only the matching
+# parents", not every model.
+TESTS_PER_MODEL_SHARED = {
+    "model.pkg.orders": ["test.pkg.not_null_orders_id", "test.pkg.rel_orders_customer"],
+    "model.pkg.customers": ["test.pkg.not_null_customers_id", "test.pkg.rel_orders_customer"],
+    "model.pkg.products": ["test.pkg.not_null_products_id"],
+}
+
 
 class TestGetTestsStatusXcomKey:
     """Tests for get_tests_status_xcom_key."""
@@ -34,15 +44,25 @@ class TestAccumulateTestResult:
 
     def test_returns_model_uid_when_test_found(self):
         results: dict[str, dict[str, str]] = {}
-        model_uid = accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
-        assert model_uid == "model.pkg.orders"
+        model_uids = accumulate_test_result("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL, results)
+        assert model_uids == ["model.pkg.orders"]
         assert results == {"model.pkg.orders": {"test.pkg.not_null_orders_id": "pass"}}
 
-    def test_returns_none_when_test_not_found(self):
+    def test_returns_empty_when_test_not_found(self):
         results: dict[str, dict[str, str]] = {}
-        model_uid = accumulate_test_result("test.pkg.unknown_test", "pass", TESTS_PER_MODEL, results)
-        assert model_uid is None
+        model_uids = accumulate_test_result("test.pkg.unknown_test", "pass", TESTS_PER_MODEL, results)
+        assert model_uids == []
         assert results == {}
+
+    def test_multi_parent_test_recorded_for_every_parent(self):
+        """A test belonging to several models is recorded for all of them, not just the first."""
+        results: dict[str, dict[str, str]] = {}
+        model_uids = accumulate_test_result("test.pkg.rel_orders_customer", "pass", TESTS_PER_MODEL_SHARED, results)
+        assert model_uids == ["model.pkg.orders", "model.pkg.customers"]
+        assert results == {
+            "model.pkg.orders": {"test.pkg.rel_orders_customer": "pass"},
+            "model.pkg.customers": {"test.pkg.rel_orders_customer": "pass"},
+        }
 
     def test_accumulates_multiple_results(self):
         results: dict[str, dict[str, str]] = {}
@@ -149,6 +169,43 @@ class TestPushTestResultOrAggregate:
             task_instance=ti,
             key="model__pkg__orders_tests_status",
             value=DbtTestStatus.FAIL,
+        )
+
+    @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
+    def test_multi_parent_test_pushes_xcom_for_every_parent(self, mock_xcom_push: MagicMock):
+        """A shared (multi-parent) test must complete and push each parent's aggregate.
+
+        Regression: crediting the shared test to only the first parent left the other
+        parent's aggregated XCom unpushed, so its test sensor deferred forever.
+        """
+        results: dict[str, dict[str, str]] = {}
+        ti = MagicMock()
+        # Each model's own test plus the shared test complete both models' expected sets.
+        push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL_SHARED, results, ti)
+        push_test_result_or_aggregate("test.pkg.not_null_customers_id", "pass", TESTS_PER_MODEL_SHARED, results, ti)
+        push_test_result_or_aggregate("test.pkg.rel_orders_customer", "pass", TESTS_PER_MODEL_SHARED, results, ti)
+        assert mock_xcom_push.call_count == 2
+        mock_xcom_push.assert_any_call(
+            task_instance=ti, key="model__pkg__orders_tests_status", value=DbtTestStatus.PASS
+        )
+        mock_xcom_push.assert_any_call(
+            task_instance=ti, key="model__pkg__customers_tests_status", value=DbtTestStatus.PASS
+        )
+
+    @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")
+    def test_multi_parent_test_failure_fails_every_parent(self, mock_xcom_push: MagicMock):
+        """A failing shared test fails both parents' aggregates, not just the first."""
+        results: dict[str, dict[str, str]] = {}
+        ti = MagicMock()
+        push_test_result_or_aggregate("test.pkg.not_null_orders_id", "pass", TESTS_PER_MODEL_SHARED, results, ti)
+        push_test_result_or_aggregate("test.pkg.not_null_customers_id", "pass", TESTS_PER_MODEL_SHARED, results, ti)
+        push_test_result_or_aggregate("test.pkg.rel_orders_customer", "fail", TESTS_PER_MODEL_SHARED, results, ti)
+        assert mock_xcom_push.call_count == 2
+        mock_xcom_push.assert_any_call(
+            task_instance=ti, key="model__pkg__orders_tests_status", value=DbtTestStatus.FAIL
+        )
+        mock_xcom_push.assert_any_call(
+            task_instance=ti, key="model__pkg__customers_tests_status", value=DbtTestStatus.FAIL
         )
 
     @patch("cosmos.operators._watcher.aggregation.safe_xcom_push")


### PR DESCRIPTION
## Description

Under `ExecutionMode.WATCHER` + `TestBehavior.AFTER_EACH`, a dbt test with more than
one parent model (e.g. a `relationships` test) is listed under every parent in
`tests_per_model` but its result was credited to only the first parent in
`accumulate_test_result` (early `return`). The other parent's expected-test set never
completed, so its `<model>_tests_status` XCom was never pushed and its test sensor
deferred until the producer terminated (then resolved unverified on producer success,
or `PRODUCER_FAILED` on producer failure).

### Fix
`accumulate_test_result` had an early `return` that stopped at the first parent. Drop it so
the result is recorded under every parent (return type `str | None` -> `list[str]`), and have
`push_test_result_or_aggregate` aggregate/push for each parent returned. Single-parent tests
are unchanged (the loop matches exactly one model); locking and keying are untouched.

Tests: added regression coverage in `tests/operators/_watcher/test_aggregation.py` (pass/fail
for a shared test, plus a no-shared-test control) and `tests/dbt/test_graph.py`.

## Related Issue(s)

closes #2900 

## Breaking Change?

No.

## Checklist

- [ ] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
