### PR TITLE
Fix mypy no-any-return error in `_resolve_env_var`

### DIFF
--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -58,7 +58,7 @@ def _resolve_env_var(template_str: str) -> str:
         return os.getenv(name, default)
 
     template = Template(template_str)
-    rendered = template.render(env_var=env_var)
+    rendered: str = template.render(env_var=env_var)
     return rendered
 
 


### PR DESCRIPTION
## Description

mypy 2.2.0 flags a new error that fails the Type-Check job on the Dependabot bump of `mirrors-mypy` to v2.2.0 (#2897):

```
cosmos/dbt/project.py:62: error: Returning Any from function declared to return "str"  [no-any-return]
```

`jinja2.Template.render()` resolves to `Any` in the pre-commit mypy environment, so `_resolve_env_var` was returning `Any` from a function declared to return `str`. This annotates the intermediate variable as `str`, making the return type explicit. No runtime behaviour change.

## Verification

Ran the Type-Check command (`pre-commit run mypy`) locally against both mypy pins:

- with the v2.2.0 rev from #2897: the `project.py:62` error is reproduced on `main` and gone with this change
- with the current v2.1.0 pin: still passes (also enforced by the commit hook)

Once this merges, #2897 can be rebased and its Type-Check should go green.

## Note for reviewers

The CI `type-check` script runs `pre-commit run mypy --files cosmos/**/*` in a shell without `globstar`, so it only checks files exactly two levels deep (46 files vs 121 locally). Running mypy on the full tree locally also surfaces 4 pre-existing `unused-ignore` errors in `cosmos/provider_info.py` and `cosmos/operators/_asynchronous/{databricks,bigquery}.py` that CI never sees. Left out of scope here to keep this PR tiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)