### PR TITLE
Document container command and image ENTRYPOINT handling for Kubernetes modes

### DIFF
--- a/cosmos/operators/_k8s_common.py
+++ b/cosmos/operators/_k8s_common.py
@@ -145,7 +145,8 @@ def build_kube_args(operator: DbtK8sOperator, context: Context, cmd_flags: list[
     ``cmds`` is preserved exactly as supplied by the user and never reassigned here. For the
     full behavior (unset ``cmds`` vs. ``["dbt"]`` vs. a custom wrapper, and the ``dbt dbt ...``
     pitfall when the image ``ENTRYPOINT`` is itself ``dbt``), see the "Container command and
-    image ENTRYPOINT" section of the Kubernetes execution mode guide (:ref:`kubernetes`).
+    image ENTRYPOINT" section of the Kubernetes execution mode guide:
+    https://astronomer.github.io/astronomer-cosmos/guides/run_dbt/container/kubernetes.html
     """
     # For the first round, we're going to assume that the command is dbt
     # This means that we don't have openlineage support, but we will create a ticket

--- a/cosmos/operators/_k8s_common.py
+++ b/cosmos/operators/_k8s_common.py
@@ -142,21 +142,10 @@ def _build_env_vars(env: dict[str, str | bytes | PathLike[Any]], existing_env_va
 def build_kube_args(operator: DbtK8sOperator, context: Context, cmd_flags: list[str] | None = None) -> None:
     """Build the dbt command, set env vars, and assign the dbt ``arguments`` on the operator.
 
-    ``cmds`` is preserved exactly as supplied by the user and never reassigned here:
-
-    - If ``cmds`` is unset, the full dbt command (including the executable) is passed as
-      ``arguments`` and ``cmds`` is left untouched, so the container image's ``ENTRYPOINT``
-      (if any) is preserved. This matters for images whose ``ENTRYPOINT`` performs setup,
-      such as sourcing secrets injected by a sidecar, before running ``dbt``.
-    - If ``cmds`` is exactly the dbt executable (``["dbt"]``), the executable is stripped from
-      ``arguments`` to avoid running ``dbt dbt ...``.
-    - If ``cmds`` is a custom wrapper (e.g. ``["/custom-entrypoint.sh"]``), it is kept as the
-      container command and the full dbt command (including the executable) is passed as
-      ``arguments`` for the wrapper to invoke.
-
-    Note: if the image's ``ENTRYPOINT`` is itself ``dbt`` (i.e. ``["dbt"]``), leaving ``cmds``
-    unset makes Kubernetes run ``ENTRYPOINT`` + ``arguments`` as ``dbt dbt ...``. Set
-    ``cmds=["dbt"]`` for such images so the leading executable is stripped from ``arguments``.
+    ``cmds`` is preserved exactly as supplied by the user and never reassigned here. For the
+    full behavior (unset ``cmds`` vs. ``["dbt"]`` vs. a custom wrapper, and the ``dbt dbt ...``
+    pitfall when the image ``ENTRYPOINT`` is itself ``dbt``), see the "Container command and
+    image ENTRYPOINT" section of the Kubernetes execution mode guide (:ref:`kubernetes`).
     """
     # For the first round, we're going to assume that the command is dbt
     # This means that we don't have openlineage support, but we will create a ticket

--- a/docs/guides/run_dbt/container/kubernetes.rst
+++ b/docs/guides/run_dbt/container/kubernetes.rst
@@ -76,7 +76,7 @@ For example, to run ``dbt`` through a custom entrypoint script baked into your i
         operator_args={"cmds": ["/custom-entrypoint.sh"]},
     )
 
-This behavior is shared by the ``kubernetes``, ``watcher_kubernetes``, ``aws_eks``, and ``gcp_gke`` execution modes, which all build their Pod command the same way.
+This behavior is shared by the ``kubernetes``, ``watcher_kubernetes``, ``aws_eks``, ``gcp_gke``, and ``watcher_gcp_gke`` execution modes, which all build their Pod command the same way.
 
 Behavior across versions
 ++++++++++++++++++++++++

--- a/docs/guides/run_dbt/container/kubernetes.rst
+++ b/docs/guides/run_dbt/container/kubernetes.rst
@@ -52,6 +52,35 @@ For instance,
 To generate dbt docs and upload them to S3 from the same Pod, use :class:`~cosmos.operators.kubernetes.DbtDocsS3KubernetesOperator` and Cosmos 1.15.0 or higher.
 See :doc:`../../dbt_docs/generating-docs` for an end-to-end example and the extra requirements for this workflow.
 
+Container command and image ENTRYPOINT
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, Cosmos leaves the Pod's ``cmds`` unset and passes the full ``dbt`` command (including the ``dbt`` executable) through the Pod's ``arguments``. This preserves the container image's ``ENTRYPOINT``, so images whose ``ENTRYPOINT`` performs setup before ``dbt`` runs (for example, sourcing secrets injected by a sidecar such as a Vault agent) continue to work.
+
+If you need to run ``dbt`` under a specific container command, set ``cmds`` via ``operator_args``. Cosmos handles the value you provide as follows:
+
+- When ``cmds`` is left unset (the default), the image ``ENTRYPOINT`` runs and the full ``dbt`` command is passed as ``arguments``.
+- When ``cmds`` is set to ``["dbt"]``, Cosmos runs ``dbt`` as the container command and passes the remaining tokens as ``arguments``.
+- When ``cmds`` is set to a custom wrapper (for example ``["/custom-entrypoint.sh"]``), Cosmos preserves it as the container command and passes the full ``dbt`` command, including the executable, as ``arguments``. The wrapper is responsible for invoking ``dbt`` with those arguments.
+
+For example, to run ``dbt`` through a custom entrypoint script baked into your image:
+
+.. code-block:: python
+
+    DbtKubernetesOperator(
+        ...,
+        operator_args={"cmds": ["/custom-entrypoint.sh"]},
+    )
+
+This behavior is shared by the ``kubernetes``, ``watcher_kubernetes``, ``aws_eks``, and ``gcp_gke`` execution modes, which all build their Pod command the same way.
+
+Behavior across versions
+++++++++++++++++++++++++
+
+- In Cosmos versions before 1.15.0, Cosmos did not set ``cmds`` on the Pod. The image ``ENTRYPOINT`` was preserved, and any ``cmds`` supplied through ``operator_args`` was used as provided.
+- In Cosmos 1.15.0, Cosmos began setting ``cmds`` to ``["dbt"]`` unconditionally. Because setting the Pod ``cmds`` overrides the container ``command``, this overrode the image ``ENTRYPOINT`` and also discarded any custom ``cmds`` value (`#2889 <https://github.com/astronomer/astronomer-cosmos/issues/2889>`__).
+- Cosmos 1.15.1 restores the earlier behavior: the image ``ENTRYPOINT`` is preserved by default, a custom ``cmds`` is honored as provided, and ``["dbt"]`` is used as the container command only when set explicitly.
+
 Step-by-step instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/docs/guides/run_dbt/container/kubernetes.rst
+++ b/docs/guides/run_dbt/container/kubernetes.rst
@@ -63,6 +63,10 @@ If you need to run ``dbt`` under a specific container command, set ``cmds`` via 
 - When ``cmds`` is set to ``["dbt"]``, Cosmos runs ``dbt`` as the container command and passes the remaining tokens as ``arguments``.
 - When ``cmds`` is set to a custom wrapper (for example ``["/custom-entrypoint.sh"]``), Cosmos preserves it as the container command and passes the full ``dbt`` command, including the executable, as ``arguments``. The wrapper is responsible for invoking ``dbt`` with those arguments.
 
+.. note::
+
+    If your image's ``ENTRYPOINT`` is itself ``dbt`` (that is, ``["dbt"]``), leaving ``cmds`` unset makes Kubernetes run ``ENTRYPOINT`` followed by ``arguments``, which results in ``dbt dbt ...``. For such images, set ``cmds=["dbt"]`` so Cosmos strips the leading executable from ``arguments``.
+
 For example, to run ``dbt`` through a custom entrypoint script baked into your image:
 
 .. code-block:: python

--- a/docs/guides/run_dbt/container/kubernetes.rst
+++ b/docs/guides/run_dbt/container/kubernetes.rst
@@ -82,7 +82,7 @@ Behavior across versions
 ++++++++++++++++++++++++
 
 - In Cosmos versions before 1.15.0, Cosmos did not set ``cmds`` on the Pod. The image ``ENTRYPOINT`` was preserved, and any ``cmds`` supplied through ``operator_args`` was used as provided.
-- In Cosmos 1.15.0, Cosmos began setting ``cmds`` to ``["dbt"]`` unconditionally. Because setting the Pod ``cmds`` overrides the container ``command``, this overrode the image ``ENTRYPOINT`` and also discarded any custom ``cmds`` value (`#2889 <https://github.com/astronomer/astronomer-cosmos/issues/2889>`__).
+- In Cosmos 1.15.0, Cosmos began setting ``cmds`` to ``["dbt"]`` unconditionally. Because setting the Pod ``cmds`` sets the container ``command`` field, this overrode the image ``ENTRYPOINT`` and also discarded any custom ``cmds`` value (`#2889 <https://github.com/astronomer/astronomer-cosmos/issues/2889>`__).
 - Cosmos 1.15.1 restores the earlier behavior: the image ``ENTRYPOINT`` is preserved by default, a custom ``cmds`` is honored as provided, and ``["dbt"]`` is used as the container command only when set explicitly.
 
 Step-by-step instructions


### PR DESCRIPTION
## Description

Follows up on the review of #2891. Documents how Cosmos builds the Kubernetes Pod
command for dbt operators: by default the image `ENTRYPOINT` is preserved and the
full dbt command (including the executable) is passed as `arguments`; how a
user-supplied `cmds` is handled; the `dbt dbt ...` pitfall for images whose
`ENTRYPOINT` is itself `dbt`; and how this behavior changed across Cosmos 1.14.x,
1.15.0, and 1.15.1.

Adds a "Container command and image ENTRYPOINT" section to the Kubernetes
execution mode guide, including a "Behavior across versions" subsection.

To avoid two copies of the same explanation drifting apart, trims the
`build_kube_args` docstring in `cosmos/operators/_k8s_common.py` to a short summary
plus a link to this guide, making the guide the single source of truth.

## Related Issue(s)

Related to #2891

## Breaking Change?

No.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
