### PR TITLE
docs: Improve privacy policy

### DIFF
--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -1,7 +1,7 @@
 Privacy Notice
 ==============
 
-By default, telemetry is disabled when running Cosmos on Astronomer: since `Astro Runtime <https://github.com/astronomer/astro-runtime>`_ 3.0-2 (released in May 2025), Airflow 3-based Astro Runtime images set the environment variable ``SCARF_NO_ANALYTICS=True``, which turns off Cosmos telemetry.
+On Astronomer, telemetry is disabled by default when using Airflow 3-based `Astro Runtime <https://github.com/astronomer/astro-runtime>`_ images: since Astro Runtime 3.0-2 (released in May 2025), these images set the environment variable ``SCARF_NO_ANALYTICS=True``, which suppresses Cosmos telemetry emission.
 
 This project follows the `Privacy Policy of Astronomer <https://www.astronomer.io/privacy/>`_.
 

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -12,7 +12,7 @@ Since May 2025, `Astro Runtime <https://www.astronomer.io/docs/runtime/runtime-r
 environment variable ``SCARF_NO_ANALYTICS=True``, which disables Cosmos telemetry by default:
 
 - Airflow 3-based images: Astro Runtime 3.0-2 and newer
-- Airflow 2-based images: Astro Runtime 11.18.0, 12.9.0, 13.0.0 and newer
+- Airflow 2-based images: Astro Runtime 11.18.0 and newer (11.x line), 12.9.0 and newer (12.x line), and all 13.x releases
 
 `Astro Private Cloud <https://www.astronomer.io/docs/astro-private-cloud/>`_ (APC) also disables telemetry by
 default, setting both ``SCARF_NO_ANALYTICS=True`` and ``DO_NOT_TRACK=True`` in all Deployments, regardless of
@@ -27,7 +27,7 @@ It assists the project maintainers in better understanding how Cosmos is used.
 Insights gained from this telemetry are critical for prioritizing patches, minor releases, and
 security fixes. Additionally, this information supports key decisions related to the development roadmap.
 
-Deployments and individual users can opt out of analytics by setting the configuration:
+Deployments and individual users can opt out of telemetry by setting the configuration:
 
 .. code-block:: ini
 

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -22,7 +22,7 @@ Collection of Data
 ------------------
 
 Astronomer Cosmos integrates `Scarf <https://about.scarf.sh/>`_ to collect basic telemetry data during operation.
-This data is collected and processed by Scarf in accordance with the `Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`_.
+This data is collected and processed by Scarf in accordance with the `Scarf Privacy Policy`_.
 It assists the project maintainers in better understanding how Cosmos is used.
 Insights gained from this telemetry are critical for prioritizing patches, minor releases, and
 security fixes. Additionally, this information supports key decisions related to the development roadmap.
@@ -38,14 +38,14 @@ or the equivalent environment variable:
 
 .. code-block:: bash
 
-    AIRFLOW__COSMOS__ENABLE_TELEMETRY=false
+    export AIRFLOW__COSMOS__ENABLE_TELEMETRY=false
 
 As described in the `Scarf documentation <https://docs.scarf.sh/gateway/#do-not-track>`_, it is also possible to opt out by setting one of the following environment variables (values are case-insensitive):
 
 .. code-block:: bash
 
-    DO_NOT_TRACK=true
-    SCARF_NO_ANALYTICS=true
+    export DO_NOT_TRACK=true
+    export SCARF_NO_ANALYTICS=true
 
 
 In addition to Scarf's default data collection, Cosmos collects the following information when running Cosmos-powered DAGs:
@@ -97,4 +97,6 @@ When the **dbt docs plugin** is accessed, the following information is collected
 
 Astronomer does not track user-identifiable information through Cosmos telemetry.
 For details on how Scarf handles the collected data, please refer to the
-`Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`__.
+`Scarf Privacy Policy`_.
+
+.. _Scarf Privacy Policy: https://about.scarf.sh/privacy-policy/

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -1,9 +1,22 @@
 Privacy Notice
 ==============
 
-On Astronomer, telemetry is disabled by default when using Airflow 3-based `Astro Runtime <https://github.com/astronomer/astro-runtime>`_ images: since Astro Runtime 3.0-2 (released in May 2025), these images set the environment variable ``SCARF_NO_ANALYTICS=True``, which suppresses Cosmos telemetry emission.
+By default, telemetry is disabled for Astronomer customers — see `Telemetry on Astronomer`_ for details.
 
 This project follows the `Privacy Policy of Astronomer <https://www.astronomer.io/privacy/>`_.
+
+Telemetry on Astronomer
+-----------------------
+
+Since May 2025, `Astro Runtime <https://www.astronomer.io/docs/runtime/runtime-release-notes>`_ images set the
+environment variable ``SCARF_NO_ANALYTICS=True``, which disables Cosmos telemetry by default:
+
+- Airflow 3-based images: Astro Runtime 3.0-2 and newer
+- Airflow 2-based images: Astro Runtime 11.18.0, 12.9.0, 13.0.0 and newer
+
+`Astro Private Cloud <https://www.astronomer.io/docs/astro-private-cloud/>`_ (APC) also disables telemetry by
+default, setting both ``SCARF_NO_ANALYTICS=True`` and ``DO_NOT_TRACK=True`` in all Deployments, regardless of
+the Astro Runtime version.
 
 Collection of Data
 ------------------
@@ -84,4 +97,4 @@ When the **dbt docs plugin** is accessed, the following information is collected
 
 Astronomer does not track user-identifiable information through Cosmos telemetry.
 For details on how Scarf handles the collected data, please refer to the
-`Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`_.
+`Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`__.

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -1,7 +1,7 @@
 Privacy Notice
 ==============
 
-By default, telemetry is disabled for Astronomer customers — see `Telemetry on Astronomer`_ for details.
+By default, telemetry is disabled for Astronomer customers running recent Astro Runtime images or Astro Private Cloud — see `Telemetry on Astronomer`_ for the specific versions.
 
 This project follows the `Privacy Policy of Astronomer <https://www.astronomer.io/privacy/>`_.
 

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -1,25 +1,33 @@
 Privacy Notice
 ==============
 
+By default, telemetry is disabled when running Cosmos on Astronomer: since `Astro Runtime <https://github.com/astronomer/astro-runtime>`_ 3.0-2 (released in May 2025), Airflow 3-based Astro Runtime images set the environment variable ``SCARF_NO_ANALYTICS=True``, which turns off Cosmos telemetry.
+
 This project follows the `Privacy Policy of Astronomer <https://www.astronomer.io/privacy/>`_.
 
 Collection of Data
 ------------------
 
 Astronomer Cosmos integrates `Scarf <https://about.scarf.sh/>`_ to collect basic telemetry data during operation.
-This data assists the project maintainers in better understanding how Cosmos is used.
+This data is collected and processed by Scarf in accordance with the `Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`_.
+It assists the project maintainers in better understanding how Cosmos is used.
 Insights gained from this telemetry are critical for prioritizing patches, minor releases, and
-security fixes. Additionally, this information supports key decisions related to the development road map.
+security fixes. Additionally, this information supports key decisions related to the development roadmap.
 
-Deployments and individual users can opt-out of analytics by setting the configuration:
-
+Deployments and individual users can opt out of analytics by setting the configuration:
 
 .. code-block::
 
-    [cosmos] enable_telemetry False
+    [cosmos]
+    enable_telemetry = False
 
+or the equivalent environment variable:
 
-As described in the `official documentation <https://docs.scarf.sh/gateway/#do-not-track>`_, it is also possible to opt out by setting one of the following environment variables:
+.. code-block::
+
+    AIRFLOW__COSMOS__ENABLE_TELEMETRY=False
+
+As described in the `Scarf documentation <https://docs.scarf.sh/gateway/#do-not-track>`_, it is also possible to opt out by setting one of the following environment variables:
 
 .. code-block::
 
@@ -27,7 +35,7 @@ As described in the `official documentation <https://docs.scarf.sh/gateway/#do-n
     SCARF_NO_ANALYTICS=True
 
 
-In addition to Scarf's default data collection, Cosmos collect the following information when running Cosmos-powered DAGs:
+In addition to Scarf's default data collection, Cosmos collects the following information when running Cosmos-powered DAGs:
 
 - Cosmos version
 - Airflow version
@@ -74,4 +82,6 @@ When the **dbt docs plugin** is accessed, the following information is collected
 - Whether a custom connection ID is used
 - Whether a custom project name is set (Airflow 3 only)
 
-No user-identifiable information (IP included) is stored in Scarf.
+Astronomer does not track user-identifiable information through Cosmos telemetry.
+For details on how Scarf handles the collected data, please refer to the
+`Scarf Privacy Policy <https://about.scarf.sh/privacy-policy/>`_.

--- a/PRIVACY_NOTICE.rst
+++ b/PRIVACY_NOTICE.rst
@@ -29,23 +29,23 @@ security fixes. Additionally, this information supports key decisions related to
 
 Deployments and individual users can opt out of analytics by setting the configuration:
 
-.. code-block::
+.. code-block:: ini
 
     [cosmos]
-    enable_telemetry = False
+    enable_telemetry = false
 
 or the equivalent environment variable:
 
-.. code-block::
+.. code-block:: bash
 
-    AIRFLOW__COSMOS__ENABLE_TELEMETRY=False
+    AIRFLOW__COSMOS__ENABLE_TELEMETRY=false
 
-As described in the `Scarf documentation <https://docs.scarf.sh/gateway/#do-not-track>`_, it is also possible to opt out by setting one of the following environment variables:
+As described in the `Scarf documentation <https://docs.scarf.sh/gateway/#do-not-track>`_, it is also possible to opt out by setting one of the following environment variables (values are case-insensitive):
 
-.. code-block::
+.. code-block:: bash
 
-    DO_NOT_TRACK=True
-    SCARF_NO_ANALYTICS=True
+    DO_NOT_TRACK=true
+    SCARF_NO_ANALYTICS=true
 
 
 In addition to Scarf's default data collection, Cosmos collects the following information when running Cosmos-powered DAGs:


### PR DESCRIPTION
## Description

Improves the privacy notice:

- State upfront that telemetry is disabled by default for Astronomer customers, with a dedicated *Telemetry on Astronomer* section: Astro Runtime images set `SCARF_NO_ANALYTICS=True` since 3.0-2 (Airflow 3-based) and 11.18.0 / 12.9.0 / 13.0.0 (Airflow 2-based), and Astro Private Cloud sets `SCARF_NO_ANALYTICS=True` and `DO_NOT_TRACK=True` for all Deployments.
- Link [Scarf's Privacy Policy](https://about.scarf.sh/privacy-policy/) where we mention data is collected by Scarf.
- Stop making claims about what Scarf stores; say Astronomer does not track user-identifiable information and defer the rest to Scarf's policy.
- Fix the opt-out config example (proper ini format), document the `AIRFLOW__COSMOS__ENABLE_TELEMETRY=False` env var alternative, and fix minor grammar issues.

## Related Issue(s)

None.

## Breaking Change?

No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [ ] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with [Claude Code](https://claude.com/claude-code)