### PR TITLE
Group github/codeql-action updates in a single Dependabot PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,13 @@ updates:
       interval: "daily"
     cooldown:
       default-days: 7
+    groups:
+      # Keep github/codeql-action/init and github/codeql-action/analyze in a single PR.
+      # CodeQL requires init and analyze to run the same version; bumping them in
+      # separate PRs leaves the pair version-skewed and fails the Analyze job.
+      codeql-action:
+        patterns:
+          - "github/codeql-action*"
     labels:
       - "dependencies"
     reviewers:


### PR DESCRIPTION
## Summary

Group `github/codeql-action*` updates into a single Dependabot PR.

CodeQL requires the `init` and `analyze` actions to run the **same** version. Dependabot was opening `github/codeql-action/init` and `github/codeql-action/analyze` as **separate** PRs, so each branch ended up with a version-skewed init/analyze pair and failed the `Analyze (actions)` / `Analyze (python)` jobs. This has recurred every codeql release, e.g. #2922 + #2925 (4.37.2) this week and #2912 + #2913 (4.37.1) last week.

## Fix

Add a `codeql-action` group to the `github-actions` ecosystem so both sub-actions bump together in one PR that lands at a single, consistent version and passes CI.

```yaml
groups:
  codeql-action:
    patterns:
      - "github/codeql-action*"
```

No change to cooldown, schedule, labels, or reviewers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
