### PR TITLE
Reduce `create_test_task_metadata` complexity

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -192,6 +192,28 @@ def _override_profile_if_needed(task_kwargs: dict[str, Any], profile_kwargs_over
         task_kwargs["profile_config"] = modified_profile_config
 
 
+_WATCHER_TO_TEST_EXECUTION_MODE = {
+    ExecutionMode.WATCHER: ExecutionMode.LOCAL,
+    ExecutionMode.WATCHER_KUBERNETES: ExecutionMode.KUBERNETES,
+    ExecutionMode.WATCHER_GCP_GKE: ExecutionMode.GCP_GKE,
+}
+
+
+def _calculate_test_operator_class(execution_mode: ExecutionMode, render_config: RenderConfig | None) -> str:
+    """Resolve the operator class path for a dbt test task.
+
+    For an ``AFTER_ALL`` test running under a ``WATCHER*`` execution mode, the test itself runs in the
+    corresponding concrete mode (LOCAL / KUBERNETES / GCP_GKE); otherwise it uses ``execution_mode`` directly.
+    """
+    if (
+        render_config is not None
+        and render_config.test_behavior == TestBehavior.AFTER_ALL
+        and execution_mode in _WATCHER_TO_TEST_EXECUTION_MODE
+    ):
+        execution_mode = _WATCHER_TO_TEST_EXECUTION_MODE[execution_mode]
+    return calculate_operator_class(execution_mode=execution_mode, dbt_class="DbtTest")
+
+
 def create_test_task_metadata(
     test_task_name: str,
     execution_mode: ExecutionMode,
@@ -255,21 +277,7 @@ def create_test_task_metadata(
     if node:
         args_to_override = node.operator_kwargs_to_override
 
-    dbt_class = "DbtTest"
-    watcher_to_test_execution_mode = {
-        ExecutionMode.WATCHER: ExecutionMode.LOCAL,
-        ExecutionMode.WATCHER_KUBERNETES: ExecutionMode.KUBERNETES,
-        ExecutionMode.WATCHER_GCP_GKE: ExecutionMode.GCP_GKE,
-    }
-    if (
-        render_config is not None
-        and render_config.test_behavior == TestBehavior.AFTER_ALL
-        and execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES, ExecutionMode.WATCHER_GCP_GKE)
-    ):
-        test_execution_mode = watcher_to_test_execution_mode[execution_mode]
-        operator_class = calculate_operator_class(execution_mode=test_execution_mode, dbt_class=dbt_class)
-    else:
-        operator_class = calculate_operator_class(execution_mode=execution_mode, dbt_class=dbt_class)
+    operator_class = _calculate_test_operator_class(execution_mode, render_config)
 
     return TaskMetadata(
         id=test_task_name,

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -192,7 +192,7 @@ def _override_profile_if_needed(task_kwargs: dict[str, Any], profile_kwargs_over
         task_kwargs["profile_config"] = modified_profile_config
 
 
-_WATCHER_TO_TEST_EXECUTION_MODE = {
+_WATCHER_TO_FALLBACK_EXECUTION_MODE = {
     ExecutionMode.WATCHER: ExecutionMode.LOCAL,
     ExecutionMode.WATCHER_KUBERNETES: ExecutionMode.KUBERNETES,
     ExecutionMode.WATCHER_GCP_GKE: ExecutionMode.GCP_GKE,
@@ -208,9 +208,9 @@ def _calculate_test_operator_class(execution_mode: ExecutionMode, render_config:
     if (
         render_config is not None
         and render_config.test_behavior == TestBehavior.AFTER_ALL
-        and execution_mode in _WATCHER_TO_TEST_EXECUTION_MODE
+        and execution_mode in _WATCHER_TO_FALLBACK_EXECUTION_MODE
     ):
-        execution_mode = _WATCHER_TO_TEST_EXECUTION_MODE[execution_mode]
+        execution_mode = _WATCHER_TO_FALLBACK_EXECUTION_MODE[execution_mode]
     return calculate_operator_class(execution_mode=execution_mode, dbt_class="DbtTest")
 
 


### PR DESCRIPTION
## Summary

Extract the WATCHER-aware test operator-class resolution out of `create_test_task_metadata` into a small `_calculate_test_operator_class` helper, to reduce the function's cyclomatic complexity.

## Why

`create_test_task_metadata` currently sits at complexity **exactly 10**, which is the ruff `C901` ceiling (`mccabe.max-complexity = 10`). It passes on `main` today, but it has **zero headroom**: any added branch tips it to 11 and fails CI. This already bit #2920, whose one-line `on_warning_callback` fix trips `C901` (11 > 10) purely because the function was at the limit.

Rather than `# noqa` the symptom, this gives the function room to breathe.

## Change

Pure, behavior-preserving extraction:
- New module-level `_WATCHER_TO_FALLBACK_EXECUTION_MODE ` map + `_calculate_test_operator_class(execution_mode, render_config)` helper holding the exact same AFTER_ALL / WATCHER* logic (the `in _WATCHER_TO_FALLBACK_EXECUTION_MODE ` membership check is the same set as the original tuple).
- `create_test_task_metadata` now calls the helper.

Result: `create_test_task_metadata` drops from 10 to ~7; ruff `C901`, `ruff check`, and `ruff format --check` all pass. No behavior change, so the existing `create_test_task_metadata` tests cover it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
