### PR TITLE
Honour dbt test `operator_kwargs` under `TestBehavior.AFTER_EACH`

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -1216,7 +1216,11 @@ def build_airflow_graph(
 
     # Operator kwargs declared by the test nodes, so a TestBehavior.AFTER_EACH test task can override the arguments
     # it inherits from the resource being tested
-    test_operator_kwargs = calculate_test_operator_kwargs(nodes, detached_nodes)
+    test_operator_kwargs = (
+        calculate_test_operator_kwargs(nodes, detached_nodes)
+        if render_config.test_behavior == TestBehavior.AFTER_EACH
+        else {}
+    )
 
     virtualenv_dir = None
 

--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -224,6 +224,7 @@ def create_test_task_metadata(
     render_config: RenderConfig | None = None,
     detached_from_parent: dict[str, list[DbtNode]] | None = None,
     enable_owner_inheritance: bool | None = None,
+    test_operator_kwargs: dict[str, Any] | None = None,
 ) -> TaskMetadata:
     """
     Create the metadata that will be used to instantiate the Airflow Task that will be used to run the Dbt test node.
@@ -237,6 +238,8 @@ def create_test_task_metadata(
     :param render_config: The RenderConfig for the dbt project. Its ``exclude`` is forwarded to the test task (for
         every test behavior); its ``select`` / ``selector`` are applied only to the TestBehavior.AFTER_ALL task.
     :param detached_from_parent: Dictionary that maps node ids and their children tests that should be run detached
+    :param test_operator_kwargs: ``operator_kwargs`` declared by the dbt test nodes this task runs. They take
+        precedence over the arguments inherited from ``node``, the resource being tested.
     :returns: The metadata necessary to instantiate the source dbt node as an Airflow task.
     """
     task_args = dict(task_args)
@@ -283,7 +286,7 @@ def create_test_task_metadata(
         id=test_task_name,
         owner=task_owner,
         operator_class=operator_class,
-        arguments={**task_args, **args_to_override},
+        arguments={**task_args, **args_to_override, **(test_operator_kwargs or {})},
         extra_context=extra_context,
     )
 
@@ -639,6 +642,7 @@ def generate_task_or_group(
     on_warning_callback: Callable[..., Any] | None = None,
     detached_from_parent: dict[str, list[DbtNode]] | None = None,
     filtered_nodes: dict[str, DbtNode] | None = None,
+    test_operator_kwargs: dict[str, dict[str, Any]] | None = None,
     **kwargs: Any,
 ) -> BaseOperator | TaskGroup | None:
     task_or_group: BaseOperator | TaskGroup | None = None
@@ -719,6 +723,7 @@ def generate_task_or_group(
                     on_warning_callback=on_warning_callback,
                     detached_from_parent=detached_from_parent,
                     enable_owner_inheritance=render_config.enable_owner_inheritance,
+                    test_operator_kwargs=(test_operator_kwargs or {}).get(node.unique_id),
                 )
                 test_task_generate_or_convert_task_args = {
                     **generate_or_convert_task_args,
@@ -956,6 +961,38 @@ def identify_detached_nodes(
                     detached_from_parent[parent_id].append(node)
 
 
+def calculate_test_operator_kwargs(
+    nodes: dict[str, DbtNode], detached_nodes: dict[str, DbtNode]
+) -> dict[str, dict[str, Any]]:
+    """
+    Map each tested node ID to the ``operator_kwargs`` declared by the test nodes that run alongside it under
+    TestBehavior.AFTER_EACH. Detached tests are skipped: they run in their own task, using their own kwargs.
+
+    Since a node's tests all run in a single Airflow task, when they declare the same kwarg with different values the
+    last one wins.
+    """
+    test_operator_kwargs: dict[str, dict[str, Any]] = {}
+    for node_id, node in nodes.items():
+        if node.resource_type != DbtResourceType.TEST or node_id in detached_nodes:
+            continue
+        node_kwargs = node.operator_kwargs_to_override
+        if not node_kwargs:
+            continue
+        for parent_id in node.depends_on:
+            parent_kwargs = test_operator_kwargs.setdefault(parent_id, {})
+            for kwarg, value in node_kwargs.items():
+                if kwarg in parent_kwargs and parent_kwargs[kwarg] != value:
+                    logger.warning(
+                        "Tests of <%s> declare conflicting values for the operator_kwarg <%s>. Using <%s>, from <%s>.",
+                        parent_id,
+                        kwarg,
+                        value,
+                        node_id,
+                    )
+                parent_kwargs[kwarg] = value
+    return test_operator_kwargs
+
+
 def create_task_groups_based_on_folder(
     dag: DAG,
     node: DbtNode,
@@ -1177,6 +1214,10 @@ def build_airflow_graph(
     detached_from_parent: dict[str, list[DbtNode]] = defaultdict(list)
     identify_detached_nodes(nodes, render_config, detached_nodes, detached_from_parent)
 
+    # Operator kwargs declared by the test nodes, so a TestBehavior.AFTER_EACH test task can override the arguments
+    # it inherits from the resource being tested
+    test_operator_kwargs = calculate_test_operator_kwargs(nodes, detached_nodes)
+
     virtualenv_dir = None
 
     if execution_mode == ExecutionMode.AIRFLOW_ASYNC:
@@ -1219,6 +1260,7 @@ def build_airflow_graph(
             # Calculated in this method:
             "detached_from_parent": detached_from_parent,
             "node_converters": render_config.node_converters or {},
+            "test_operator_kwargs": test_operator_kwargs,
         }
 
         task_or_group = generate_task_or_group(**task_or_group_args, filtered_nodes=nodes)

--- a/docs/guides/run_dbt/operators/overriding-operator-args.rst
+++ b/docs/guides/run_dbt/operators/overriding-operator-args.rst
@@ -89,14 +89,33 @@ Since all the tests of a dbt node run in a single Airflow task, if they declare 
 the last one wins and Cosmos logs a warning. Tests without a parent resource (e.g. a singular test that does not
 ``ref()`` any model) are not rendered under ``TestBehavior.AFTER_EACH``, so their ``operator_kwargs`` do not apply.
 
+Other test behaviors
+~~~~~~~~~~~~~~~~~~~~
+
+The tests' ``operator_kwargs`` are applied when Cosmos renders a test task for the resource being tested, which is the
+case for ``TestBehavior.AFTER_EACH``. For the remaining behaviors:
+
+- With ``TestBehavior.AFTER_ALL``, every test runs in a single project-wide task that is not associated with any dbt
+  node, so it uses ``operator_args`` and the tests' ``operator_kwargs`` do not apply. To retry models but not tests, set
+  ``operator_args={"retries": 0}`` and override ``retries`` for the models in ``dbt_project.yml``.
+- With ``TestBehavior.BUILD``, there is no separate test task: tests run as part of the resource's ``dbt build``, using
+  that resource's arguments.
+- Detached tests are rendered as their own task, from the test node itself, so they always use their own
+  ``operator_kwargs``.
+
 Unit tests
 ~~~~~~~~~~
 
-Unit tests (dbt 1.8+) are declared as ``unit_tests`` and are not rendered as Airflow tasks by Cosmos. They still run as
-part of the test task of the resource they test, because ``dbt test --select <resource>`` selects them, so the
-``operator_kwargs`` declared under ``unit_tests`` in ``dbt_project.yml`` (or in the unit test ``config``) have no effect.
-The arguments used are the ones described above: those inherited from the resource being tested, overridden by the ones
-its data tests declare.
+Unit tests (dbt 1.8+) are declared as ``unit_tests`` and are not rendered as Airflow tasks by Cosmos. When the resource
+they test also has data tests, they run as part of that resource's test task, because ``dbt test --select <resource>``
+selects them. The ``operator_kwargs`` declared under ``unit_tests`` in ``dbt_project.yml`` (or in the unit test
+``config``) have no effect: the arguments used are the ones described above, inherited from the resource being tested and
+overridden by the ones its data tests declare.
+
+When a resource has unit tests but no data tests, Cosmos does not create a test task for it under
+``TestBehavior.AFTER_EACH`` at all, so nothing runs its unit tests. Whether they run otherwise depends on the dbt
+command the surrounding task issues - the project-wide ``dbt test`` of ``TestBehavior.AFTER_ALL``, or the
+``dbt build`` of ``TestBehavior.BUILD``.
 
 .. code-block:: yaml
 

--- a/docs/guides/run_dbt/operators/overriding-operator-args.rst
+++ b/docs/guides/run_dbt/operators/overriding-operator-args.rst
@@ -65,9 +65,45 @@ retrying tests, which is useful when retrying a slow test would delay subsequent
             operator_kwargs:
               retries: 0
 
-This works for both dbt test types. Generic (schema) tests are configured as above, or individually in the model YAML,
-while singular tests can also declare ``{{ config(meta={"cosmos": {"operator_kwargs": {...}}}) }}`` in their SQL file.
+The ``data_tests`` configuration above applies to both types of dbt data test. Generic (schema) tests can also be
+configured individually in the model YAML, and singular tests can declare
+``{{ config(meta={"cosmos": {"operator_kwargs": {...}}}) }}`` in their SQL file:
+
+.. code-block:: yaml
+
+    # models/schema.yml - a single generic test that should not be retried
+    version: 2
+    models:
+      - name: orders
+        columns:
+          - name: order_id
+            data_tests:
+              - unique:
+                  config:
+                    meta:
+                      cosmos:
+                        operator_kwargs:
+                          retries: 0
 
 Since all the tests of a dbt node run in a single Airflow task, if they declare the same argument with different values,
 the last one wins and Cosmos logs a warning. Tests without a parent resource (e.g. a singular test that does not
 ``ref()`` any model) are not rendered under ``TestBehavior.AFTER_EACH``, so their ``operator_kwargs`` do not apply.
+
+Unit tests
+~~~~~~~~~~
+
+Unit tests (dbt 1.8+) are declared as ``unit_tests`` and are not rendered as Airflow tasks by Cosmos. They still run as
+part of the test task of the resource they test, because ``dbt test --select <resource>`` selects them, so the
+``operator_kwargs`` declared under ``unit_tests`` in ``dbt_project.yml`` (or in the unit test ``config``) have no effect.
+The arguments used are the ones described above: those inherited from the resource being tested, overridden by the ones
+its data tests declare.
+
+.. code-block:: yaml
+
+    # dbt_project.yml - this has no effect, since Cosmos does not create a task for unit tests
+    unit_tests:
+      my_dbt_project:
+        +meta:
+          cosmos:
+            operator_kwargs:
+              retries: 0

--- a/docs/guides/run_dbt/operators/overriding-operator-args.rst
+++ b/docs/guides/run_dbt/operators/overriding-operator-args.rst
@@ -38,3 +38,36 @@ While configuring in the dbt model YAML (e.g. ``models/schema.yml``) a different
 More information about this feature can be found in :ref:`custom-airflow-properties`.
 
 To learn how to customise the profile per dbt model or Cosmos task, check :ref:`profile-customise-per-node`.
+
+.. _operator-args-test-nodes:
+
+Overriding operator arguments for dbt tests
+-------------------------------------------
+
+When using ``TestBehavior.AFTER_EACH``, the test task inherits the operator arguments of the resource it tests, and then
+applies the ``operator_kwargs`` declared by the tests it runs. This allows, for example, retrying model runs without
+retrying tests, which is useful when retrying a slow test would delay subsequent DAG runs:
+
+.. code-block:: yaml
+
+    # dbt_project.yml - retry every model run twice, but never retry their tests
+    models:
+      my_dbt_project:
+        +meta:
+          cosmos:
+            operator_kwargs:
+              retries: 2
+
+    data_tests:  # named `tests` before dbt 1.8
+      my_dbt_project:
+        +meta:
+          cosmos:
+            operator_kwargs:
+              retries: 0
+
+This works for both dbt test types. Generic (schema) tests are configured as above, or individually in the model YAML,
+while singular tests can also declare ``{{ config(meta={"cosmos": {"operator_kwargs": {...}}}) }}`` in their SQL file.
+
+Since all the tests of a dbt node run in a single Airflow task, if they declare the same argument with different values,
+the last one wins and Cosmos logs a warning. Tests without a parent resource (e.g. a singular test that does not
+``ref()`` any model) are not rendered under ``TestBehavior.AFTER_EACH``, so their ``operator_kwargs`` do not apply.

--- a/docs/guides/run_dbt/operators/overriding-operator-args.rst
+++ b/docs/guides/run_dbt/operators/overriding-operator-args.rst
@@ -42,8 +42,7 @@ To learn how to customise the profile per dbt model or Cosmos task, check :ref:`
 .. _operator-args-test-nodes:
 
 Overriding operator arguments for dbt tests
--------------------------------------------
-
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 When using ``TestBehavior.AFTER_EACH``, the test task inherits the operator arguments of the resource it tests, and then
 applies the ``operator_kwargs`` declared by the tests it runs. This allows, for example, retrying model runs without
 retrying tests, which is useful when retrying a slow test would delay subsequent DAG runs:

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -2896,3 +2896,30 @@ def test_detached_test_node_operator_kwargs_are_not_applied_to_the_parent_test_t
     )
     nodes = {parent.unique_id: parent, detached_test.unique_id: detached_test}
     assert calculate_test_operator_kwargs(nodes, detached_nodes={detached_test.unique_id: detached_test}) == {}
+
+
+def test_test_node_operator_kwargs_do_not_apply_to_after_all_test_task():
+    """The TestBehavior.AFTER_ALL task is not associated with any node, so it keeps the DAG-level arguments."""
+    nodes = _model_and_test_nodes(model_kwargs={"retries": 2}, test_kwargs={"retries": 0})
+    with DAG("test-test-node-kwargs-after-all", start_date=datetime(2022, 1, 1)) as dag:
+        build_airflow_graph(
+            nodes=nodes,
+            dag=dag,
+            execution_mode=ExecutionMode.LOCAL,
+            test_indirect_selection=TestIndirectSelection.EAGER,
+            task_args={
+                "project_dir": SAMPLE_PROJ_PATH,
+                "profile_config": ProfileConfig(
+                    profile_name="default",
+                    target_name="default",
+                    profile_mapping=PostgresUserPasswordProfileMapping(
+                        conn_id="fake_conn", profile_args={"schema": "public"}
+                    ),
+                ),
+                "retries": 3,
+            },
+            render_config=RenderConfig(test_behavior=TestBehavior.AFTER_ALL),
+            dbt_project_name="astro_shop",
+        )
+    assert dag.task_dict["my_model_run"].retries == 2
+    assert dag.task_dict["astro_shop_test"].retries == 3

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -28,6 +28,7 @@ from cosmos.airflow.graph import (
     calculate_detached_node_name,
     calculate_leaves,
     calculate_operator_class,
+    calculate_test_operator_kwargs,
     create_task_groups_based_on_folder,
     create_task_metadata,
     create_test_task_metadata,
@@ -2797,3 +2798,101 @@ def test_create_task_metadata_seed_rendering_always_no_flag():
     )
     assert metadata.operator_class == "cosmos.operators.local.DbtSeedLocalOperator"
     assert "should_run_if_seed_changed" not in metadata.extra_context
+
+
+def _model_and_test_nodes(model_kwargs, test_kwargs, second_test_kwargs=None):
+    model = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.my_model",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=SAMPLE_PROJ_PATH,
+        original_file_path=Path("models/my_model.sql"),
+        config={"materialized": "table", "meta": {"cosmos": {"operator_kwargs": model_kwargs}}},
+        has_test=True,
+        has_non_detached_test=True,
+    )
+    nodes = {model.unique_id: model}
+    for index, kwargs in enumerate([test_kwargs, second_test_kwargs]):
+        if kwargs is None:
+            continue
+        test = DbtNode(
+            unique_id=f"{DbtResourceType.TEST.value}.{SAMPLE_PROJ_PATH.stem}.my_test_{index}",
+            resource_type=DbtResourceType.TEST,
+            depends_on=[model.unique_id],
+            path_base=SAMPLE_PROJ_PATH,
+            original_file_path=Path("models/schema.yml"),
+            config={"meta": {"cosmos": {"operator_kwargs": kwargs}}},
+        )
+        nodes[test.unique_id] = test
+    return nodes
+
+
+def _render_after_each(dag_id, nodes, retries=3):
+    with DAG(dag_id, start_date=datetime(2022, 1, 1)) as dag:
+        build_airflow_graph(
+            nodes=nodes,
+            dag=dag,
+            execution_mode=ExecutionMode.LOCAL,
+            test_indirect_selection=TestIndirectSelection.EAGER,
+            task_args={
+                "project_dir": SAMPLE_PROJ_PATH,
+                "profile_config": ProfileConfig(
+                    profile_name="default",
+                    target_name="default",
+                    profile_mapping=PostgresUserPasswordProfileMapping(
+                        conn_id="fake_conn", profile_args={"schema": "public"}
+                    ),
+                ),
+                "retries": retries,
+            },
+            render_config=RenderConfig(test_behavior=TestBehavior.AFTER_EACH),
+            dbt_project_name="astro_shop",
+        )
+    return dag
+
+
+def test_test_node_operator_kwargs_override_the_ones_inherited_from_the_model():
+    """A test declaring `retries` overrides the value it would inherit from the model it tests (#2130)."""
+    nodes = _model_and_test_nodes(model_kwargs={"retries": 2}, test_kwargs={"retries": 0})
+    dag = _render_after_each("test-test-node-kwargs", nodes)
+    assert dag.task_dict["my_model.run"].retries == 2
+    assert dag.task_dict["my_model.test"].retries == 0
+
+
+def test_test_node_operator_kwargs_are_merged_with_the_ones_inherited_from_the_model():
+    """Arguments the test does not declare are still inherited from the model it tests."""
+    nodes = _model_and_test_nodes(model_kwargs={"retries": 2, "pool": "model_pool"}, test_kwargs={"retries": 0})
+    dag = _render_after_each("test-test-node-kwargs-merge", nodes)
+    assert dag.task_dict["my_model.test"].retries == 0
+    assert dag.task_dict["my_model.test"].pool == "model_pool"
+
+
+def test_conflicting_test_node_operator_kwargs_log_warning(caplog):
+    """Tests of a node run in a single task, so conflicting values are resolved as last-one-wins, with a warning."""
+    nodes = _model_and_test_nodes(model_kwargs={}, test_kwargs={"retries": 1}, second_test_kwargs={"retries": 0})
+    dag = _render_after_each("test-conflicting-test-node-kwargs", nodes)
+    assert dag.task_dict["my_model.test"].retries == 0
+    assert "declare conflicting values for the operator_kwarg <retries>" in caplog.text
+
+
+def test_detached_test_node_operator_kwargs_are_not_applied_to_the_parent_test_task():
+    """Detached tests run in their own task, so their kwargs do not leak into their parents' test tasks."""
+    parent = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.my_model",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=SAMPLE_PROJ_PATH,
+        original_file_path=Path("models/my_model.sql"),
+        config={"materialized": "table"},
+        has_test=True,
+    )
+    detached_test = DbtNode(
+        unique_id=f"{DbtResourceType.TEST.value}.{SAMPLE_PROJ_PATH.stem}.my_detached_test",
+        resource_type=DbtResourceType.TEST,
+        depends_on=[parent.unique_id, "model.other"],
+        path_base=SAMPLE_PROJ_PATH,
+        original_file_path=Path("models/schema.yml"),
+        config={"meta": {"cosmos": {"operator_kwargs": {"retries": 0}}}},
+    )
+    nodes = {parent.unique_id: parent, detached_test.unique_id: detached_test}
+    assert calculate_test_operator_kwargs(nodes, detached_nodes={detached_test.unique_id: detached_test}) == {}


### PR DESCRIPTION
## Problem

Issue #2130: users want to retry **model runs** but **not tests** — retrying a 30-minute test delays subsequent DAG runs.

With the default `TestBehavior.AFTER_EACH` this was impossible through any configuration. `create_test_task_metadata` applies `node.operator_kwargs_to_override` whenever it is given a node, and the AFTER_EACH test task is created from the **tested** node, because it needs that node's `select`, owner, profile override and detached-test excludes. So:

- `retries` set on a model also retried its after-each test;
- `operator_kwargs` declared on the **test** was silently ignored — the exact configuration the issue thread assumed already worked.

The separation does work under `TestBehavior.AFTER_ALL`, but only because that task is created with **no node**, so there is nothing to inherit. That is a consequence of `node=None`, not a feature, and switching to `after_all` changes DAG semantics: tests no longer gate downstream models.

## Solution

The AFTER_EACH test task now applies the `operator_kwargs` of the dbt tests it runs, on top of the ones inherited from the tested resource. No new Cosmos argument — the dbt-side configuration users already write is simply honoured:

```yaml
# dbt_project.yml
models:
  jaffle_shop:
    +meta:
      cosmos:
        operator_kwargs:
          retries: 2

data_tests:  # named `tests` before dbt 1.8
  jaffle_shop:
    +meta:
      cosmos:
        operator_kwargs:
          retries: 0
```

Design notes:

- **Additive.** Arguments the tests do not declare are still inherited, so a model's `pool`/`queue` keeps reaching its test task.
- **Both dbt test types.** Verified against a dbt 1.11 parse that generic (schema) and singular (SQL) tests both carry `config.meta` and a `depends_on` parent — including a singular test declaring `{{ config(meta={"cosmos": {"operator_kwargs": {...}}}) }}` inline.
- **Detached tests are skipped** — they render as their own task and already honour their own kwargs.
- **Conflicts.** All the tests of a node run in a single `dbt test --select <node>` task, so when two tests declare the same argument with different values it is last-one-wins plus a warning log.
- **Parse cost.** One `O(N)` pass with an early-out for tests that declare nothing: 7.7 ms for a synthetic 20k-node project (5k models, 15k tests) when no test declares `operator_kwargs`, 11.2 ms when all 15k do.

## Verification

- Rendered a real `DbtDag` (AF 3.1.8) from the `dev/dags/dbt/jaffle_shop` manifest with `operator_args={"retries": 7}`, models `+meta retries: 2` and `data_tests +meta retries: 0`: every `*.run` task has `retries=2`, every `*.test` task `retries=0`, seeds keep the DAG-level `7`, and the conflicting-kwargs warning fires for the model whose singular test declares a different value.
- 4 new regression tests, plus the full unit suite on AF 2.10 (`hatch run tests.py3.11-2.10-1.9:test`): 1878 passed. The two `tests/dbt/test_graph.py` cache-hash failures also fail on unmodified `main` on this machine (macOS folder hash), unrelated to this change.
- `hatch run tests.py3.10-3.1-1.9:type-check` and `pre-commit` pass.
- Strict docs build (`sphinx-build -W`) clean for the edited page.

## Relationship to #2835

#2835 documents the `AFTER_ALL` workaround and states the `AFTER_EACH` limitation. If this lands, that note should point here instead. Both are safe to merge in either order — they touch different files.

Closes #2130

🤖 Generated with Claude Code (https://claude.com/claude-code)