### PR TITLE
fix: Honor `on_warning_callback` passed via `operator_args`

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -176,6 +176,22 @@ def forward_render_exclude_to_test(task_args: dict[str, Any], render_config: Ren
     task_args["exclude"] = _convert_list_to_str(merged)
 
 
+def _honor_on_warning_callback(task_args: dict[str, Any], on_warning_callback: Callable[..., Any] | None) -> None:
+    """
+    Resolve the effective ``on_warning_callback`` for a node command that supports it, in-place.
+
+    The top-level ``DbtDag`` / ``DbtTaskGroup`` / ``DbtToAirflowConverter`` argument takes precedence. When it is
+    unset (``None``), a callback the user passed through ``operator_args`` -- which reaches us already inside
+    ``task_args`` -- is preserved instead of being silently dropped.
+
+    The key is always set, so the operator is handed an explicit ``None`` when neither source supplies a callback.
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    if on_warning_callback is None:
+        on_warning_callback = task_args.get("on_warning_callback")
+    task_args["on_warning_callback"] = on_warning_callback
+
+
 def _override_profile_if_needed(task_kwargs: dict[str, Any], profile_kwargs_override: dict[str, Any]) -> None:
     """
     Changes in-place the profile configuration if it needs to be overridden.
@@ -240,7 +256,7 @@ def create_test_task_metadata(
     :returns: The metadata necessary to instantiate the source dbt node as an Airflow task.
     """
     task_args = dict(task_args)
-    task_args["on_warning_callback"] = on_warning_callback
+    _honor_on_warning_callback(task_args, on_warning_callback)
     # Test operators (DbtTest*) do not emit DatasetAlias
     task_args["emit_datasets"] = False
     extra_context = {}
@@ -462,7 +478,7 @@ def create_task_metadata(  # noqa: C901
                 args[models_select_key] = f"{node.resource_name}"
             if test_indirect_selection != TestIndirectSelection.EAGER:
                 args["indirect_selection"] = test_indirect_selection.value
-            args["on_warning_callback"] = on_warning_callback
+            _honor_on_warning_callback(args, on_warning_callback)
             # Under BUILD, tests run inline with ``dbt build`` (there is no separate per-model test task),
             # so forward the render-level exclude here too — otherwise an exclusion such as
             # exclude=["resource_type:unit_test"] would not be honored for BUILD. See #1763.
@@ -480,7 +496,7 @@ def create_task_metadata(  # noqa: C901
             )
         elif node.resource_type == DbtResourceType.SOURCE:
             args["select"] = f"source:{node.resource_name}"
-            args["on_warning_callback"] = on_warning_callback
+            _honor_on_warning_callback(args, on_warning_callback)
 
             if (render_config.source_rendering_behavior == SourceRenderingBehavior.NONE) or (
                 render_config.source_rendering_behavior == SourceRenderingBehavior.WITH_TESTS_OR_FRESHNESS

--- a/docs/guides/translate_dbt_to_airflow/managing-sources.rst
+++ b/docs/guides/translate_dbt_to_airflow/managing-sources.rst
@@ -68,6 +68,10 @@ on_warning_callback callback
 
 The ``on_warning_callback`` is a callback parameter available on the ``DbtSourceLocalOperator``. This callback is triggered when a warning occurs during the execution of the ``dbt source freshness`` command. The callback accepts the task context, which includes additional parameters: test_names and test_results
 
+As with test warnings, this callback can be given either as a top-level ``DbtDag`` / ``DbtTaskGroup`` argument or
+inside ``operator_args``, and the top-level argument wins when both are given. See :ref:`testing-behavior` for
+details.
+
 Example:
 
 .. literalinclude:: ../../../dev/dags/example_source_rendering.py

--- a/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
+++ b/docs/guides/translate_dbt_to_airflow/testing-behavior.rst
@@ -112,6 +112,14 @@ When at least one WARN message is present, the function passed to ``on_warning_c
     ``on_warning_callback`` method above. However, these warnings will not be included in the ``test_names`` and
     ``test_results`` context variables, which are specific to test-related warnings.
 
+.. note::
+
+    ``on_warning_callback`` can be given either as a top-level ``DbtDag`` / ``DbtTaskGroup`` argument, as in the
+    example above, or inside ``operator_args``, since it is also a valid argument of the underlying ``dbt test``,
+    ``dbt build`` and ``dbt source freshness`` operators. When both are given, the top-level argument wins.
+    In Cosmos 1.15.0 and earlier, a callback passed only through ``operator_args`` was silently dropped, so the
+    top-level argument remains the recommended form.
+
 
 Tests with multiple parents
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/tests/airflow/test_graph.py
+++ b/tests/airflow/test_graph.py
@@ -23,6 +23,7 @@ from cosmos.airflow.graph import (
     _add_teardown_task,
     _add_watcher_producer_task,
     _convert_list_to_str,
+    _honor_on_warning_callback,
     _snake_case_to_camelcase,
     build_airflow_graph,
     calculate_detached_node_name,
@@ -926,6 +927,32 @@ def test_create_task_metadata_build_mode_forwards_render_config_exclude():
     assert metadata.arguments["exclude"] == "resource_type:unit_test"
 
 
+def test_create_task_metadata_build_honors_on_warning_callback_from_task_args():
+    """Under TestBehavior.BUILD there is no separate test task, so an ``on_warning_callback`` passed through
+    ``operator_args`` must reach the build task instead of being dropped by the unset top-level argument.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    operator_args_callback = MagicMock()
+    model_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.my_project.model_a",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=Path("base_path"),
+        original_file_path=Path("models/model_a.sql"),
+        fqn=["my_project", "model_a"],
+    )
+    metadata = create_task_metadata(
+        model_node,
+        execution_mode=ExecutionMode.LOCAL,
+        args={"on_warning_callback": operator_args_callback},
+        dbt_dag_task_group_identifier="",
+        render_config=RenderConfig(test_behavior=TestBehavior.BUILD),
+    )
+    assert metadata.operator_class == "cosmos.operators.local.DbtBuildLocalOperator"
+    assert metadata.arguments["on_warning_callback"] is operator_args_callback
+
+
 def test_create_task_metadata_ephemeral_empty_operator_inherits_owner():
     """The ephemeral EmptyOperator inherits the dbt model owner when owner inheritance is enabled (default)."""
     metadata = create_task_metadata(
@@ -1001,6 +1028,34 @@ def test_create_task_metadata_source_with_rendering_options(
     if metadata:
         assert metadata.id == expected_id
         assert metadata.operator_class == expected_operator_class
+
+
+def test_create_task_metadata_source_honors_on_warning_callback_from_task_args():
+    """``dbt source freshness`` tasks accept ``on_warning_callback``, so one passed through ``operator_args``
+    must not be dropped by the unset top-level argument.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    operator_args_callback = MagicMock()
+    source_node = DbtNode(
+        unique_id=f"{DbtResourceType.SOURCE.value}.my_folder.my_source",
+        resource_type=DbtResourceType.SOURCE,
+        depends_on=[],
+        path_base=Path("."),
+        original_file_path=Path("."),
+        tags=[],
+        config={},
+        has_freshness=True,
+    )
+    metadata = create_task_metadata(
+        source_node,
+        execution_mode=ExecutionMode.LOCAL,
+        args={"on_warning_callback": operator_args_callback},
+        dbt_dag_task_group_identifier="",
+        render_config=RenderConfig(source_rendering_behavior=SourceRenderingBehavior.ALL),
+    )
+    assert metadata.operator_class == "cosmos.operators.local.DbtSourceLocalOperator"
+    assert metadata.arguments["on_warning_callback"] is operator_args_callback
 
 
 @pytest.mark.parametrize("use_task_group", (None, True, False))
@@ -1410,6 +1465,84 @@ def test_create_test_task_metadata(node_type, node_unique_id, test_indirect_sele
         **{"task_arg": "value", "on_warning_callback": True, "emit_datasets": False},
         **additional_arguments,
     }
+
+
+def test_create_test_task_metadata_honors_on_warning_callback_from_task_args():
+    """An ``on_warning_callback`` passed through ``operator_args`` (and therefore already inside ``task_args``)
+    must not be dropped by an unset top-level ``on_warning_callback``.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    operator_args_callback = MagicMock()
+    sample_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.my_folder.node_name",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=Path("."),
+        original_file_path=Path("."),
+        tags=[],
+        config={},
+    )
+    metadata = create_test_task_metadata(
+        test_task_name="test",
+        execution_mode=ExecutionMode.LOCAL,
+        test_indirect_selection=TestIndirectSelection.EAGER,
+        task_args={"on_warning_callback": operator_args_callback},
+        node=sample_node,
+    )
+    assert metadata.arguments["on_warning_callback"] is operator_args_callback
+
+
+def test_create_test_task_metadata_top_level_on_warning_callback_takes_precedence():
+    """When ``on_warning_callback`` is given both top-level and through ``operator_args``, the top-level
+    DbtDag / DbtTaskGroup argument wins.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    operator_args_callback = MagicMock()
+    top_level_callback = MagicMock()
+    sample_node = DbtNode(
+        unique_id=f"{DbtResourceType.MODEL.value}.my_folder.node_name",
+        resource_type=DbtResourceType.MODEL,
+        depends_on=[],
+        path_base=Path("."),
+        original_file_path=Path("."),
+        tags=[],
+        config={},
+    )
+    metadata = create_test_task_metadata(
+        test_task_name="test",
+        execution_mode=ExecutionMode.LOCAL,
+        test_indirect_selection=TestIndirectSelection.EAGER,
+        task_args={"on_warning_callback": operator_args_callback},
+        on_warning_callback=top_level_callback,
+        node=sample_node,
+    )
+    assert metadata.arguments["on_warning_callback"] is top_level_callback
+
+
+@pytest.mark.parametrize(
+    "task_args_callback,top_level_callback,expected_callback",
+    [
+        pytest.param("task_args", None, "task_args", id="only-operator-args"),
+        pytest.param(None, "top_level", "top_level", id="only-top-level"),
+        pytest.param("task_args", "top_level", "top_level", id="top-level-wins"),
+        pytest.param(None, None, None, id="neither-set"),
+    ],
+)
+def test_honor_on_warning_callback(task_args_callback, top_level_callback, expected_callback):
+    """The key is always set, so the operator is handed an explicit ``None`` when neither form is used, but a
+    ``task_args`` value is only overwritten when the top-level argument is set.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    callbacks = {"task_args": MagicMock(), "top_level": MagicMock(), None: None}
+    task_args = {} if task_args_callback is None else {"on_warning_callback": callbacks[task_args_callback]}
+
+    _honor_on_warning_callback(task_args, callbacks[top_level_callback])
+
+    assert "on_warning_callback" in task_args
+    assert task_args["on_warning_callback"] is callbacks[expected_callback]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -20,12 +20,18 @@ from cosmos.constants import (
     InvocationMode,
     LoadMode,
     SeedRenderingBehavior,
+    SourceRenderingBehavior,
     TestBehavior,
 )
 from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
-from cosmos.operators.local import DbtRunLocalOperator
+from cosmos.operators.local import (
+    DbtBuildLocalOperator,
+    DbtRunLocalOperator,
+    DbtSourceLocalOperator,
+    DbtTestLocalOperator,
+)
 from cosmos.profiles.postgres import PostgresUserPasswordProfileMapping
 from cosmos.telemetry import _decompress_telemetry_metadata
 
@@ -1682,3 +1688,43 @@ def test_dbt_dag_renders_ephemeral_model_as_dbt_run_when_disabled():
     ephemeral_task = dag.tasks_map["model.altered_jaffle_shop.ephemeral_customers"]
     assert isinstance(ephemeral_task, DbtRunLocalOperator)
     assert not isinstance(ephemeral_task, EmptyOperator)
+
+
+@pytest.mark.parametrize(
+    "test_behavior,expected_operator_classes",
+    [
+        pytest.param(TestBehavior.AFTER_EACH, (DbtSourceLocalOperator, DbtTestLocalOperator), id="after-each"),
+        pytest.param(TestBehavior.BUILD, (DbtBuildLocalOperator, DbtSourceLocalOperator), id="build"),
+        pytest.param(TestBehavior.AFTER_ALL, (DbtSourceLocalOperator, DbtTestLocalOperator), id="after-all"),
+    ],
+)
+def test_dbt_dag_honors_on_warning_callback_from_operator_args(test_behavior, expected_operator_classes):
+    """``on_warning_callback`` is a first-class DbtDag argument, but ``operator_args`` is also forwarded to the
+    operators, so passing it there is a reasonable mental model. Every rendered operator that supports the
+    callback (dbt test, dbt source freshness, dbt build) must receive it.
+
+    See https://github.com/astronomer/astronomer-cosmos/issues/2869.
+    """
+    on_warning_callback = MagicMock()
+    dag = DbtDag(
+        dag_id=f"on_warning_callback_{test_behavior.value}",
+        start_date=datetime(2024, 4, 16),
+        project_config=ProjectConfig(
+            dbt_project_path=ALTERED_JAFFLE_SHOP_DBT_PROJECT,
+            manifest_path=ALTERED_JAFFLE_SHOP_DBT_PROJECT / "target" / "manifest.json",
+        ),
+        execution_config=ExecutionConfig(execution_mode=ExecutionMode.LOCAL),
+        render_config=RenderConfig(
+            load_method=LoadMode.DBT_MANIFEST,
+            test_behavior=test_behavior,
+            source_rendering_behavior=SourceRenderingBehavior.ALL,
+            emit_datasets=False,
+        ),
+        profile_config=sample_profile_config,
+        operator_args={"on_warning_callback": on_warning_callback},
+    )
+    tasks = [task for task in dag.tasks if isinstance(task, expected_operator_classes)]
+    # Every operator type that supports the callback is actually present in the rendered DAG.
+    assert {type(task) for task in tasks} == set(expected_operator_classes)
+    for task in tasks:
+        assert task.on_warning_callback is on_warning_callback, task.task_id


### PR DESCRIPTION
## Description

`on_warning_callback` is a first-class `DbtDag` / `DbtTaskGroup` argument, but `operator_args` is also forwarded to the underlying operators, so passing it there is a reasonable mental model. It was silently dropped: each of the three sites that wires the callback copies `task_args` (which already holds anything from `operator_args`) and then unconditionally overwrites the callback with the top-level value, which defaults to `None`.

This isolates the resolution into `_honor_on_warning_callback` and applies it at all three sites, so the top-level argument still wins when set, but an `operator_args` callback is preserved when it is not:

- `create_test_task_metadata`, for `dbt test` tasks
- `create_task_metadata`, `TestBehavior.BUILD` branch, for `dbt build` tasks
- `create_task_metadata`, `DbtResourceType.SOURCE` branch, for `dbt source freshness` tasks

All three were confirmed broken by rendering real DAGs and inspecting `on_warning_callback` on the instantiated operators, not by reading the code. The key is always set, so an operator is still handed an explicit `None` when neither form supplies a callback.

This supersedes #2918 and #2920, which each fixed the first site with an equivalent implementation. Both are credited as co-authors.

## Tests

- Per-site regression tests for all three sites. Each was verified to fail without the fix (reverting only the three call sites, keeping the helper, yields exactly one failure per site).
- A precedence test (the top-level argument wins when both are given) and a parametrised unit test for the helper, including the "neither set" case that pins the always-set-the-key invariant.
- An end-to-end `DbtDag` test over `AFTER_EACH` / `BUILD` / `AFTER_ALL`, asserting every rendered operator that supports the callback actually receives it.

`tests/airflow/test_graph.py` 159 passed; the new `tests/test_converter.py` test 3 passed; `tests/airflow/ tests/test_converter.py tests/dbt/test_pruning.py` 229 passed with 3 pre-existing failures that also fail on `main` (missing `airflow.providers.docker` locally). All 24 pre-commit hooks pass, including mypy. `sphinx-build -W` succeeds.

## Docs

Documents that both forms work and which one wins, in `testing-behavior.rst` and `managing-sources.rst`. #2869 asked for a docs note either way.

## Not covered here

Found while verifying, all pre-existing and out of scope for this issue, worth separate issues:

- The watcher test sensors (`DbtTestWatcherOperator` and its Kubernetes/GKE variants) have no `on_warning_callback` support at all, so even the top-level argument is swallowed.
- `DbtBuildKubernetesOperator` / `DbtBuildGcpGkeOperator` likewise swallow it, as they are not `DbtWarning*Operator` subclasses.
- Custom `render_config.node_converters` still receive the unresolved top-level value.

## Related Issue(s)

Closes #2869

## Breaking Change?

No. Behaviour only changes when `on_warning_callback` is present in `operator_args` and the top-level argument is unset, which was previously a silent no-op.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
