### PR TITLE
Address #2942 review feedback: manifest-mode hashing, additive excluded dirs, hash construction

### DIFF
--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -38,6 +38,11 @@ DEFAULT_PROJECT_HASH_EXCLUDED_DIRS = frozenset(
     {".git", DBT_TARGET_DIR_NAME, DBT_DEFAULT_PACKAGES_FOLDER, DBT_LOG_DIR_NAME}
 )
 
+# Conventional dbt resource-content directory names. cosmos.settings warns (but does not block) if a
+# user adds any of these to project_hash_excluded_dirs, since excluding them would silently stop DAG
+# versioning / the partial-parse and dbt-ls caches from reacting to real project changes.
+DBT_AUTHORED_CONTENT_DIRS = frozenset({"models", "seeds", "snapshots", "analyses", "macros", "tests"})
+
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"
 

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -38,9 +38,7 @@ DEFAULT_PROJECT_HASH_EXCLUDED_DIRS = frozenset(
     {".git", DBT_TARGET_DIR_NAME, DBT_DEFAULT_PACKAGES_FOLDER, DBT_LOG_DIR_NAME}
 )
 
-# Conventional dbt resource-content directory names. cosmos.settings warns (but does not block) if a
-# user adds any of these to project_hash_excluded_dirs, since excluding them would silently stop DAG
-# versioning / the partial-parse and dbt-ls caches from reacting to real project changes.
+# Conventional dbt resource-content directory names; see cosmos.settings for how these are used.
 DBT_AUTHORED_CONTENT_DIRS = frozenset({"models", "seeds", "snapshots", "analyses", "macros", "tests"})
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -38,8 +38,8 @@ DEFAULT_PROJECT_HASH_EXCLUDED_DIRS = frozenset(
     {".git", DBT_TARGET_DIR_NAME, DBT_DEFAULT_PACKAGES_FOLDER, DBT_LOG_DIR_NAME}
 )
 
-# Conventional dbt resource-content directory names; see cosmos.settings for how these are used.
-DBT_AUTHORED_CONTENT_DIRS = frozenset({"models", "seeds", "snapshots", "analyses", "macros", "tests"})
+# Conventional dbt project content directory names; see cosmos.settings for how these are used.
+DBT_PROJECT_CONTENT_DIRS = frozenset({"models", "seeds", "snapshots", "analyses", "macros", "tests"})
 
 DEFAULT_OPENLINEAGE_NAMESPACE = "cosmos"
 OPENLINEAGE_PRODUCER = "https://github.com/astronomer/astronomer-cosmos/"

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import copy
 import hashlib
 import inspect
-import json
 import os
 import platform
 import time
@@ -62,23 +61,11 @@ from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
 
-# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
-# in the project changed, so they must be dropped before hashing or the hash would too.
-_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
-
 
 def _calculate_manifest_version_hash(manifest_path: Any) -> str:
-    """Content checksum of a dbt manifest file, ignoring metadata fields that change on every
-    dbt invocation even when the project itself hasn't (``generated_at``, ``invocation_id``, ...).
-    """
+    """Content checksum of a dbt manifest file."""
     with manifest_path.open("rb") as fp:
-        manifest = json.load(fp)
-    metadata = manifest.get("metadata")
-    if isinstance(metadata, dict):
-        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
-            metadata.pop(key, None)
-    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.md5(canonical).hexdigest()
+        return hashlib.md5(fp.read()).hexdigest()
 
 
 def migrate_to_new_interface(

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -57,9 +57,11 @@ from cosmos.exceptions import CosmosValueError
 from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
 from cosmos.log import get_logger
 from cosmos.telemetry import _compress_telemetry_metadata, should_emit
-from cosmos.versioning import _HASH_READ_CHUNK_SIZE, _create_folder_version_hash
+from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
+
+_MANIFEST_HASH_READ_CHUNK_SIZE = 1024 * 1024
 
 
 def migrate_to_new_interface(
@@ -450,7 +452,7 @@ class DbtToAirflowConverter:
                 try:
                     manifest_hasher = hashlib.md5()
                     with manifest_path.open("rb") as fp:
-                        while chunk := fp.read(_HASH_READ_CHUNK_SIZE):
+                        while chunk := fp.read(_MANIFEST_HASH_READ_CHUNK_SIZE):
                             manifest_hasher.update(chunk)
                     dbt_project_hash = hashlib.md5(
                         f"{dbt_project_hash}\0{manifest_hasher.hexdigest()}".encode()

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -446,7 +446,8 @@ class DbtToAirflowConverter:
             if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
                 # target/ is pruned from the folder walk above, so fold in the manifest's own checksum.
                 manifest_checksum = manifest_path.checksum()
-                dbt_project_hash = hashlib.md5(f"{dbt_project_hash}{manifest_checksum}".encode()).hexdigest()
+                if manifest_checksum:
+                    dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()
 
             hash_suffix = f"\n\n**dbt project hash:** `{dbt_project_hash}`"
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import copy
 import hashlib
 import inspect
+import json
 import os
 import platform
 import time
@@ -61,20 +62,26 @@ from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
 
-_MANIFEST_HASH_READ_CHUNK_SIZE = 1024 * 1024
+# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
+# in the project changed, so they must be dropped before hashing or the hash would too.
+_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
 
 
 def _calculate_manifest_version_hash(manifest_path: Any) -> str:
-    """Content checksum of a dbt manifest file, streamed in chunks.
+    """Content checksum of a dbt manifest file, ignoring metadata fields that change on every
+    dbt invocation even when the project itself hasn't (``generated_at``, ``invocation_id``, ...).
 
     A separate, named call site (mirroring ``_create_folder_version_hash``) rather than inlined
     in the caller, so it can be overridden independently of the folder hash.
     """
-    hasher = hashlib.md5()
     with manifest_path.open("rb") as fp:
-        while chunk := fp.read(_MANIFEST_HASH_READ_CHUNK_SIZE):
-            hasher.update(chunk)
-    return hasher.hexdigest()
+        manifest = json.load(fp)
+    metadata = manifest.get("metadata")
+    if isinstance(metadata, dict):
+        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
+            metadata.pop(key, None)
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.md5(canonical).hexdigest()
 
 
 def migrate_to_new_interface(

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -70,9 +70,6 @@ _VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation
 def _calculate_manifest_version_hash(manifest_path: Any) -> str:
     """Content checksum of a dbt manifest file, ignoring metadata fields that change on every
     dbt invocation even when the project itself hasn't (``generated_at``, ``invocation_id``, ...).
-
-    A separate, named call site (mirroring ``_create_folder_version_hash``) rather than inlined
-    in the caller, so it can be overridden independently of the folder hash.
     """
     with manifest_path.open("rb") as fp:
         manifest = json.load(fp)
@@ -466,9 +463,7 @@ class DbtToAirflowConverter:
 
             manifest_path = self.dbt_graph.project.manifest_path
             if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
-                # target/ is pruned from the folder walk above, so fold in the manifest's own content
-                # checksum -- not manifest_path.checksum(), whose fsspec-default metadata (mtime/inode
-                # for local files, generation/updated for GCS) changes on a byte-identical re-sync.
+                # target/ is pruned from the folder walk above, so fold in the manifest's own checksum.
                 try:
                     manifest_checksum = _calculate_manifest_version_hash(manifest_path)
                     dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -444,10 +444,7 @@ class DbtToAirflowConverter:
 
             manifest_path = self.dbt_graph.project.manifest_path
             if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
-                # ``target/`` (where manifest_path conventionally lives) is pruned from the folder walk
-                # above, so a manifest regenerated with no other file changes wouldn't otherwise change
-                # this hash. Fold in a cheap metadata checksum of the manifest itself -- not a full
-                # content read -- so DAG versioning still reacts to manifest-only changes.
+                # target/ is pruned from the folder walk above, so fold in the manifest's own checksum.
                 manifest_checksum = manifest_path.checksum()
                 dbt_project_hash = hashlib.md5(f"{dbt_project_hash}{manifest_checksum}".encode()).hexdigest()
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -64,6 +64,19 @@ logger = get_logger(__name__)
 _MANIFEST_HASH_READ_CHUNK_SIZE = 1024 * 1024
 
 
+def _calculate_manifest_version_hash(manifest_path: Any) -> str:
+    """Content checksum of a dbt manifest file, streamed in chunks.
+
+    A separate, named call site (mirroring ``_create_folder_version_hash``) rather than inlined
+    in the caller, so it can be overridden independently of the folder hash.
+    """
+    hasher = hashlib.md5()
+    with manifest_path.open("rb") as fp:
+        while chunk := fp.read(_MANIFEST_HASH_READ_CHUNK_SIZE):
+            hasher.update(chunk)
+    return hasher.hexdigest()
+
+
 def migrate_to_new_interface(
     execution_config: ExecutionConfig, project_config: ProjectConfig, render_config: RenderConfig
 ):
@@ -450,13 +463,8 @@ class DbtToAirflowConverter:
                 # checksum -- not manifest_path.checksum(), whose fsspec-default metadata (mtime/inode
                 # for local files, generation/updated for GCS) changes on a byte-identical re-sync.
                 try:
-                    manifest_hasher = hashlib.md5()
-                    with manifest_path.open("rb") as fp:
-                        while chunk := fp.read(_MANIFEST_HASH_READ_CHUNK_SIZE):
-                            manifest_hasher.update(chunk)
-                    dbt_project_hash = hashlib.md5(
-                        f"{dbt_project_hash}\0{manifest_hasher.hexdigest()}".encode()
-                    ).hexdigest()
+                    manifest_checksum = _calculate_manifest_version_hash(manifest_path)
+                    dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()
                 except Exception as e:
                     logger.warning("Failed to fold dbt manifest checksum into the DAG version hash: %s", e)
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -4,7 +4,9 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import inspect
+import json
 import os
 import platform
 import time
@@ -59,6 +61,27 @@ from cosmos.telemetry import _compress_telemetry_metadata, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
+
+# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
+# in the project changed, so they must be dropped before hashing or the hash would too.
+_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
+
+
+def _calculate_manifest_version_hash(manifest_path: Any) -> str:
+    """Content checksum of a dbt manifest file, ignoring metadata fields that change on every
+    dbt invocation even when the project itself hasn't (``generated_at``, ``invocation_id``, ...).
+
+    A separate, named call site (mirroring ``_create_folder_version_hash``) rather than inlined
+    in the caller, so it can be overridden independently of the folder hash.
+    """
+    with manifest_path.open("rb") as fp:
+        manifest = json.load(fp)
+    metadata = manifest.get("metadata")
+    if isinstance(metadata, dict):
+        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
+            metadata.pop(key, None)
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.md5(canonical).hexdigest()
 
 
 def migrate_to_new_interface(
@@ -439,12 +462,18 @@ class DbtToAirflowConverter:
             return
 
         try:
+            dbt_project_hash = _create_folder_version_hash(self.dbt_graph.project_path)
+
             manifest_path = self.dbt_graph.project.manifest_path
-            is_manifest_mode = self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None
-            dbt_project_hash = _create_folder_version_hash(
-                self.dbt_graph.project_path,
-                manifest_path=manifest_path if is_manifest_mode else None,
-            )
+            if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
+                # target/ is pruned from the folder walk above, so fold in the manifest's own content
+                # checksum -- not manifest_path.checksum(), whose fsspec-default metadata (mtime/inode
+                # for local files, generation/updated for GCS) changes on a byte-identical re-sync.
+                try:
+                    manifest_checksum = _calculate_manifest_version_hash(manifest_path)
+                    dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()
+                except Exception as e:
+                    logger.warning("Failed to fold dbt manifest checksum into the DAG version hash: %s", e)
 
             hash_suffix = f"\n\n**dbt project hash:** `{dbt_project_hash}`"
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 import copy
+import hashlib
 import inspect
 import os
 import platform
@@ -440,6 +441,16 @@ class DbtToAirflowConverter:
 
         try:
             dbt_project_hash = _create_folder_version_hash(self.dbt_graph.project_path)
+
+            manifest_path = self.dbt_graph.project.manifest_path
+            if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
+                # ``target/`` (where manifest_path conventionally lives) is pruned from the folder walk
+                # above, so a manifest regenerated with no other file changes wouldn't otherwise change
+                # this hash. Fold in a cheap metadata checksum of the manifest itself -- not a full
+                # content read -- so DAG versioning still reacts to manifest-only changes.
+                manifest_checksum = manifest_path.checksum()
+                dbt_project_hash = hashlib.md5(f"{dbt_project_hash}{manifest_checksum}".encode()).hexdigest()
+
             hash_suffix = f"\n\n**dbt project hash:** `{dbt_project_hash}`"
 
             if dag.doc_md:

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -57,7 +57,7 @@ from cosmos.exceptions import CosmosValueError
 from cosmos.listeners.task_instance_listener import _get_profile_config_attribute
 from cosmos.log import get_logger
 from cosmos.telemetry import _compress_telemetry_metadata, should_emit
-from cosmos.versioning import _create_folder_version_hash
+from cosmos.versioning import _HASH_READ_CHUNK_SIZE, _create_folder_version_hash
 
 logger = get_logger(__name__)
 
@@ -444,10 +444,19 @@ class DbtToAirflowConverter:
 
             manifest_path = self.dbt_graph.project.manifest_path
             if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
-                # target/ is pruned from the folder walk above, so fold in the manifest's own checksum.
-                manifest_checksum = manifest_path.checksum()
-                if manifest_checksum:
-                    dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()
+                # target/ is pruned from the folder walk above, so fold in the manifest's own content
+                # checksum -- not manifest_path.checksum(), whose fsspec-default metadata (mtime/inode
+                # for local files, generation/updated for GCS) changes on a byte-identical re-sync.
+                try:
+                    manifest_hasher = hashlib.md5()
+                    with manifest_path.open("rb") as fp:
+                        while chunk := fp.read(_HASH_READ_CHUNK_SIZE):
+                            manifest_hasher.update(chunk)
+                    dbt_project_hash = hashlib.md5(
+                        f"{dbt_project_hash}\0{manifest_hasher.hexdigest()}".encode()
+                    ).hexdigest()
+                except Exception as e:
+                    logger.warning("Failed to fold dbt manifest checksum into the DAG version hash: %s", e)
 
             hash_suffix = f"\n\n**dbt project hash:** `{dbt_project_hash}`"
 

--- a/cosmos/converter.py
+++ b/cosmos/converter.py
@@ -4,9 +4,7 @@
 from __future__ import annotations
 
 import copy
-import hashlib
 import inspect
-import json
 import os
 import platform
 import time
@@ -61,27 +59,6 @@ from cosmos.telemetry import _compress_telemetry_metadata, should_emit
 from cosmos.versioning import _create_folder_version_hash
 
 logger = get_logger(__name__)
-
-# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
-# in the project changed, so they must be dropped before hashing or the hash would too.
-_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
-
-
-def _calculate_manifest_version_hash(manifest_path: Any) -> str:
-    """Content checksum of a dbt manifest file, ignoring metadata fields that change on every
-    dbt invocation even when the project itself hasn't (``generated_at``, ``invocation_id``, ...).
-
-    A separate, named call site (mirroring ``_create_folder_version_hash``) rather than inlined
-    in the caller, so it can be overridden independently of the folder hash.
-    """
-    with manifest_path.open("rb") as fp:
-        manifest = json.load(fp)
-    metadata = manifest.get("metadata")
-    if isinstance(metadata, dict):
-        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
-            metadata.pop(key, None)
-    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.md5(canonical).hexdigest()
 
 
 def migrate_to_new_interface(
@@ -462,18 +439,12 @@ class DbtToAirflowConverter:
             return
 
         try:
-            dbt_project_hash = _create_folder_version_hash(self.dbt_graph.project_path)
-
             manifest_path = self.dbt_graph.project.manifest_path
-            if self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None:
-                # target/ is pruned from the folder walk above, so fold in the manifest's own content
-                # checksum -- not manifest_path.checksum(), whose fsspec-default metadata (mtime/inode
-                # for local files, generation/updated for GCS) changes on a byte-identical re-sync.
-                try:
-                    manifest_checksum = _calculate_manifest_version_hash(manifest_path)
-                    dbt_project_hash = hashlib.md5(f"{dbt_project_hash}\0{manifest_checksum}".encode()).hexdigest()
-                except Exception as e:
-                    logger.warning("Failed to fold dbt manifest checksum into the DAG version hash: %s", e)
+            is_manifest_mode = self.dbt_graph.load_method == LoadMode.DBT_MANIFEST and manifest_path is not None
+            dbt_project_hash = _create_folder_version_hash(
+                self.dbt_graph.project_path,
+                manifest_path=manifest_path if is_manifest_mode else None,
+            )
 
             hash_suffix = f"\n\n**dbt project hash:** `{dbt_project_hash}`"
 

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -13,6 +13,7 @@ except ImportError:
     from airflow.configuration import conf
 
 from cosmos.constants import (
+    DBT_AUTHORED_CONTENT_DIRS,
     DEFAULT_COSMOS_CACHE_DIR_NAME,
     DEFAULT_OPENLINEAGE_NAMESPACE,
     DEFAULT_PROJECT_HASH_EXCLUDED_DIRS,
@@ -23,14 +24,22 @@ DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir: Path = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache: bool = conf.getboolean("cosmos", "enable_cache", fallback=True)
 enable_dag_versioning = conf.getboolean("cosmos", "enable_dag_versioning", fallback=True)
-# Directory names pruned from the dbt project content hash walk (cosmos/versioning.py). Defaults to
-# dbt/VCS-generated folders; setting this replaces the default entirely. See #2857.
-_dag_versioning_excluded_dirs_conf = conf.get("cosmos", "project_hash_excluded_dirs", fallback="")
-project_hash_excluded_dirs: frozenset[str] = (
-    frozenset(dirname.strip() for dirname in _dag_versioning_excluded_dirs_conf.split(",") if dirname.strip())
-    if _dag_versioning_excluded_dirs_conf.strip()
-    else DEFAULT_PROJECT_HASH_EXCLUDED_DIRS
+# Directory names pruned from the dbt project content hash walk (cosmos/versioning.py). Additive on top
+# of the dbt/VCS-generated folders in DEFAULT_PROJECT_HASH_EXCLUDED_DIRS, which are always pruned so that
+# setting this can't accidentally stop excluding .git/target/dbt_packages/logs. See #2857.
+_project_hash_excluded_dirs_conf = conf.get("cosmos", "project_hash_excluded_dirs", fallback="")
+_project_hash_excluded_dirs_extra = frozenset(
+    dirname.strip() for dirname in _project_hash_excluded_dirs_conf.split(",") if dirname.strip()
 )
+_suspicious_project_hash_excluded_dirs = _project_hash_excluded_dirs_extra & DBT_AUTHORED_CONTENT_DIRS
+if _suspicious_project_hash_excluded_dirs:
+    warnings.warn(
+        f"`project_hash_excluded_dirs` includes {sorted(_suspicious_project_hash_excluded_dirs)}, which look like "
+        "dbt-authored content directories. Excluding them means real project changes there won't be detected by "
+        "DAG versioning or the partial-parse/dbt-ls caches.",
+        UserWarning,
+    )
+project_hash_excluded_dirs: frozenset[str] = DEFAULT_PROJECT_HASH_EXCLUDED_DIRS | _project_hash_excluded_dirs_extra
 enable_dataset_alias = conf.getboolean("cosmos", "enable_dataset_alias", fallback=True)
 enable_uri_xcom = conf.getboolean("cosmos", "enable_uri_xcom", fallback=False)
 use_dataset_airflow3_uri_standard = conf.getboolean(

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -24,9 +24,7 @@ DEFAULT_CACHE_DIR = Path(tempfile.gettempdir(), DEFAULT_COSMOS_CACHE_DIR_NAME)
 cache_dir: Path = Path(conf.get("cosmos", "cache_dir", fallback=DEFAULT_CACHE_DIR) or DEFAULT_CACHE_DIR)
 enable_cache: bool = conf.getboolean("cosmos", "enable_cache", fallback=True)
 enable_dag_versioning = conf.getboolean("cosmos", "enable_dag_versioning", fallback=True)
-# Directory names pruned from the dbt project content hash walk (cosmos/versioning.py). Additive on top
-# of the dbt/VCS-generated folders in DEFAULT_PROJECT_HASH_EXCLUDED_DIRS, which are always pruned so that
-# setting this can't accidentally stop excluding .git/target/dbt_packages/logs. See #2857.
+# Additive on top of DEFAULT_PROJECT_HASH_EXCLUDED_DIRS, which are always pruned. See #2857.
 _project_hash_excluded_dirs_conf = conf.get("cosmos", "project_hash_excluded_dirs", fallback="")
 _project_hash_excluded_dirs_extra = frozenset(
     dirname.strip() for dirname in _project_hash_excluded_dirs_conf.split(",") if dirname.strip()

--- a/cosmos/settings.py
+++ b/cosmos/settings.py
@@ -13,7 +13,7 @@ except ImportError:
     from airflow.configuration import conf
 
 from cosmos.constants import (
-    DBT_AUTHORED_CONTENT_DIRS,
+    DBT_PROJECT_CONTENT_DIRS,
     DEFAULT_COSMOS_CACHE_DIR_NAME,
     DEFAULT_OPENLINEAGE_NAMESPACE,
     DEFAULT_PROJECT_HASH_EXCLUDED_DIRS,
@@ -29,11 +29,11 @@ _project_hash_excluded_dirs_conf = conf.get("cosmos", "project_hash_excluded_dir
 _project_hash_excluded_dirs_extra = frozenset(
     dirname.strip() for dirname in _project_hash_excluded_dirs_conf.split(",") if dirname.strip()
 )
-_suspicious_project_hash_excluded_dirs = _project_hash_excluded_dirs_extra & DBT_AUTHORED_CONTENT_DIRS
+_suspicious_project_hash_excluded_dirs = _project_hash_excluded_dirs_extra & DBT_PROJECT_CONTENT_DIRS
 if _suspicious_project_hash_excluded_dirs:
     warnings.warn(
         f"`project_hash_excluded_dirs` includes {sorted(_suspicious_project_hash_excluded_dirs)}, which look like "
-        "dbt-authored content directories. Excluding them means real project changes there won't be detected by "
+        "dbt project content directories. Excluding them means real project changes there won't be detected by "
         "DAG versioning or the partial-parse/dbt-ls caches.",
         UserWarning,
     )

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -51,11 +51,13 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
     if pruned_dirs:
         logger.debug("Pruned %s excluded directories while hashing the dbt project folder %s", pruned_dirs, dir_path)
 
-    for filepath in sorted(filepaths):
+    relative_posix_paths = {filepath: Path(filepath).relative_to(dir_path).as_posix() for filepath in filepaths}
+    for filepath in sorted(filepaths, key=lambda fp: relative_posix_paths[fp]):
         # Include the path so that renaming a file also changes the hash; dbt derives node
         # names from file names, so a content-preserving rename still changes the project.
-        # Null-byte separator avoids a path/content boundary ambiguity; as_posix() is OS-independent.
-        hasher.update(Path(filepath).relative_to(dir_path).as_posix().encode())
+        # Null-byte separator avoids a path/content boundary ambiguity; as_posix() is OS-independent,
+        # and sorting by it (not the OS-native filepath) keeps iteration order OS-independent too.
+        hasher.update(relative_posix_paths[filepath].encode())
         hasher.update(b"\0")
         try:
             with open(str(filepath), "rb") as fp:

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
 import hashlib
+import json
 import os
 from collections.abc import Collection
 from pathlib import Path
+from typing import Any
 
 from cosmos import settings
 from cosmos.log import get_logger
@@ -14,8 +16,17 @@ logger = get_logger(__name__)
 # (e.g. a misplaced manifest.json) don't get loaded into memory whole
 _HASH_READ_CHUNK_SIZE = 1024 * 1024
 
+# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
+# in the project changed, so they must be dropped before hashing or the hash would too.
+_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
 
-def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] | None = None) -> str:
+
+def _create_folder_version_hash(
+    dir_path: Path,
+    excluded_dirs: Collection[str] | None = None,
+    manifest_path: Any | None = None,
+    **kwargs: Any,
+) -> str:
     """
     Given a directory, iterate through its content and create a hash that will change in case the
     contents of the directory change. The value should not change if the values of the directory do not change, even if
@@ -25,6 +36,13 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
     tree. When ``excluded_dirs`` is None, the ``[cosmos] project_hash_excluded_dirs`` setting is used,
     which defaults to generated folders such as ``target/``, ``dbt_packages/``, ``logs/`` and ``.git/``.
     Pass an explicit collection (including an empty one) to override the setting.
+
+    ``manifest_path``, when given, folds the dbt manifest's own content checksum into the result --
+    needed under ``LoadMode.DBT_MANIFEST``, since the manifest conventionally lives under ``target/``
+    (excluded above) and may not even live under ``dir_path`` at all. Metadata fields that dbt stamps on
+    every invocation (``generated_at``, ``invocation_id``, ...) are ignored, so a manifest regenerated
+    from an unchanged project still hashes the same. A read/parse failure is caught and logged, falling
+    back to the folder hash alone. ``**kwargs`` absorbs future extensions without another signature bump.
 
     This method output must be concise and it currently changes based on operating system.
     """
@@ -66,4 +84,28 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
         except FileNotFoundError:
             logger.warning("The dbt project folder contains a symbolic link to a non-existent file: %s", filepath)
 
-    return hasher.hexdigest()
+    folder_hash = hasher.hexdigest()
+
+    if manifest_path is None:
+        return folder_hash
+
+    try:
+        manifest_checksum = _manifest_content_checksum(manifest_path)
+    except Exception as e:
+        logger.warning("Failed to fold dbt manifest checksum into the project version hash: %s", e)
+        return folder_hash
+
+    return hashlib.md5(f"{folder_hash}\0{manifest_checksum}".encode()).hexdigest()
+
+
+def _manifest_content_checksum(manifest_path: Any) -> str:
+    """MD5 of a dbt manifest's content, ignoring metadata fields dbt stamps on every invocation
+    (``generated_at``, ``invocation_id``, ...) even when the project itself hasn't changed."""
+    with manifest_path.open("rb") as fp:
+        manifest = json.load(fp)
+    metadata = manifest.get("metadata")
+    if isinstance(metadata, dict):
+        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
+            metadata.pop(key, None)
+    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
+    return hashlib.md5(canonical).hexdigest()

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -53,8 +53,12 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
 
     for filepath in sorted(filepaths):
         # Include the path so that renaming a file also changes the hash; dbt derives node
-        # names from file names, so a content-preserving rename still changes the project
-        hasher.update(os.path.relpath(filepath, dir_path).encode())
+        # names from file names, so a content-preserving rename still changes the project.
+        # A null-byte separator prevents a path/content boundary ambiguity (e.g. path "a" +
+        # content "bc" would otherwise hash the same as path "ab" + content "c"), and .as_posix()
+        # keeps the hash consistent across platforms regardless of the OS path separator.
+        hasher.update(Path(filepath).relative_to(dir_path).as_posix().encode())
+        hasher.update(b"\0")
         try:
             with open(str(filepath), "rb") as fp:
                 while chunk := fp.read(_HASH_READ_CHUNK_SIZE):

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -26,7 +26,7 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
     which defaults to generated folders such as ``target/``, ``dbt_packages/``, ``logs/`` and ``.git/``.
     Pass an explicit collection (including an empty one) to override the setting.
 
-    This method output must be concise and it currently changes based on operating system.
+    This method output must be concise, and is consistent across operating systems.
     """
     # This approach is less efficient than using modified time
     # sum([path.stat().st_mtime for path in dir_path.glob("**/*")])

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -54,9 +54,7 @@ def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] |
     for filepath in sorted(filepaths):
         # Include the path so that renaming a file also changes the hash; dbt derives node
         # names from file names, so a content-preserving rename still changes the project.
-        # A null-byte separator prevents a path/content boundary ambiguity (e.g. path "a" +
-        # content "bc" would otherwise hash the same as path "ab" + content "c"), and .as_posix()
-        # keeps the hash consistent across platforms regardless of the OS path separator.
+        # Null-byte separator avoids a path/content boundary ambiguity; as_posix() is OS-independent.
         hasher.update(Path(filepath).relative_to(dir_path).as_posix().encode())
         hasher.update(b"\0")
         try:

--- a/cosmos/versioning.py
+++ b/cosmos/versioning.py
@@ -1,11 +1,9 @@
 from __future__ import annotations
 
 import hashlib
-import json
 import os
 from collections.abc import Collection
 from pathlib import Path
-from typing import Any
 
 from cosmos import settings
 from cosmos.log import get_logger
@@ -16,17 +14,8 @@ logger = get_logger(__name__)
 # (e.g. a misplaced manifest.json) don't get loaded into memory whole
 _HASH_READ_CHUNK_SIZE = 1024 * 1024
 
-# dbt stamps these into every manifest's `metadata` on every invocation, even when nothing else
-# in the project changed, so they must be dropped before hashing or the hash would too.
-_VOLATILE_MANIFEST_METADATA_KEYS = ("generated_at", "invocation_id", "invocation_started_at")
 
-
-def _create_folder_version_hash(
-    dir_path: Path,
-    excluded_dirs: Collection[str] | None = None,
-    manifest_path: Any | None = None,
-    **kwargs: Any,
-) -> str:
+def _create_folder_version_hash(dir_path: Path, excluded_dirs: Collection[str] | None = None) -> str:
     """
     Given a directory, iterate through its content and create a hash that will change in case the
     contents of the directory change. The value should not change if the values of the directory do not change, even if
@@ -36,13 +25,6 @@ def _create_folder_version_hash(
     tree. When ``excluded_dirs`` is None, the ``[cosmos] project_hash_excluded_dirs`` setting is used,
     which defaults to generated folders such as ``target/``, ``dbt_packages/``, ``logs/`` and ``.git/``.
     Pass an explicit collection (including an empty one) to override the setting.
-
-    ``manifest_path``, when given, folds the dbt manifest's own content checksum into the result --
-    needed under ``LoadMode.DBT_MANIFEST``, since the manifest conventionally lives under ``target/``
-    (excluded above) and may not even live under ``dir_path`` at all. Metadata fields that dbt stamps on
-    every invocation (``generated_at``, ``invocation_id``, ...) are ignored, so a manifest regenerated
-    from an unchanged project still hashes the same. A read/parse failure is caught and logged, falling
-    back to the folder hash alone. ``**kwargs`` absorbs future extensions without another signature bump.
 
     This method output must be concise and it currently changes based on operating system.
     """
@@ -84,28 +66,4 @@ def _create_folder_version_hash(
         except FileNotFoundError:
             logger.warning("The dbt project folder contains a symbolic link to a non-existent file: %s", filepath)
 
-    folder_hash = hasher.hexdigest()
-
-    if manifest_path is None:
-        return folder_hash
-
-    try:
-        manifest_checksum = _manifest_content_checksum(manifest_path)
-    except Exception as e:
-        logger.warning("Failed to fold dbt manifest checksum into the project version hash: %s", e)
-        return folder_hash
-
-    return hashlib.md5(f"{folder_hash}\0{manifest_checksum}".encode()).hexdigest()
-
-
-def _manifest_content_checksum(manifest_path: Any) -> str:
-    """MD5 of a dbt manifest's content, ignoring metadata fields dbt stamps on every invocation
-    (``generated_at``, ``invocation_id``, ...) even when the project itself hasn't changed."""
-    with manifest_path.open("rb") as fp:
-        manifest = json.load(fp)
-    metadata = manifest.get("metadata")
-    if isinstance(metadata, dict):
-        for key in _VOLATILE_MANIFEST_METADATA_KEYS:
-            metadata.pop(key, None)
-    canonical = json.dumps(manifest, sort_keys=True, separators=(",", ":")).encode()
-    return hashlib.md5(canonical).hexdigest()
+    return hasher.hexdigest()

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -52,9 +52,9 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
     folders such as ``target/`` and ``dbt_packages/`` can be large, and reading them on every DAG parse
     is expensive on network-backed storage. This setting is additive: ``.git``, ``target``,
     ``dbt_packages`` and ``logs`` are always excluded, regardless of this value. A matching directory
-    name is skipped wherever it appears in the project tree. Cosmos logs a warning (but does not block)
-    if this includes a dbt-authored content directory, such as ``models`` or ``macros``, since excluding
-    one means real changes there won't be detected.
+    name is skipped wherever it appears in the project tree. Cosmos emits a ``UserWarning`` (but does not
+    block) if this includes a dbt-authored content directory, such as ``models`` or ``macros``, since
+    excluding one means real changes there won't be detected.
 
     - Default: unset (only the always-excluded ``.git, target, dbt_packages, logs`` apply)
     - Environment Variable: ``AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS``

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -37,6 +37,8 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 `enable_dag_versioning`_:
     **Airflow 3+ only:** when enabled (default), Cosmos computes a hash of the dbt project directory and appends
     it to the DAG's ``doc_md`` so that Airflow 3's DAG versioning can detect when dbt project files change.
+    Under ``LoadMode.DBT_MANIFEST``, the manifest file's own content checksum is folded into this hash as well,
+    since the manifest conventionally lives under ``target/``, which is excluded from the directory walk.
     On Airflow 2.x, ``doc_md`` is not modified for this purpose (the setting has no effect there).
     When disabled on Airflow 3+, the hash is not computed (faster DAG parsing) and DAG versioning will not
     reflect dbt project content changes from this mechanism.

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -55,7 +55,7 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
     is expensive on network-backed storage. This setting is additive: ``.git``, ``target``,
     ``dbt_packages`` and ``logs`` are always excluded, regardless of this value. A matching directory
     name is skipped wherever it appears in the project tree. Cosmos emits a ``UserWarning`` (but does not
-    block) if this includes a dbt-authored content directory, such as ``models`` or ``macros``, since
+    block) if this includes a dbt project content directory, such as ``models`` or ``macros``, since
     excluding one means real changes there won't be detected.
 
     - Default: unset (only the always-excluded ``.git, target, dbt_packages, logs`` apply)

--- a/docs/reference/configs/cosmos-conf.rst
+++ b/docs/reference/configs/cosmos-conf.rst
@@ -47,13 +47,16 @@ This page lists all available `Apache Airflow® <https://airflow.apache.org/>`_ 
 .. _project_hash_excluded_dirs:
 
 `project_hash_excluded_dirs`_:
-    Comma-separated list of directory names that Cosmos skips when hashing the dbt project directory
-    (used by ``enable_dag_versioning`` and the partial-parse/dbt-ls cache keys). Generated folders such
-    as ``target/`` and ``dbt_packages/`` can be large, and reading them on every DAG parse is expensive
-    on network-backed storage. Setting this replaces the default list entirely. A matching directory
-    name is skipped wherever it appears in the project tree.
+    Comma-separated list of additional directory names that Cosmos skips when hashing the dbt project
+    directory (used by ``enable_dag_versioning`` and the partial-parse/dbt-ls cache keys). Generated
+    folders such as ``target/`` and ``dbt_packages/`` can be large, and reading them on every DAG parse
+    is expensive on network-backed storage. This setting is additive: ``.git``, ``target``,
+    ``dbt_packages`` and ``logs`` are always excluded, regardless of this value. A matching directory
+    name is skipped wherever it appears in the project tree. Cosmos logs a warning (but does not block)
+    if this includes a dbt-authored content directory, such as ``models`` or ``macros``, since excluding
+    one means real changes there won't be detected.
 
-    - Default: ``.git, target, dbt_packages, logs``
+    - Default: unset (only the always-excluded ``.git, target, dbt_packages, logs`` apply)
     - Environment Variable: ``AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS``
 
 .. _enable_cache_dbt_ls:

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2639,9 +2639,9 @@ def test_save_dbt_ls_cache(mock_variable_set, mock_datetime, tmp_dbt_project_dir
     if sys.platform == "darwin":
         # macOS has historically produced a different directory hash than Linux; the hash below is the
         # Linux value, which recent macOS versions also produce. Adjust if a macOS release diverges again.
-        assert hash_dir in ("052500661481799729b72b1d4f6a5bb1",)
+        assert hash_dir in ("d41b4e9b7a78b09bcfc85d79b108886d",)
     else:
-        assert hash_dir == "052500661481799729b72b1d4f6a5bb1"
+        assert hash_dir == "d41b4e9b7a78b09bcfc85d79b108886d"
 
 
 @patch("cosmos.dbt.graph.datetime")
@@ -2680,9 +2680,9 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
     if sys.platform == "darwin":
         # macOS has historically produced a different directory hash than Linux; the hash below is the
         # Linux value, which recent macOS versions also produce. Adjust if a macOS release diverges again.
-        assert hash_dir in ("052500661481799729b72b1d4f6a5bb1",)
+        assert hash_dir in ("d41b4e9b7a78b09bcfc85d79b108886d",)
     else:
-        assert hash_dir == "052500661481799729b72b1d4f6a5bb1"
+        assert hash_dir == "d41b4e9b7a78b09bcfc85d79b108886d"
 
 
 @pytest.mark.skipif(AIRFLOW_VERSION.major < _AIRFLOW3_MAJOR_VERSION, reason="AirflowRuntimeError is Airflow 3+ only")

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import tempfile
 from contextlib import nullcontext as does_not_raise
@@ -1443,54 +1442,18 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
 
 
 def test_calculate_manifest_version_hash_is_content_derived(tmp_path):
-    """The hash reflects the manifest's nodes, not its path, and is stable across key ordering."""
+    """The hash reflects the manifest's bytes, not its path."""
     manifest_a = tmp_path / "a.json"
-    manifest_a.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.a": {}}}))
+    manifest_a.write_bytes(b'{"nodes": {"model.a": {}}}')
 
     manifest_b = tmp_path / "b.json"
-    manifest_b.write_text(json.dumps({"nodes": {"model.a": {}}, "metadata": {"dbt_version": "1.9.0"}}))
+    manifest_b.write_bytes(b'{"nodes": {"model.a": {}}}')
 
     manifest_c = tmp_path / "c.json"
-    manifest_c.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.b": {}}}))
+    manifest_c.write_bytes(b'{"nodes": {"model.b": {}}}')
 
     assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
     assert _calculate_manifest_version_hash(manifest_a) != _calculate_manifest_version_hash(manifest_c)
-
-
-def test_calculate_manifest_version_hash_ignores_volatile_metadata(tmp_path):
-    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
-    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
-    manifest_a = tmp_path / "a.json"
-    manifest_a.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "dbt_version": "1.9.0",
-                    "generated_at": "2026-01-01T00:00:00Z",
-                    "invocation_id": "aaaa",
-                    "invocation_started_at": "2026-01-01T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    manifest_b = tmp_path / "b.json"
-    manifest_b.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "dbt_version": "1.9.0",
-                    "generated_at": "2026-01-02T00:00:00Z",
-                    "invocation_id": "bbbb",
-                    "invocation_started_at": "2026-01-02T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
 
 
 @skipif_airflow_lt_3_dag_doc_hash
@@ -1520,14 +1483,14 @@ def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
     hash_without_manifest = dag.doc_md
 
     manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
+    manifest_path.write_bytes(b"manifest_v1")
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
     converter.dbt_graph.project.manifest_path = manifest_path
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v1 = dag.doc_md
 
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
+    manifest_path.write_bytes(b"manifest_v2")
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v2 = dag.doc_md

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,4 +1,3 @@
-import json
 import logging
 import tempfile
 from contextlib import nullcontext as does_not_raise
@@ -24,12 +23,7 @@ from cosmos.constants import (
     SourceRenderingBehavior,
     TestBehavior,
 )
-from cosmos.converter import (
-    DbtToAirflowConverter,
-    _calculate_manifest_version_hash,
-    validate_arguments,
-    validate_initial_user_config,
-)
+from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators.local import (
@@ -1442,64 +1436,12 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
     mock_hash_func.assert_not_called()
 
 
-def test_calculate_manifest_version_hash_is_content_derived(tmp_path):
-    """The hash reflects the manifest's nodes, not its path, and is stable across key ordering."""
-    manifest_a = tmp_path / "a.json"
-    manifest_a.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.a": {}}}))
-
-    manifest_b = tmp_path / "b.json"
-    manifest_b.write_text(json.dumps({"nodes": {"model.a": {}}, "metadata": {"dbt_version": "1.9.0"}}))
-
-    manifest_c = tmp_path / "c.json"
-    manifest_c.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.b": {}}}))
-
-    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
-    assert _calculate_manifest_version_hash(manifest_a) != _calculate_manifest_version_hash(manifest_c)
-
-
-def test_calculate_manifest_version_hash_ignores_volatile_metadata(tmp_path):
-    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
-    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
-    manifest_a = tmp_path / "a.json"
-    manifest_a.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "dbt_version": "1.9.0",
-                    "generated_at": "2026-01-01T00:00:00Z",
-                    "invocation_id": "aaaa",
-                    "invocation_started_at": "2026-01-01T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    manifest_b = tmp_path / "b.json"
-    manifest_b.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "dbt_version": "1.9.0",
-                    "generated_at": "2026-01-02T00:00:00Z",
-                    "invocation_id": "bbbb",
-                    "invocation_started_at": "2026-01-02T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
-
-
 @skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
-def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
-    mock_load_dbt_graph, mock_hash_func, tmp_path
-):
-    """Under LoadMode.DBT_MANIFEST, the manifest's checksum must be folded into the DAG-versioning hash."""
+def test_dag_versioning_passes_manifest_path_only_in_manifest_mode(mock_load_dbt_graph, mock_hash_func, tmp_path):
+    """_create_folder_version_hash does its own manifest handling (see test_versioning.py); converter.py's
+    only job is to pass manifest_path through under LoadMode.DBT_MANIFEST, and None otherwise."""
     mock_hash_func.return_value = "folder_hash"
     dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
 
@@ -1517,55 +1459,18 @@ def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
         profile_config=profile_config,
         execution_config=execution_config,
     )
-    hash_without_manifest = dag.doc_md
-
     manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
-    converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
     converter.dbt_graph.project.manifest_path = manifest_path
+
+    converter.dbt_graph.load_method = LoadMode.DBT_LS
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
-    hash_with_manifest_v1 = dag.doc_md
-
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
-    dag.doc_md = None
-    converter._add_dbt_project_hash_to_dag_docs(dag)
-    hash_with_manifest_v2 = dag.doc_md
-
-    assert hash_without_manifest != hash_with_manifest_v1
-    assert hash_with_manifest_v1 != hash_with_manifest_v2
-
-
-@skipif_airflow_lt_3_dag_doc_hash
-@patch("cosmos.converter._create_folder_version_hash")
-@patch("cosmos.converter.DbtGraph.load")
-def test_dag_versioning_hash_survives_manifest_checksum_failure(mock_load_dbt_graph, mock_hash_func):
-    """A manifest read failure must not drop the folder hash that was already computed."""
-    mock_hash_func.return_value = "folder_hash"
-    dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
-
-    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
-    profile_config = ProfileConfig(
-        profile_name="test",
-        target_name="test",
-        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
-    )
-    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
-
-    converter = DbtToAirflowConverter(
-        dag=dag,
-        project_config=project_config,
-        profile_config=profile_config,
-        execution_config=execution_config,
-    )
+    mock_hash_func.assert_called_with(converter.dbt_graph.project_path, manifest_path=None)
 
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
-    converter.dbt_graph.project.manifest_path = MagicMock(open=MagicMock(side_effect=OSError("boom")))
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
-
-    assert dag.doc_md is not None
-    assert "folder_hash" in dag.doc_md
+    mock_hash_func.assert_called_with(converter.dbt_graph.project_path, manifest_path=manifest_path)
 
 
 @pytest.mark.skipif(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1439,7 +1439,9 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
 @skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
-def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(mock_load_dbt_graph, mock_hash_func):
+def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
+    mock_load_dbt_graph, mock_hash_func, tmp_path
+):
     """Under LoadMode.DBT_MANIFEST, the manifest's checksum must be folded into the DAG-versioning hash."""
     mock_hash_func.return_value = "folder_hash"
     dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
@@ -1460,19 +1462,53 @@ def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(mock_l
     )
     hash_without_manifest = dag.doc_md
 
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(b"manifest_v1")
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
-    converter.dbt_graph.project.manifest_path = MagicMock(checksum=MagicMock(return_value="manifest_v1"))
+    converter.dbt_graph.project.manifest_path = manifest_path
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v1 = dag.doc_md
 
-    converter.dbt_graph.project.manifest_path.checksum.return_value = "manifest_v2"
+    manifest_path.write_bytes(b"manifest_v2")
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v2 = dag.doc_md
 
     assert hash_without_manifest != hash_with_manifest_v1
     assert hash_with_manifest_v1 != hash_with_manifest_v2
+
+
+@skipif_airflow_lt_3_dag_doc_hash
+@patch("cosmos.converter._create_folder_version_hash")
+@patch("cosmos.converter.DbtGraph.load")
+def test_dag_versioning_hash_survives_manifest_checksum_failure(mock_load_dbt_graph, mock_hash_func):
+    """A manifest read failure must not drop the folder hash that was already computed."""
+    mock_hash_func.return_value = "folder_hash"
+    dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
+
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+
+    converter = DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+    )
+
+    converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
+    converter.dbt_graph.project.manifest_path = MagicMock(open=MagicMock(side_effect=OSError("boom")))
+    dag.doc_md = None
+    converter._add_dbt_project_hash_to_dag_docs(dag)
+
+    assert dag.doc_md is not None
+    assert "folder_hash" in dag.doc_md
 
 
 @pytest.mark.skipif(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import tempfile
 from contextlib import nullcontext as does_not_raise
@@ -23,7 +24,12 @@ from cosmos.constants import (
     SourceRenderingBehavior,
     TestBehavior,
 )
-from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
+from cosmos.converter import (
+    DbtToAirflowConverter,
+    _calculate_manifest_version_hash,
+    validate_arguments,
+    validate_initial_user_config,
+)
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators.local import (
@@ -1436,12 +1442,64 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
     mock_hash_func.assert_not_called()
 
 
+def test_calculate_manifest_version_hash_is_content_derived(tmp_path):
+    """The hash reflects the manifest's nodes, not its path, and is stable across key ordering."""
+    manifest_a = tmp_path / "a.json"
+    manifest_a.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.a": {}}}))
+
+    manifest_b = tmp_path / "b.json"
+    manifest_b.write_text(json.dumps({"nodes": {"model.a": {}}, "metadata": {"dbt_version": "1.9.0"}}))
+
+    manifest_c = tmp_path / "c.json"
+    manifest_c.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.b": {}}}))
+
+    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
+    assert _calculate_manifest_version_hash(manifest_a) != _calculate_manifest_version_hash(manifest_c)
+
+
+def test_calculate_manifest_version_hash_ignores_volatile_metadata(tmp_path):
+    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
+    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
+    manifest_a = tmp_path / "a.json"
+    manifest_a.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_version": "1.9.0",
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "invocation_id": "aaaa",
+                    "invocation_started_at": "2026-01-01T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    manifest_b = tmp_path / "b.json"
+    manifest_b.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_version": "1.9.0",
+                    "generated_at": "2026-01-02T00:00:00Z",
+                    "invocation_id": "bbbb",
+                    "invocation_started_at": "2026-01-02T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
+
+
 @skipif_airflow_lt_3_dag_doc_hash
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
-def test_dag_versioning_passes_manifest_path_only_in_manifest_mode(mock_load_dbt_graph, mock_hash_func, tmp_path):
-    """_create_folder_version_hash does its own manifest handling (see test_versioning.py); converter.py's
-    only job is to pass manifest_path through under LoadMode.DBT_MANIFEST, and None otherwise."""
+def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
+    mock_load_dbt_graph, mock_hash_func, tmp_path
+):
+    """Under LoadMode.DBT_MANIFEST, the manifest's checksum must be folded into the DAG-versioning hash."""
     mock_hash_func.return_value = "folder_hash"
     dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
 
@@ -1459,18 +1517,55 @@ def test_dag_versioning_passes_manifest_path_only_in_manifest_mode(mock_load_dbt
         profile_config=profile_config,
         execution_config=execution_config,
     )
-    manifest_path = tmp_path / "manifest.json"
-    converter.dbt_graph.project.manifest_path = manifest_path
+    hash_without_manifest = dag.doc_md
 
-    converter.dbt_graph.load_method = LoadMode.DBT_LS
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
+    converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
+    converter.dbt_graph.project.manifest_path = manifest_path
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
-    mock_hash_func.assert_called_with(converter.dbt_graph.project_path, manifest_path=None)
+    hash_with_manifest_v1 = dag.doc_md
+
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
+    dag.doc_md = None
+    converter._add_dbt_project_hash_to_dag_docs(dag)
+    hash_with_manifest_v2 = dag.doc_md
+
+    assert hash_without_manifest != hash_with_manifest_v1
+    assert hash_with_manifest_v1 != hash_with_manifest_v2
+
+
+@skipif_airflow_lt_3_dag_doc_hash
+@patch("cosmos.converter._create_folder_version_hash")
+@patch("cosmos.converter.DbtGraph.load")
+def test_dag_versioning_hash_survives_manifest_checksum_failure(mock_load_dbt_graph, mock_hash_func):
+    """A manifest read failure must not drop the folder hash that was already computed."""
+    mock_hash_func.return_value = "folder_hash"
+    dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
+
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+
+    converter = DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+    )
 
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
+    converter.dbt_graph.project.manifest_path = MagicMock(open=MagicMock(side_effect=OSError("boom")))
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
-    mock_hash_func.assert_called_with(converter.dbt_graph.project_path, manifest_path=manifest_path)
+
+    assert dag.doc_md is not None
+    assert "folder_hash" in dag.doc_md
 
 
 @pytest.mark.skipif(

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1440,10 +1440,7 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
 @patch("cosmos.converter._create_folder_version_hash")
 @patch("cosmos.converter.DbtGraph.load")
 def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(mock_load_dbt_graph, mock_hash_func):
-    """``target/`` (where ``manifest_path`` conventionally lives) is pruned from the folder hash walk, so
-    a manifest regenerated with no local source changes (e.g. by a separate CI compile step) wouldn't
-    otherwise change the DAG-versioning hash under ``LoadMode.DBT_MANIFEST``. The manifest's own checksum
-    must be folded in so DAG versioning still reacts to it."""
+    """Under LoadMode.DBT_MANIFEST, the manifest's checksum must be folded into the DAG-versioning hash."""
     mock_hash_func.return_value = "folder_hash"
     dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
 
@@ -1463,15 +1460,12 @@ def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(mock_l
     )
     hash_without_manifest = dag.doc_md
 
-    # Simulate LoadMode.DBT_MANIFEST having resolved, with a manifest living under the pruned target/
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
     converter.dbt_graph.project.manifest_path = MagicMock(checksum=MagicMock(return_value="manifest_v1"))
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v1 = dag.doc_md
 
-    # Folder hash is unchanged (still mocked to "folder_hash"), but the manifest checksum changed -- the
-    # combined hash must change too, since the manifest is the sole source of truth in this mode.
     converter.dbt_graph.project.manifest_path.checksum.return_value = "manifest_v2"
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1436,6 +1436,51 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
     mock_hash_func.assert_not_called()
 
 
+@skipif_airflow_lt_3_dag_doc_hash
+@patch("cosmos.converter._create_folder_version_hash")
+@patch("cosmos.converter.DbtGraph.load")
+def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(mock_load_dbt_graph, mock_hash_func):
+    """``target/`` (where ``manifest_path`` conventionally lives) is pruned from the folder hash walk, so
+    a manifest regenerated with no local source changes (e.g. by a separate CI compile step) wouldn't
+    otherwise change the DAG-versioning hash under ``LoadMode.DBT_MANIFEST``. The manifest's own checksum
+    must be folded in so DAG versioning still reacts to it."""
+    mock_hash_func.return_value = "folder_hash"
+    dag = DAG("test_dag", start_date=datetime(2024, 1, 1))
+
+    project_config = ProjectConfig(dbt_project_path=SAMPLE_DBT_PROJECT)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profile_mapping=PostgresUserPasswordProfileMapping(conn_id="test", profile_args={}),
+    )
+    execution_config = ExecutionConfig(execution_mode=ExecutionMode.LOCAL)
+
+    converter = DbtToAirflowConverter(
+        dag=dag,
+        project_config=project_config,
+        profile_config=profile_config,
+        execution_config=execution_config,
+    )
+    hash_without_manifest = dag.doc_md
+
+    # Simulate LoadMode.DBT_MANIFEST having resolved, with a manifest living under the pruned target/
+    converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
+    converter.dbt_graph.project.manifest_path = MagicMock(checksum=MagicMock(return_value="manifest_v1"))
+    dag.doc_md = None
+    converter._add_dbt_project_hash_to_dag_docs(dag)
+    hash_with_manifest_v1 = dag.doc_md
+
+    # Folder hash is unchanged (still mocked to "folder_hash"), but the manifest checksum changed -- the
+    # combined hash must change too, since the manifest is the sole source of truth in this mode.
+    converter.dbt_graph.project.manifest_path.checksum.return_value = "manifest_v2"
+    dag.doc_md = None
+    converter._add_dbt_project_hash_to_dag_docs(dag)
+    hash_with_manifest_v2 = dag.doc_md
+
+    assert hash_without_manifest != hash_with_manifest_v1
+    assert hash_with_manifest_v1 != hash_with_manifest_v2
+
+
 @pytest.mark.skipif(
     AIRFLOW_VERSION >= Version("3.0.0"),
     reason="Airflow 2.x skips dbt project hash; behavior asserted only on Airflow 2",

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,3 +1,4 @@
+import hashlib
 import logging
 import tempfile
 from contextlib import nullcontext as does_not_raise
@@ -23,7 +24,12 @@ from cosmos.constants import (
     SourceRenderingBehavior,
     TestBehavior,
 )
-from cosmos.converter import DbtToAirflowConverter, validate_arguments, validate_initial_user_config
+from cosmos.converter import (
+    DbtToAirflowConverter,
+    _calculate_manifest_version_hash,
+    validate_arguments,
+    validate_initial_user_config,
+)
 from cosmos.dbt.graph import DbtGraph, DbtNode
 from cosmos.exceptions import CosmosValueError
 from cosmos.operators.local import (
@@ -1434,6 +1440,15 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
 
     assert dag.doc_md is None
     mock_hash_func.assert_not_called()
+
+
+def test_calculate_manifest_version_hash_is_content_derived(tmp_path):
+    """The hash reflects the manifest's bytes, not its path or metadata, and reads large files in chunks."""
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_bytes(b"a")
+    manifest_path.write_bytes(b"a" * 3_000_000)  # larger than the read chunk size
+
+    assert _calculate_manifest_version_hash(manifest_path) == hashlib.md5(b"a" * 3_000_000).hexdigest()
 
 
 @skipif_airflow_lt_3_dag_doc_hash

--- a/tests/test_converter.py
+++ b/tests/test_converter.py
@@ -1,4 +1,4 @@
-import hashlib
+import json
 import logging
 import tempfile
 from contextlib import nullcontext as does_not_raise
@@ -1443,12 +1443,54 @@ def test_dag_versioning_skipped_when_setting_disabled(mock_load_dbt_graph, mock_
 
 
 def test_calculate_manifest_version_hash_is_content_derived(tmp_path):
-    """The hash reflects the manifest's bytes, not its path or metadata, and reads large files in chunks."""
-    manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_bytes(b"a")
-    manifest_path.write_bytes(b"a" * 3_000_000)  # larger than the read chunk size
+    """The hash reflects the manifest's nodes, not its path, and is stable across key ordering."""
+    manifest_a = tmp_path / "a.json"
+    manifest_a.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.a": {}}}))
 
-    assert _calculate_manifest_version_hash(manifest_path) == hashlib.md5(b"a" * 3_000_000).hexdigest()
+    manifest_b = tmp_path / "b.json"
+    manifest_b.write_text(json.dumps({"nodes": {"model.a": {}}, "metadata": {"dbt_version": "1.9.0"}}))
+
+    manifest_c = tmp_path / "c.json"
+    manifest_c.write_text(json.dumps({"metadata": {"dbt_version": "1.9.0"}, "nodes": {"model.b": {}}}))
+
+    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
+    assert _calculate_manifest_version_hash(manifest_a) != _calculate_manifest_version_hash(manifest_c)
+
+
+def test_calculate_manifest_version_hash_ignores_volatile_metadata(tmp_path):
+    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
+    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
+    manifest_a = tmp_path / "a.json"
+    manifest_a.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_version": "1.9.0",
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "invocation_id": "aaaa",
+                    "invocation_started_at": "2026-01-01T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    manifest_b = tmp_path / "b.json"
+    manifest_b.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "dbt_version": "1.9.0",
+                    "generated_at": "2026-01-02T00:00:00Z",
+                    "invocation_id": "bbbb",
+                    "invocation_started_at": "2026-01-02T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    assert _calculate_manifest_version_hash(manifest_a) == _calculate_manifest_version_hash(manifest_b)
 
 
 @skipif_airflow_lt_3_dag_doc_hash
@@ -1478,14 +1520,14 @@ def test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode(
     hash_without_manifest = dag.doc_md
 
     manifest_path = tmp_path / "manifest.json"
-    manifest_path.write_bytes(b"manifest_v1")
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
     converter.dbt_graph.load_method = LoadMode.DBT_MANIFEST
     converter.dbt_graph.project.manifest_path = manifest_path
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v1 = dag.doc_md
 
-    manifest_path.write_bytes(b"manifest_v2")
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
     dag.doc_md = None
     converter._add_dbt_project_hash_to_dag_docs(dag)
     hash_with_manifest_v2 = dag.doc_md

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -121,7 +121,7 @@ def test_project_hash_excluded_dirs_env_var_is_additive():
     clear=True,
 )
 def test_project_hash_excluded_dirs_warns_on_dbt_authored_content_dir():
-    """Cosmos warns but still applies the setting when it includes a dbt-authored content dir."""
+    """Cosmos warns but still applies the setting when it includes a dbt project content dir."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         reload(settings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -104,9 +104,30 @@ def test_project_hash_excluded_dirs_defaults_to_generated_dirs():
 
 @patch.dict(
     os.environ,
-    {"AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS": "target, dbt_packages , scratch"},
+    {"AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS": "scratch, build"},
     clear=True,
 )
-def test_project_hash_excluded_dirs_env_var_replaces_default():
+def test_project_hash_excluded_dirs_env_var_is_additive():
+    """The env var adds to the defaults; it cannot un-exclude .git/target/dbt_packages/logs."""
     reload(settings)
-    assert settings.project_hash_excluded_dirs == frozenset({"target", "dbt_packages", "scratch"})
+    assert settings.project_hash_excluded_dirs == frozenset(
+        {".git", "target", "dbt_packages", "logs", "scratch", "build"}
+    )
+
+
+@patch.dict(
+    os.environ,
+    {"AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS": "models, scratch"},
+    clear=True,
+)
+def test_project_hash_excluded_dirs_warns_on_dbt_authored_content_dir():
+    """Excluding a dbt-authored content directory (e.g. models) silently breaks change detection,
+    so Cosmos warns -- but still applies the setting, since this might be intentional."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        reload(settings)
+
+    assert any(issubclass(w.category, UserWarning) and "models" in str(w.message) for w in caught)
+    assert settings.project_hash_excluded_dirs == frozenset(
+        {".git", "target", "dbt_packages", "logs", "models", "scratch"}
+    )

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -121,8 +121,7 @@ def test_project_hash_excluded_dirs_env_var_is_additive():
     clear=True,
 )
 def test_project_hash_excluded_dirs_warns_on_dbt_authored_content_dir():
-    """Excluding a dbt-authored content directory (e.g. models) silently breaks change detection,
-    so Cosmos warns -- but still applies the setting, since this might be intentional."""
+    """Cosmos warns but still applies the setting when it includes a dbt-authored content dir."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")
         reload(settings)

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -120,7 +120,7 @@ def test_project_hash_excluded_dirs_env_var_is_additive():
     {"AIRFLOW__COSMOS__PROJECT_HASH_EXCLUDED_DIRS": "models, scratch"},
     clear=True,
 )
-def test_project_hash_excluded_dirs_warns_on_dbt_authored_content_dir():
+def test_project_hash_excluded_dirs_warns_on_dbt_project_content_dir():
     """Cosmos warns but still applies the setting when it includes a dbt project content dir."""
     with warnings.catch_warnings(record=True) as caught:
         warnings.simplefilter("always")

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -164,6 +164,18 @@ def test__create_folder_version_hash_reads_large_files_in_chunks(tmp_path):
     payload = b"select 1\n" * 300_000  # ~2.7MB, larger than the 1MB read chunk
     _write_file(project_dir, "models/big_model.sql", payload)
 
-    expected = hashlib.md5(b"models/big_model.sql" + payload).hexdigest()
+    expected = hashlib.md5(b"models/big_model.sql\x00" + payload).hexdigest()
 
     assert _create_folder_version_hash(project_dir) == expected
+
+
+def test__create_folder_version_hash_no_path_content_boundary_ambiguity(tmp_path):
+    """A path/content split that would collide without a separator (path "a" + content "bc" vs.
+    path "ab" + content "c") must hash differently, since the two describe different projects."""
+    project_a = tmp_path / "project_a"
+    _write_file(project_a, "a", b"bc")
+
+    project_b = tmp_path / "project_b"
+    _write_file(project_b, "ab", b"c")
+
+    assert _create_folder_version_hash(project_a) != _create_folder_version_hash(project_b)

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,8 +1,6 @@
 import hashlib
-import json
 import logging
 from pathlib import Path
-from unittest.mock import MagicMock
 
 from cosmos import settings
 from cosmos.versioning import _create_folder_version_hash
@@ -180,74 +178,3 @@ def test__create_folder_version_hash_no_path_content_boundary_ambiguity(tmp_path
     _write_file(project_b, "ab", b"c")
 
     assert _create_folder_version_hash(project_a) != _create_folder_version_hash(project_b)
-
-
-def test__create_folder_version_hash_folds_in_manifest_path(tmp_path):
-    """manifest_path need not live under dir_path at all (e.g. target/ is pruned from the walk, or the
-    manifest is deployed standalone), and its content must still affect the result."""
-    project_dir = tmp_path / "project"
-    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
-
-    manifest_path = tmp_path / "elsewhere" / "manifest.json"
-    manifest_path.parent.mkdir(parents=True)
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
-
-    without_manifest = _create_folder_version_hash(project_dir)
-    with_manifest_v1 = _create_folder_version_hash(project_dir, manifest_path=manifest_path)
-
-    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
-    with_manifest_v2 = _create_folder_version_hash(project_dir, manifest_path=manifest_path)
-
-    assert without_manifest != with_manifest_v1
-    assert with_manifest_v1 != with_manifest_v2
-
-
-def test__create_folder_version_hash_manifest_ignores_volatile_metadata(tmp_path):
-    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
-    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
-    project_dir = tmp_path / "project"
-    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
-
-    manifest_a = tmp_path / "a.json"
-    manifest_a.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "generated_at": "2026-01-01T00:00:00Z",
-                    "invocation_id": "aaaa",
-                    "invocation_started_at": "2026-01-01T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    manifest_b = tmp_path / "b.json"
-    manifest_b.write_text(
-        json.dumps(
-            {
-                "metadata": {
-                    "generated_at": "2026-01-02T00:00:00Z",
-                    "invocation_id": "bbbb",
-                    "invocation_started_at": "2026-01-02T00:00:00Z",
-                },
-                "nodes": {"model.a": {}},
-            }
-        )
-    )
-
-    assert _create_folder_version_hash(project_dir, manifest_path=manifest_a) == _create_folder_version_hash(
-        project_dir, manifest_path=manifest_b
-    )
-
-
-def test__create_folder_version_hash_survives_manifest_read_failure(tmp_path):
-    """A manifest read/parse failure must not drop the folder hash that was already computed."""
-    project_dir = tmp_path / "project"
-    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
-
-    broken_manifest_path = MagicMock(open=MagicMock(side_effect=OSError("boom")))
-
-    assert _create_folder_version_hash(project_dir, manifest_path=broken_manifest_path) == _create_folder_version_hash(
-        project_dir
-    )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -1,6 +1,8 @@
 import hashlib
+import json
 import logging
 from pathlib import Path
+from unittest.mock import MagicMock
 
 from cosmos import settings
 from cosmos.versioning import _create_folder_version_hash
@@ -178,3 +180,74 @@ def test__create_folder_version_hash_no_path_content_boundary_ambiguity(tmp_path
     _write_file(project_b, "ab", b"c")
 
     assert _create_folder_version_hash(project_a) != _create_folder_version_hash(project_b)
+
+
+def test__create_folder_version_hash_folds_in_manifest_path(tmp_path):
+    """manifest_path need not live under dir_path at all (e.g. target/ is pruned from the walk, or the
+    manifest is deployed standalone), and its content must still affect the result."""
+    project_dir = tmp_path / "project"
+    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
+
+    manifest_path = tmp_path / "elsewhere" / "manifest.json"
+    manifest_path.parent.mkdir(parents=True)
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}}}))
+
+    without_manifest = _create_folder_version_hash(project_dir)
+    with_manifest_v1 = _create_folder_version_hash(project_dir, manifest_path=manifest_path)
+
+    manifest_path.write_text(json.dumps({"nodes": {"model.a": {}, "model.b": {}}}))
+    with_manifest_v2 = _create_folder_version_hash(project_dir, manifest_path=manifest_path)
+
+    assert without_manifest != with_manifest_v1
+    assert with_manifest_v1 != with_manifest_v2
+
+
+def test__create_folder_version_hash_manifest_ignores_volatile_metadata(tmp_path):
+    """generated_at/invocation_id/invocation_started_at change on every dbt invocation even when
+    the project doesn't, so two otherwise-identical manifests must hash the same despite them."""
+    project_dir = tmp_path / "project"
+    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
+
+    manifest_a = tmp_path / "a.json"
+    manifest_a.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "generated_at": "2026-01-01T00:00:00Z",
+                    "invocation_id": "aaaa",
+                    "invocation_started_at": "2026-01-01T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    manifest_b = tmp_path / "b.json"
+    manifest_b.write_text(
+        json.dumps(
+            {
+                "metadata": {
+                    "generated_at": "2026-01-02T00:00:00Z",
+                    "invocation_id": "bbbb",
+                    "invocation_started_at": "2026-01-02T00:00:00Z",
+                },
+                "nodes": {"model.a": {}},
+            }
+        )
+    )
+
+    assert _create_folder_version_hash(project_dir, manifest_path=manifest_a) == _create_folder_version_hash(
+        project_dir, manifest_path=manifest_b
+    )
+
+
+def test__create_folder_version_hash_survives_manifest_read_failure(tmp_path):
+    """A manifest read/parse failure must not drop the folder hash that was already computed."""
+    project_dir = tmp_path / "project"
+    _write_file(project_dir, "models/stg_orders.sql", b"select * from orders")
+
+    broken_manifest_path = MagicMock(open=MagicMock(side_effect=OSError("boom")))
+
+    assert _create_folder_version_hash(project_dir, manifest_path=broken_manifest_path) == _create_folder_version_hash(
+        project_dir
+    )

--- a/tests/test_versioning.py
+++ b/tests/test_versioning.py
@@ -170,8 +170,7 @@ def test__create_folder_version_hash_reads_large_files_in_chunks(tmp_path):
 
 
 def test__create_folder_version_hash_no_path_content_boundary_ambiguity(tmp_path):
-    """A path/content split that would collide without a separator (path "a" + content "bc" vs.
-    path "ab" + content "c") must hash differently, since the two describe different projects."""
+    """path='a',content='bc' and path='ab',content='c' must hash differently despite equal concatenation."""
     project_a = tmp_path / "project_a"
     _write_file(project_a, "a", b"bc")
 


### PR DESCRIPTION
## Description

Follow-up to #2942 (Skip generated dirs when hashing the dbt project folder), addressing the review feedback from https://github.com/astronomer/astronomer-cosmos/pull/2942#pullrequestreview-4843989274 that wasn't resolved before merging.

- **Manifest-mode DAG-versioning gap**: `_add_dbt_project_hash_to_dag_docs` now folds in a content checksum of the manifest file under `LoadMode.DBT_MANIFEST`, via a new standalone `_calculate_manifest_version_hash` (not `ObjectStoragePath.checksum()`, whose fsspec-default metadata — mtime/inode locally, generation/updated on GCS — changes on a byte-identical re-sync). Since `target/` (where the manifest conventionally lives) is pruned from the folder hash walk, a manifest regenerated with no local source changes would otherwise never bump the DAG version hash. The fold-in runs in its own `try`/`except`, so a manifest read failure falls back to the folder hash alone instead of dropping the hash suffix entirely for that parse.
- **`project_hash_excluded_dirs` is now additive**, not a full replacement, on top of the always-excluded `.git`/`target`/`dbt_packages`/`logs`. A user adding one custom generated dir can no longer accidentally stop excluding the defaults.
- **Warns (doesn't block) on suspicious values**: if the configured list includes a dbt project content directory (`models`, `macros`, `seeds`, `snapshots`, `analyses`, `tests`), Cosmos emits a `UserWarning`, since excluding one of those would silently stop DAG versioning / caches from reacting to real project changes.
- **Hash construction**: `_create_folder_version_hash` now separates each file's path from its content with a null byte (previously `path_bytes + content_bytes` had no delimiter, so e.g. path `a` + content `bc` hashed identically to path `ab` + content `c`), hashes the POSIX-form relative path so the digest no longer varies by OS path separator, and sorts files by that same POSIX path so the hash iteration order can't diverge across OSes either.

This changes the resulting hash values again (on top of #2942's own one-time change), so any deployments that already picked up #2942 will see one more DAG-version bump / cache refresh when this lands — same one-time-refresh tradeoff #2942 already called out, not a new concern.

## Design notes

- `_calculate_manifest_version_hash` is a separate function from `_create_folder_version_hash`, not merged into it. An earlier version of this PR did merge them (adding a `manifest_path` parameter to `_create_folder_version_hash`), but that was reverted at @pankajkoti's request — no definite reason required it, and it changed a function signature with no upside.
- The manifest hash is a plain content hash of the file, no more and no less. An earlier version stripped dbt-generated `metadata` fields (`generated_at`, `invocation_id`, ...) before hashing, on the theory that a background recompile could regenerate the manifest with unchanged content. That was dropped: in the intended workflow the manifest is checked into git alongside the DAG code, so any change to it reflects a real, intentional recompile.

## Review feedback addressed

- **Copilot**: OS-dependent hash iteration order, missing delimiter/falsy-checksum handling on the manifest fold-in (now moot — see Design notes), and a docs wording mismatch (`UserWarning` vs. "logs a warning"). Left the `stacklevel` suggestion on the settings warning as-is — it fires from module-level code at import/reload time with no single meaningful caller frame, same as the existing `watcher_dbt_execution_queue` deprecation warning a few lines below it.
- **@kaxil**: `ObjectStoragePath.checksum()` isn't content-derived on every fsspec backend, so a byte-identical manifest re-sync would still bump the DAG version — switched to hashing the manifest's actual content. Also flagged that the manifest fold-in shared a `try` with the folder hash, so a failure there dropped the whole hash suffix rather than just the manifest signal; now isolated in its own `try`/`except`. Docs for `enable_dag_versioning` now mention the manifest fold-in.
- **@pankajkoti**: confirmed `DbtGraph.load()` always resolves `LoadMode.AUTOMATIC` to a concrete mode before this code runs, so no `AUTOMATIC` branch is needed. Renamed `DBT_AUTHORED_CONTENT_DIRS` to `DBT_PROJECT_CONTENT_DIRS` (dbt doesn't author those dirs, users do) and updated the warning/docs wording to match. Pushed back on merging the manifest hash into `_create_folder_version_hash` (see Design notes) — reverted.

## Tests

- New: `test_dag_versioning_hash_folds_in_manifest_checksum_for_manifest_mode`, `test_dag_versioning_hash_survives_manifest_checksum_failure`, `test_calculate_manifest_version_hash_is_content_derived`, `test__create_folder_version_hash_no_path_content_boundary_ambiguity`, `test_project_hash_excluded_dirs_env_var_is_additive` (renamed/updated from the old "replaces default" test), `test_project_hash_excluded_dirs_warns_on_dbt_project_content_dir`.
- Updated expected hash digests in `tests/dbt/test_graph.py` for the new construction.
- `tests/test_versioning.py`, `tests/test_settings.py`, `tests/test_converter.py` all pass, verified under the Airflow 3.2 test matrix (where the manifest-mode tests execute rather than skip).
- `pre-commit` (incl. mypy) and `sphinx-build -W` both clean.

## Related

Follow-up to #2942. Credit to @goingforstudying-ctrl for the original PR.
