### PR TITLE
WATCHER dataset emission silently disabled when profiles.yml uses dbt Jinja filters

### DIFF
--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -156,12 +156,15 @@ def _render_profile_field(field: str, value: str, namespace_field: bool = False)
     Resolver-read fields fail instead so literal Jinja cannot enter an emitted namespace.
     """
     try:
-        return _resolve_profiles_yml_env_var(value)
+        rendered = _resolve_profiles_yml_env_var(value)
     except TemplateError as error:
         if namespace_field:
             raise TemplateError(f"Could not render Jinja in namespace field '{field}'") from error
         logger.debug("Could not render Jinja in profiles.yml field '%s'; using the raw value", field, exc_info=True)
         return value
+    if namespace_field and not rendered.strip():
+        raise TemplateError(f"Namespace field '{field}' rendered to an empty value")
+    return rendered
 
 
 def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any]]:

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -12,7 +12,7 @@ from packaging.version import Version
 
 from cosmos import settings
 from cosmos.constants import _DATASET_EMITTING_RESOURCE_TYPES, AIRFLOW_VERSION
-from cosmos.dbt.project import _resolve_env_var
+from cosmos.dbt.project import _resolve_profiles_yml_env_var
 from cosmos.log import get_logger
 
 if TYPE_CHECKING:
@@ -100,6 +100,24 @@ _ADAPTER_NAMESPACE_RESOLVERS: dict[str, Any] = {
     "duckdb": lambda p: f"duckdb://{p.get('path', '')}",
 }
 
+# Profile fields read by each resolver. An unrenderable value in one of these fields must abort
+# namespace derivation instead of allowing literal Jinja syntax into the emitted URI.
+_ADAPTER_NAMESPACE_FIELDS: dict[str, set[str]] = {
+    "postgres": {"host", "port"},
+    "redshift": {"host", "port"},
+    "bigquery": set(),
+    "snowflake": {"account"},
+    "databricks": {"host"},
+    "spark": {"host", "port", "method"},
+    "trino": {"host", "port"},
+    "clickhouse": {"host", "port"},
+    "sqlserver": {"server", "port"},
+    "dremio": {"software_host", "port"},
+    "athena": {"region_name"},
+    "glue": {"region", "account_id", "role_arn"},
+    "duckdb": {"path"},
+}
+
 
 def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_id: str) -> str:
     """
@@ -130,15 +148,18 @@ def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_i
     return "__".join(identifiers_list)
 
 
-def _render_profile_field(field: str, value: str) -> str:
-    """Render one profiles.yml field, keeping the raw value when its Jinja cannot be rendered.
+def _render_profile_field(field: str, value: str, namespace_field: bool = False) -> str:
+    """Render one profiles.yml field, keeping irrelevant raw values when necessary.
 
     Fields the namespace resolvers never read (e.g. ``threads``) may use Jinja that this
     renderer does not support; one such field must not abort derivation for the whole profile.
+    Resolver-read fields fail instead so literal Jinja cannot enter an emitted namespace.
     """
     try:
-        return _resolve_env_var(value)
-    except TemplateError:
+        return _resolve_profiles_yml_env_var(value)
+    except TemplateError as error:
+        if namespace_field:
+            raise TemplateError(f"Could not render Jinja in namespace field '{field}'") from error
         logger.debug("Could not render Jinja in profiles.yml field '%s'; using the raw value", field, exc_info=True)
         return value
 
@@ -160,12 +181,27 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
         with open(profile_config.profiles_yml_filepath) as f:
             profiles = yaml.safe_load(f)
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
+        raw_adapter_type = target.get("type", "")
+        adapter_type = (
+            _render_profile_field("type", raw_adapter_type, namespace_field=True)
+            if isinstance(raw_adapter_type, str)
+            else raw_adapter_type
+        )
+        namespace_fields = _ADAPTER_NAMESPACE_FIELDS.get(adapter_type, set())
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
         # Render per field so one unrenderable field cannot abort the whole profile (#2948).
         target = {
-            key: _render_profile_field(key, value) if isinstance(value, str) else value for key, value in target.items()
+            key: (
+                (
+                    adapter_type
+                    if key == "type"
+                    else _render_profile_field(key, value, namespace_field=key in namespace_fields)
+                )
+                if isinstance(value, str)
+                else value
+            )
+            for key, value in target.items()
         }
-        adapter_type = target.get("type", "")
         return adapter_type, target
 
     return "", {}
@@ -188,9 +224,10 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
     """
     try:
         adapter_type, profile_dict = _get_profile_dict(profile_config)
-    except (AttributeError, KeyError, TypeError, OSError, yaml.YAMLError, TemplateError):
+    except (AttributeError, KeyError, TypeError, OSError, yaml.YAMLError, TemplateError) as error:
         logger.warning(
-            "Unable to extract profile info for dataset namespace derivation; dataset emission will be skipped.",
+            "Unable to extract profile info for dataset namespace derivation (%s); dataset emission will be skipped.",
+            error,
             exc_info=True,
         )
         return None

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -130,6 +130,19 @@ def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_i
     return "__".join(identifiers_list)
 
 
+def _render_profile_field(field: str, value: str) -> str:
+    """Render one profiles.yml field, keeping the raw value when its Jinja cannot be rendered.
+
+    Fields the namespace resolvers never read (e.g. ``threads``) may use Jinja that this
+    renderer does not support; one such field must not abort derivation for the whole profile.
+    """
+    try:
+        return _resolve_env_var(value)
+    except TemplateError:
+        logger.debug("Could not render Jinja in profiles.yml field '%s'; using the raw value", field, exc_info=True)
+        return value
+
+
 def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any]]:
     """
     Extract the adapter type and profile dict from a ProfileConfig.
@@ -148,7 +161,10 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
             profiles = yaml.safe_load(f)
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
-        target = {key: _resolve_env_var(value) if isinstance(value, str) else value for key, value in target.items()}
+        # Render per field so one unrenderable field cannot abort the whole profile (#2948).
+        target = {
+            key: _render_profile_field(key, value) if isinstance(value, str) else value for key, value in target.items()
+        }
         adapter_type = target.get("type", "")
         return adapter_type, target
 
@@ -173,7 +189,10 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
     try:
         adapter_type, profile_dict = _get_profile_dict(profile_config)
     except (AttributeError, KeyError, TypeError, OSError, yaml.YAMLError, TemplateError):
-        logger.debug("Unable to extract profile info for dataset namespace derivation", exc_info=True)
+        logger.warning(
+            "Unable to extract profile info for dataset namespace derivation; dataset emission will be skipped.",
+            exc_info=True,
+        )
         return None
 
     if not adapter_type:

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -100,6 +100,7 @@ _ADAPTER_NAMESPACE_RESOLVERS: dict[str, Any] = {
     "duckdb": lambda p: f"duckdb://{p.get('path', '')}",
 }
 
+
 def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_id: str) -> str:
     """
     Given the Airflow DAG, Airflow TaskGroup and the Airflow Task ID, return the name of the
@@ -163,20 +164,16 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
         raw_adapter_type = target.get("type", "")
         adapter_type = (
-            _render_profile_field("type", raw_adapter_type)
-            if isinstance(raw_adapter_type, str)
-            else raw_adapter_type
+            _render_profile_field("type", raw_adapter_type) if isinstance(raw_adapter_type, str) else raw_adapter_type
         )
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
         # Render per field so one unrenderable field cannot abort the whole profile (#2948).
         target = {
             key: (
-                adapter_type
-                if key == "type"
-                else _render_profile_field(key, value)
+                (adapter_type if key == "type" else _render_profile_field(key, value))
+                if isinstance(value, str)
+                else value
             )
-            if isinstance(value, str)
-            else value
             for key, value in target.items()
         }
         return adapter_type, target

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -100,25 +100,6 @@ _ADAPTER_NAMESPACE_RESOLVERS: dict[str, Any] = {
     "duckdb": lambda p: f"duckdb://{p.get('path', '')}",
 }
 
-# Profile fields read by each resolver. An unrenderable value in one of these fields must abort
-# namespace derivation instead of allowing literal Jinja syntax into the emitted URI.
-_ADAPTER_NAMESPACE_FIELDS: dict[str, set[str]] = {
-    "postgres": {"host", "port"},
-    "redshift": {"host", "port"},
-    "bigquery": set(),
-    "snowflake": {"account"},
-    "databricks": {"host"},
-    "spark": {"host", "port", "method"},
-    "trino": {"host", "port"},
-    "clickhouse": {"host", "port"},
-    "sqlserver": {"server", "port"},
-    "dremio": {"software_host", "port"},
-    "athena": {"region_name"},
-    "glue": {"region", "account_id", "role_arn"},
-    "duckdb": {"path"},
-}
-
-
 def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_id: str) -> str:
     """
     Given the Airflow DAG, Airflow TaskGroup and the Airflow Task ID, return the name of the
@@ -148,23 +129,19 @@ def get_dataset_alias_name(dag: DAG | None, task_group: TaskGroup | None, task_i
     return "__".join(identifiers_list)
 
 
-def _render_profile_field(field: str, value: str, namespace_field: bool = False) -> str:
-    """Render one profiles.yml field, keeping irrelevant raw values when necessary.
+def _render_profile_field(field: str, value: str) -> str:
+    """Render one profiles.yml field, falling back to the raw value on unsupported Jinja.
 
-    Fields the namespace resolvers never read (e.g. ``threads``) may use Jinja that this
-    renderer does not support; one such field must not abort derivation for the whole profile.
-    Resolver-read fields fail instead so literal Jinja cannot enter an emitted namespace.
+    Every field gets the raw-value fallback so that one unrenderable field cannot
+    abort derivation for the whole profile.  Validation of the final namespace
+    string in ``get_dataset_namespace`` catches any residual problems (unrendered
+    Jinja, empty components) in a single place.
     """
     try:
-        rendered = _resolve_profiles_yml_env_var(value)
-    except TemplateError as error:
-        if namespace_field:
-            raise TemplateError(f"Could not render Jinja in namespace field '{field}'") from error
+        return _resolve_profiles_yml_env_var(value)
+    except TemplateError:
         logger.debug("Could not render Jinja in profiles.yml field '%s'; using the raw value", field, exc_info=True)
         return value
-    if namespace_field and not rendered.strip():
-        raise TemplateError(f"Namespace field '{field}' rendered to an empty value")
-    return rendered
 
 
 def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any]]:
@@ -186,23 +163,20 @@ def _get_profile_dict(profile_config: ProfileConfig) -> tuple[str, dict[str, Any
         target = profiles[profile_config.profile_name]["outputs"][profile_config.target_name]
         raw_adapter_type = target.get("type", "")
         adapter_type = (
-            _render_profile_field("type", raw_adapter_type, namespace_field=True)
+            _render_profile_field("type", raw_adapter_type)
             if isinstance(raw_adapter_type, str)
             else raw_adapter_type
         )
-        namespace_fields = _ADAPTER_NAMESPACE_FIELDS.get(adapter_type, set())
         # dbt renders env_var() Jinja in profiles.yml; replicate that since we read the file directly.
         # Render per field so one unrenderable field cannot abort the whole profile (#2948).
         target = {
             key: (
-                (
-                    adapter_type
-                    if key == "type"
-                    else _render_profile_field(key, value, namespace_field=key in namespace_fields)
-                )
-                if isinstance(value, str)
-                else value
+                adapter_type
+                if key == "type"
+                else _render_profile_field(key, value)
             )
+            if isinstance(value, str)
+            else value
             for key, value in target.items()
         }
         return adapter_type, target
@@ -250,6 +224,27 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
                 adapter_type,
             )
             return None
+        # Reject namespaces that still contain unrendered Jinja syntax.  Individual
+        # fields fall back to their raw value when the renderer does not support the
+        # Jinja they use, so the final namespace is the single place to catch this.
+        if "{{" in namespace or "{%" in namespace:
+            logger.warning(
+                "Resolved namespace '%s' for adapter '%s' contains unrendered Jinja; skipping dataset emission.",
+                namespace,
+                adapter_type,
+            )
+            return None
+        # Reject namespaces with an empty host component (e.g. "postgres://:5432"
+        # from a missing or empty host field).
+        if "://" in namespace:
+            authority = namespace.split("://", 1)[1].split("/")[0]
+            if authority and ":" in authority and not authority.rsplit(":", 1)[0]:
+                logger.debug(
+                    "Resolved namespace '%s' for adapter '%s' has an empty host; skipping dataset emission.",
+                    namespace,
+                    adapter_type,
+                )
+                return None
         return namespace
 
     # Unknown adapters: return None so dataset emission is skipped.

--- a/cosmos/dataset.py
+++ b/cosmos/dataset.py
@@ -236,7 +236,7 @@ def get_dataset_namespace(profile_config: ProfileConfig) -> str | None:
         if "://" in namespace:
             authority = namespace.split("://", 1)[1].split("/")[0]
             if authority and ":" in authority and not authority.rsplit(":", 1)[0]:
-                logger.debug(
+                logger.warning(
                     "Resolved namespace '%s' for adapter '%s' has an empty host; skipping dataset emission.",
                     namespace,
                     adapter_type,

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -28,11 +28,13 @@ from cosmos.log import get_logger
 
 logger = get_logger(__name__)
 
+_JINJA_ENV = Environment()
+
 # dbt renders profiles.yml values through a Jinja environment that registers its custom filters
 # (as_number, as_bool, as_text, as_native). In dbt's text-mode environment these filters are
-# identity functions; register the same no-ops so templates using them render here too.
-_JINJA_ENV = Environment()
-_JINJA_ENV.filters.update({name: lambda x: x for name in ("as_number", "as_bool", "as_text", "as_native")})
+# identity functions. Keep them scoped to profiles.yml so they cannot affect dbt_project.yml.
+_PROFILES_JINJA_ENV = Environment()
+_PROFILES_JINJA_ENV.filters.update({name: lambda x: x for name in ("as_number", "as_bool", "as_text", "as_native")})
 
 
 def has_non_empty_dependencies_file(project_path: Path) -> bool:
@@ -52,6 +54,17 @@ def has_non_empty_dependencies_file(project_path: Path) -> bool:
     return False
 
 
+def _render_env_var(template_str: str, environment: Environment) -> str:
+    """Render a Jinja string with dbt's ``env_var`` function."""
+
+    def env_var(name: str, default: str = "") -> str:
+        return os.getenv(name, default)
+
+    template = environment.from_string(template_str)
+    rendered: str = template.render(env_var=env_var)
+    return rendered
+
+
 def _resolve_env_var(template_str: str) -> str:
     """
     Given a Jinja template string, resolve the environment variables, declared using the dbt syntax,
@@ -65,12 +78,13 @@ def _resolve_env_var(template_str: str) -> str:
     '/usr/local/airflow/dags/dbt/dbt_packages_test'
     """
 
-    def env_var(name: str, default: str = "") -> str:
-        return os.getenv(name, default)
+    return _render_env_var(template_str, _JINJA_ENV)
 
-    template = _JINJA_ENV.from_string(template_str)
-    rendered: str = template.render(env_var=env_var)
-    return rendered
+
+def _resolve_profiles_yml_env_var(template_str: str) -> str:
+    """Render a profiles.yml value with dbt's text-only filters available."""
+
+    return _render_env_var(template_str, _PROFILES_JINJA_ENV)
 
 
 def get_dbt_packages_subpath(source_folder: Path) -> str:

--- a/cosmos/dbt/project.py
+++ b/cosmos/dbt/project.py
@@ -8,7 +8,7 @@ from contextlib import contextmanager
 from pathlib import Path
 
 import yaml
-from jinja2 import Template
+from jinja2 import Environment
 
 from cosmos import settings
 from cosmos.constants import (
@@ -27,6 +27,12 @@ from cosmos.exceptions import CosmosValueError
 from cosmos.log import get_logger
 
 logger = get_logger(__name__)
+
+# dbt renders profiles.yml values through a Jinja environment that registers its custom filters
+# (as_number, as_bool, as_text, as_native). In dbt's text-mode environment these filters are
+# identity functions; register the same no-ops so templates using them render here too.
+_JINJA_ENV = Environment()
+_JINJA_ENV.filters.update({name: lambda x: x for name in ("as_number", "as_bool", "as_text", "as_native")})
 
 
 def has_non_empty_dependencies_file(project_path: Path) -> bool:
@@ -62,7 +68,7 @@ def _resolve_env_var(template_str: str) -> str:
     def env_var(name: str, default: str = "") -> str:
         return os.getenv(name, default)
 
-    template = Template(template_str)
+    template = _JINJA_ENV.from_string(template_str)
     rendered: str = template.render(env_var=env_var)
     return rendered
 

--- a/tests/dbt/test_project.py
+++ b/tests/dbt/test_project.py
@@ -129,6 +129,17 @@ def test_resolve_env_var_with_complex_template_unset_var():
     assert result == "dbt_packages"
 
 
+@patch.dict(os.environ, {"DBT_THREADS": "8"})
+def test_resolve_env_var_with_dbt_filters():
+    """dbt's documented profiles.yml filters (as_number, as_bool, as_text, as_native) are
+    registered as identity no-ops, matching dbt's text-mode Jinja environment (#2948)."""
+    assert _resolve_env_var("{{ env_var('DBT_THREADS', 4) | as_number }}") == "8"
+    assert _resolve_env_var("{{ env_var('UNSET_DBT_THREADS', 4) | as_number }}") == "4"
+    assert _resolve_env_var("{{ env_var('UNSET_DBT_SSL', 'true') | as_bool }}") == "true"
+    assert _resolve_env_var("{{ 'raw' | as_text }}") == "raw"
+    assert _resolve_env_var("{{ '[1, 2]' | as_native }}") == "[1, 2]"
+
+
 @patch.dict(os.environ, {"ENV_SUFFIX": "prod"})
 def test_get_dbt_packages_subpath_with_env_var_template(tmpdir):
     """Test get_dbt_packages_subpath with env_var in packages-install-path."""

--- a/tests/dbt/test_project.py
+++ b/tests/dbt/test_project.py
@@ -5,12 +5,14 @@ from unittest.mock import patch
 
 import pytest
 import yaml
+from jinja2 import TemplateAssertionError
 from packaging.version import Version
 
 from cosmos.constants import DBT_DEFAULT_PACKAGES_FOLDER, DBT_PROJECT_FILENAME, PACKAGE_LOCKFILE_YML
 from cosmos.dbt.project import (
     _resolve_dags_folder,
     _resolve_env_var,
+    _resolve_profiles_yml_env_var,
     change_working_directory,
     copy_dbt_packages,
     copy_manifest_file_if_exists,
@@ -130,14 +132,20 @@ def test_resolve_env_var_with_complex_template_unset_var():
 
 
 @patch.dict(os.environ, {"DBT_THREADS": "8"})
-def test_resolve_env_var_with_dbt_filters():
+def test_resolve_profiles_yml_env_var_with_dbt_filters():
     """dbt's documented profiles.yml filters (as_number, as_bool, as_text, as_native) are
     registered as identity no-ops, matching dbt's text-mode Jinja environment (#2948)."""
-    assert _resolve_env_var("{{ env_var('DBT_THREADS', 4) | as_number }}") == "8"
-    assert _resolve_env_var("{{ env_var('UNSET_DBT_THREADS', 4) | as_number }}") == "4"
-    assert _resolve_env_var("{{ env_var('UNSET_DBT_SSL', 'true') | as_bool }}") == "true"
-    assert _resolve_env_var("{{ 'raw' | as_text }}") == "raw"
-    assert _resolve_env_var("{{ '[1, 2]' | as_native }}") == "[1, 2]"
+    assert _resolve_profiles_yml_env_var("{{ env_var('DBT_THREADS', 4) | as_number }}") == "8"
+    assert _resolve_profiles_yml_env_var("{{ env_var('UNSET_DBT_THREADS', 4) | as_number }}") == "4"
+    assert _resolve_profiles_yml_env_var("{{ env_var('UNSET_DBT_SSL', 'true') | as_bool }}") == "true"
+    assert _resolve_profiles_yml_env_var("{{ 'raw' | as_text }}") == "raw"
+    assert _resolve_profiles_yml_env_var("{{ '[1, 2]' | as_native }}") == "[1, 2]"
+
+
+def test_resolve_env_var_does_not_use_profiles_yml_filters():
+    """Profiles-only filters must not change rendering of dbt_project.yml values."""
+    with pytest.raises(TemplateAssertionError, match="No filter named 'as_number'"):
+        _resolve_env_var("{{ env_var('DBT_THREADS', 4) | as_number }}")
 
 
 @patch.dict(os.environ, {"ENV_SUFFIX": "prod"})

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -190,9 +190,9 @@ my_profile:
         profile_config.target_name = "dev"
         assert get_dataset_namespace(profile_config) == "postgres://dbhost.internal:5433"
 
-    def test_profiles_yml_filepath_undefined_jinja_returns_none(self, tmp_path):
-        """profiles.yml referencing an undefined Jinja name (not env_var) fails to render; the caller's
-        catch-all returns None instead of propagating the Jinja error and breaking DAG parsing."""
+    def test_profiles_yml_filepath_unrenderable_field_keeps_raw_value(self, tmp_path):
+        """A field whose Jinja cannot be rendered degrades to its raw value instead of aborting
+        namespace derivation for the whole profile (#2948)."""
         profiles_yml = tmp_path / "profiles.yml"
         profiles_yml.write_text("""
 my_profile:
@@ -207,13 +207,70 @@ my_profile:
         profile_config.profiles_yml_filepath = str(profiles_yml)
         profile_config.profile_name = "my_profile"
         profile_config.target_name = "dev"
-        assert get_dataset_namespace(profile_config) is None
+        assert get_dataset_namespace(profile_config) == "postgres://db-{{ this.is_not_env_var }}.prod.internal:5433"
+
+    def test_profiles_yml_filepath_with_dbt_jinja_filters(self, tmp_path, monkeypatch):
+        """Regression test for #2948: dbt's documented profiles.yml filters (as_number, as_bool)
+        on fields the namespace resolvers never read must not disable dataset emission."""
+        monkeypatch.setenv("DB_HOST", "dbhost")
+        monkeypatch.setenv("DBT_THREADS", "8")
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('DB_HOST') }}"
+      port: 5433
+      user: user
+      pass: pass
+      dbname: mydb
+      schema: public
+      threads: "{{ env_var('DBT_THREADS', 4) | as_number }}"
+      connect_timeout: "{{ env_var('DBT_CONNECT_TIMEOUT', 10) | as_number }}"
+      use_ssl: "{{ env_var('DBT_USE_SSL', 'true') | as_bool }}"
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://dbhost:5433"
+
+    def test_profiles_yml_filepath_unknown_filter_on_irrelevant_field(self, tmp_path):
+        """A field using a Jinja filter this renderer does not know keeps its raw value; the
+        namespace is still derived from the remaining fields (#2948)."""
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: dbhost
+      port: 5433
+      threads: "{{ env_var('DBT_THREADS', 4) | no_such_filter }}"
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "postgres://dbhost:5433"
 
     def test_returns_none_on_error(self):
         profile_config = MagicMock()
         profile_config.profile_mapping = None
         profile_config.profiles_yml_filepath = "/nonexistent/path.yml"
         assert get_dataset_namespace(profile_config) is None
+
+    def test_returns_none_on_error_logs_warning(self, caplog):
+        """A profile that cannot be read at all must surface as a WARNING, not a DEBUG line (#2948)."""
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = "/nonexistent/path.yml"
+        with caplog.at_level(logging.WARNING):
+            assert get_dataset_namespace(profile_config) is None
+        assert "Unable to extract profile info for dataset namespace derivation" in caplog.text
 
     def test_returns_none_when_no_profile_info(self):
         """When neither profile_mapping nor profiles_yml_filepath is set, returns None."""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -190,9 +190,8 @@ my_profile:
         profile_config.target_name = "dev"
         assert get_dataset_namespace(profile_config) == "postgres://dbhost.internal:5433"
 
-    def test_profiles_yml_filepath_unrenderable_field_keeps_raw_value(self, tmp_path):
-        """A field whose Jinja cannot be rendered degrades to its raw value instead of aborting
-        namespace derivation for the whole profile (#2948)."""
+    def test_profiles_yml_filepath_unrenderable_namespace_field_returns_none(self, tmp_path, caplog):
+        """An unrenderable resolver-read field must not leak literal Jinja into the namespace."""
         profiles_yml = tmp_path / "profiles.yml"
         profiles_yml.write_text("""
 my_profile:
@@ -207,7 +206,9 @@ my_profile:
         profile_config.profiles_yml_filepath = str(profiles_yml)
         profile_config.profile_name = "my_profile"
         profile_config.target_name = "dev"
-        assert get_dataset_namespace(profile_config) == "postgres://db-{{ this.is_not_env_var }}.prod.internal:5433"
+        with caplog.at_level(logging.WARNING):
+            assert get_dataset_namespace(profile_config) is None
+        assert "namespace field 'host'" in caplog.text
 
     def test_profiles_yml_filepath_with_dbt_jinja_filters(self, tmp_path, monkeypatch):
         """Regression test for #2948: dbt's documented profiles.yml filters (as_number, as_bool)

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -210,6 +210,27 @@ my_profile:
             assert get_dataset_namespace(profile_config) is None
         assert "namespace field 'host'" in caplog.text
 
+    def test_profiles_yml_filepath_empty_namespace_field_returns_none(self, tmp_path, caplog, monkeypatch):
+        """A missing env_var without a default must not emit an empty namespace component."""
+        monkeypatch.delenv("COSMOS_MISSING_NAMESPACE_HOST", raising=False)
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: postgres
+      host: "{{ env_var('COSMOS_MISSING_NAMESPACE_HOST') }}"
+      port: 5433
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        with caplog.at_level(logging.WARNING):
+            assert get_dataset_namespace(profile_config) is None
+        assert "Namespace field 'host' rendered to an empty value" in caplog.text
+
     def test_profiles_yml_filepath_with_dbt_jinja_filters(self, tmp_path, monkeypatch):
         """Regression test for #2948: dbt's documented profiles.yml filters (as_number, as_bool)
         on fields the namespace resolvers never read must not disable dataset emission."""

--- a/tests/test_dataset.py
+++ b/tests/test_dataset.py
@@ -208,7 +208,7 @@ my_profile:
         profile_config.target_name = "dev"
         with caplog.at_level(logging.WARNING):
             assert get_dataset_namespace(profile_config) is None
-        assert "namespace field 'host'" in caplog.text
+        assert "unrendered Jinja" in caplog.text
 
     def test_profiles_yml_filepath_empty_namespace_field_returns_none(self, tmp_path, caplog, monkeypatch):
         """A missing env_var without a default must not emit an empty namespace component."""
@@ -229,7 +229,66 @@ my_profile:
         profile_config.target_name = "dev"
         with caplog.at_level(logging.WARNING):
             assert get_dataset_namespace(profile_config) is None
-        assert "Namespace field 'host' rendered to an empty value" in caplog.text
+        assert "empty host" in caplog.text
+
+    def test_profiles_yml_filepath_glue_empty_role_arn_with_account_id(self, tmp_path):
+        """role_arn is never read when account_id is set, so an empty role_arn is irrelevant
+        to the namespace and must not disable dataset emission."""
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: glue
+      region: us-east-1
+      account_id: "123456789012"
+      role_arn: "{{ env_var('GLUE_ROLE_ARN', '') }}"
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "arn:aws:glue:us-east-1:123456789012"
+
+    def test_profiles_yml_filepath_glue_empty_account_id_falls_through_to_role_arn(self, tmp_path):
+        """An empty account_id falls through to the role_arn fallback in the glue resolver."""
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: glue
+      region: us-east-1
+      account_id: "{{ env_var('GLUE_ACCOUNT_ID', '') }}"
+      role_arn: "arn:aws:iam::999888777666:role/my-role"
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "arn:aws:glue:us-east-1:999888777666"
+
+    def test_profiles_yml_filepath_spark_empty_method_with_port(self, tmp_path):
+        """method is only used for the default port; an empty method must not disable emission
+        when port is explicitly set."""
+        profiles_yml = tmp_path / "profiles.yml"
+        profiles_yml.write_text("""
+my_profile:
+  outputs:
+    dev:
+      type: spark
+      host: sparkhost
+      port: 10000
+      method: "{{ env_var('SPARK_METHOD', '') }}"
+""")
+        profile_config = MagicMock()
+        profile_config.profile_mapping = None
+        profile_config.profiles_yml_filepath = str(profiles_yml)
+        profile_config.profile_name = "my_profile"
+        profile_config.target_name = "dev"
+        assert get_dataset_namespace(profile_config) == "spark://sparkhost:10000"
 
     def test_profiles_yml_filepath_with_dbt_jinja_filters(self, tmp_path, monkeypatch):
         """Regression test for #2948: dbt's documented profiles.yml filters (as_number, as_bool)


### PR DESCRIPTION
Ran into the scenario from #2948 while poking at watcher-mode dataset emission, and it reproduces exactly as described there.

Any profiles.yml field using dbt's documented as_number/as_bool filters, e.g. `threads: "{{ env_var('DBT_THREADS', 4) | as_number }}"`, makes `get_dataset_namespace` return None. #2879 renders every string field through a bare `jinja2.Template` that doesn't know dbt's filters, the TemplateAssertionError gets swallowed at DEBUG level, and None disables dataset emission for the entire run. So a filter on `threads`, which the namespace resolvers never even read, silently kills every asset event. Downstream asset-scheduled DAGs just never fire.

What I changed:

`_resolve_env_var` now renders through a Jinja environment that registers dbt's as_number/as_bool/as_text/as_native filters as identity no-ops. That's what dbt's own text-mode environment does with them (`TEXT_FILTERS` in `dbt_common.clients.jinja`), so the semantics match dbt instead of inventing new ones.

`_get_profile_dict` renders fields independently now. If one field's template can't be rendered at all (unknown filter, undefined name), it keeps the raw value instead of aborting the whole profile.

The catch-all in `get_dataset_namespace` logs at WARNING instead of DEBUG, since returning None there means zero datasets for the run and nobody would notice otherwise.

One behavior change worth flagging: a field that genuinely can't render (e.g. `host: "db-{{ this.is_not_env_var }}.prod.internal"`) now degrades to its raw value in the namespace instead of disabling emission for the whole run. That restores the pre-1.15.1 behavior for that one field, and I updated the existing test to match. Seemed like the right trade-off given the alternative is silently dropping all asset events, but happy to revisit if you'd rather keep the None.

Verified with the profiles.yml from the issue: before, the namespace comes back None; after, `postgres://localhost:5432` as expected. TestGetDatasetNamespace (21 tests now) and the _resolve_env_var tests pass, black and ruff clean.

Credit to @hellowithchicken for the pinpoint root-cause analysis in the issue.

Fixes #2948
