### PR TITLE
ci(docs): exclude bot-blocked Stack Exchange links from linkcheck

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -45,6 +45,6 @@ exclude = [
     'https://github\.com/your-org/',
     # Bot-blocked — Stack Exchange / Stack Overflow return 403 to automated
     # clients (even with a browser UA); pages resolve fine in a real browser.
-    'https://[a-z]+\.stackexchange\.com',
-    'https://stackoverflow\.com',
+    'https://[a-z0-9-]+\.stackexchange\.com',
+    'https://([a-z0-9-]+\.)?stackoverflow\.com',
 ]

--- a/lychee.toml
+++ b/lychee.toml
@@ -43,4 +43,8 @@ exclude = [
     'https://www\.astronomer\.io/docs/learn/airflow-ui',
     # Intentional placeholder in example snippets, not a real repository.
     'https://github\.com/your-org/',
+    # Bot-blocked — Stack Exchange / Stack Overflow return 403 to automated
+    # clients (even with a browser UA); pages resolve fine in a real browser.
+    'https://[a-z]+\.stackexchange\.com',
+    'https://stackoverflow\.com',
 ]


### PR DESCRIPTION
## What

Add the Stack Exchange network (and Stack Overflow) to the `exclude` list in `lychee.toml`.

## Why

The "Build Sphinx documentation" → `linkcheck` job fails on a single pre-existing
external link — `https://devops.stackexchange.com/questions/676/...`, referenced in
`docs/guides/run_dbt/container/docker.rst`. Stack Exchange bot-blocks automated clients,
returning **403 even with a real browser User-Agent**, while the page resolves fine in a
real browser. This is a bot-block, not a broken link.

Because `docs-build.yml` triggers on any `cosmos/**` or `docs/**` change and lychee then
checks *all* docs, this breaks linkcheck on unrelated PRs (e.g. #2950, which only touches
Python). `main` itself would fail if the docs build were re-run.

## Fix

Exclude the whole `*.stackexchange.com` network plus `stackoverflow.com`, matching the
convention `lychee.toml` already documents for bot-blocked hosts (`docs.aws.amazon.com`,
`charts.bitnami.com`, `join.slack.com`). The `docker.rst` link is left in place — it's
useful and valid; per the file's own convention it's excluded from checking, not removed.

## Verification

Ran locally exactly as CI does:

    lychee --no-progress --config lychee.toml 'docs/**/*.rst'
    # 527 Total ✅ 447 OK 🚫 0 Errors 👻 80 Excluded

Confirmed the `devops.stackexchange.com` link now falls under Excluded rather than Errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)