### PR TITLE
Fix broken Slack invite links to #airflow-dbt channel

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@
     :alt: Commit activity
 
 .. |slack| image:: https://img.shields.io/badge/slack-%23airflow--dbt-white.svg?logo=slack&style=social
-    :target: https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q
+    :target: https://apache-airflow.slack.com/archives/C059CC42E9W
     :alt: Slack #airflow-dbt
 
 .. |health| image:: https://insights.linuxfoundation.org/api/badge/health-score?project=astronomer-astronomer-cosmos
@@ -88,7 +88,7 @@ This will generate an Airflow DAG that looks like this:
 
 Community
 _________
-- Join us on the Airflow `Slack <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ at #airflow-dbt
+- Join us on the Airflow `Slack <https://apache-airflow.slack.com/archives/C059CC42E9W>`_ at #airflow-dbt
 
 
 Changelog

--- a/docs/policy/contributors-roles.rst
+++ b/docs/policy/contributors-roles.rst
@@ -14,7 +14,7 @@ Contributors
 
 A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the Astronomer Cosmos project.
 
-Cosmos contributors can be found in the Astronomer Cosmos Github `insights page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://apache-airflow.slack.com/archives/C059CC42E9W>`_ Slack channel.
+Cosmos contributors can be found in the Astronomer Cosmos GitHub `insights page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://apache-airflow.slack.com/archives/C059CC42E9W>`_ Slack channel.
 
 Contributors are responsible for:
 

--- a/docs/policy/contributors-roles.rst
+++ b/docs/policy/contributors-roles.rst
@@ -14,7 +14,7 @@ Contributors
 
 A contributor is anyone who wants to contribute code, documentation, tests, ideas, or anything to the Astronomer Cosmos project.
 
-Cosmos contributors can be found in the Astronomer Cosmos Github `insights page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ Slack channel.
+Cosmos contributors can be found in the Astronomer Cosmos Github `insights page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://apache-airflow.slack.com/archives/C059CC42E9W>`_ Slack channel.
 
 Contributors are responsible for:
 

--- a/docs/policy/contributors.rst
+++ b/docs/policy/contributors.rst
@@ -28,4 +28,4 @@ Contributors
 ~~~~~~~~~~~~
 
 Many people are improving Astronomer Cosmos each day.
-Find more contributors `in our GitHub page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://join.slack.com/t/apache-airflow/shared_invite/zt-1zy8e8h85-es~fn19iMzUmkhPwnyRT6Q>`_ Slack channel.
+Find more contributors `in our GitHub page <https://github.com/astronomer/astronomer-cosmos/graphs/contributors>`_ and in the `#airflow-dbt <https://apache-airflow.slack.com/archives/C059CC42E9W>`_ Slack channel.


### PR DESCRIPTION
## Summary
- Replaces the expired `join.slack.com` invite links with the working `#airflow-dbt` channel URL (`https://apache-airflow.slack.com/archives/C059CC42E9W`), matching the link already used in `docs/index.rst`.
- Updated `README.rst` (badge target + Community section) and `docs/policy/contributors-roles.rst` / `docs/policy/contributors.rst`.

Closes #2953

## Test plan
- [x] Verified no remaining references to the dead `join.slack.com` invite link in the repo
- [x] Confirmed the new URL matches the one already working in `docs/index.rst`