### PR TITLE
Ignore all Slack hosts in the lychee link checker

### DIFF
--- a/lychee.toml
+++ b/lychee.toml
@@ -29,8 +29,8 @@ exclude_loopback = true
 # URLs an automated checker cannot verify, plus intentional placeholders.
 # Genuinely broken links are fixed in the docs, not excluded here.
 exclude = [
-    # Auth wall — Slack invite links return 403 to unauthenticated requests.
-    'https://join\.slack\.com',
+    # Auth wall — Slack links return 403 to unauthenticated requests.
+    'https://[a-z0-9-]+\.slack\.com',
     # Flaky / rate-limited from CI — intermittent TLS failures.
     'https://ossrank\.com',
     # Bot-blocked — the Bitnami Helm chart repo returns 403 to non-Helm clients.


### PR DESCRIPTION
## Description

The `linkcheck` CI job started failing on `main` with 403s for
`https://apache-airflow.slack.com/archives/C059CC42E9W` in `docs/index.rst`,
`docs/policy/contributors.rst` and `docs/policy/contributors-roles.rst`.

`lychee.toml` already excluded Slack, but only the invite-link host
(`join.slack.com`). #2956 replaced those invite links with workspace channel
links on `apache-airflow.slack.com`, which no exclude pattern matched. Slack
serves 403 to unauthenticated requests for workspace links just as it does for
invite links, and `accept` deliberately treats 403 as a failure, so the job went
red.

Widened the pattern to cover every `*.slack.com` host — `join` still matches
`[a-z0-9-]+`, so this replaces the old entry rather than adding to it.

```diff
-    # Auth wall — Slack invite links return 403 to unauthenticated requests.
-    'https://join\.slack\.com',
+    # Auth wall — Slack links return 403 to unauthenticated requests.
+    'https://[a-z0-9-]+\.slack\.com',
```

## Related Issue(s)

Follow-up to #2956.

## Breaking Change?

No.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

The `linkcheck` job on this PR is the test.

🤖 Generated with Claude Code (https://claude.com/claude-code)