### PR TITLE
Pin dbt Fusion and cap the fusion job runtime

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -503,6 +503,7 @@ jobs:
     needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     permissions:
       contents: read
     strategy:

--- a/scripts/test/integration-dbtf.sh
+++ b/scripts/test/integration-dbtf.sh
@@ -15,8 +15,8 @@ rm -rf dbt/jaffle_shop/dbt_packages;
 # Note: the dbt Fusion Engine is in Beta! Bugs and missing functionality compared to dbt Core will be resolved
 # continuously in the lead-up to a final release (see more details in https://github.com/dbt-labs/dbt-fusion)
 
-# Install dbt fusion (2.0.0-beta.26 on 23 June 2025)
-curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update
+# Install dbt fusion, pinned: the default latest (2.0.0-preview.209) hangs on the BigQuery test
+curl -fsSL https://public.cdn.getdbt.com/fs/install/install.sh | sh -s -- --update --version 2.0.0-preview.205
 
 pytest -vv \
     tests/test_dbtf.py \


### PR DESCRIPTION
Draft — opened to verify the pin actually makes `Run-Integration-dbt-fusion-Tests` complete instead of hanging.

## Description

`scripts/test/integration-dbtf.sh` installed Fusion with no `--version`, so `install.sh` resolved
the `latest` tag from `https://public.cdn.getdbt.com/fs/versions.json` at run time. Fusion
**2.0.0-preview.209** (released 2026-08-13) hangs indefinitely in
`test_dbt_fusion[dbt_fusion_local_bigquery_dag]`.

Evidence:

| Run | Fusion version | Result |
|---|---|---|
| [31704692413](https://github.com/astronomer/astronomer-cosmos/actions/runs/31704692413) (08-13 13:25) | `2.0.0-preview.205` | 3 passed in 144s |
| [31711799857](https://github.com/astronomer/astronomer-cosmos/actions/runs/31711799857) (08-14 14:57) | `2.0.0-preview.209` | Snowflake test passed, BigQuery test never returned, killed at 6h |

The hung job's cleanup logs `Terminate orphan process: pid (5661) (dbt)`, so a live Fusion process
is what is stuck, not Airflow or pytest. Because the version is unpinned, this broke every branch
at once with no commit — it is currently blocking #2965 and #2957.

Two changes:

- Pin `2.0.0-preview.205`, the last version this suite passed on.
- Add `timeout-minutes: 60` to the job, which had none and so ran to GitHub's 6h default.
  `Run-Integration-Tests` already carries the same cap.

## Related Issue(s)

Unblocks #2965 and #2957. Removing this pin is tracked in #2967, where the BigQuery hang also
needs reporting to [dbt-labs/dbt-fusion](https://github.com/dbt-labs/dbt-fusion).

## Breaking Change?

No — CI only.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

The `Run-Integration-dbt-fusion-Tests` jobs on this PR are the test.

> [!NOTE]
> `pull_request_target` loads the workflow from `main`, so the `timeout-minutes` change does not
> apply to this PR's own run — only the pinned script does, since that comes from the PR checkout.
> If the pin fails, this run will still take 6h to die.

🤖 Generated with Claude Code (https://claude.com/claude-code)
