### PR TITLE
Clarify missing profile field errors

### DIFF
--- a/cosmos/profiles/base.py
+++ b/cosmos/profiles/base.py
@@ -235,7 +235,15 @@ class BaseProfileMapping(ABC):
             value = self.get_dbt_value(field)
 
             if value is None:
-                raise CosmosValueError(f"Could not find a value for secret field {field}.")
+                airflow_fields = self.airflow_param_mapping.get(field, [])
+                if isinstance(airflow_fields, str):
+                    airflow_fields = [airflow_fields]
+                connection_fields = ", ".join(repr(item) for item in airflow_fields) or "none"
+                raise CosmosValueError(
+                    f"{type(self).__name__} could not resolve required dbt profile field {field!r} from profile_args "
+                    f"or Airflow connection {self.conn_id!r} (connection fields: {connection_fields}). "
+                    "Check that the connection uses the authentication method expected by this profile mapping."
+                )
 
             env_vars[env_var_name] = str(value)
 

--- a/tests/profiles/test_base_profile.py
+++ b/tests/profiles/test_base_profile.py
@@ -56,6 +56,22 @@ def test_disable_event_tracking(disable_event_tracking: bool):
         assert test_profile.env_vars["DBT_SEND_ANONYMOUS_USAGE_STATS"] == "False"
 
 
+def test_missing_secret_error_includes_profile_mapping_context(monkeypatch: pytest.MonkeyPatch):
+    test_profile = TestProfileMapping(conn_id="fake_conn_id")
+    test_profile.secret_fields = ["password"]
+    test_profile.airflow_param_mapping = {"password": ["password", "extra.password"]}
+    monkeypatch.setattr(test_profile, "get_dbt_value", lambda _: None)
+
+    with pytest.raises(CosmosValueError) as error:
+        test_profile.env_vars
+
+    assert str(error.value) == (
+        "TestProfileMapping could not resolve required dbt profile field 'password' from profile_args or Airflow "
+        "connection 'fake_conn_id' (connection fields: 'password', 'extra.password'). Check that the connection uses "
+        "the authentication method expected by this profile mapping."
+    )
+
+
 def test_disable_event_tracking_and_send_anonymous_usage_stats():
     expected_cosmos_error = (
         "Cannot set both disable_event_tracking and "


### PR DESCRIPTION
## Description

Improve missing secret-field errors from profile mappings by including the mapping class, connection ID, and Airflow connection fields that Cosmos consulted. The message also points users toward authentication-method mismatches without exposing profile or connection values.

## Related Issue(s)

Closes #2968

## Breaking Change?

No. This only changes the text of an existing error.

## Checklist

- [x] I have made corresponding changes to the documentation (not required; error-message-only change)
- [x] I have added tests that prove my fix is effective or that my feature works

## Testing

- `hatch run tests.py3.12-3.1-1.9:test` — 1,943 passed, 10 skipped, 125 deselected, 2 xfailed
- `hatch run tests.py3.12-3.1-1.9:type-check` — passed
- `pre-commit run --files cosmos/profiles/base.py tests/profiles/test_base_profile.py` — passed

The full `pre-commit run --all-files` reached mypy and reported four pre-existing unused `type: ignore` comments in unrelated files; all hooks pass on the changed files.

🤖 Generated with Codex (https://openai.com/codex)
