### PR TITLE
Vuln: Require authentication on the Airflow 3 Cosmos dbt docs routes

### DIFF
--- a/cosmos/plugin/airflow3.py
+++ b/cosmos/plugin/airflow3.py
@@ -18,7 +18,7 @@ except ImportError:
     from airflow.configuration import conf
 from airflow.plugins_manager import AirflowPlugin
 from airflow.sdk import ObjectStoragePath
-from fastapi import FastAPI
+from fastapi import Depends, FastAPI, HTTPException, status
 from fastapi.responses import HTMLResponse, JSONResponse, Response
 from packaging.version import Version
 
@@ -130,9 +130,32 @@ def _load_projects_from_conf() -> dict[str, dict[str, str | None]]:
     return projects
 
 
+def cosmos_auth_dependencies() -> list[Any]:
+    """
+    Build the authentication/authorization dependencies applied to every Cosmos route.
+
+    Airflow 3 attaches authentication to its own routers, so a plugin sub-app mounted with
+    ``app.mount()`` does not inherit it. This is the AF3 equivalent of the ``@has_access`` guard used
+    by the Airflow 2 plugin: the caller must be authenticated and allowed to read plugin views.
+    If the Airflow security helpers cannot be imported, the routes fail closed.
+    """
+    try:
+        from airflow.api_fastapi.auth.managers.models.resource_details import AccessView
+        from airflow.api_fastapi.core_api.security import requires_access_view
+    except ImportError:
+        logger.warning("Airflow API auth helpers are unavailable: denying access to the Cosmos dbt docs routes.")
+
+        def deny_all() -> None:
+            raise HTTPException(status_code=status.HTTP_403_FORBIDDEN, detail="Forbidden")
+
+        return [Depends(deny_all)]
+
+    return [Depends(requires_access_view(AccessView.PLUGINS))]
+
+
 def create_cosmos_fastapi_app() -> FastAPI:  # noqa: C901
     ensure_airflow_version_supported()
-    app = FastAPI()
+    app = FastAPI(dependencies=cosmos_auth_dependencies())
 
     projects = _load_projects_from_conf()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -212,7 +212,7 @@ type-check = "pre-commit run mypy --files cosmos/**/*"
 addopts = "--ignore-glob=**/dbt_packages/*"
 filterwarnings = ["ignore::DeprecationWarning"]
 minversion = "6.0"
-markers = ["integration", "perf", "dbtfusion"]
+markers = ["integration", "perf", "dbtfusion", "plugin_auth"]
 
 ######################################
 # DOCS

--- a/tests/plugin/test_plugin_af3.py
+++ b/tests/plugin/test_plugin_af3.py
@@ -35,6 +35,16 @@ def _isolate_env():
         yield
 
 
+@pytest.fixture(autouse=True)
+def _bypass_plugin_auth(request):
+    """Bypass the routes' auth guard, except for tests marked with ``plugin_auth``."""
+    if "plugin_auth" in request.keywords:
+        yield
+        return
+    with patch("airflow.api_fastapi.core_api.security.requires_access_view", return_value=lambda: None):
+        yield
+
+
 def _reload_af3_module(api_base: str | None = None):
     # Reload module to recompute API_BASE_PATH under patched env
     with patch.dict(os.environ, {"AIRFLOW__API__BASE_URL": api_base or ""}, clear=False):
@@ -525,6 +535,71 @@ def test_dbt_docs_emits_telemetry_local_storage(mock_emit, tmp_path: Path):
             "has_custom_name": False,
         },
     )
+
+
+@skip_pre_airflow_31
+@pytest.mark.plugin_auth
+def test_routes_require_authentication(tmp_path: Path):
+    """Unauthenticated requests must not reach the dbt docs, manifest or catalog."""
+    docs_dir = tmp_path / "target"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "index.html").write_text("<head></head><body>dbt</body>")
+    (docs_dir / "manifest.json").write_text(json.dumps({"nodes": {"model.a": {"raw_code": "select 1"}}}))
+    (docs_dir / "catalog.json").write_text(json.dumps({"sources": {}}))
+
+    af3, app = _app_with_projects({"core": {"dir": str(docs_dir), "index": "index.html"}})
+    client = TestClient(app)
+
+    for route in ("/core/dbt_docs", "/core/dbt_docs_index.html", "/core/manifest.json", "/core/catalog.json"):
+        response = client.get(route)
+        assert response.status_code == 401
+        assert "raw_code" not in response.text
+
+
+@skip_pre_airflow_31
+@pytest.mark.plugin_auth
+def test_routes_forbidden_for_unauthorized_user(tmp_path: Path):
+    """An authenticated user without plugin view access gets a 403."""
+    from airflow.api_fastapi.core_api import security
+
+    docs_dir = tmp_path / "target"
+    docs_dir.mkdir(parents=True)
+    (docs_dir / "manifest.json").write_text(json.dumps({"nodes": {}}))
+
+    af3, app = _app_with_projects({"core": {"dir": str(docs_dir), "index": "index.html"}})
+    app.dependency_overrides[security.get_user] = lambda: "some-user"
+    client = TestClient(app)
+
+    with patch.object(security, "get_auth_manager") as mock_get_auth_manager:
+        mock_get_auth_manager.return_value.is_authorized_view.return_value = False
+        assert client.get("/core/manifest.json").status_code == 403
+
+        mock_get_auth_manager.return_value.is_authorized_view.return_value = True
+        response = client.get("/core/manifest.json")
+
+    assert response.status_code == 200
+    assert response.json() == {"nodes": {}}
+
+
+@skip_pre_airflow_31
+@pytest.mark.plugin_auth
+def test_auth_dependencies_fail_closed_without_airflow_security():
+    """If the Airflow security helpers cannot be imported, the routes deny every request."""
+    import sys
+
+    from fastapi import FastAPI
+
+    af3 = _reload_af3_module()
+    with patch.dict(sys.modules, {"airflow.api_fastapi.core_api.security": None}):
+        dependencies = af3.cosmos_auth_dependencies()
+
+    app = FastAPI(dependencies=dependencies)
+
+    @app.get("/ping")
+    def ping() -> str:
+        return "pong"
+
+    assert TestClient(app).get("/ping").status_code == 403
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Description

The Airflow 3 plugin mounts its FastAPI sub-app under `/cosmos` with `app.mount()`. Airflow 3 attaches auth per-router via `Depends(...)` rather than as global middleware, so a mounted sub-app inherits nothing — every dbt docs route (`dbt_docs`, `dbt_docs_index.html`, `manifest.json`, `catalog.json`) was reachable without credentials, exposing model SQL and schema metadata. The Airflow 2 plugin guards the equivalent views with `@has_access(MENU_ACCESS_PERMISSIONS)`; this restores parity.

```python
app = FastAPI(dependencies=cosmos_auth_dependencies())
# cosmos_auth_dependencies() -> [Depends(requires_access_view(AccessView.PLUGINS))]
# import failure -> [Depends(deny_all)]  # 403, fail closed
```

`AccessView.PLUGINS` maps to the viewer role in `SimpleAuthManager`, matching the AF2 `RESOURCE_WEBSITE` read permission, and `get_user` accepts the API-server JWT cookie, so the in-UI iframe keeps working.

Reproduced and verified against a local Airflow 3.3 cluster (Astro CLI runtime `3.3-4`, `SimpleAuthManager` with `all_admins=False`, one project configured via `[cosmos] dbt_docs_projects`):

| request | before | after |
| --- | --- | --- |
| unauthenticated `GET /cosmos/jaffle/manifest.json` | 200 + full manifest | 401 |
| unauthenticated `catalog.json` / `dbt_docs_index.html` / `dbt_docs` | 200 | 401 |
| `Authorization: Bearer <token>` or `_token` cookie | 200 | 200 |

## Related Issue(s)

Fixes the code scan finding "Airflow 3 FastAPI dbt-docs plugin routes have no authentication (regression from Airflow 2)" (`sfind-94bfb1c9f5af4cd48621524b82e3ce85`).

## Breaking Change?

Callers that scraped these endpoints anonymously must now authenticate. This is the intended behavior and matches Airflow 2.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

Devin-Org: engineering

Link to Devin session: https://app.devin.ai/sessions/e7bbf6409f75432c8acf3264279353dc
<!-- devin-review-badge-staging-begin -->

---

#### Devin Review
| Status | Commit |
|---|---|
| ⚪ Not started | — |

> [Run Devin Review](https://staging.itsdev.in/review/COG-GTM/astronomer-cosmos/pull/1?analyze=true)

<a href="https://staging.itsdev.in/review/COG-GTM/astronomer-cosmos/pull/1" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-staging-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-staging-light.svg?v=1" alt="Open in Devin Review (Staging)">
  </picture>
</a>
<!-- devin-review-badge-staging-end -->