### PR TITLE
Resolve exclude graph selectors against the full project graph

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -1442,13 +1442,21 @@ def select_nodes(
     if not select and not exclude:
         return nodes
     validate_filters(exclude, select)
-    subset_ids = apply_select_filter(nodes, project_dir, select)
-    if select:
-        nodes = get_nodes_from_subset(nodes, subset_ids)
-    exclude_ids = apply_exclude_filter(nodes, project_dir, exclude)
-    subset_ids = set(nodes.keys()) - exclude_ids
 
-    return get_nodes_from_subset(nodes, subset_ids)
+    # Resolve `exclude` against the full project graph, before `select` narrows it.
+    # Graph operators (`+tag:x`, `tag:x+`, `+model_name`, ...) traverse outwards from
+    # the nodes matching the selector, so if those root nodes were dropped by `select`
+    # the traversal has nothing to start from and shared ancestors or descendants are
+    # silently kept. dbt evaluates both filters against the whole graph and subtracts
+    # afterwards; this does the same.
+    exclude_ids = apply_exclude_filter(nodes, project_dir, exclude)
+
+    if select:
+        subset_ids = apply_select_filter(nodes, project_dir, select)
+    else:
+        subset_ids = set(nodes.keys())
+
+    return get_nodes_from_subset(nodes, subset_ids - exclude_ids)
 
 
 def get_nodes_from_subset(nodes: dict[str, DbtNode], subset_ids: set[str]) -> dict[str, DbtNode]:

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -547,6 +547,21 @@ def test_select_nodes_by_child_and_precursors_exclude_tags():
     assert sorted(selected.keys()) == expected
 
 
+def test_select_nodes_exclude_graph_selector_resolves_against_full_graph():
+    """
+    Graph operators in ``exclude`` must be resolved against the full project graph,
+    not against the subset already narrowed by ``select``.
+
+    ``+child`` selects child and its ancestors. ``+tag:test`` should exclude sibling1
+    (the only node tagged ``test``) together with its ancestors, which are shared with
+    child. sibling1 itself is not part of the ``select`` result, so resolving the
+    exclude against the narrowed subset finds no root node to traverse from and
+    silently leaves those shared ancestors in.
+    """
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+child"], exclude=["+tag:test"])
+    assert sorted(selected.keys()) == [child_node.unique_id]
+
+
 def test_select_node_by_child_and_precursors_partial_tree():
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=sample_nodes, select=["+parent"])
     expected = [another_grandparent_node.unique_id, grandparent_node.unique_id, parent_node.unique_id]


### PR DESCRIPTION
Closes #2964.

## What was happening

`select_nodes()` applied the `select` filter first and reassigned `nodes` to the narrowed subset, then ran the `exclude` filter against that subset:

```python
subset_ids = apply_select_filter(nodes, project_dir, select)
if select:
    nodes = get_nodes_from_subset(nodes, subset_ids)
exclude_ids = apply_exclude_filter(nodes, project_dir, exclude)
subset_ids = set(nodes.keys()) - exclude_ids
```

Graph operators traverse outwards from the nodes matching the selector, so when those root nodes were not part of the `select` result there was nothing to traverse from. `exclude_ids` came back empty and shared ancestors or descendants were silently kept — no error, and no indication that the exclude had not been applied.

## The change

Compute `exclude_ids` against the full node set, then subtract it from the `select` result. dbt evaluates both filters against the whole graph and subtracts afterwards, so this also brings Cosmos closer to dbt's own semantics.

Behaviour is unchanged when only one of `select` / `exclude` is given.

## Reproduction

Added `test_select_nodes_exclude_graph_selector_resolves_against_full_graph`, using the existing fixture graph.

`select=["+child"]` selects `child` and its ancestors. `exclude=["+tag:test"]` should remove `sibling1` (the only node tagged `test`) together with its ancestors, which are shared with `child`. `sibling1` is not part of the `select` result.

| | nodes returned |
|---|---|
| Before | `child`, `parent`, `grandparent`, `another_grandparent` |
| After | `child` |

## Note on local test runs

Six tests in `tests/dbt/test_selector.py` fail on my machine both with and without this change — they are `path:` glob tests that do not match Windows path separators. I verified the failing set is identical before and after, so this introduces no regressions there.
