### PR TITLE
Keep ProjectConfig relative paths when the project root comes from RenderConfig

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -266,6 +266,9 @@ class ProjectConfig:
     models_paths: list[Path]
     seeds_paths: list[Path]
     snapshots_paths: list[Path]
+    models_relative_paths: list[Path]
+    seeds_relative_paths: list[Path]
+    snapshots_relative_paths: list[Path]
     project_name: str
 
     def __init__(
@@ -301,6 +304,12 @@ class ProjectConfig:
             "snapshots_relative_paths",
         )
         # Assigned here, not as a class-level default, so instances don't share one mutable list.
+        # The relative paths are kept regardless of whether dbt_project_path is set on this config:
+        # the project root may instead be supplied through RenderConfig/ExecutionConfig, and rendering
+        # still needs to know which directories the user configured.
+        self.models_relative_paths = [Path(p) for p in _as_path_list(models_relative_paths)]
+        self.seeds_relative_paths = [Path(p) for p in _as_path_list(seeds_relative_paths)]
+        self.snapshots_relative_paths = [Path(p) for p in _as_path_list(snapshots_relative_paths)]
         self.models_paths = []
         self.seeds_paths = []
         self.snapshots_paths = []
@@ -317,9 +326,9 @@ class ProjectConfig:
 
         if dbt_project_path:
             self.dbt_project_path = Path(dbt_project_path)
-            self.models_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(models_relative_paths)]
-            self.seeds_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(seeds_relative_paths)]
-            self.snapshots_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(snapshots_relative_paths)]
+            self.models_paths = [self.dbt_project_path / p for p in self.models_relative_paths]
+            self.seeds_paths = [self.dbt_project_path / p for p in self.seeds_relative_paths]
+            self.snapshots_paths = [self.dbt_project_path / p for p in self.snapshots_relative_paths]
             if not project_name:
                 self.project_name = self.dbt_project_path.stem
 

--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -82,6 +82,20 @@ def _normalize_path(path: str | None) -> str:
         return Path(path.replace("\\", "/")).as_posix()
 
 
+def _configured_dirs(absolute_paths: list[Path], relative_paths: list[Path], project_path: Path | None) -> list[str]:
+    """
+    Returns the model/seed/snapshot directories to hand to LegacyDbtProject, relative to the project root.
+
+    ProjectConfig only builds absolute paths when its own dbt_project_path is set. When the root comes
+    from RenderConfig/ExecutionConfig instead, fall back to the relative paths the user configured, so
+    they aren't silently replaced by LegacyDbtProject's defaults.
+    """
+    dirs = _relative_dirs(absolute_paths, project_path)
+    if dirs is not None:
+        return dirs
+    return [p.as_posix() for p in relative_paths]
+
+
 def _relative_dirs(paths: list[Path], project_path: Path | None) -> list[str] | None:
     """Returns each path's location relative to project_path, preserving nested subdirectories."""
     # None (not []) triggers LegacyDbtProject's own default; only do that when project_path is unset,
@@ -1123,9 +1137,15 @@ class DbtGraph:
         project = LegacyDbtProject(
             project_name=self.render_config.project_path.stem,
             dbt_root_path=self.render_config.project_path.parent.as_posix(),
-            dbt_models_dir=_relative_dirs(self.project.models_paths, self.project.dbt_project_path),
-            dbt_seeds_dir=_relative_dirs(self.project.seeds_paths, self.project.dbt_project_path),
-            dbt_snapshots_dir=_relative_dirs(self.project.snapshots_paths, self.project.dbt_project_path),
+            dbt_models_dir=_configured_dirs(
+                self.project.models_paths, self.project.models_relative_paths, self.project.dbt_project_path
+            ),
+            dbt_seeds_dir=_configured_dirs(
+                self.project.seeds_paths, self.project.seeds_relative_paths, self.project.dbt_project_path
+            ),
+            dbt_snapshots_dir=_configured_dirs(
+                self.project.snapshots_paths, self.project.snapshots_relative_paths, self.project.dbt_project_path
+            ),
             dbt_vars=self.dbt_vars,
         )
         nodes = {}

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -1517,6 +1517,59 @@ def test_load_via_custom_parser_with_nested_model_dir(tmp_path):
     assert dbt_graph.nodes["my_model"].unique_id == "model.nested_project.my_model"
 
 
+def test_load_via_custom_parser_with_nested_model_dir_and_split_project_path(tmp_path):
+    """
+    The project root may come from RenderConfig/ExecutionConfig rather than ProjectConfig. In that case
+    ProjectConfig cannot build absolute models_paths, and the relative dirs the user configured must
+    still be honoured instead of falling back to LegacyDbtProject's default "models" directory.
+    """
+    project_dir = tmp_path / "split_project"
+    (project_dir / "custom" / "models").mkdir(parents=True)
+    (project_dir / "custom" / "models" / "my_model.sql").write_text("select 1")
+    (project_dir / "profiles.yml").write_text(
+        "test:\n"
+        "  target: test\n"
+        "  outputs:\n"
+        "    test:\n"
+        "      type: postgres\n"
+        "      host: localhost\n"
+        "      user: user\n"
+        "      password: pass\n"
+        "      port: 5432\n"
+        "      dbname: db\n"
+        "      schema: public\n"
+        "      threads: 1\n"
+    )
+
+    # No dbt_project_path here: the project root is supplied by RenderConfig/ExecutionConfig below,
+    # so ProjectConfig has no root to build absolute paths from.
+    project_config = ProjectConfig(
+        manifest_path=project_dir / "target" / "manifest.json",
+        project_name="split_project",
+        models_relative_paths="custom/models",
+    )
+    assert project_config.models_paths == []
+
+    execution_config = ExecutionConfig(dbt_project_path=project_dir)
+    render_config = RenderConfig(dbt_project_path=project_dir, source_rendering_behavior=SOURCE_RENDERING_BEHAVIOR)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profiles_yml_filepath=project_dir / "profiles.yml",
+    )
+    dbt_graph = DbtGraph(
+        project=project_config,
+        profile_config=profile_config,
+        render_config=render_config,
+        execution_config=execution_config,
+    )
+
+    dbt_graph.load_via_custom_parser()
+
+    assert "my_model" in dbt_graph.nodes
+    assert dbt_graph.nodes["my_model"].unique_id == "model.split_project.my_model"
+
+
 def test_load_via_custom_parser_with_explicit_empty_models_relative_paths(tmp_path):
     """
     models_relative_paths=[] means "no model directories" and must not fall back to crawling the

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -53,6 +53,38 @@ def test_init_with_project_path_and_list_relative_paths():
     ]
 
 
+def test_relative_paths_kept_without_project_path():
+    """
+    The configured relative paths must survive even when ProjectConfig.dbt_project_path is not set,
+    because the project root may instead come from RenderConfig/ExecutionConfig. Previously they were
+    silently discarded and rendering fell back to the default `models`/`seeds`/`snapshots` folders.
+    """
+    project_config = ProjectConfig(
+        manifest_path=DBT_PROJECTS_ROOT_DIR / "manifest.json",
+        project_name="split_path_project",
+        models_relative_paths=["custom/models"],
+        seeds_relative_paths=["custom/seeds"],
+        snapshots_relative_paths=["custom/snapshots"],
+    )
+
+    assert project_config.dbt_project_path is None
+    assert project_config.models_paths == []
+    assert project_config.models_relative_paths == [Path("custom/models")]
+    assert project_config.seeds_relative_paths == [Path("custom/seeds")]
+    assert project_config.snapshots_relative_paths == [Path("custom/snapshots")]
+
+
+def test_relative_paths_default_when_not_configured():
+    """An omitted relative path falls back to the dbt default, an explicitly empty list stays empty."""
+    defaulted = ProjectConfig(manifest_path=DBT_PROJECTS_ROOT_DIR / "manifest.json", project_name="p")
+    assert defaulted.models_relative_paths == [Path("models")]
+
+    emptied = ProjectConfig(
+        manifest_path=DBT_PROJECTS_ROOT_DIR / "manifest.json", project_name="p", models_relative_paths=[]
+    )
+    assert emptied.models_relative_paths == []
+
+
 def test_models_paths_not_shared_across_instances():
     """
     models_paths/seeds_paths/snapshots_paths must not be a shared mutable default - mutating one


### PR DESCRIPTION
Closes #2926.

## What was happening

`ProjectConfig` only stored the configured `models` / `seeds` / `snapshots` relative paths when its own `dbt_project_path` was set:

```python
if dbt_project_path:
    self.dbt_project_path = Path(dbt_project_path)
    self.models_paths = [self.dbt_project_path / Path(p) for p in _as_path_list(models_relative_paths)]
    ...
```

When the project root was supplied through `RenderConfig` / `ExecutionConfig` instead, the relative paths were discarded with no warning. Under `LoadMode.CUSTOM`, `_relative_dirs()` then returned `None` and `LegacyDbtProject` fell back to the default `models` / `seeds` / `snapshots` folders, so a project laid out as `custom/models/` rendered an incomplete or empty DAG.

## The change

- `ProjectConfig` now normalizes and keeps `models_relative_paths`, `seeds_relative_paths` and `snapshots_relative_paths` regardless of where the project root is configured. Absolute `*_paths` are still only built when `dbt_project_path` is set, so nothing changes for existing configurations.
- `DbtGraph.load_via_custom_parser()` falls back to those relative paths when the absolute ones are unavailable, via a small `_configured_dirs()` helper.

The distinction between an omitted value and an explicitly empty list is preserved: an omitted argument still resolves to the dbt default (`models`), while `models_relative_paths=[]` stays empty.

## Reproduction

Using the configuration from the issue:

```python
ProjectConfig(
    manifest_path=manifest_path,
    project_name="split_path_project",
    models_relative_paths=["custom/models"],
)
```

| | `models_relative_paths` | directory searched by the custom parser |
|---|---|---|
| Before | discarded | `models/` |
| After | `[Path("custom/models")]` | `custom/models/` |

## Tests

Added to `tests/test_config.py`:

- `test_relative_paths_kept_without_project_path` — relative paths survive when `dbt_project_path` is unset, while `models_paths` stays empty.
- `test_relative_paths_default_when_not_configured` — an omitted argument falls back to `models`; an explicitly empty list stays empty.

## Note on local test runs

Roughly 70 tests in `tests/test_config.py` and `tests/dbt/test_graph.py` fail on my Windows machine both with and without this change (path separators and subprocess behaviour). I compared the failing sets before and after and they are identical apart from the two new tests flipping to passing, so this introduces no regressions there.
