### PR TITLE
Support config.group and group: selectors

### DIFF
--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -21,7 +21,7 @@ if TYPE_CHECKING:
 
 
 CONFIG_META_PATH = "meta"
-SUPPORTED_CONFIG = ["materialized", "schema", "tags", CONFIG_META_PATH]
+SUPPORTED_CONFIG = ["materialized", "schema", "tags", "group", CONFIG_META_PATH]
 PATH_SELECTOR = "path:"
 TAG_SELECTOR = "tag:"
 FQN_SELECTOR = "fqn:"
@@ -291,9 +291,10 @@ class GraphSelector:
 
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
-            # currently tags, materialized, schema and meta are the only supported config keys
+            # currently tags, materialized, schema, group and meta are the only supported config keys
             # logic is separated into two conditions because the config 'tags' contains a
-            # list of tags, the config 'materialized' & 'schema' contain strings and meta contains dictionaries
+            # list of tags, the configs 'materialized', 'schema' & 'group' contain strings and meta contains
+            # dictionaries
             if config_selection_key == "tags":
                 root_nodes.update(
                     {
@@ -305,6 +306,7 @@ class GraphSelector:
             elif config_selection_key in (
                 "materialized",
                 "schema",
+                "group",
             ):
                 root_nodes.update(
                     {

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -29,6 +29,7 @@ CONFIG_SELECTOR = "config."
 SOURCE_SELECTOR = "source:"
 EXPOSURE_SELECTOR = "exposure:"
 PACKAGE_SELECTOR = "package:"
+GROUP_SELECTOR = "group:"
 RESOURCE_TYPE_SELECTOR = "resource_type:"
 EXCLUDE_RESOURCE_TYPE_SELECTOR = "exclude_resource_type:"
 PLUS_SELECTOR = "+"
@@ -289,6 +290,13 @@ class GraphSelector:
                     {node_id for node_id, node in nodes.items() if node.package_name == package_selection}
                 )
 
+        elif self.node_name.startswith(GROUP_SELECTOR):
+            group_selection = self.node_name[len(GROUP_SELECTOR) :].strip()
+            if group_selection:
+                root_nodes.update(
+                    {node_id for node_id, node in nodes.items() if node.config.get("group") == group_selection}
+                )
+
         elif CONFIG_SELECTOR in self.node_name:
             config_selection_key, config_selection_value = self.node_name[len(CONFIG_SELECTOR) :].split(":")
             # currently tags, materialized, schema, group and meta are the only supported config keys
@@ -397,6 +405,7 @@ class SelectorConfig:
         self.sources: list[str] = []
         self.exposures: list[str] = []
         self.packages: list[str] = []
+        self.groups: list[str] = []
         self.bare_identifiers: list[str] = (
             []
         )  # bare strings: match by package_name, node name or folder name (dbt ls-like)
@@ -416,6 +425,7 @@ class SelectorConfig:
             or self.sources
             or self.exposures
             or self.packages
+            or self.groups
             or self.bare_identifiers
             or self.resource_types
             or self.exclude_resource_types
@@ -453,6 +463,7 @@ class SelectorConfig:
             SOURCE_SELECTOR: self._parse_source_selector,
             EXPOSURE_SELECTOR: self._parse_exposure_selector,
             PACKAGE_SELECTOR: self._parse_package_selector,
+            GROUP_SELECTOR: self._parse_group_selector,
             RESOURCE_TYPE_SELECTOR: self._parse_resource_type_selector,
             EXCLUDE_RESOURCE_TYPE_SELECTOR: self._parse_exclude_resource_type_selector,
             FQN_SELECTOR: self._parse_fqn_selector,
@@ -540,6 +551,15 @@ class SelectorConfig:
             )
         self.packages.append(package_name)
 
+    def _parse_group_selector(self, item: str) -> None:
+        index = len(GROUP_SELECTOR)
+        group_name = item[index:].strip()
+        if not group_name:
+            raise CosmosValueError(
+                "group: selector requires a non-empty group name (e.g. select=['group:customer_mart'])"
+            )
+        self.groups.append(group_name)
+
     def __repr__(self) -> str:
         return (
             "SelectorConfig("
@@ -551,6 +571,7 @@ class SelectorConfig:
             + f"resource={self.resource_types}, "
             + f"exposures={self.exposures}, "
             + f"packages={self.packages}, "
+            + f"groups={self.groups}, "
             + f"bare_identifiers={self.bare_identifiers}, "
             + f"exclude_resource={self.exclude_resource_types}, "
             + f"other={self.other}, "
@@ -692,6 +713,9 @@ class NodeSelector:
         if self.config.packages and not self._is_package_matching(node):
             return False
 
+        if self.config.groups and not self._is_group_matching(node):
+            return False
+
         if self.config.bare_identifiers and not self._is_bare_identifier_matching(node):
             return False
 
@@ -733,6 +757,10 @@ class NodeSelector:
     def _is_package_matching(self, node: DbtNode) -> bool:
         """Checks if the node's package is in the config's package list."""
         return (node.package_name or "") in self.config.packages
+
+    def _is_group_matching(self, node: DbtNode) -> bool:
+        """Checks if the node's dbt group is in the config's group list. Ungrouped nodes never match."""
+        return node.config.get("group") in self.config.groups
 
     def _is_bare_identifier_matching(self, node: DbtNode) -> bool:
         """Bare identifiers match by package_name, node name, or path segment (e.g. folder name)."""
@@ -1014,6 +1042,7 @@ class YamlSelectors:
             PATH_SELECTOR[:-1]: PATH_SELECTOR,
             SOURCE_SELECTOR[:-1]: SOURCE_SELECTOR,
             EXPOSURE_SELECTOR[:-1]: EXPOSURE_SELECTOR,
+            GROUP_SELECTOR[:-1]: GROUP_SELECTOR,
             RESOURCE_TYPE_SELECTOR[:-1]: RESOURCE_TYPE_SELECTOR,
             EXCLUDE_RESOURCE_TYPE_SELECTOR[:-1]: EXCLUDE_RESOURCE_TYPE_SELECTOR,
         }
@@ -1493,6 +1522,7 @@ def validate_filters(exclude: list[str], select: list[str]) -> None:
                 or filter_parameter.startswith(SOURCE_SELECTOR)
                 or filter_parameter.startswith(EXPOSURE_SELECTOR)
                 or filter_parameter.startswith(PACKAGE_SELECTOR)
+                or filter_parameter.startswith(GROUP_SELECTOR)
                 or PLUS_SELECTOR in filter_parameter
                 or any([filter_parameter.startswith(CONFIG_SELECTOR + config) for config in SUPPORTED_CONFIG])
             ):

--- a/cosmos/dbt/selector.py
+++ b/cosmos/dbt/selector.py
@@ -696,7 +696,11 @@ class NodeSelector:
         return True
 
     def _passes_selector_filters(self, node: DbtNode) -> bool:
-        """Return True if node matches all configured selector filters (path, fqn, resource_type, source, exposure)."""
+        """Return True if node matches all configured selector filters.
+
+        Filters: path, fqn, resource_type, exclude_resource_type, source, exposure, package, group,
+        bare identifier.
+        """
         if self.config.paths and not self._is_path_matching(node):
             return False
         if self.config.fqns and not self._is_fqn_matching(node):

--- a/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
+++ b/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
@@ -19,6 +19,7 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``config.meta.some_key:some_value``: include/exclude models with ``config.meta_some_key: some_value``
 - ``config.materialized:table``: include/exclude models with the config ``materialized: table``
 - ``config.group:customer_mart``: include/exclude models with the config ``group: customer_mart``
+- ``group:customer_mart``: include/exclude nodes that belong to the dbt group ``customer_mart``. This is dbt's shorthand for ``config.group:customer_mart`` and selects the same nodes. The group name must be non-empty (use ``group:customer_mart``, not ``group:``).
 - ``path:analytics/tables``: include/exclude models in the ``analytics/tables`` directory. In this example, ``analytics/table`` is a relative path, but absolute paths are also supported.
 - ``+node_name+1`` (graph operators): include/exclude the node with name ``node_name``, all its parents, and its first generation of children (`dbt graph selector docs <https://docs.getdbt.com/reference/node-selection/graph-operators>`_)
 - ``+/path/to/model_g+`` (graph operators): include/exclude all the nodes in the absolute path ``/path/to/model_g``, their parents and children. Relative paths are also supported.

--- a/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
+++ b/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
@@ -16,7 +16,7 @@ Using ``select`` and ``exclude``
 The ``select`` and ``exclude`` parameters are lists, with values like the following:
 
 - ``tag:my_tag``: include/exclude models with the tag ``my_tag``
-- ``config.meta.some_key:some_value``: include/exclude models with ``config.meta_some_key: some_value``
+- ``config.meta.some_key:some_value``: include/exclude models with the config ``meta: {some_key: some_value}``
 - ``config.materialized:table``: include/exclude models with the config ``materialized: table``
 - ``config.group:customer_mart``: include/exclude models with the config ``group: customer_mart``
 - ``group:customer_mart``: include/exclude nodes that belong to the dbt group ``customer_mart``. This is dbt's shorthand for ``config.group:customer_mart`` and selects the same nodes. The group name must be non-empty (use ``group:customer_mart``, not ``group:``).

--- a/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
+++ b/docs/guides/translate_dbt_to_airflow/selecting-excluding.rst
@@ -18,6 +18,7 @@ The ``select`` and ``exclude`` parameters are lists, with values like the follow
 - ``tag:my_tag``: include/exclude models with the tag ``my_tag``
 - ``config.meta.some_key:some_value``: include/exclude models with ``config.meta_some_key: some_value``
 - ``config.materialized:table``: include/exclude models with the config ``materialized: table``
+- ``config.group:customer_mart``: include/exclude models with the config ``group: customer_mart``
 - ``path:analytics/tables``: include/exclude models in the ``analytics/tables`` directory. In this example, ``analytics/table`` is a relative path, but absolute paths are also supported.
 - ``+node_name+1`` (graph operators): include/exclude the node with name ``node_name``, all its parents, and its first generation of children (`dbt graph selector docs <https://docs.getdbt.com/reference/node-selection/graph-operators>`_)
 - ``+/path/to/model_g+`` (graph operators): include/exclude all the nodes in the absolute path ``/path/to/model_g``, their parents and children. Relative paths are also supported.

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -449,6 +449,65 @@ def test_load_via_manifest_skips_dbt_loom_external_nodes(tmp_path, caplog):
     assert "Skipping node `model.upstream_project.external_model` because it has no file path" in caplog.text
 
 
+def test_load_via_manifest_with_select_config_group(tmp_path):
+    """``config.group`` selectors filter manifest nodes, as reported in issue #1784."""
+    manifest_content = {
+        "nodes": {
+            "model.my_project.customer_mart_model": {
+                "resource_type": "model",
+                "original_file_path": "models/customer_mart_model.sql",
+                "package_name": "my_project",
+                "depends_on": {"nodes": []},
+                "tags": [],
+                "config": {"materialized": "table", "group": "customer_mart"},
+            },
+            "model.my_project.finance_model": {
+                "resource_type": "model",
+                "original_file_path": "models/finance_model.sql",
+                "package_name": "my_project",
+                "depends_on": {"nodes": []},
+                "tags": [],
+                "config": {"materialized": "table", "group": "finance"},
+            },
+            "model.my_project.ungrouped_model": {
+                "resource_type": "model",
+                "original_file_path": "models/ungrouped_model.sql",
+                "package_name": "my_project",
+                "depends_on": {"nodes": []},
+                "tags": [],
+                "config": {"materialized": "table"},
+            },
+        },
+        "sources": {},
+        "exposures": {},
+    }
+
+    manifest_path = tmp_path / "manifest.json"
+    manifest_path.write_text(json.dumps(manifest_content))
+
+    project_path = tmp_path / "my_project"
+    project_path.mkdir()
+
+    project_config = ProjectConfig(dbt_project_path=project_path, manifest_path=manifest_path)
+    profile_config = ProfileConfig(
+        profile_name="test",
+        target_name="test",
+        profiles_yml_filepath=DBT_PROJECTS_ROOT_DIR / DBT_PROJECT_NAME / "profiles.yml",
+    )
+    execution_config = ExecutionConfig(dbt_project_path=project_path)
+    dbt_graph = DbtGraph(
+        project=project_config,
+        execution_config=execution_config,
+        profile_config=profile_config,
+        render_config=RenderConfig(select=["config.group:customer_mart"]),
+    )
+
+    dbt_graph.load_from_dbt_manifest()
+
+    assert len(dbt_graph.nodes) == 3
+    assert set(dbt_graph.filtered_nodes) == {"model.my_project.customer_mart_model"}
+
+
 @pytest.mark.parametrize(
     "project_name,manifest_filepath,model_filepath",
     [(DBT_PROJECT_NAME, SAMPLE_MANIFEST, "customers.sql"), ("jaffle_shop_python", SAMPLE_MANIFEST_PY, "customers.py")],

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -449,8 +449,9 @@ def test_load_via_manifest_skips_dbt_loom_external_nodes(tmp_path, caplog):
     assert "Skipping node `model.upstream_project.external_model` because it has no file path" in caplog.text
 
 
-def test_load_via_manifest_with_select_config_group(tmp_path):
-    """``config.group`` selectors filter manifest nodes, as reported in issue #1784."""
+@pytest.mark.parametrize("statement", ["config.group:customer_mart", "group:customer_mart"])
+def test_load_via_manifest_with_group_selectors(tmp_path, statement):
+    """Both group selector spellings filter manifest nodes, as reported in issue #1784."""
     manifest_content = {
         "nodes": {
             "model.my_project.customer_mart_model": {
@@ -499,7 +500,7 @@ def test_load_via_manifest_with_select_config_group(tmp_path):
         project=project_config,
         execution_config=execution_config,
         profile_config=profile_config,
-        render_config=RenderConfig(select=["config.group:customer_mart"]),
+        render_config=RenderConfig(select=[statement]),
     )
 
     dbt_graph.load_from_dbt_manifest()

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -2735,7 +2735,7 @@ def test_save_yaml_selectors_cache(mock_variable_set, mock_datetime, tmp_dbt_pro
     hash_dir, hash_selectors, hash_impl = version.split(",")
 
     assert hash_selectors == "43303af03e84e3b51fbfcf598261fae4"
-    assert hash_impl == "86424c8b70c2e9b6d1f595c7ec9a8291"
+    assert hash_impl == "f5bbb2a96eaa08e94514faabb78c5ed3"
 
     if sys.platform == "darwin":
         # macOS has historically produced a different directory hash than Linux; the hash below is the

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1481,6 +1481,11 @@ def test_exposure_selector():
             {"select": ["config.meta.allow_pii:true"], "exclude": None},
         ),
         (
+            "config_method_group",
+            {"name": "config_method_group", "definition": {"method": "config.group", "value": "customer_mart"}},
+            {"select": ["config.group:customer_mart"], "exclude": None},
+        ),
+        (
             "source_method",
             {"name": "source_method", "definition": {"method": "source", "value": "raw_*"}},
             {"select": ["source:raw_*"], "exclude": None},
@@ -2105,3 +2110,102 @@ def test_selector_reference_resolves_from_cache():
 
     assert base_result == {"select": ["tag:nightly"], "exclude": None}
     assert reference_result == base_result
+
+
+# Nodes used by the ``config.group`` selector tests
+# https://github.com/astronomer/astronomer-cosmos/issues/1784
+finance_base_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.finance_base",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/finance_base.sql"),
+    tags=[],
+    config={"materialized": "view"},
+)
+
+finance_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.finance",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[finance_base_node.unique_id],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen2/models/finance.sql"),
+    tags=[],
+    config={"materialized": "view", "group": "finance"},
+)
+
+finance_child_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.finance_child",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[finance_node.unique_id],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen3/models/finance_child.sql"),
+    tags=[],
+    config={"materialized": "table"},
+)
+
+customer_mart_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.customer_mart",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/customer_mart.sql"),
+    tags=[],
+    config={"materialized": "table", "group": "customer_mart"},
+)
+
+ungrouped_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.ungrouped",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/ungrouped.sql"),
+    tags=[],
+    config={"materialized": "view"},
+)
+
+grouped_sample_nodes = {
+    node.unique_id: node
+    for node in (finance_base_node, finance_node, finance_child_node, customer_mart_node, ungrouped_node)
+}
+
+
+@pytest.mark.parametrize(
+    "statement,expected_nodes",
+    [
+        ("config.group:finance", [finance_node]),
+        ("config.group:customer_mart", [customer_mart_node]),
+        ("config.group:finance+", [finance_node, finance_child_node]),
+        ("+config.group:finance", [finance_base_node, finance_node]),
+        ("config.group:unknown_group", []),
+    ],
+)
+def test_select_nodes_by_select_config_group(statement, expected_nodes):
+    """``config.group:<name>`` selects the nodes whose dbt config declares that group, and supports graph operators."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=[statement])
+    assert selected == {node.unique_id: node for node in expected_nodes}
+
+
+def test_select_nodes_by_exclude_config_group():
+    """``config.group:<name>`` removes the grouped nodes and leaves every other node untouched."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, exclude=["config.group:finance"])
+    expected = {
+        finance_base_node.unique_id: finance_base_node,
+        finance_child_node.unique_id: finance_child_node,
+        customer_mart_node.unique_id: customer_mart_node,
+        ungrouped_node.unique_id: ungrouped_node,
+    }
+    assert selected == expected
+
+
+@pytest.mark.parametrize(
+    "statement,expected_nodes",
+    [
+        ("config.group:finance,config.materialized:view", [finance_node]),
+        ("config.group:finance,config.materialized:table", []),
+    ],
+)
+def test_select_nodes_by_config_group_intersection(statement, expected_nodes):
+    """``config.group`` intersects with the other config selectors instead of overriding them."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=[statement])
+    assert selected == {node.unique_id: node for node in expected_nodes}

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -2254,3 +2254,72 @@ def test_select_nodes_raises_on_empty_group_selector():
         with pytest.raises(CosmosValueError) as err_info:
             select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, **filters)
         assert "group: selector requires a non-empty group name" in err_info.value.args[0]
+
+
+# A group with more than one member, used for the union/intersection group tests above.
+finance_alpha_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.finance_alpha",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/finance_alpha.sql"),
+    tags=["nightly"],
+    config={"materialized": "view", "group": "finance", "tags": ["nightly"]},
+)
+
+finance_beta_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.finance_beta",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/finance_beta.sql"),
+    tags=[],
+    config={"materialized": "view", "group": "finance"},
+)
+
+marketing_node = DbtNode(
+    unique_id=f"{DbtResourceType.MODEL.value}.{SAMPLE_PROJ_PATH.stem}.marketing",
+    resource_type=DbtResourceType.MODEL,
+    depends_on=[],
+    path_base=SAMPLE_PROJ_PATH,
+    original_file_path=Path("gen1/models/marketing.sql"),
+    tags=["nightly"],
+    config={"materialized": "view", "group": "marketing", "tags": ["nightly"]},
+)
+
+multi_member_group_nodes = {node.unique_id: node for node in (finance_alpha_node, finance_beta_node, marketing_node)}
+
+
+@pytest.mark.parametrize(
+    "select,expected_nodes",
+    [
+        # Every member of the group is selected, not just the first match.
+        (["group:finance"], [finance_alpha_node, finance_beta_node]),
+        # Separate list entries are a union.
+        (["group:finance", "group:marketing"], [finance_alpha_node, finance_beta_node, marketing_node]),
+        # A comma is an intersection, and it composes with non-config selectors.
+        (["group:finance,tag:nightly"], [finance_alpha_node]),
+        (["group:finance,tag:unknown_tag"], []),
+    ],
+)
+def test_select_nodes_by_group_union_and_intersection(select, expected_nodes):
+    """``group:`` unions across list entries and intersects within a comma-separated entry."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=multi_member_group_nodes, select=select)
+    assert selected == {node.unique_id: node for node in expected_nodes}
+
+
+@pytest.mark.parametrize("statement", ["group:+", "+group:"])
+def test_select_nodes_by_empty_group_with_graph_operator(statement):
+    """An empty group name combined with a graph operator matches nothing.
+
+    ``GraphSelector`` never validates its selector values, so this matches the existing behaviour of
+    ``package:+``, ``tag:+`` and ``source:+`` rather than the ``CosmosValueError`` raised by a bare ``group:``.
+    """
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=multi_member_group_nodes, select=[statement])
+    assert selected == {}
+
+
+def test_is_empty_config_with_only_groups(selector_config):
+    """``groups`` alone must keep a selector config from being treated as empty."""
+    selector_config.groups = ["finance"]
+    assert selector_config.is_empty is False

--- a/tests/dbt/test_selector.py
+++ b/tests/dbt/test_selector.py
@@ -1486,6 +1486,11 @@ def test_exposure_selector():
             {"select": ["config.group:customer_mart"], "exclude": None},
         ),
         (
+            "group_method",
+            {"name": "group_method", "definition": {"method": "group", "value": "customer_mart"}},
+            {"select": ["group:customer_mart"], "exclude": None},
+        ),
+        (
             "source_method",
             {"name": "source_method", "definition": {"method": "source", "value": "raw_*"}},
             {"select": ["source:raw_*"], "exclude": None},
@@ -1676,11 +1681,6 @@ def test_valid_graph_operator_yaml_selectors(selector_name, selector_definition,
             "file_method",
             {"name": "file_method", "definition": {"method": "file", "value": "my_model.sql"}},
             "Unsupported selector method: 'file'",
-        ),
-        (
-            "group_method",
-            {"name": "group_method", "definition": {"method": "group", "value": "finance"}},
-            "Unsupported selector method: 'group'",
         ),
         (
             "metric_method",
@@ -2209,3 +2209,48 @@ def test_select_nodes_by_config_group_intersection(statement, expected_nodes):
     """``config.group`` intersects with the other config selectors instead of overriding them."""
     selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=[statement])
     assert selected == {node.unique_id: node for node in expected_nodes}
+
+
+@pytest.mark.parametrize(
+    "statement,expected_nodes",
+    [
+        ("group:finance", [finance_node]),
+        ("group:customer_mart", [customer_mart_node]),
+        ("group:finance+", [finance_node, finance_child_node]),
+        ("+group:finance", [finance_base_node, finance_node]),
+        ("group:unknown_group", []),
+    ],
+)
+def test_select_nodes_by_select_group(statement, expected_nodes):
+    """``group:<name>`` is dbt's shorthand for ``config.group:<name>`` and supports the same graph operators."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=[statement])
+    assert selected == {node.unique_id: node for node in expected_nodes}
+
+
+def test_select_nodes_by_exclude_group():
+    """``group:<name>`` removes the grouped nodes and leaves every other node untouched."""
+    selected = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, exclude=["group:finance"])
+    expected = {
+        finance_base_node.unique_id: finance_base_node,
+        finance_child_node.unique_id: finance_child_node,
+        customer_mart_node.unique_id: customer_mart_node,
+        ungrouped_node.unique_id: ungrouped_node,
+    }
+    assert selected == expected
+
+
+def test_select_nodes_by_group_is_equivalent_to_config_group():
+    """Both spellings read the same dbt config key, so they must select the same nodes."""
+    by_group = select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=["group:finance"])
+    by_config_group = select_nodes(
+        project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, select=["config.group:finance"]
+    )
+    assert by_group == by_config_group == {finance_node.unique_id: finance_node}
+
+
+def test_select_nodes_raises_on_empty_group_selector():
+    """An empty ``group:`` would silently match nothing; fail loudly instead, as ``package:`` does."""
+    for filters in ({"select": ["group:"]}, {"exclude": ["group:"]}):
+        with pytest.raises(CosmosValueError) as err_info:
+            select_nodes(project_dir=SAMPLE_PROJ_PATH, nodes=grouped_sample_nodes, **filters)
+        assert "group: selector requires a non-empty group name" in err_info.value.args[0]


### PR DESCRIPTION
## Description

dbt lets a model declare a `group`, and exposes it for node selection through two spellings that read the same value — `node.config["group"]`:

- `config.group:finance` (`ConfigSelectorMethod`)
- `group:finance` (`GroupSelectorMethod`, the shorthand dbt's docs lead with)

Cosmos supported neither. `SUPPORTED_CONFIG` listed only `materialized`, `schema`, `tags` and `meta`, and `group:` was explicitly rejected as an unsupported method, so both of these raised:

```python
RenderConfig(load_method=LoadMode.DBT_MANIFEST, select=["config.group:customer_mart"])
RenderConfig(load_method=LoadMode.DBT_MANIFEST, select=["group:customer_mart"])
```

```
CosmosValueError: Invalid select filter: config.group:customer_mart
```

Teams that already model ownership with dbt groups had to duplicate that information as tags purely to drive orchestration.

### The change

**`config.group`** — `"group"` added to `SUPPORTED_CONFIG` and to the string-valued branch of the graph selector. Every consumer of `SUPPORTED_CONFIG` picks the key up, so `select`, `exclude`, graph operators, intersections, YAML selectors and `validate_filters` all work from those two lines.

**`group:`** — a new `GROUP_SELECTOR`, shaped like the existing `package:` selector: a branch in `GraphSelector.filter_nodes`, a `SelectorConfig` field and parser, `NodeSelector._is_group_matching`, an entry in `validate_filters`, and a YAML `method_mappings` entry so `method: group` works in `selectors.yml`.

Both spellings resolve against `node.config["group"]`, so they select identically — there is a test asserting exactly that.

No new parsing was required: both loaders already store the node's whole `config` dict.

### Design notes

- **Exact matching, not fnmatch.** dbt's `GroupSelectorMethod` globs, but every other Cosmos selector (`source:`, `package:`, `fqn:`) is exact even where dbt allows wildcards. Making `group:` the sole wildcard-capable selector in the module seemed more surprising than useful. Happy to switch if you'd rather track dbt exactly.
- **Empty `group:` raises** `CosmosValueError` rather than silently matching nothing, mirroring `package:`.
- **`group:+` does not raise.** A graph operator routes the statement through `GraphSelector`, which validates no selector values, so an empty name there matches nothing — exactly as `package:+`, `tag:+` and `source:+` already do. I mirrored that rather than giving `group:` a contract the neighbouring selectors don't have, and added a test pinning the asymmetry. Happy to tighten `GraphSelector` for all of them in a follow-up if you'd prefer.
- One existing test asserted `method: group` was an unsupported YAML selector method. It is removed, since that is the behaviour this PR changes.

### dbt version compatibility

`group` has been a field on the node config since dbt 1.5, so it is present across the whole supported matrix in `pyproject.toml`:

| dbt | Evidence |
|---|---|
| 1.8 – 1.12 | `group: Optional[str]` on `NodeAndTestConfig`, inherited by `NodeConfig` |
| 2.0 (Fusion) | `pub group: Option<String>` on `ModelConfig`, serialized into the manifest `config` |

## Related Issue(s)

closes #1784

## Breaking Change?

No. This only widens the set of accepted selectors; both spellings previously raised `CosmosValueError`.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

### Testing

27 test cases across 12 test functions. The behavioural ones were written failing first.

`tests/dbt/test_selector.py`:

- both spellings, parametrized: `select` (plain, `x+`, `+x`, unknown group), `exclude`, and a YAML-selector case
- union across separate list entries, intersection within a comma-separated entry, and intersection composing with a non-config selector (`group:finance,tag:nightly`)
- a group with more than one member selects every member
- an equivalence test asserting `group:finance` and `config.group:finance` return the same nodes
- the empty-`group:` error, and the empty-name-with-graph-operator behaviour
- `SelectorConfig.is_empty` with only `groups` set

`tests/dbt/test_graph.py`: a `LoadMode.DBT_MANIFEST` test parametrized over both spellings, since manifest mode is what the issue reports.

Every line this PR adds to `selector.py` is covered, checked by diffing the added line numbers against coverage's missing list. On branch coverage, the false arm of the new empty-name guard is exercised; the equivalent guard in the `package:` branch it was modelled on is still partial.

No `LoadMode.DBT_LS` test: in that mode the selectors are handed straight to the dbt CLI, so there is no Cosmos code path to exercise.

Also verified end-to-end against a real manifest generated by dbt-core 1.11.3 (a two-model project with `finance` and `marketing` groups): `config.group` is populated, and both spellings select and exclude the expected node.

Full unit suite: 1938 passed. `pre-commit run` clean on the changed files, mypy clean, `sphinx-build --fail-on-warning` succeeds.
