### PR TITLE
Fix AttributeError masking the real dbt error on run-operation failure

### DIFF
--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -107,6 +107,12 @@ def run_command(
     return result
 
 
+def _node_label(node_result: Any) -> str:
+    """``run-operation`` yields ``RunResultOutput``, which has no ``node`` (#2982)."""
+    node = getattr(node_result, "node", None)
+    return str(getattr(node, "name", None) or getattr(node_result, "unique_id", None) or "unknown")
+
+
 def extract_message_by_status(
     result: dbtRunnerResult, status_levels: list[str] | None = None
 ) -> tuple[list[str], list[str]]:
@@ -128,7 +134,7 @@ def extract_message_by_status(
 
     for node_result in result.result.results:
         if node_result.status in status_levels:
-            node_names.append(str(node_result.node.name))
+            node_names.append(_node_label(node_result))
             node_results.append(str(node_result.message))
 
     return node_names, node_results

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -15,6 +15,8 @@ from cosmos.operators.watcher import DbtProducerWatcherOperator
 
 sys.modules.pop("dbt.cli.main", None)
 
+from types import SimpleNamespace
+
 import pytest
 
 import cosmos.dbt.runner as dbt_runner
@@ -377,3 +379,23 @@ def test_dbt_runner_caching_and_callbacks(valid_dbt_project_dir):
             assert not instances[0].callbacks
             # 3. Second instance has one callback
             assert len(instances[1].callbacks) == 1
+
+
+def test_extract_message_by_status_falls_back_to_unique_id_without_node():
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
+    result = SimpleNamespace(result=SimpleNamespace(results=[entry]))
+
+    names, messages = dbt_runner.extract_message_by_status(result, ["error"])
+
+    assert names == ["macro.probe.boom"]
+    assert messages == ["None"]
+
+
+def test_extract_message_by_status_still_prefers_node_name():
+    entry = SimpleNamespace(status="error", node=SimpleNamespace(name="my_model"), message="boom")
+    result = SimpleNamespace(result=SimpleNamespace(results=[entry]))
+
+    names, messages = dbt_runner.extract_message_by_status(result, ["error"])
+
+    assert names == ["my_model"]
+    assert messages == ["boom"]


### PR DESCRIPTION
## Description

`extract_message_by_status()` reads `node_result.node.name` for every failed entry.
That assumption holds for `run`, `build` and `test`, whose entries are `RunResult`,
but `run-operation` yields `RunResultOutput`, which has no `node` attribute at all —
it identifies the macro through `unique_id` instead.

Because the access happens *while reporting a failure*, the resulting
`AttributeError` replaces the error being reported, and the macro's real error never
reaches the task log. A failing `DbtRunOperationLocalOperator` currently surfaces:

```
AttributeError: 'RunResultOutput' object has no attribute 'node'
```

This falls back to `unique_id` when `node` is absent, so the failure path no longer
raises and the reported label stays meaningful.

Reproducible without a warehouse:

```python
result = dbtRunner().invoke(["run-operation", "boom", "--project-dir", p, "--profiles-dir", p])
entry = result.result.results[0]
# RunResultOutput(status='error', unique_id='macro.probe.boom', message=None)
hasattr(entry, "node")   # False
```

Note this only unblocks the *label*. dbt sets `message=None` for run-operation
results (`dbt/task/run_operation.py`), so the macro text itself still only exists in
the event stream (`RunningOperationCaughtError`). That part is discussed in the issue
and is not addressed here.

## Related Issue(s)

Fixes #2982

## Breaking Change?

No. Entries that carry a `node` keep reporting the node name — covered by
`test_extract_message_by_status_still_prefers_node_name`.

## Checklist

- [x] I have made corresponding changes to the documentation (not needed — internal helper)
- [x] I have added tests that prove my fix is effective or that my feature works

Both new tests were verified against the change: reverting the fix makes
`test_extract_message_by_status_falls_back_to_unique_id_without_node` fail while the
rest keep passing.
