### PR TITLE
Surface the macro error on run-operation failure with dbt < 1.12

### DIFF
--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -148,7 +148,8 @@ def run_command(
     # to the dbt executable.
     cli_args = command[1:]
     macro_errors: list[str] = []
-    # Global flags precede the subcommand (see ``build_cmd``), so match anywhere.
+    # ``build_cmd`` puts flags on both sides of the subcommand — dbt global flags before it,
+    # ``add_global_flags()``/``dbt_cmd_flags`` after it — so a positional check is not safe here.
     if "run-operation" in cli_args:
         callbacks = [*(callbacks or []), _collect_macro_errors(macro_errors)]
     # ``exclude_dags_folder_from_sys_path`` must enter *before* ``change_working_directory`` so it

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -21,6 +21,9 @@ else:  # pragma: no cover
 
 logger = get_logger(__name__)
 
+# dbt events carrying the macro error text of a failed ``run-operation``.
+MACRO_ERROR_EVENTS = ("RunningOperationCaughtError", "RunningOperationUncaughtError")
+
 if TYPE_CHECKING:  # pragma: no cover
     from dbt.cli.main import dbtRunner, dbtRunnerResult
 
@@ -81,6 +84,33 @@ def _cleanup_dbt_adapters() -> None:
     gc.collect()
 
 
+def _collect_macro_errors(collected: list[str]) -> Callable[[Any], None]:
+    def collect(event: Any) -> None:
+        # dbt wraps a raising callback as GenericExceptionOnRun, so never raise from here.
+        try:
+            info = getattr(event, "info", None)
+            if getattr(info, "name", None) not in MACRO_ERROR_EVENTS:
+                return
+            msg = getattr(info, "msg", None)
+            if msg:
+                collected.append(str(msg))
+        except Exception:  # pragma: no cover
+            logger.debug("Unable to read a dbt event while collecting macro errors", exc_info=True)
+
+    return collect
+
+
+def _fill_missing_messages(result: dbtRunnerResult, macro_errors: list[str]) -> None:
+    """dbt < 1.12 hardcodes ``message=None`` on run-operation results (dbt-labs/dbt-core#12730)."""
+    if not macro_errors:
+        return
+
+    message = "\n".join(macro_errors)
+    for node_result in getattr(result.result, "results", None) or []:
+        if getattr(node_result, "message", None) is None:
+            node_result.message = message
+
+
 def run_command(
     command: list[str], env: dict[str, str], cwd: str, callbacks: list[Callable] | None = None, **kwargs: Any  # type: ignore[type-arg]
 ) -> dbtRunnerResult:
@@ -91,6 +121,10 @@ def run_command(
     # command that is used by `InvocationMode.SUBPROCESS`, and in that scenario the first command is necessarily the path
     # to the dbt executable.
     cli_args = command[1:]
+    macro_errors: list[str] = []
+    # Global flags precede the subcommand (see ``build_cmd``), so match anywhere.
+    if "run-operation" in cli_args:
+        callbacks = [*(callbacks or []), _collect_macro_errors(macro_errors)]
     # ``exclude_dags_folder_from_sys_path`` must enter *before* ``change_working_directory`` so it
     # resolves ``DAGS_FOLDER`` against the Airflow process cwd. A relative ``DAGS_FOLDER`` resolved
     # after the chdir would point at the dbt project dir and fail to strip the real DAGs folder.
@@ -103,6 +137,8 @@ def run_command(
             # Reset dbt adapters to release semaphores (run on all exit paths)
             # See: https://github.com/astronomer/astronomer-cosmos/issues/2334
             _cleanup_dbt_adapters()
+
+    _fill_missing_messages(result, macro_errors)
 
     return result
 

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import gc
+import json
 import sys
 from collections.abc import Callable
 from functools import cache as functools_cache
@@ -84,17 +85,31 @@ def _cleanup_dbt_adapters() -> None:
     gc.collect()
 
 
+def dbt_event_to_json(event: Any) -> str:
+    """Serialise a dbt ``EventMsg`` to JSON so DBT_RUNNER consumers read the SUBPROCESS field names.
+
+    Not byte-identical to a ``--log-format json`` line, so read the payload with ``.get()``.
+
+    ``google.protobuf.json_format`` is a transitive dependency of dbt-core and is always available
+    when ``InvocationMode.DBT_RUNNER`` is in use.
+    """
+    from google.protobuf.json_format import MessageToJson
+
+    return str(MessageToJson(event, preserving_proto_field_name=True))
+
+
 def _collect_macro_errors(collected: list[str]) -> Callable[[Any], None]:
     def collect(event: Any) -> None:
-        # dbt wraps a raising callback as GenericExceptionOnRun, so never raise from here.
+        # Never raise: dbt wraps a raising callback as GenericExceptionOnRun, which would replace
+        # the dbt error this callback exists to surface with the callback's own failure.
         try:
-            info = getattr(event, "info", None)
-            if getattr(info, "name", None) not in MACRO_ERROR_EVENTS:
+            info = json.loads(dbt_event_to_json(event)).get("info", {})
+            if info.get("name") not in MACRO_ERROR_EVENTS:
                 return
-            msg = getattr(info, "msg", None)
+            msg = info.get("msg")
             if msg:
                 collected.append(str(msg))
-        except Exception:  # pragma: no cover
+        except Exception:
             logger.debug("Unable to read a dbt event while collecting macro errors", exc_info=True)
 
     return collect

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -120,8 +120,19 @@ def _fill_missing_messages(result: dbtRunnerResult, macro_errors: list[str]) -> 
     if not macro_errors:
         return
 
+    node_results = getattr(result.result, "results", None) or []
+    if not node_results:
+        # Debug log rather than an exception: a Cosmos-side complaint about the result shape would
+        # hide the run-operation failure the user came for. It still surfaces the contract change.
+        logger.debug(
+            "Collected %d dbt macro error event(s) but no run-operation result to attach them to "
+            "(result.result.results is missing or empty)",
+            len(macro_errors),
+        )
+        return
+
     message = "\n".join(macro_errors)
-    for node_result in getattr(result.result, "results", None) or []:
+    for node_result in node_results:
         if getattr(node_result, "message", None) is None:
             node_result.message = message
 

--- a/cosmos/operators/watcher.py
+++ b/cosmos/operators/watcher.py
@@ -26,6 +26,7 @@ from cosmos.constants import (
 )
 from cosmos.dataset import get_dataset_namespace
 from cosmos.dbt.graph import DbtNode
+from cosmos.dbt.runner import dbt_event_to_json
 from cosmos.log import get_logger
 from cosmos.operators._watcher import safe_xcom_push
 from cosmos.operators._watcher.base import (
@@ -196,8 +197,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
     Both modes feed the same parser (``store_dbt_resource_status_from_log``):
     - SUBPROCESS: each JSON log line from stdout is parsed directly.
     - DBT_RUNNER: each ``EventMsg`` from the dbt callback is serialised to JSON via
-      ``google.protobuf.json_format.MessageToJson`` — a transitive dbt-core dependency — and then
-      passed through the same parser.
+      ``cosmos.dbt.runner.dbt_event_to_json`` and then passed through the same parser.
 
     As each ``NodeFinished`` event arrives the operator pushes the per-model status to XCom under
     key ``<unique_id>_status`` so downstream sensors can react without waiting for the full build
@@ -286,9 +286,6 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
         captured via closure so the unified ``store_dbt_resource_status_from_log`` parser can be
         reused identically to the SUBPROCESS path.
 
-        ``google.protobuf.json_format`` is a transitive dependency of dbt-core and is always
-        available when ``InvocationMode.DBT_RUNNER`` is in use.
-
         The callback is only registered when ``context`` is present (i.e. during task execution,
         not during auxiliary calls such as ``dbt deps``). Without a context there is no XCom
         backend to push to, so registering a callback would cause it to raise and dbt would emit
@@ -327,10 +324,7 @@ class DbtProducerWatcherOperator(DbtBuildMixin, DbtLocalBaseOperator):
 
             def _event_callback(event: Any) -> None:
                 try:
-                    from google.protobuf.json_format import MessageToJson
-
-                    json_str = MessageToJson(event, preserving_proto_field_name=True)
-                    parse(json_str, extra_kwargs)
+                    parse(dbt_event_to_json(event), extra_kwargs)
                 except Exception as e:
                     self.log.exception("Error in dbt event callback: %s", e)
                     if not callback_error:

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -495,15 +495,15 @@ def test_run_command_registers_macro_collector_only_for_run_operation():
     assert len(seen[1]) == 1
 
 
-def test_run_command_fills_message_when_global_flags_precede_run_operation():
-    """build_cmd puts dbt global flags before the subcommand."""
+def test_run_command_fills_message_when_flags_surround_run_operation():
+    """build_cmd puts flags on both sides of the subcommand, so position tells nothing."""
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
     fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
     event = _dbt_event("RunningOperationCaughtError", exc="Database Error in boom")
 
     _patched_run_command(
         _run_operation_runner(event, fake_result, []),
-        ["dbt", "--log-level", "debug", "--no-partial-parse", "run-operation", "boom"],
+        ["dbt", "--log-level", "debug", "run-operation", "boom", "--vars", "{}", "--quiet"],
     )
 
     assert "Database Error in boom" in entry.message

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -519,6 +519,16 @@ def test_dbt_event_to_json_exposes_the_event_info_fields():
     assert "Database Error in boom" in info["msg"]
 
 
+def test_fill_missing_messages_logs_when_there_is_nowhere_to_attach():
+    """A dbt result without ``results`` must surface as a debug log, never as an exception."""
+    result = SimpleNamespace(result=SimpleNamespace())
+
+    with patch.object(dbt_runner, "logger") as mock_logger:
+        dbt_runner._fill_missing_messages(result, ["Database Error in boom"])
+
+    assert mock_logger.debug.call_count == 1
+
+
 def test_run_command_swallows_a_failure_to_read_a_dbt_event():
     """A collector that raises would reach dbt as GenericExceptionOnRun, hiding the real error."""
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -399,3 +399,89 @@ def test_extract_message_by_status_still_prefers_node_name():
 
     assert names == ["my_model"]
     assert messages == ["boom"]
+
+
+def _run_operation_runner(event, fake_result, seen):
+    def fake_get_runner(callbacks=None):
+        seen.append(callbacks)
+        runner = MagicMock()
+
+        def invoke(cli_args):
+            for callback in callbacks or []:
+                callback(event)
+            return fake_result
+
+        runner.invoke.side_effect = invoke
+        return runner
+
+    return fake_get_runner
+
+
+def _patched_run_command(fake_get_runner, command):
+    with (
+        patch.object(dbt_runner, "get_runner", side_effect=fake_get_runner),
+        patch.object(dbt_runner, "_cleanup_dbt_adapters"),
+        patch.object(dbt_runner, "change_working_directory"),
+        patch.object(dbt_runner, "environ"),
+        patch.object(dbt_runner, "logger"),
+    ):
+        return dbt_runner.run_command(command=command, env={}, cwd="/tmp/project")
+
+
+def test_run_command_fills_run_operation_message_from_macro_error_event():
+    """dbt < 1.12 leaves message unset, so the macro error is only available as an event."""
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
+    fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
+    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="Database Error in boom"))
+
+    _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
+
+    assert entry.message == "Database Error in boom"
+
+
+def test_run_command_keeps_run_operation_message_set_by_dbt():
+    """On dbt >= 1.12 the message is already populated and must not be overwritten."""
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message="Database Error in boom")
+    fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
+    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="event text"))
+
+    _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
+
+    assert entry.message == "Database Error in boom"
+
+
+def test_run_command_ignores_unrelated_events():
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
+    fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
+    event = SimpleNamespace(info=SimpleNamespace(name="LogStartLine", msg="starting"))
+
+    _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
+
+    assert entry.message is None
+
+
+def test_run_command_registers_macro_collector_only_for_run_operation():
+    fake_result = SimpleNamespace(success=True, exception=None, result=None)
+    seen = []
+    event = SimpleNamespace(info=SimpleNamespace(name="LogStartLine", msg="starting"))
+    fake_get_runner = _run_operation_runner(event, fake_result, seen)
+
+    _patched_run_command(fake_get_runner, ["dbt", "run"])
+    _patched_run_command(fake_get_runner, ["dbt", "run-operation", "boom"])
+
+    assert seen[0] is None
+    assert len(seen[1]) == 1
+
+
+def test_run_command_fills_message_when_global_flags_precede_run_operation():
+    """build_cmd puts dbt global flags before the subcommand."""
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
+    fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
+    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="Database Error in boom"))
+
+    _patched_run_command(
+        _run_operation_runner(event, fake_result, []),
+        ["dbt", "--log-level", "debug", "--no-partial-parse", "run-operation", "boom"],
+    )
+
+    assert entry.message == "Database Error in boom"

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -1,3 +1,4 @@
+import json
 import os
 import shutil
 import sys
@@ -401,6 +402,18 @@ def test_extract_message_by_status_still_prefers_node_name():
     assert messages == ["boom"]
 
 
+def _dbt_event(event_class: str, **kwargs):
+    """Build a real dbt ``EventMsg``.
+
+    The collector goes through dbt's protobuf event shape, so a hand-rolled stand-in would not
+    exercise the path that actually breaks when dbt changes its event fields.
+    """
+    from dbt.events import types as dbt_event_types
+    from dbt_common.events.base_types import msg_from_base_event
+
+    return msg_from_base_event(getattr(dbt_event_types, event_class)(**kwargs))
+
+
 def _run_operation_runner(event, fake_result, seen):
     def fake_get_runner(callbacks=None):
         seen.append(callbacks)
@@ -423,47 +436,56 @@ def _patched_run_command(fake_get_runner, command):
         patch.object(dbt_runner, "_cleanup_dbt_adapters"),
         patch.object(dbt_runner, "change_working_directory"),
         patch.object(dbt_runner, "environ"),
-        patch.object(dbt_runner, "logger"),
+        patch.object(dbt_runner, "logger") as mock_logger,
     ):
-        return dbt_runner.run_command(command=command, env={}, cwd="/tmp/project")
+        return dbt_runner.run_command(command=command, env={}, cwd="/tmp/project"), mock_logger
 
 
 def test_run_command_fills_run_operation_message_from_macro_error_event():
     """dbt < 1.12 leaves message unset, so the macro error is only available as an event."""
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
     fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
-    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="Database Error in boom"))
+    event = _dbt_event("RunningOperationCaughtError", exc="Database Error in boom")
 
     _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
 
-    assert entry.message == "Database Error in boom"
+    # dbt < 1.12 prefixes the event text ("Encountered an error while running operation: ..."),
+    # so assert the macro error is carried rather than pinning dbt's own wording.
+    assert "Database Error in boom" in entry.message
 
 
 def test_run_command_keeps_run_operation_message_set_by_dbt():
     """On dbt >= 1.12 the message is already populated and must not be overwritten."""
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message="Database Error in boom")
     fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
-    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="event text"))
+    event = _dbt_event("RunningOperationUncaughtError", exc="event text")
 
-    _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
+    _, mock_logger = _patched_run_command(
+        _run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"]
+    )
 
     assert entry.message == "Database Error in boom"
+    assert mock_logger.debug.call_count == 0
 
 
 def test_run_command_ignores_unrelated_events():
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
     fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
-    event = SimpleNamespace(info=SimpleNamespace(name="LogStartLine", msg="starting"))
+    event = _dbt_event("MainReportVersion", version="1.9.0", log_version=3)
 
-    _patched_run_command(_run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"])
+    _, mock_logger = _patched_run_command(
+        _run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"]
+    )
 
     assert entry.message is None
+    # Without this the test also passes when the event was never read at all.
+    assert mock_logger.debug.call_count == 0
 
 
 def test_run_command_registers_macro_collector_only_for_run_operation():
     fake_result = SimpleNamespace(success=True, exception=None, result=None)
     seen = []
-    event = SimpleNamespace(info=SimpleNamespace(name="LogStartLine", msg="starting"))
+    event = _dbt_event("MainReportVersion", version="1.9.0", log_version=3)
     fake_get_runner = _run_operation_runner(event, fake_result, seen)
 
     _patched_run_command(fake_get_runner, ["dbt", "run"])
@@ -477,11 +499,36 @@ def test_run_command_fills_message_when_global_flags_precede_run_operation():
     """build_cmd puts dbt global flags before the subcommand."""
     entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
     fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
-    event = SimpleNamespace(info=SimpleNamespace(name="RunningOperationCaughtError", msg="Database Error in boom"))
+    event = _dbt_event("RunningOperationCaughtError", exc="Database Error in boom")
 
     _patched_run_command(
         _run_operation_runner(event, fake_result, []),
         ["dbt", "--log-level", "debug", "--no-partial-parse", "run-operation", "boom"],
     )
 
-    assert entry.message == "Database Error in boom"
+    assert "Database Error in boom" in entry.message
+
+
+def test_dbt_event_to_json_exposes_the_event_info_fields():
+    """Both invocation modes read ``info.name``/``info.msg``, so keep those names locked."""
+    event = _dbt_event("RunningOperationCaughtError", exc="Database Error in boom")
+
+    info = json.loads(dbt_runner.dbt_event_to_json(event))["info"]
+
+    assert info["name"] == "RunningOperationCaughtError"
+    assert "Database Error in boom" in info["msg"]
+
+
+def test_run_command_swallows_a_failure_to_read_a_dbt_event():
+    """A collector that raises would reach dbt as GenericExceptionOnRun, hiding the real error."""
+    entry = SimpleNamespace(status="error", unique_id="macro.probe.boom", message=None)
+    fake_result = SimpleNamespace(success=False, exception=None, result=SimpleNamespace(results=[entry]))
+    event = _dbt_event("RunningOperationCaughtError", exc="Database Error in boom")
+
+    with patch.object(dbt_runner, "dbt_event_to_json", side_effect=RuntimeError("unreadable event")):
+        _, mock_logger = _patched_run_command(
+            _run_operation_runner(event, fake_result, []), ["dbt", "run-operation", "boom"]
+        )
+
+    assert entry.message is None
+    assert mock_logger.debug.call_count == 1


### PR DESCRIPTION
## What

- Registers an internal dbt event callback for `run-operation` invocations.
- Fills `RunResultOutput.message` from the collected macro error when dbt left it unset.
- Follow-up to #2983, which covered part 1 of #2982. This covers part 2.

## Why

- dbt hardcoded `message=None` on `run-operation` results until 1.12.
- The macro error text was only emitted as an event: `RunningOperationCaughtError` / `RunningOperationUncaughtError`.
- With part 1 fixed, `extract_message_by_status()` completes but renders `macro.my_project.my_macro: None` on older dbt.
- dbt-labs/dbt-core#12730 populates `message` from dbt 1.12 onwards, so this change is a no-op there.
- It can be dropped once dbt < 1.12 is no longer supported.

## Verification

Real runs against a minimal duckdb project whose macro executes `select * from table_that_does_not_exist`:

| dbt-core | raised `CosmosDbtRunError` |
|---|---|
| 1.10.23 | `macro.repro.boom: Encountered an error while running operation: Runtime Error / Catalog Error: Table with name table_that_does_not_exist does not exist!` |
| 1.12.3 | `macro.repro.boom: Runtime Error / Catalog Error: Table with name table_that_does_not_exist does not exist!` |

- On dbt < 1.12 the text carries dbt's own event prefix; on 1.12+ the value dbt set is untouched.
- `tests/dbt/test_runner.py`: 18 passed.
- The two `test_handle_exception_if_needed_after_*` failures reproduce identically on `main`; they need a Postgres env.
- `black`, `ruff check` and `mypy --config-file ./pyproject.toml cosmos/dbt/runner.py`: no new findings.

## Notes

- Only `InvocationMode.DBT_RUNNER` is affected.
- `SUBPROCESS` runs dbt out of process, so no Python callback can attach — and none is needed there.
- `handle_exception_subprocess` already logs the full dbt output, which contains the macro error. This answers the question in #2982.
- The callback attaches only when the subcommand is `run-operation`, so other commands keep using the cached runner.
- Both lists are created per invocation, so no state is shared between runs.
- The callback never raises; dbt wraps a raising callback as `GenericExceptionOnRun`, as `operators/watcher.py` already notes.
- `target/run_results.json` is written by dbt before the result returns, so the file on disk still has `message: null` on dbt < 1.12.

Refs #2982

🤖 Generated with Claude Code (https://claude.com/claude-code)
