### PR TITLE
Run the Cosmos test suite against Astronomer Runtime alpha images

### DIFF
--- a/.github/actions/setup-cosmos-runtime/action.yml
+++ b/.github/actions/setup-cosmos-runtime/action.yml
@@ -1,0 +1,24 @@
+name: Setup cosmos on Runtime image
+description: >-
+  Install OS build deps and cosmos + dbt adapters + pytest tooling into an Astronomer Runtime
+  image's own Python environment (keeping the image's pinned Airflow). Used by the container jobs
+  in test-runtime-alpha.yml. Requires the job to run inside the Runtime image as root.
+
+inputs:
+  extras:
+    description: Comma-separated cosmos optional-dependency extras to install.
+    required: false
+    default: dbt-postgres
+
+runs:
+  using: composite
+  steps:
+    - name: Install OS build deps for dbt adapters
+      shell: bash
+      run: |
+        apt-get update
+        apt-get install -y --no-install-recommends build-essential libpq-dev
+
+    - name: Install cosmos + test tooling into the Runtime image
+      shell: bash
+      run: bash scripts/test/runtime-alpha-setup.sh "${{ inputs.extras }}"

--- a/.github/actions/setup-cosmos-runtime/action.yml
+++ b/.github/actions/setup-cosmos-runtime/action.yml
@@ -21,4 +21,7 @@ runs:
 
     - name: Install cosmos + test tooling into the Runtime image
       shell: bash
-      run: bash scripts/test/runtime-alpha-setup.sh "${{ inputs.extras }}"
+      # Pass the input through env (not interpolated into the command) to avoid template injection.
+      env:
+        COSMOS_EXTRAS: ${{ inputs.extras }}
+      run: bash scripts/test/runtime-alpha-setup.sh "$COSMOS_EXTRAS"

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -73,7 +73,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -102,7 +102,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -173,7 +173,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     env:
       # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
@@ -205,7 +205,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -257,7 +257,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -310,7 +310,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -372,7 +372,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -431,7 +431,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -490,7 +490,7 @@ jobs:
     container:
       # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
       # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -593,7 +593,7 @@ jobs:
         env:
           # Secrets/contexts pass through the environment (never interpolated into the command line)
           # and are forwarded into the container with `docker run -e NAME` (value-from-environment).
-          RUNTIME_IMAGE: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+          RUNTIME_IMAGE: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-2-alpha1' }}-python-${{ matrix.python-version }}
           AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
         run: |

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -37,12 +37,6 @@ on:
         default: '["1.12"]'
         type: string
 
-  # TEMP (remove before merge): run in cosmos CI on pushes to this branch. workflow_dispatch only
-  # works once the workflow is on the default branch, so we use push + input fallbacks to validate.
-  push:
-    branches:
-      - pankajkoti/boss-610-integration-of-cosmos-tests-with-runtime-alpha-release
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runtime_version }}
   cancel-in-progress: true
@@ -63,10 +57,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -89,11 +83,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
         split-group: [1, 2, 3]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -159,10 +153,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     env:
       # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
@@ -188,11 +182,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.9"]
         num-models: [1, 10, 50, 100, 500]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -239,10 +233,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.11"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -290,10 +284,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.8"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -350,10 +344,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.8", "1.9", "1.10", "1.11"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -399,7 +393,6 @@ jobs:
           POSTGRES_PORT: 5432
 
   Run-Integration-Tests-Expensive:
-    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip real Databricks on the pre-PR push run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -407,10 +400,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -456,7 +449,6 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
   Run-Integration-dbt-Fusion-Tests:
-    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip real Snowflake on the pre-PR push run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -464,10 +456,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["2.0"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -531,7 +523,6 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
-    # TEMP: enabled on push to iterate on this experimental suite in CI.
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -539,7 +530,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        python-version: ${{ fromJSON(inputs.python_versions) }}
         dbt-version: ["1.11"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -571,7 +562,7 @@ jobs:
         env:
           # Secrets/contexts pass through the environment (never interpolated into the command line)
           # and are forwarded into the container with `docker run -e NAME` (value-from-environment).
-          RUNTIME_IMAGE: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+          RUNTIME_IMAGE: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
           AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
         run: |

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -71,7 +71,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -98,7 +100,9 @@ jobs:
         dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
         split-group: [1, 2, 3]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -167,7 +171,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     env:
       # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
@@ -197,7 +203,9 @@ jobs:
         dbt-version: ["1.9"]
         num-models: [1, 10, 50, 100, 500]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -247,7 +255,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.11"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -298,7 +308,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -358,7 +370,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8", "1.9", "1.10", "1.11"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -415,7 +429,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     services:
       postgres:
@@ -472,7 +488,9 @@ jobs:
         python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["2.0"]
     container:
-      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
+      # The Runtime image tag is a workflow input (an arbitrary alpha version), so it cannot be
+      # digest-pinned. Suppress zizmor's unpinned-images finding for these container images.
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }} # zizmor: ignore[unpinned-images]
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -531,7 +531,7 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
-    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip experimental KinD suite on the pre-PR push run
+    # TEMP: enabled on push to iterate on this experimental suite in CI.
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -276,6 +276,14 @@ jobs:
       - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Point the runner path the dbt-loom config hardcodes at the container workspace
+        # The cross_project dbt_loom.config.yml files hardcode the runner checkout path
+        # (/home/runner/work/astronomer-cosmos/astronomer-cosmos/...). That path does not exist in a
+        # container job, where the checkout is mounted elsewhere ($GITHUB_WORKSPACE). Symlink it so
+        # the hardcoded manifest path resolves. Follow-up: make the config paths env-var driven.
+        run: |
+          mkdir -p /home/runner/work/astronomer-cosmos
+          ln -sfn "$GITHUB_WORKSPACE" /home/runner/work/astronomer-cosmos/astronomer-cosmos
       - name: Run dbt-loom integration tests
         run: bash scripts/test/integration-dbt-loom.sh "$DBT_VERSION"
         env:
@@ -418,7 +426,7 @@ jobs:
           POSTGRES_PORT: 5432
 
   Run-Integration-Tests-Expensive:
-    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Databricks, dispatch-only (skips on PR)
+    if: ${{ github.event_name != 'pull_request' }} # TEMP: paid Databricks, run on push (once per commit) not on the PR event
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -477,7 +485,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
   Run-Integration-dbt-Fusion-Tests:
-    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Snowflake, dispatch-only (skips on PR)
+    if: ${{ github.event_name != 'pull_request' }} # TEMP: paid Snowflake, run on push (once per commit) not on the PR event
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -554,8 +562,12 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
+    # Skipped on push/PR for now (pod-execution failures + a watcher-test hang). Kept dispatchable
+    # for investigation. Follow-up ticket tracks fixing and re-enabling it.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    # Hard cap so a hanging watcher test cannot burn the full hour on a manual dispatch.
+    timeout-minutes: 30
     permissions:
       contents: read
     strategy:

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -114,7 +114,9 @@ jobs:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run integration tests (split ${{ matrix.split-group }}/3)
         run: |
-          bash scripts/test/integration-setup.sh "$DBT_VERSION"
+          # Scope ERROR log level to setup only: the Runtime image prints plugin warnings to stdout
+          # on `airflow version`, which the setup script parses to choose db migrate vs init.
+          AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR bash scripts/test/integration-setup.sh "$DBT_VERSION"
           bash scripts/test/integration.sh
         env:
           DBT_VERSION: ${{ matrix.dbt-version }}
@@ -211,7 +213,9 @@ jobs:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run performance tests (${{ matrix.num-models }} models)
         run: |
-          bash scripts/test/performance-setup.sh "$DBT_VERSION"
+          # ERROR log level scoped to setup: keep the image's plugin warnings out of the
+          # `airflow version` output the setup script parses (db migrate vs init routing).
+          AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR bash scripts/test/performance-setup.sh "$DBT_VERSION"
           bash scripts/test/performance.sh
         env:
           DBT_VERSION: ${{ matrix.dbt-version }}
@@ -260,6 +264,10 @@ jobs:
       - name: Run dbt-loom integration tests
         run: bash scripts/test/integration-dbt-loom.sh "$DBT_VERSION"
         env:
+          # This suite runs setup + tests in one script, so ERROR log level applies to the whole
+          # run. It keeps the Runtime image's plugin warnings out of the `airflow version` output
+          # the script parses to choose db migrate vs init (AF3 has no `db init`).
+          AIRFLOW__LOGGING__LOGGING_LEVEL: ERROR
           DBT_VERSION: ${{ matrix.dbt-version }}
           AIRFLOW_HOME: ${{ github.workspace }}
           PYTHONPATH: ${{ github.workspace }}
@@ -307,6 +315,9 @@ jobs:
       - name: Run dbt 1.8 integration tests
         run: bash scripts/test/integration-dbt-1-8.sh
         env:
+          # Setup + tests in one script (see dbt-loom job): ERROR log level keeps plugin warnings
+          # out of the `airflow version` output the script parses for db routing.
+          AIRFLOW__LOGGING__LOGGING_LEVEL: ERROR
           AIRFLOW_HOME: ${{ github.workspace }}
           AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
           AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
@@ -364,6 +375,9 @@ jobs:
       - name: Run dbt async integration tests (dbt ${{ matrix.dbt-version }})
         run: bash scripts/test/integration-dbt-async.sh "$DBT_VERSION"
         env:
+          # Setup + tests in one script (see dbt-loom job): ERROR log level keeps plugin warnings
+          # out of the `airflow version` output the script parses for db routing.
+          AIRFLOW__LOGGING__LOGGING_LEVEL: ERROR
           DBT_VERSION: ${{ matrix.dbt-version }}
           AIRFLOW_HOME: ${{ github.workspace }}
           PYTHONPATH: ${{ github.workspace }}
@@ -417,7 +431,8 @@ jobs:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run expensive (Databricks) integration tests
         run: |
-          bash scripts/test/integration-setup.sh "$DBT_VERSION"
+          # ERROR log level scoped to setup (see integration job for why).
+          AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR bash scripts/test/integration-setup.sh "$DBT_VERSION"
           DATABRICKS_UNIQUE_ID="$GITHUB_RUN_ID" bash scripts/test/integration-expensive.sh
         env:
           DBT_VERSION: ${{ matrix.dbt-version }}
@@ -477,6 +492,9 @@ jobs:
           bash scripts/test/integration-dbtf-setup.sh
           bash scripts/test/integration-dbtf.sh
         env:
+          # Setup + tests in one flow (see dbt-loom job): ERROR log level keeps plugin warnings
+          # out of the `airflow version` output the setup script parses for db routing.
+          AIRFLOW__LOGGING__LOGGING_LEVEL: ERROR
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
           AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
           AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -43,6 +43,10 @@ on:
   # and Snowflake suites are gated to workflow_dispatch only, so they do not run on the PR.
   pull_request:
     branches: [main]
+  # Also run on every push to the PR branch (in addition to pull_request), so each commit runs.
+  push:
+    branches:
+      - pankajkoti/boss-610-integration-of-cosmos-tests-with-runtime-alpha-release
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runtime_version }}

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -37,6 +37,12 @@ on:
         default: '["1.12"]'
         type: string
 
+  # TEMP (remove before merge): run in cosmos CI on pushes to this branch. workflow_dispatch only
+  # works once the workflow is on the default branch, so we use push + input fallbacks to validate.
+  push:
+    branches:
+      - pankajkoti/boss-610-integration-of-cosmos-tests-with-runtime-alpha-release
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runtime_version }}
   cancel-in-progress: true
@@ -57,10 +63,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -83,11 +89,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
         split-group: [1, 2, 3]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -151,10 +157,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     env:
       # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
@@ -180,11 +186,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
         num-models: [1, 10, 50, 100, 500]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -229,10 +235,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.11"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -276,10 +282,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -333,10 +339,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8", "1.9", "1.10", "1.11"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -379,6 +385,7 @@ jobs:
           POSTGRES_PORT: 5432
 
   Run-Integration-Tests-Expensive:
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip real Databricks on the pre-PR push run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -386,10 +393,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -434,6 +441,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
   Run-Integration-dbt-Fusion-Tests:
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip real Snowflake on the pre-PR push run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -441,10 +449,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["2.0"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -505,6 +513,7 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: skip experimental KinD suite on the pre-PR push run
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -512,7 +521,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.11"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -544,7 +553,7 @@ jobs:
         env:
           # Secrets/contexts pass through the environment (never interpolated into the command line)
           # and are forwarded into the container with `docker run -e NAME` (value-from-environment).
-          RUNTIME_IMAGE: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+          RUNTIME_IMAGE: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
           AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
         run: |

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -79,7 +79,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run unit tests
@@ -118,7 +118,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run integration tests (split ${{ matrix.split-group }}/3)
@@ -182,7 +182,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run telemetry tests
@@ -221,7 +221,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run performance tests (${{ matrix.num-models }} models)
@@ -273,7 +273,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run dbt-loom integration tests
@@ -326,7 +326,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run dbt 1.8 integration tests
@@ -388,7 +388,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run dbt async integration tests (dbt ${{ matrix.dbt-version }})
@@ -447,7 +447,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run expensive (Databricks) integration tests
@@ -496,7 +496,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: ./.github/actions/setup-cosmos-runtime
+      - uses: $/.github/actions/setup-cosmos-runtime
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Set RESOURCE_PREFIX (Snowflake-safe, no periods or dashes)

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -59,6 +59,12 @@ env:
   # integration environment installs. Validated to resolve under the Runtime image's pinned Airflow.
   COSMOS_TEST_EXTRAS: "dbt-postgres,dbt-bigquery,dbt-databricks,dbt-vertica,dbt-duckdb,amazon,google,microsoft,kubernetes,docker,openlineage"
 
+# Container jobs default `run` steps to `sh`, which lacks bash features (e.g. ${var//pattern/repl}).
+# Force bash (present in the Runtime image) for every run step.
+defaults:
+  run:
+    shell: bash
+
 jobs:
   Run-Unit-Tests:
     runs-on: ubuntu-latest
@@ -562,11 +568,11 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
-    # Skipped on push/PR for now (pod-execution failures + a watcher-test hang). Kept dispatchable
-    # for investigation. Follow-up ticket tracks fixing and re-enabling it.
-    if: ${{ github.event_name == 'workflow_dispatch' }}
+    # Disabled for now: pod-execution failures plus a watcher-test hang. Tracked in a follow-up
+    # ticket that will fix and re-enable it (flip this to run). Kept in the workflow (not deleted)
+    # so the follow-up has the full job to iterate on.
+    if: false
     runs-on: ubuntu-latest
-    # Hard cap so a hanging watcher test cannot burn the full hour on a manual dispatch.
     timeout-minutes: 30
     permissions:
       contents: read

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -586,6 +586,8 @@ jobs:
             -e AIRFLOW_CONN_EXAMPLE_CONN="postgres://postgres:postgres@localhost:5432/postgres" \
             -e AIRFLOW_CONN_AWS_S3_CONN \
             -e AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT=90.0 \
+            -e AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR \
+            -e PYTEST_TIMEOUT=600 \
             -e COSMOS_CONN_POSTGRES_PASSWORD \
             -e DATABRICKS_CLUSTER_ID=mock -e DATABRICKS_HOST=mock \
             -e DATABRICKS_WAREHOUSE_ID=mock -e DATABRICKS_TOKEN=mock \

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -1,0 +1,577 @@
+name: test-runtime-alpha
+
+# Run the Cosmos test suites (from this checkout / latest main) AGAINST a published Astronomer
+# Runtime alpha image, to validate that cosmos still works on that exact Airflow build before the
+# alpha graduates to a stable release. See BOSS-610.
+#
+# Model: the Runtime image supplies Airflow. Each job runs inside the image (as a job container),
+# installs cosmos + dbt adapters + pytest tooling on top of it
+# (scripts/test/runtime-alpha-setup.sh, via the setup-cosmos-runtime composite action), and reuses
+# cosmos's existing scripts/test/*.sh run scripts unchanged. Because the image fixes the Airflow
+# version, the usual python x airflow x dbt matrix collapses to python (from the image tag) x dbt.
+#
+# The specialised suites keep the dbt version(s) cosmos's own CI pins for them, but take their
+# Python from the image (an AF3 alpha only publishes 3.12+, not cosmos CI's 3.11). Secret-gated
+# suites reuse the same repo secrets cosmos's test.yml uses.
+
+on:
+  workflow_dispatch:
+    inputs:
+      runtime_version:
+        description: "Astronomer Runtime alpha version (image tag), e.g. 3.0-1-alpha1"
+        required: true
+        type: string
+      registry:
+        description: "Runtime image repository (without tag)"
+        required: false
+        default: "astrocrpublic.azurecr.io/runtime-dev"
+        type: string
+      python_versions:
+        description: 'JSON list of Python versions the alpha publishes, e.g. ["3.12","3.13"]'
+        required: false
+        default: '["3.12"]'
+        type: string
+      dbt_versions:
+        description: 'JSON list of dbt minor versions for the unit + integration suites, e.g. ["1.12"]'
+        required: false
+        default: '["1.12"]'
+        type: string
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runtime_version }}
+  cancel-in-progress: true
+
+env:
+  SCARF_NO_ANALYTICS: "true"
+  # Provider + dbt-adapter extras the test modules import. Without these, pytest collection fails to
+  # import modules like tests/operators/test_kubernetes.py. Mirrors the provider set cosmos's own
+  # integration environment installs. Validated to resolve under the Runtime image's pinned Airflow.
+  COSMOS_TEST_EXTRAS: "dbt-postgres,dbt-bigquery,dbt-databricks,dbt-vertica,dbt-duckdb,amazon,google,microsoft,kubernetes,docker,openlineage"
+
+jobs:
+  Run-Unit-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run unit tests
+        run: bash scripts/test/unit.sh
+        env:
+          AIRFLOW_HOME: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}
+
+  Run-Integration-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+        split-group: [1, 2, 3]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run integration tests (split ${{ matrix.split-group }}/3)
+        run: |
+          bash scripts/test/integration-setup.sh "$DBT_VERSION"
+          bash scripts/test/integration.sh
+        env:
+          DBT_VERSION: ${{ matrix.dbt-version }}
+          PYTEST_SPLITS: 3
+          PYTEST_SPLIT_GROUP: ${{ matrix.split-group }}
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
+          AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0
+          AIRFLOW_HOME: ${{ github.workspace }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 120
+          AIRFLOW__CORE__DAG_FILE_PROCESSOR_TIMEOUT: 120
+          AIRFLOW__DAG_PROCESSOR__DAGBAG_IMPORT_TIMEOUT: 120
+          AIRFLOW__DAG_PROCESSOR__DAG_FILE_PROCESSOR_TIMEOUT: 120
+          # In a container job the Postgres service is reached by its label hostname.
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
+          DATABRICKS_HOST: mock
+          DATABRICKS_WAREHOUSE_ID: mock
+          DATABRICKS_TOKEN: mock
+          DATABRICKS_CLUSTER_ID: mock
+          PYTHONPATH: ${{ github.workspace }}
+          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+          AIRFLOW_CONN_DUCKDB_DEFAULT: "duckdb:///?host=''"
+
+  Run-Telemetry-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.9"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    env:
+      # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
+      SCARF_NO_ANALYTICS: "false"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run telemetry tests
+        run: bash scripts/test/telemetry.sh
+        env:
+          AIRFLOW_HOME: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}
+
+  Run-Performance-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.9"]
+        num-models: [1, 10, 50, 100, 500]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run performance tests (${{ matrix.num-models }} models)
+        run: |
+          bash scripts/test/performance-setup.sh "$DBT_VERSION"
+          bash scripts/test/performance.sh
+        env:
+          DBT_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_HOME: ${{ github.workspace }}
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 180.0
+          PYTHONPATH: ${{ github.workspace }}
+          MODEL_COUNT: ${{ matrix.num-models }}
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+
+  Run-Integration-dbt-Loom-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.11"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run dbt-loom integration tests
+        run: bash scripts/test/integration-dbt-loom.sh "$DBT_VERSION"
+        env:
+          DBT_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_HOME: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          AIRFLOW__COSMOS__ENABLE_CACHE: 0
+          DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+
+  Run-Integration-dbt-1-8-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.8"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run dbt 1.8 integration tests
+        run: bash scripts/test/integration-dbt-1-8.sh
+        env:
+          AIRFLOW_HOME: ${{ github.workspace }}
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          PYTHONPATH: ${{ github.workspace }}
+          AIRFLOW__COSMOS__ENABLE_CACHE: 0
+          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+          DATABRICKS_CLUSTER_ID: mock
+          DATABRICKS_HOST: mock
+          DATABRICKS_WAREHOUSE_ID: mock
+          DATABRICKS_TOKEN: mock
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+          DBT_PROJECT_NAME: "altered_jaffle_shop"
+          TEST_SINGLE_DAG: "basic_cosmos_task_group.py"
+
+  Run-Integration-dbt-Async-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.8", "1.9", "1.10", "1.11"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run dbt async integration tests (dbt ${{ matrix.dbt-version }})
+        run: bash scripts/test/integration-dbt-async.sh "$DBT_VERSION"
+        env:
+          DBT_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_HOME: ${{ github.workspace }}
+          PYTHONPATH: ${{ github.workspace }}
+          DBT_PROJECT_NAME: "altered_jaffle_shop"
+          AIRFLOW__COSMOS__ENABLE_DATASET_ALIAS: 0
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          AIRFLOW__COSMOS__ENABLE_CACHE: 0
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+          DBT_ADAPTER_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+
+  Run-Integration-Tests-Expensive:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.9"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    services:
+      postgres:
+        image: postgres@sha256:4cd697181d4bd3ddc41a09012f339fa8cb5a8cd3d8b30130ea8378c176b6c494 # 14.18
+        env:
+          POSTGRES_PASSWORD: postgres
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Run expensive (Databricks) integration tests
+        run: |
+          bash scripts/test/integration-setup.sh "$DBT_VERSION"
+          DATABRICKS_UNIQUE_ID="$GITHUB_RUN_ID" bash scripts/test/integration-expensive.sh
+        env:
+          DBT_VERSION: ${{ matrix.dbt-version }}
+          AIRFLOW_HOME: ${{ github.workspace }}
+          AIRFLOW_CONN_EXAMPLE_CONN: postgres://postgres:postgres@postgres:5432/postgres
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          AIRFLOW_CONN_AZURE_ABFS_CONN: ${{ secrets.AIRFLOW_CONN_AZURE_ABFS_CONN }}
+          PYTHONPATH: ${{ github.workspace }}
+          AIRFLOW_CONN_DATABRICKS_DEFAULT: ${{ secrets.AIRFLOW_CONN_DATABRICKS_DEFAULT }}
+          DATABRICKS_CLUSTER_ID: ${{ secrets.DATABRICKS_CLUSTER_ID }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+          POSTGRES_HOST: postgres
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: postgres
+          POSTGRES_SCHEMA: public
+          POSTGRES_PORT: 5432
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH: "s3://cosmos-remote-cache/target_compiled/"
+          AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
+
+  Run-Integration-dbt-Fusion-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["2.0"]
+    container:
+      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      options: --user root
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: ./.github/actions/setup-cosmos-runtime
+        with:
+          extras: ${{ env.COSMOS_TEST_EXTRAS }}
+      - name: Set RESOURCE_PREFIX (Snowflake-safe, no periods or dashes)
+        id: set-resource-prefix
+        env:
+          RUN_ID: ${{ github.run_id }}
+          PY_VERSION: ${{ matrix.python-version }}
+          RT_VERSION: ${{ inputs.runtime_version }}
+          DBT_VERSION: ${{ matrix.dbt-version }}
+        run: |
+          PREFIX="COSMOS_${RUN_ID}_PY${PY_VERSION}_RT${RT_VERSION}_DBT${DBT_VERSION}"
+          PREFIX="${PREFIX//[^A-Za-z0-9_]/_}"
+          echo "prefix=$PREFIX" >> "$GITHUB_OUTPUT"
+      - name: Run dbt Fusion integration tests
+        run: |
+          bash scripts/test/integration-dbtf-setup.sh
+          bash scripts/test/integration-dbtf.sh
+        env:
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
+          AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0
+          AIRFLOW_HOME: ${{ github.workspace }}
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          PYTHONPATH: ${{ github.workspace }}
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+          AIRFLOW_CONN_GCP_GS_CONN: ${{ secrets.AIRFLOW_CONN_GCP_GS_CONN }}
+          RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
+      - name: Clean up Snowflake resources
+        if: always()
+        run: |
+          pip install snowflake-connector-python
+          python scripts/ci_dbtf_delete_snowflake_resources.py
+        env:
+          SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
+          SNOWFLAKE_USER: ${{ secrets.SNOWFLAKE_USER }}
+          SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
+          SNOWFLAKE_SCHEMA: ${{ secrets.SNOWFLAKE_SCHEMA }}
+          SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_DATABASE: ${{ secrets.SNOWFLAKE_DATABASE }}
+          RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
+
+  # NOTE: Unlike the other suites, the Kubernetes suite does not run "inside" the Runtime image.
+  # In cosmos CI, Airflow runs on the runner and only the dbt task pods run in the KinD cluster
+  # (from a separate python:3.12 + dbt image, not an Airflow image). Here we run the Airflow +
+  # cosmos side inside the Runtime image via `docker run` (mounting the Docker socket + kubeconfig,
+  # host networking) so cosmos's KubernetesPodOperator, running on the alpha's Airflow, drives the
+  # cluster. This suite could not be validated locally like the others and is expected to need
+  # iteration on its first live run.
+  Run-Kubernetes-Tests:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ${{ fromJSON(inputs.python_versions) }}
+        dbt-version: ["1.11"]
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - name: Create KinD cluster
+        uses: container-tools/kind-action@0ad70e2299366b0e1552c7240f4e4567148f723e # v2.0.4
+
+      - name: Build and load the dbt task images into KinD
+        run: |
+          cd dev
+          docker build --progress=plain --no-cache -t dbt-jaffle-shop:1.0.0 -f Dockerfile.postgres_profile_docker_k8s .
+          docker build --progress=plain --no-cache -t dbt-watcher-failing-tests:1.0.0 -f Dockerfile.watcher_failing_tests_k8s .
+          kind load docker-image dbt-jaffle-shop:1.0.0
+          kind load docker-image dbt-watcher-failing-tests:1.0.0
+
+      - name: Deploy in-cluster Postgres and port-forward
+        run: |
+          kubectl create secret generic postgres-secrets \
+            --from-literal=host=postgres-postgresql.default.svc.cluster.local \
+            --from-literal=password=postgres
+          kubectl apply -f scripts/test/postgres-deployment.yaml
+          kubectl wait --for=condition=available --timeout=180s deployment/postgres || kubectl get pods -A
+          nohup kubectl port-forward --address 0.0.0.0 svc/postgres 5432:5432 > /tmp/pg-port-forward.log 2>&1 &
+          sleep 5
+
+      - name: Run kubernetes tests on the Runtime image (Airflow from the alpha)
+        env:
+          # Secrets/contexts pass through the environment (never interpolated into the command line)
+          # and are forwarded into the container with `docker run -e NAME` (value-from-environment).
+          RUNTIME_IMAGE: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+          AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
+          COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
+        run: |
+          docker pull "$RUNTIME_IMAGE"
+          docker run --rm --network host --user root \
+            -v /var/run/docker.sock:/var/run/docker.sock \
+            -v "$HOME/.kube":/root/.kube \
+            -v "$PWD":/work -w /work \
+            -e KUBECONFIG=/root/.kube/config \
+            -e AIRFLOW_HOME=/work \
+            -e PYTHONPATH=/work \
+            -e AIRFLOW_CONN_EXAMPLE_CONN="postgres://postgres:postgres@localhost:5432/postgres" \
+            -e AIRFLOW_CONN_AWS_S3_CONN \
+            -e AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT=90.0 \
+            -e COSMOS_CONN_POSTGRES_PASSWORD \
+            -e DATABRICKS_CLUSTER_ID=mock -e DATABRICKS_HOST=mock \
+            -e DATABRICKS_WAREHOUSE_ID=mock -e DATABRICKS_TOKEN=mock \
+            -e POSTGRES_HOST=localhost -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=postgres \
+            -e POSTGRES_DB=postgres -e POSTGRES_SCHEMA=public -e POSTGRES_PORT=5432 \
+            "$RUNTIME_IMAGE" bash -c '
+              set -euxo pipefail
+              apt-get update && apt-get install -y --no-install-recommends build-essential libpq-dev curl
+              # kubectl + kind for the in-container setup script.
+              curl -fsSL -o /usr/local/bin/kubectl "https://dl.k8s.io/release/$(curl -fsSL https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+              chmod +x /usr/local/bin/kubectl
+              curl -fsSL -o /usr/local/bin/kind https://kind.sigs.k8s.io/dl/v0.32.0/kind-linux-amd64
+              chmod +x /usr/local/bin/kind
+              bash scripts/test/runtime-alpha-setup.sh "dbt-postgres,kubernetes"
+              bash scripts/test/integration-kubernetes.sh
+            '

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -85,7 +85,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run unit tests
@@ -124,7 +124,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run integration tests (split ${{ matrix.split-group }}/3)
@@ -188,7 +188,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run telemetry tests
@@ -227,7 +227,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run performance tests (${{ matrix.num-models }} models)
@@ -279,7 +279,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Point the runner path the dbt-loom config hardcodes at the container workspace
@@ -340,7 +340,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run dbt 1.8 integration tests
@@ -402,7 +402,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run dbt async integration tests (dbt ${{ matrix.dbt-version }})
@@ -432,7 +432,7 @@ jobs:
           POSTGRES_PORT: 5432
 
   Run-Integration-Tests-Expensive:
-    if: ${{ github.event_name != 'pull_request' }} # TEMP: paid Databricks, run on push (once per commit) not on the PR event
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Databricks, dispatch-only (validated once, remaining failure tracked in BOSS-662)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -461,7 +461,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Run expensive (Databricks) integration tests
@@ -491,7 +491,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
   Run-Integration-dbt-Fusion-Tests:
-    if: ${{ github.event_name != 'pull_request' }} # TEMP: paid Snowflake, run on push (once per commit) not on the PR event
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Snowflake, dispatch-only (serialization + cloud validation tracked in BOSS-662)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -510,7 +510,7 @@ jobs:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
-      - uses: $/.github/actions/setup-cosmos-runtime
+      - uses: ./.github/actions/setup-cosmos-runtime # zizmor: ignore[self-repository]
         with:
           extras: ${{ env.COSMOS_TEST_EXTRAS }}
       - name: Set RESOURCE_PREFIX (Snowflake-safe, no periods or dashes)
@@ -568,10 +568,10 @@ jobs:
   # cluster. This suite could not be validated locally like the others and is expected to need
   # iteration on its first live run.
   Run-Kubernetes-Tests:
-    # Disabled for now: pod-execution failures plus a watcher-test hang. Tracked in a follow-up
-    # ticket that will fix and re-enable it (flip this to run). Kept in the workflow (not deleted)
-    # so the follow-up has the full job to iterate on.
-    if: false
+    # Disabled: pod-execution failures plus a watcher-test hang, tracked in BOSS-662. Kept in the
+    # workflow (not deleted) so the follow-up has the full job to iterate on. Re-enable by setting
+    # the RUN_KUBERNETES_SUITE repo variable to 'true' (a plain `if: false` trips actionlint).
+    if: ${{ vars.RUN_KUBERNETES_SUITE == 'true' }}
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:

--- a/.github/workflows/test-runtime-alpha.yml
+++ b/.github/workflows/test-runtime-alpha.yml
@@ -37,6 +37,13 @@ on:
         default: '["1.12"]'
         type: string
 
+  # TEMP (remove before merge): run this workflow on the PR itself with a default image, so
+  # reviewers can see it execute. pull_request events do not populate workflow_dispatch inputs,
+  # so the jobs fall back to the defaults in the `|| '...'` expressions below. The paid Databricks
+  # and Snowflake suites are gated to workflow_dispatch only, so they do not run on the PR.
+  pull_request:
+    branches: [main]
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}-${{ inputs.runtime_version }}
   cancel-in-progress: true
@@ -57,10 +64,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -83,11 +90,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
-        dbt-version: ${{ fromJSON(inputs.dbt_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
+        dbt-version: ${{ fromJSON(inputs.dbt_versions || '["1.12"]') }}
         split-group: [1, 2, 3]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -153,10 +160,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     env:
       # The telemetry test asserts Scarf analytics IS on, so override the workflow-global value.
@@ -182,11 +189,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
         num-models: [1, 10, 50, 100, 500]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -233,10 +240,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.11"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -284,10 +291,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -344,10 +351,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.8", "1.9", "1.10", "1.11"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -393,6 +400,7 @@ jobs:
           POSTGRES_PORT: 5432
 
   Run-Integration-Tests-Expensive:
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Databricks, dispatch-only (skips on PR)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -400,10 +408,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.9"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     services:
       postgres:
@@ -449,6 +457,7 @@ jobs:
           AIRFLOW__COSMOS__REMOTE_TARGET_PATH_CONN_ID: aws_s3_conn
 
   Run-Integration-dbt-Fusion-Tests:
+    if: ${{ github.event_name == 'workflow_dispatch' }} # TEMP: paid Snowflake, dispatch-only (skips on PR)
     runs-on: ubuntu-latest
     timeout-minutes: 60
     permissions:
@@ -456,10 +465,10 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["2.0"]
     container:
-      image: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+      image: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
       options: --user root
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -530,7 +539,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ${{ fromJSON(inputs.python_versions) }}
+        python-version: ${{ fromJSON(inputs.python_versions || '["3.12"]') }}
         dbt-version: ["1.11"]
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
@@ -562,7 +571,7 @@ jobs:
         env:
           # Secrets/contexts pass through the environment (never interpolated into the command line)
           # and are forwarded into the container with `docker run -e NAME` (value-from-environment).
-          RUNTIME_IMAGE: ${{ inputs.registry }}:${{ inputs.runtime_version }}-python-${{ matrix.python-version }}
+          RUNTIME_IMAGE: ${{ inputs.registry || 'astrocrpublic.azurecr.io/runtime-dev' }}:${{ inputs.runtime_version || '3.3-7-alpha2' }}-python-${{ matrix.python-version }}
           AIRFLOW_CONN_AWS_S3_CONN: ${{ secrets.AIRFLOW_CONN_AWS_S3_CONN }}
           COSMOS_CONN_POSTGRES_PASSWORD: ${{ secrets.COSMOS_CONN_POSTGRES_PASSWORD }}
         run: |

--- a/scripts/test/requirements-test-tools.txt
+++ b/scripts/test/requirements-test-tools.txt
@@ -1,0 +1,23 @@
+# Pytest tooling for running the Cosmos test suite against a prebuilt Astronomer Runtime
+# image (see scripts/test/runtime-alpha-setup.sh and .github/workflows/test-runtime-alpha.yml).
+#
+# This is the runtime subset of `[tool.hatch.envs.tests].dependencies` in pyproject.toml -- only
+# what pytest needs to collect and run. It deliberately DROPS:
+#   * Werkzeug<3.0.0 and other version-pinned entries -- the Runtime image already pins its own
+#     Airflow-compatible versions, and forcing the Hatch env's pins on top would fight the image
+#     (e.g. Werkzeug<3 conflicts with an Airflow 3 image). Letting the image's pins stand is the
+#     whole point: surfacing real cosmos-on-Runtime compatibility.
+#   * type-check-only deps (types-*, sqlalchemy-stubs, pre-commit) -- not needed to run tests.
+# Keep this in sync with the pytest tooling listed in the Hatch `tests` env.
+packaging>=22.0
+pytest>=6.0
+pytest-split
+pytest-dotenv
+pytest-rerunfailures
+pytest-timeout
+pytest-cov
+pytest-describe
+pytest-asyncio
+requests-mock
+orjson
+sentry-sdk

--- a/scripts/test/runtime-alpha-setup.sh
+++ b/scripts/test/runtime-alpha-setup.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Prepare an Astronomer Runtime image's own Python environment to run the Cosmos test suite
+# AGAINST the Airflow that ships in that image.
+#
+# Unlike scripts/test/pre-install-airflow.sh (which pip-pins a specific Airflow), this installs
+# NO Airflow: the Runtime image already provides it. We only add cosmos (from the checked-out
+# source), its dbt adapters, and the pytest tooling on top. The downstream run scripts
+# (integration-setup.sh / integration.sh / unit.sh) already use whatever `airflow` is on PATH,
+# so they run unchanged against the image's Airflow build.
+#
+# Usage: runtime-alpha-setup.sh [COSMOS_EXTRAS]
+#   COSMOS_EXTRAS  comma-separated cosmos optional-dependency extras (default: dbt-postgres)
+set -euxo pipefail
+
+COSMOS_EXTRAS="${1:-dbt-postgres}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+# Astronomer Runtime images ship /pyproject.toml carrying [tool.uv].constraint-dependencies, so
+# that `uv pip install` stays pinned to the image's Airflow build. uv discovers this file by
+# walking up from the install directory. Some alpha images write an invalid PEP440
+# [project].version there (e.g. "3.3-7-alpha2" -- valid TOML, but not a valid version), which
+# makes uv abort parsing the file and therefore abort EVERY install run under it. We never use
+# that version, so neutralise just that line to a valid placeholder; the constraint-dependencies
+# below it are left untouched and still applied. Guarded on existence so older images are a no-op.
+RUNTIME_UV_PYPROJECT="${RUNTIME_UV_PYPROJECT:-/pyproject.toml}"
+if [ -f "$RUNTIME_UV_PYPROJECT" ]; then
+  echo "Neutralising [project].version in ${RUNTIME_UV_PYPROJECT} (Runtime image ships an invalid PEP440 version that breaks uv)."
+  sed -i -E '0,/^version = /{s/^version = .*/version = "0.0.0"/}' "$RUNTIME_UV_PYPROJECT"
+fi
+
+pip install -U uv
+
+# Install cosmos (editable, from this checkout) + requested dbt adapters, letting the image's
+# pinned Airflow stand (cosmos only floors apache-airflow>=2.9.0, so uv won't reinstall Airflow).
+uv pip install --system -e "${REPO_ROOT}[${COSMOS_EXTRAS}]"
+
+# Pytest tooling needed to collect and run the suite.
+uv pip install --system -r "${SCRIPT_DIR}/requirements-test-tools.txt"
+
+# Some integration tests execute dbt in a separate virtualenv (subprocess invocation mode).
+# pre-install-airflow.sh normally creates this; reproduce it here since we skip that script.
+python -m venv "${REPO_ROOT}/venv-subprocess"
+"${REPO_ROOT}/venv-subprocess/bin/pip" install -U "dbt-core<2.0" dbt-postgres
+
+# Compatibility signal: show the resolved Airflow / dbt / cosmos versions actually in play.
+uv pip freeze | grep -Ei 'airflow|dbt|cosmos' || true
+airflow version

--- a/scripts/test/runtime-alpha-setup.sh
+++ b/scripts/test/runtime-alpha-setup.sh
@@ -32,9 +32,26 @@ fi
 
 pip install -U uv
 
+# Pin apache-airflow-providers-* to the versions cosmos tests against (from its per-Airflow
+# lockfile), so provider operators match what cosmos supports. The async BigQuery operator, for
+# example, reassigns __bases__ to the google provider's operator and breaks when the image resolves
+# a newer google provider than cosmos supports. Keyed off the image's Airflow minor. Providers are
+# dbt-agnostic, so the dbt-1.12 lockfile is used regardless of the suite's dbt version. Only
+# providers are constrained, so the image's Airflow and the per-suite dbt re-pins are left untouched.
+AF_MINOR="$(AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR airflow version 2>/dev/null | grep -oE '^[0-9]+\.[0-9]+' | head -1 || true)"
+LOCKFILE="${REPO_ROOT}/requirements/requirements-airflow-${AF_MINOR}-dbt-1.12.txt"
+PROVIDER_CONSTRAINT_ARGS=()
+if [ -n "$AF_MINOR" ] && [ -f "$LOCKFILE" ]; then
+  grep -E '^apache-airflow-providers-' "$LOCKFILE" > /tmp/cosmos-provider-pins.txt
+  PROVIDER_CONSTRAINT_ARGS=(-c /tmp/cosmos-provider-pins.txt)
+  echo "Pinning providers to cosmos's tested set from ${LOCKFILE}."
+else
+  echo "No cosmos lockfile for Airflow '${AF_MINOR}'; installing providers unpinned."
+fi
+
 # Install cosmos (editable, from this checkout) + requested dbt adapters, letting the image's
 # pinned Airflow stand (cosmos only floors apache-airflow>=2.9.0, so uv won't reinstall Airflow).
-uv pip install --system -e "${REPO_ROOT}[${COSMOS_EXTRAS}]"
+uv pip install --system "${PROVIDER_CONSTRAINT_ARGS[@]}" -e "${REPO_ROOT}[${COSMOS_EXTRAS}]"
 
 # Pytest tooling needed to collect and run the suite.
 uv pip install --system -r "${SCRIPT_DIR}/requirements-test-tools.txt"

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -9,6 +9,7 @@ import tempfile
 import zlib
 from pathlib import Path
 from unittest.mock import MagicMock, call, mock_open, patch
+from urllib.parse import urlparse
 
 import pytest
 from airflow import DAG
@@ -818,10 +819,12 @@ def test_run_operator_dataset_inlets_and_outlets_airflow_3_onwards(caplog):
 
     new_test_dag(dag)
     assert "Assigning outlets with DatasetAlias in Airflow 3" in caplog.text
-    assert (
-        "Outlets: [Asset(name='postgres://0.0.0.0:5432/postgres/public/stg_customers', uri='postgres://0.0.0.0:5432/postgres/public/stg_customers'"
-        in caplog.text
-    )
+    # The Asset URI host:port comes from the example_conn connection, which differs between setups
+    # (0.0.0.0 on a runner, the service hostname inside a container). Derive it so the assertion is
+    # host-agnostic.
+    conn = urlparse(os.environ.get("AIRFLOW_CONN_EXAMPLE_CONN", "postgres://user:pass@0.0.0.0:5432/postgres"))
+    expected_asset = f"postgres://{conn.hostname}:{conn.port or 5432}/postgres/public/stg_customers"
+    assert f"Outlets: [Asset(name='{expected_asset}', uri='{expected_asset}'" in caplog.text
 
 
 @pytest.mark.integration

--- a/tests/perf/test_performance.py
+++ b/tests/perf/test_performance.py
@@ -104,6 +104,11 @@ def test_perf_dag():
         # verify the integrity of the dag
         assert len(dag.tasks) == num_models
 
+        # Airflow 3.1+ requires the DAG serialized before dag.test(); do it outside the timed region.
+        from tests.utils import serialize_dag_to_db
+
+        serialize_dag_to_db(dag)
+
         # measure the time before and after the dag is run
 
         start = time.time()

--- a/tests/test_async_example_dag.py
+++ b/tests/test_async_example_dag.py
@@ -64,4 +64,6 @@ def get_dag_ids() -> list[str]:
 def test_example_dag(session, dag_id: str):
     dag_bag = get_dag_bag()
     dag = dag_bag.get_dag(dag_id)
+    # Airflow 3.1+ requires the DAG serialized before dag.test().
+    test_utils.serialize_dag_to_db(dag)
     dag.test()

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -64,30 +64,37 @@ def check_dag_state(dag_run: DagRun | None, expected_dag_state: DagRunState = Da
     return True
 
 
+def serialize_dag_to_db(dag: DAG) -> None:
+    """Serialize ``dag`` to the metadata DB.
+
+    Airflow 3.1+ requires a DAG to be serialized before ``dag.test()`` / ``create_dagrun()``,
+    which check for DagVersion and DagModel records. No-op on older Airflow.
+    """
+    if AIRFLOW_VERSION < version.Version("3.1"):
+        return
+
+    try:
+        from airflow.dag_processing.dagbag import sync_bag_to_db
+    except ImportError:
+        from airflow.models.dagbag import sync_bag_to_db
+
+    from airflow.models.dagbundle import DagBundleModel
+    from airflow.utils.session import create_session
+
+    # Create the DagBundle the DagModel foreign key needs (mimics manager.sync_bundles_to_db()),
+    # then bag + sync to create the DagModel and DagVersion records.
+    with create_session() as session:
+        session.merge(DagBundleModel(name="test_bundle"))
+        session.commit()
+
+    dagbag = make_dag_bag(include_examples=False)
+    dagbag.bag_dag(dag)
+    sync_bag_to_db(dagbag, bundle_name="test_bundle", bundle_version="1")
+
+
 def new_test_dag(dag: DAG, expected_dag_state: DagRunState = DagRunState.SUCCESS) -> DagRun:
     if AIRFLOW_VERSION >= version.Version("3.1"):
-        # Airflow 3.1+ requires DAG to be serialized to database before calling dag.test()
-        # because create_dagrun() checks for DagVersion and DagModel records
-
-        try:
-            from airflow.dag_processing.dagbag import sync_bag_to_db
-        except ImportError:
-            from airflow.models.dagbag import sync_bag_to_db
-
-        from airflow.models.dagbundle import DagBundleModel
-        from airflow.utils.session import create_session
-
-        # Create DagBundle if it doesn't exist (required for DagModel foreign key)
-        # This mimics what get_bagged_dag does via manager.sync_bundles_to_db()
-        with create_session() as session:
-            dag_bundle = DagBundleModel(name="test_bundle")
-            session.merge(dag_bundle)
-            session.commit()
-
-        # This creates both DagModel and DagVersion records
-        dagbag = make_dag_bag(include_examples=False)
-        dagbag.bag_dag(dag)
-        sync_bag_to_db(dagbag, bundle_name="test_bundle", bundle_version="1")
+        serialize_dag_to_db(dag)
         dr = dag.test(logical_date=timezone.utcnow())
     elif AIRFLOW_VERSION >= version.Version("3.0"):
         # In Airflow 3.0, dag.test() does not properly register Assets as active, must be registered manually


### PR DESCRIPTION
## What and why

Adds a manually dispatched (`workflow_dispatch`) GitHub Actions workflow that runs cosmos's own test suites (from the checked-out ref, latest `main` by default) against a published **Astronomer Runtime alpha** image, so cosmos's compatibility with the alpha's exact Airflow build is validated before that alpha graduates to a stable release.

Run it with the alpha version:
```
gh workflow run test-runtime-alpha.yml -f runtime_version=3.3-2-alpha1
```
Inputs: `runtime_version` (required), `registry` (choice, default `astrocrpublic.azurecr.io/runtime-dev`), `python_versions` (JSON, default `["3.12"]`), `run_paid_suites` (boolean, default `false`, runs the paid Databricks + Snowflake suites).

## How it works

The Runtime image supplies Airflow. Each suite runs inside the image as a job container, installs cosmos + dbt adapters + pytest tooling on top of the image's pinned Airflow via `scripts/test/runtime-alpha-setup.sh` (shared by a small composite action), and reuses cosmos's existing `scripts/test/*.sh` run scripts. Because the image fixes the Airflow version, the python x airflow x dbt matrix collapses to python (from the image tag) x dbt. Providers come from the image's own constraints, so each suite runs against the exact provider versions the alpha ships rather than an overridden set.

## What is included

- `.github/workflows/test-runtime-alpha.yml`, a `setup-cosmos-runtime` composite action, `scripts/test/runtime-alpha-setup.sh`, and `scripts/test/requirements-test-tools.txt`.
- A few cosmos test-harness fixes needed to run on Airflow 3.1+ inside a container:
  - `serialize_dag_to_db` helper so perf and async tests serialize the DAG before `dag.test()` (Airflow 3.1+ requires it).
  - Host-agnostic Asset URI assertion in `test_local.py` (was hardcoding the runner's Postgres host).
  - The dbt-loom job symlinks the runner path its config hardcodes to the container workspace.

## Validation (alpha `3.3-2-alpha1`, py3.12)

Green against the alpha's own provider set: unit, integration (x3), telemetry, performance (x5), dbt-1.8, dbt-loom. The install seam, Postgres, secret injection, and the matrix are all exercised.

Deferred to **BOSS-662**: the dbt-async suite (its async BigQuery operator reassigns `__bases__` to the google provider's operator and breaks on the google `22.4.0` the alpha ships, disabled via the `RUN_DBT_ASYNC_SUITE` repo variable), the Kubernetes suite (pod-execution failures plus a watcher hang, disabled), the dbt-Fusion suite (same Airflow 3.1+ serialization pattern, then Snowflake/BigQuery validation), and one Databricks python-models test. The paid Databricks and Snowflake suites run only when `run_paid_suites` is set.

## Runtime image issues found

1. The alpha image ships `/pyproject.toml` with an invalid PEP440 `version`, which makes `uv pip install` abort inside the image. Worked around in the setup helper by neutralizing that line.
2. `airflow version` prints plugin warnings to stdout, breaking scripts that parse it for `db migrate` vs the AF3-removed `db init`. Worked around with `AIRFLOW__LOGGING__LOGGING_LEVEL=ERROR` scoped to setup.

## Review hardening

- `registry` is a `type: choice` allowlist so a dispatcher cannot redirect the secret-bearing jobs to an arbitrary image.
- Python 3.14 is excluded from the suites that force an older dbt with no 3.14 wheels (dbt-loom, dbt-1.8, async), mirroring test-unprivileged.yml.
- Removed the inert `dbt_versions` axis (the unit and integration suites never installed the matrix dbt).
- The paid suites sit behind the `run_paid_suites` boolean, a durable gate that stays off once the workflow is dispatch-only.
- A `Report-Suite-Coverage` job writes a ran-vs-skipped manifest to the run summary, so a green run states which suites were gated off.
- Version guards use release tuples (pre-release safe), and the pyproject version patch is asserted with tomllib.

Closes astronomer/oss-integrations-private#613
Closes BOSS-610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
