### PR TITLE
Clean up leftover dbt-core <1.8 references after PR #2939

### DIFF
--- a/cosmos/config.py
+++ b/cosmos/config.py
@@ -587,7 +587,7 @@ class ExecutionConfig:
     :param virtualenv_dir: Directory path to locate the (cached) virtual env that
     should be used for execution when execution mode is set to `ExecutionMode.VIRTUALENV`
     :param async_py_requirements:  A list of Python packages to install when `ExecutionMode.AIRFLOW_ASYNC` is used. This parameter is required only if both `enable_setup_async_task` and `enable_teardown_async_task` are set to `True`.
-    Example: `["dbt-postgres==1.5.0"]`
+    Example: `["dbt-postgres==1.8.0"]`
     :param setup_operator_args: A dictionary of producer operator parameters. These will override the values supplied in operator_args for producer operator.
         Pass ``freshness_callback`` here in `ExecutionMode.WATCHER` to override the default skip-propagation logic when ``source_rendering_behavior`` is not ``NONE``. **Experimental**.
         The callable receives ``(context, dag, task_group, nodes, sources_json)`` and must return a list of ``(unique_id, state)`` tuples.

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -498,7 +498,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
         """Invokes the dbt command programmatically."""
         if not dbt_runner.is_available():
             raise CosmosDbtRunError(
-                "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
+                "Could not import dbt core. Ensure that dbt-core is installed and available in the environment where the operator is running."
             )
 
         return dbt_runner.run_command(command, env, cwd, callbacks=self._dbt_runner_callbacks, **kwargs)
@@ -556,16 +556,13 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.profile_config.target_name,
         ]
         if self.invocation_mode == InvocationMode.DBT_RUNNER:
-            from dbt.version import __version__ as dbt_version
-
-            if Version(dbt_version) >= Version("1.5.6"):
-                # PR #1484 introduced the use of dbtRunner during DAG parsing. As a result, invoking dbtRunner again
-                # during task execution can lead to task hangs—especially on Airflow 2.x. Investigation revealed that
-                # the issue stems from how dbtRunner handles static parsing. Cosmos copies the dbt project to temporary
-                # directories, and the use of different temp paths between parsing and execution appears to interfere
-                # with dbt's static parsing behavior. As a workaround, passing the --no-static-parser flag avoids these
-                # hangs and ensures reliable task execution.
-                dbt_flags.append("--no-static-parser")
+            # PR #1484 introduced the use of dbtRunner during DAG parsing. As a result, invoking dbtRunner again
+            # during task execution can lead to task hangs—especially on Airflow 2.x. Investigation revealed that
+            # the issue stems from how dbtRunner handles static parsing. Cosmos copies the dbt project to temporary
+            # directories, and the use of different temp paths between parsing and execution appears to interfere
+            # with dbt's static parsing behavior. As a workaround, passing the --no-static-parser flag avoids these
+            # hangs and ensures reliable task execution.
+            dbt_flags.append("--no-static-parser")
         return dbt_flags
 
     def _install_dependencies(

--- a/cosmos/operators/virtualenv.py
+++ b/cosmos/operators/virtualenv.py
@@ -59,7 +59,7 @@ class DbtVirtualenvBaseOperator(DbtLocalBaseOperator):
     and deleted at the end of the operator execution.
 
     :param py_requirements: If defined, creates a virtual environment with the specified dependencies. Example:
-           ["dbt-postgres==1.5.0"]
+           ["dbt-postgres==1.8.0"]
     :param pip_install_options: Pip options to use when installing Python dependencies. Example: ["--upgrade", "--no-cache-dir"]
     :param py_system_site_packages: Whether or not all the Python packages from the Airflow instance will be accessible
            within the virtual environment (if py_requirements argument is specified).

--- a/docs/guides/dbt_docs/generating-docs.rst
+++ b/docs/guides/dbt_docs/generating-docs.rst
@@ -209,9 +209,6 @@ All of the DbtDocsOperator accept the ``--static`` flag. To learn more about the
 The static flag is used to generate a single doc file that can be hosted directly from cloud storage.
 By having a single documentation file, you can make use of Access control can be configured through Identity-Aware Proxy (IAP), and making it easy to host.
 
-.. note::
-    The static flag is only available from dbt-core >=1.7
-
 The following code snippet shows how to provide this flag with the default jaffle_shop project:
 
 

--- a/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
+++ b/docs/guides/dbt_setup/execution-modes-local-conflicts.rst
@@ -38,14 +38,6 @@ Examples of errors
 
 .. code-block:: bash
 
-  ERROR: Cannot install apache-airflow==3.1 and dbt-core==1.5 because these package versions have conflicting dependencies.
-
-  The conflict is caused by:
-      dbt-core 1.5.0 depends on Jinja2==3.1.2
-      apache-airflow-core 3.1.0 depends on jinja2>=3.1.5
-
-.. code-block:: bash
-
   ERROR: Cannot install apache-airflow==3.0 and dbt-core==1.10.0 because these package versions have conflicting dependencies.
 
   The conflict is caused by:
@@ -70,7 +62,7 @@ The table was created by running  `nox <https://nox.thea.codes/en/stable/>`__ wi
     @nox.session(python=["3.10"])
     @nox.parametrize(
         "dbt_version",
-        ["1.5", "1.6", "1.7", "1.8", "1.9", "1.10", "1.11", "1.12"],
+        ["1.8", "1.9", "1.10", "1.11", "1.12"],
     )
     @nox.parametrize(
         "airflow_version",

--- a/docs/guides/translate_dbt_to_airflow/managing-sources.rst
+++ b/docs/guides/translate_dbt_to_airflow/managing-sources.rst
@@ -4,7 +4,7 @@ Managing sources
 ================
 
 .. note::
-    This feature is only available for dbt-core >= 1.5 and cosmos >= 1.6.0.
+    This feature is only available for cosmos >= 1.6.0.
 
 By default, Cosmos does not render dbt sources automatically. Instead, you need to configure the rendering of sources explicitly.
 You can control this behavior using the ``source_rendering_behavior`` field in the ``RenderConfig`` object. This is how it works:

--- a/docs/guides/translate_dbt_to_airflow/parsing-methods.rst
+++ b/docs/guides/translate_dbt_to_airflow/parsing-methods.rst
@@ -126,7 +126,7 @@ To use this:
 Starting in Cosmos 1.5, Cosmos will cache the output of the ``dbt ls`` command, to improve the performance of this
 parsing method. Learn more :ref:`here <caching>`.
 
-Since Cosmos 1.9, it will attempt to use dbt as a library, and run ``dbt ls`` using the ``dbtRunner``  that is available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__. This mode requires dbt version 1.5.0 or higher.
+Since Cosmos 1.9, it will attempt to use dbt as a library, and run ``dbt ls`` using the ``dbtRunner``  that is available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__.
 This mode,  named ``InvocationMode.DBT_RUNNER``, also depends on dbt being installed in the same Python virtual environment as Airflow.
 In previous Cosmos versions, Cosmos would always run ``dbt ls`` using the  Python ``subprocess`` module, which can lead to significant CPU and memory usage.
 

--- a/docs/guides/translate_dbt_to_airflow/render-config.rst
+++ b/docs/guides/translate_dbt_to_airflow/render-config.rst
@@ -42,7 +42,7 @@ How to run dbt ls (invocation mode)
 
 When using ``LoadMode.DBT_LS``, Cosmos runs ``dbt ls`` to parse the dbt project.
 
-Since Cosmos 1.9, it will attempt to use dbt as a library, and run ``dbt ls`` using the ``dbtRunner``  that is available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__. This mode requires dbt version 1.5.0 or higher.
+Since Cosmos 1.9, it will attempt to use dbt as a library, and run ``dbt ls`` using the ``dbtRunner``  that is available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__.
 This mode,  named ``InvocationMode.DBT_RUNNER``, also depends on dbt being installed in the same Python virtual environment as Airflow.
 In previous Cosmos versions, Cosmos would always run ``dbt ls`` using the  Python ``subprocess`` module, which can lead to significant CPU and memory usage (including OOM errors), both in the scheduler and worker nodes.
 
@@ -52,7 +52,7 @@ Although ``InvocationMode.DBT_RUNNER`` is the default behaviour in Cosmos 1.9, u
 
 2. ``InvocationMode.DBT_RUNNER``: (default since Cosmos 1.9) In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
    In order to use this mode, dbt must be installed in the same local environment. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and is faster than ``InvocationMode.SUBPROCESS``. \
-   This mode requires dbt version 1.5.0 or higher. It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
+   It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
 
 Users may opt to use ``InvocationMode.SUBPROCESS`` when they have multiple Python virtual environments with different versions of dbt and its adaptors,
 and do not want Cosmos to use the dbt version installed in the same Python Virtualenv as Airflow to parse the DAG.

--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -10,11 +10,11 @@ For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes
 
 2. ``InvocationMode.DBT_RUNNER``: In this mode, Cosmos uses the ``dbtRunner`` available for `dbt programmatic invocations <https://docs.getdbt.com/reference/programmatic-invocations>`__ to run dbt commands. \
    In order to use this mode, dbt must be installed in the same local environment. This mode does not have the overhead of spawning new subprocesses or parsing the output of dbt commands and is faster than ``InvocationMode.SUBPROCESS``. \
-   This mode requires dbt version 1.5.0 or higher. It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
+   It is up to the user to resolve :ref:`execution-modes-local-conflicts` when using this mode.
 
 .. note::
 
-   When ``InvocationMode.DBT_RUNNER`` is used with dbt-core 1.5.6 or later,
+   When ``InvocationMode.DBT_RUNNER`` is used,
    Cosmos automatically appends ``--no-static-parser`` to every dbt command
    it invokes. Cosmos copies the dbt project into a temporary directory at
    both DAG parse time and task execution time, and the differing temp paths

--- a/docs/optimize_performance/invocation_mode.rst
+++ b/docs/optimize_performance/invocation_mode.rst
@@ -14,13 +14,14 @@ For ``ExecutionMode.LOCAL`` execution mode, Cosmos supports two invocation modes
 
 .. note::
 
-   When ``InvocationMode.DBT_RUNNER`` is used,
+   When ``InvocationMode.DBT_RUNNER`` is used with ``ExecutionMode.LOCAL``,
    Cosmos automatically appends ``--no-static-parser`` to every dbt command
-   it invokes. Cosmos copies the dbt project into a temporary directory at
-   both DAG parse time and task execution time, and the differing temp paths
-   can interfere with dbt's static parser and cause task hangs. Disabling the
-   static parser is a workaround for this interaction. If you rely on dbt's
-   static parser, use ``InvocationMode.SUBPROCESS`` instead. See
+   it invokes during task execution. Cosmos copies the dbt project into a
+   temporary directory at both DAG parse time and task execution time, and
+   the differing temp paths can interfere with dbt's static parser and
+   cause task hangs. Disabling the static parser is a workaround for this
+   interaction. If you rely on dbt's static parser, use
+   ``InvocationMode.SUBPROCESS`` instead. See
    `#1751 <https://github.com/astronomer/astronomer-cosmos/issues/1751>`_ and
    `#1760 <https://github.com/astronomer/astronomer-cosmos/pull/1760>`_ for the
    investigation that led to this workaround.

--- a/docs/optimize_performance/memory_optimization.rst
+++ b/docs/optimize_performance/memory_optimization.rst
@@ -59,7 +59,7 @@ Cosmos provides various configuration options and execution modes to optimize me
 
 **What it does**: Uses ``dbtRunner`` (dbt programmatic API) instead of Python subprocess, reducing memory and CPU overhead.
 
-**Requirements**: dbt version 1.5.0+ and dbt installed in the same Python environment as Airflow.
+**Requirements**: dbt installed in the same Python environment as Airflow.
 
 **Default**: default behaviour for ``ExecutionMode.LOCAL`` since 1.4.0, default behaviour for ``RenderConfig.DBT_LS`` since Cosmos 1.9.0
 

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -375,7 +375,7 @@ def test_dbt_base_operator_run_dbt_runner_cannot_import():
         project_dir="my/dir",
         invocation_mode=InvocationMode.DBT_RUNNER,
     )
-    expected_error_message = "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
+    expected_error_message = "Could not import dbt core. Ensure that dbt-core is installed and available in the environment where the operator is running."
     with patch.dict(sys.modules, {"dbt.cli.main": None}):
         with pytest.raises(CosmosDbtRunError, match=expected_error_message):
             dbt_base_operator.run_dbt_runner(command=["cmd"], env={}, cwd="some-project")

--- a/tests/operators/test_virtualenv.py
+++ b/tests/operators/test_virtualenv.py
@@ -469,7 +469,7 @@ def test_build_and_run_cmd_invokes_interceptors(mock_run_command):
         project_dir="my/dir",
         vars=None,
         env=None,
-        py_requirements=["dbt-postgres==1.5.0"],
+        py_requirements=["dbt-postgres==1.8.0"],
         interceptors=[interceptor_modify_vars_and_env],
     )
 

--- a/tests/test_example_dags.py
+++ b/tests/test_example_dags.py
@@ -11,7 +11,6 @@ import pytest
 from airflow.models.dagbag import DagBag
 from airflow.utils.db import create_default_connections
 from airflow.utils.session import provide_session
-from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION, PARTIALLY_SUPPORTED_AIRFLOW_VERSIONS
@@ -20,7 +19,6 @@ from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
-DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
 KUBERNETES_DAGS = ["jaffle_shop_kubernetes", "jaffle_shop_watcher_kubernetes"]
 # DAGs whose source tables must be seeded first; run via the dedicated tests below.
 DAGS_WITH_SEED_DEPENDENCY = ["watcher_source_rendering_dag", "source_pruning_dag"]
@@ -62,13 +60,6 @@ def get_dag_bag() -> DagBag:  # noqa: C901
         for dagfile in IGNORED_DAG_FILES:
             print(f"Adding {dagfile} to .airflowignore")
             file.writelines([f"{dagfile}\n"])
-
-        if DBT_VERSION < Version("1.6.0"):
-            file.writelines(["example_model_version.py\n"])
-            file.writelines(["example_operators.py\n"])
-
-        if DBT_VERSION < Version("1.5.0"):
-            file.writelines(["example_source_rendering.py\n"])
 
         if AIRFLOW_VERSION >= Version("3.0.0"):
             file.writelines("example_cosmos_cleanup_dag.py\n")

--- a/tests/test_example_dags_no_connections.py
+++ b/tests/test_example_dags_no_connections.py
@@ -5,7 +5,6 @@ from pathlib import Path
 
 import pytest
 from airflow.models.dagbag import DagBag
-from dbt.version import get_installed_version as get_dbt_version
 from packaging.version import Version
 
 from cosmos.constants import AIRFLOW_VERSION
@@ -14,7 +13,6 @@ from . import utils as test_utils
 
 EXAMPLE_DAGS_DIR = Path(__file__).parent.parent / "dev/dags"
 AIRFLOW_IGNORE_FILE = EXAMPLE_DAGS_DIR / ".airflowignore"
-DBT_VERSION = Version(get_dbt_version().to_version_string()[1:])
 
 IGNORED_DAG_FILES = [
     "performance_dag.py",
@@ -33,16 +31,6 @@ def get_dag_bag() -> DagBag:
             print(f"Adding {dagfile} to .airflowignore")
             file.writelines([f"{dagfile}\n"])
 
-        # Ignore Async DAG for dbt <=1.5
-        if DBT_VERSION <= Version("1.5.0"):
-            file.writelines(["simple_dag_async.py\n"])
-
-        if DBT_VERSION < Version("1.5.0"):
-            file.writelines(["example_source_rendering.py\n"])
-
-        if DBT_VERSION < Version("1.6.0"):
-            file.writelines(["example_model_version.py\n"])
-            file.writelines(["example_operators.py\n"])
         # cosmos_profile_mapping uses the automatic profile rendering from an Airflow connection.
         # so we can't parse that without live connections
         for file_name in ["cosmos_profile_mapping.py"]:


### PR DESCRIPTION
Follow-up to #2939 (raised min supported dbt Core to 1.8). Removes a few things that PR left behind:

- A dead `Version(dbt_version) >= Version("1.5.6")` check in `local.py` (always true now).
- Doc notes gated on dbt-core versions below the new floor (1.5/1.6/1.7).
- `.airflowignore` branches in example-DAG tests that only applied to dbt <1.6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)