### PR TITLE
Fail when dbt ls via dbtRunner returns no JSON records

### DIFF
--- a/cosmos/dbt/graph.py
+++ b/cosmos/dbt/graph.py
@@ -332,6 +332,13 @@ def run_command_with_subprocess(command: list[str], tmp_dir: Path, env_vars: dic
     return stdout
 
 
+def _is_json_record(line: str) -> bool:
+    try:
+        return isinstance(json.loads(line), dict)
+    except (json.decoder.JSONDecodeError, TypeError):
+        return False
+
+
 def run_command_with_dbt_runner(command: list[str], tmp_dir: Path | None, env_vars: dict[str, str]) -> str:
     """Run a command with dbtRunner, returning the stdout."""
     response = dbt_runner.run_command(command=command, env=env_vars, cwd=str(tmp_dir))
@@ -345,6 +352,21 @@ def run_command_with_dbt_runner(command: list[str], tmp_dir: Path | None, env_va
     )
     if response.result:
         stdout = "\n".join(result_list)
+
+    # dbt-core 1.x returns one JSON record per node for `dbt ls --output json`; dbt-core 2.0's dbtRunner
+    # returns bare node names instead, which `parse_dbt_ls_output` would skip one by one, leaving an
+    # empty Dag with no error. See https://github.com/astronomer/astronomer-cosmos/issues/2992
+    if (
+        response.success
+        and result_list
+        and command[1] == "ls"
+        and not any(_is_json_record(item) for item in result_list)
+    ):
+        raise CosmosLoadDbtException(
+            f"dbt ls run through dbtRunner returned {len(result_list)} entries that are not JSON records "
+            f"(first: {result_list[0]!r}). The installed dbt does not return `--output json` records through "
+            "its Python API; set RenderConfig.invocation_mode=InvocationMode.SUBPROCESS."
+        )
 
     if not response.success:
         if response.exception:
@@ -402,11 +424,14 @@ def run_command(
 def parse_dbt_ls_output(project_path: Path | None, ls_stdout: str) -> dict[str, DbtNode]:
     """Parses the output of `dbt ls` into a dictionary of `DbtNode` instances."""
     nodes = {}
+    skipped_lines: list[str] = []
     for line in ls_stdout.split("\n"):
         try:
             node_dict = json.loads(line.strip())
         except json.decoder.JSONDecodeError:
             logger.debug("Skipped dbt ls line: %s", line)
+            if line.strip():
+                skipped_lines.append(line)
         else:
             if project_path is None:
                 continue
@@ -449,6 +474,13 @@ def parse_dbt_ls_output(project_path: Path | None, ls_stdout: str) -> dict[str, 
             else:
                 nodes[node.unique_id] = node
                 logger.debug("Parsed dbt resource `%s` of type `%s`", node.unique_id, node.resource_type)
+    if not nodes and skipped_lines:
+        logger.warning(
+            "dbt ls output had %d non-empty line(s) and none parsed as a JSON record, so no dbt nodes were "
+            "loaded. First skipped line: %s",
+            len(skipped_lines),
+            skipped_lines[0],
+        )
     return nodes
 
 

--- a/tests/dbt/test_graph.py
+++ b/tests/dbt/test_graph.py
@@ -36,6 +36,7 @@ from cosmos.dbt.graph import (
     _relative_dirs,
     parse_dbt_ls_output,
     run_command,
+    run_command_with_dbt_runner,
     run_command_with_subprocess,
 )
 from cosmos.dbt.selector import YamlSelectors
@@ -1977,6 +1978,40 @@ def test_run_command_forcing_dbt_runner(mock_dbt_runner, mock_subprocess, tmp_db
     assert mock_dbt_runner.called
 
 
+@patch("cosmos.dbt.graph.dbt_runner.run_command")
+def test_run_command_with_dbt_runner_raises_when_ls_result_is_not_json(mock_run_command):
+    # dbt-core 2.0 dbtRunner returns node names instead of the `--output json` records (#2992)
+    mock_run_command.return_value = MagicMock(success=True, result=["probe.a", "probe.b"], exception=None)
+
+    with pytest.raises(CosmosLoadDbtException) as err_info:
+        run_command_with_dbt_runner(["dbt", "ls", "--output", "json"], Path("/tmp/project"), {})
+
+    assert "2 entries that are not JSON records" in str(err_info.value)
+    assert "InvocationMode.SUBPROCESS" in str(err_info.value)
+
+
+@patch("cosmos.dbt.graph.dbt_runner.run_command")
+def test_run_command_with_dbt_runner_joins_json_records(mock_run_command):
+    as_object = MagicMock()
+    as_object.to_dict.return_value = {"unique_id": "model.probe.b"}
+    mock_run_command.return_value = MagicMock(
+        success=True, result=['{"unique_id": "model.probe.a"}', as_object], exception=None
+    )
+
+    stdout = run_command_with_dbt_runner(["dbt", "ls", "--output", "json"], Path("/tmp/project"), {})
+
+    assert stdout.split("\n") == ['{"unique_id": "model.probe.a"}', '{"unique_id": "model.probe.b"}']
+
+
+@patch("cosmos.dbt.graph.dbt_runner.run_command")
+def test_run_command_with_dbt_runner_only_checks_ls_results(mock_run_command):
+    mock_run_command.return_value = MagicMock(success=True, result=["Installing dbt-labs/dbt_utils"], exception=None)
+
+    stdout = run_command_with_dbt_runner(["dbt", "deps"], Path("/tmp/project"), {})
+
+    assert stdout == "Installing dbt-labs/dbt_utils"
+
+
 @pytest.mark.integration
 def test_run_command_with_dbt_runner_exception(tmp_dbt_project_dir):
     with pytest.raises(CosmosLoadDbtException) as err_info:
@@ -2132,6 +2167,23 @@ def test_parse_dbt_ls_output():
     nodes = parse_dbt_ls_output(Path("fake-project"), fake_ls_stdout)
 
     assert expected_nodes == nodes
+
+
+def test_parse_dbt_ls_output_warns_when_no_line_is_a_json_record(caplog):
+    with caplog.at_level(logging.WARNING):
+        nodes = parse_dbt_ls_output(Path("fake-project"), "probe.a\nprobe.b\n")
+
+    assert nodes == {}
+    assert "2 non-empty line(s) and none parsed as a JSON record" in caplog.text
+    assert "First skipped line: probe.a" in caplog.text
+
+
+def test_parse_dbt_ls_output_does_not_warn_on_empty_stdout(caplog):
+    with caplog.at_level(logging.WARNING):
+        nodes = parse_dbt_ls_output(Path("fake-project"), "\n")
+
+    assert nodes == {}
+    assert "none parsed as a JSON record" not in caplog.text
 
 
 def test_parse_dbt_ls_output_with_json_without_tags_or_config():


### PR DESCRIPTION
## Description

With dbt-core 2.0 installed in the Airflow environment, `RenderConfig(invocation_mode=InvocationMode.DBT_RUNNER, load_method=LoadMode.DBT_LS)` renders a Dag with **zero tasks and no error**. `run_command_with_dbt_runner` joins `response.result` into the stdout that `parse_dbt_ls_output` reads; dbt-core 1.x returns one JSON record per node for `dbt ls --output json`, dbt-core 2.0's `dbtRunner` returns bare node names (`['probe.a', 'probe.b']`), so every line fails `json.loads`, is skipped at debug level, and the graph comes out empty.

Changes:

- `run_command_with_dbt_runner`: when a successful `ls` result has no JSON record, raise `CosmosLoadDbtException` naming the entries and pointing at `InvocationMode.SUBPROCESS` (the path that works with that dbt). Non-`ls` commands (`deps`) are not checked.
- `parse_dbt_ls_output`: log a warning when a non-empty output produced no nodes, with the count and the first skipped line, for whichever invocation mode produced it. Per-line debug logging unchanged.
- Tests: three for the runner path (non-JSON `ls` result raises; JSON strings and `to_dict()` objects are joined as before; `deps` is not checked), two for the parser warning.

Behaviour on 1.x is unchanged: `dbt ls --output json` through `dbtRunner` returns JSON strings, so the new check never fires there.

## Related Issue(s)

closes #2992

## Breaking Change?

No. A configuration that previously rendered an empty Dag now fails at parse time with an actionable message.

## Checklist

- [x] I have made corresponding changes to the documentation (if required) — none required
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
