### PR TITLE
Support dbt Core 2.0 through InvocationMode.SUBPROCESS

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -592,6 +592,67 @@ jobs:
           RESOURCE_PREFIX: ${{ steps.set-resource-prefix.outputs.prefix }}
 
 
+  Run-Integration-dbt-core-2-Tests:
+    needs: [Authorize, Check-changed-files]
+    if: needs.Check-changed-files.outputs.code_changed == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    permissions:
+      contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12"]
+        airflow-version: ["2.10", "3.0"]
+        dbt-version: ["2.0"]  # dbt Core 2.0, the Rust engine; requires Python >= 3.11
+
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ github.event.pull_request.head.sha || github.ref }}
+          persist-credentials: false
+          # Safe under pull_request_target: this job runs only after the Authorize job's
+          # owner-review environment gate approves the run (see the Authorize job above).
+          allow-unsafe-pr-checkout: true
+
+      - uses: actions/cache@55cc8345863c7cc4c66a329aec7e433d2d1c52a9 # v6.1.0
+        with:
+          path: |
+            ~/.cache/pip
+            ~/.cache/uv
+          key: integration-dbt-core-2-${{ runner.os }}-${{ matrix.python-version }}-${{ matrix.airflow-version }}--${{ matrix.dbt-version }}${{ hashFiles('pyproject.toml') }}
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install packages and dependencies
+        run: |
+          python -m pip install uv
+          uv pip install --system "hatch>=1.14.2"
+          hatch -e tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }} run pip freeze
+
+      - name: Test Cosmos against Airflow ${{ matrix.airflow-version }}, Python ${{ matrix.python-version }} and dbt-core ${{ matrix.dbt-version }}
+        run: |
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-core-2-setup
+          hatch run tests.py${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}:test-integration-dbt-core-2
+        env:
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_LS: 0
+          AIRFLOW__COSMOS__ENABLE_CACHE_DBT_YAML_SELECTORS: 0
+          AIRFLOW__COSMOS__ENABLE_LAX_SELECTOR_PARSING: 0
+          AIRFLOW_HOME: /home/runner/work/astronomer-cosmos/astronomer-cosmos/
+          AIRFLOW__CORE__DAGBAG_IMPORT_TIMEOUT: 90.0
+          PYTHONPATH: /home/runner/work/astronomer-cosmos/astronomer-cosmos/:$PYTHONPATH
+
+      - name: Upload coverage to GitHub
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: coverage-integration-test-dbt-core-2-${{ matrix.python-version }}-${{ matrix.airflow-version }}-${{ matrix.dbt-version }}
+          path: .coverage
+          include-hidden-files: true
+
+
   Run-Kubernetes-Tests:
     needs: [Authorize, Check-changed-files]
     if: needs.Check-changed-files.outputs.code_changed == 'true'
@@ -671,6 +732,7 @@ jobs:
       - Run-Integration-Tests-Expensive
       - Run-Integration-Tests-DBT-Async
       - Run-Integration-dbt-fusion-Tests
+      - Run-Integration-dbt-core-2-Tests
       - Run-Kubernetes-Tests
     runs-on: ubuntu-latest
     permissions:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,7 +10,7 @@ An Apache Airflow provider library that orchestrates dbt projects as Airflow DAG
 
 ### Running Tests
 
-Unit tests (excluding integration/perf/dbtfusion):
+Unit tests (excluding integration/perf/dbtfusion/dbtcore2):
 ```bash
 hatch run tests.py3.11-2.10-1.9:test
 hatch run tests.py3.11-2.10-1.9:test-cov   # with coverage
@@ -227,4 +227,4 @@ Controlled by `TestBehavior` enum:
 - Python minimum: **3.10**
 - mypy: strict mode
 - Ruff rules: C901 (complexity), D300, I (imports), F (pyflakes); max complexity 10
-- pytest markers: `integration`, `perf`, `dbtfusion`
+- pytest markers: `integration`, `perf`, `dbtfusion`, `dbtcore2`

--- a/cosmos/dbt/runner.py
+++ b/cosmos/dbt/runner.py
@@ -25,14 +25,34 @@ if TYPE_CHECKING:  # pragma: no cover
     from dbt.cli.main import dbtRunner, dbtRunnerResult
 
 
+UNAVAILABLE_MESSAGE = (
+    "Could not import dbt core. Ensure that dbt-core >= v1.5 and < 2.0 is installed and available in the "
+    "environment where the operator is running, or set InvocationMode.SUBPROCESS, the only mode supported "
+    "with dbt-core 2.x."
+)
+
+
 @cache
 def is_available() -> bool:
     """
-    Checks if the dbt runner is available (if dbt-core is installed in the same Python virtualenv as Airflow)."
+    Checks if the dbt runner is available: dbt-core is installed in the same Python virtualenv as Airflow and
+    exposes the Python API Cosmos drives, ``dbt.cli.main.dbtRunner`` together with ``dbt.version``.
+
+    dbt-core 2.x ships ``dbtRunner`` without event callbacks or ``dbt.version`` and returns bare node names from
+    ``ls``; Cosmos runs it through ``InvocationMode.SUBPROCESS`` instead.
+    See https://github.com/astronomer/astronomer-cosmos/issues/2993
     """
     try:
         from dbt.cli.main import dbtRunner  # noqa
     except ImportError:
+        return False
+    try:
+        from dbt.version import __version__  # noqa
+    except ImportError:
+        logger.info(
+            "dbt is importable but does not expose the dbt-core 1.x Python API (dbt.version), as in dbt-core 2.x. "
+            "Cosmos will invoke dbt as a subprocess."
+        )
         return False
     return True
 

--- a/cosmos/operators/local.py
+++ b/cosmos/operators/local.py
@@ -493,9 +493,7 @@ class AbstractDbtLocalBase(AbstractDbtBase):
     def run_dbt_runner(self, command: list[str], env: dict[str, str], cwd: str, **kwargs: Any) -> dbtRunnerResult:
         """Invokes the dbt command programmatically."""
         if not dbt_runner.is_available():
-            raise CosmosDbtRunError(
-                "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
-            )
+            raise CosmosDbtRunError(dbt_runner.UNAVAILABLE_MESSAGE)
 
         return dbt_runner.run_command(command, env, cwd, callbacks=self._dbt_runner_callbacks, **kwargs)
 
@@ -552,6 +550,8 @@ class AbstractDbtLocalBase(AbstractDbtBase):
             self.profile_config.target_name,
         ]
         if self.invocation_mode == InvocationMode.DBT_RUNNER:
+            if not dbt_runner.is_available():
+                raise CosmosDbtRunError(dbt_runner.UNAVAILABLE_MESSAGE)
             from dbt.version import __version__ as dbt_version
 
             if Version(dbt_version) >= Version("1.5.6"):

--- a/docs/guides/dbt_setup/dbt-core-2.rst
+++ b/docs/guides/dbt_setup/dbt-core-2.rst
@@ -1,0 +1,68 @@
+.. _dbt_core_2:
+
+dbt Core 2.0 support
+====================
+
+.. versionadded:: 1.16
+
+`dbt Core 2.0 <https://github.com/dbt-labs/dbt-core>`_ is the Apache-2.0 release of the Rust engine that also powers :ref:`dbt Fusion <dbt_fusion>`.
+It is published on PyPI as ``dbt-core`` (also ``dbt-oss`` and, from 2.0.0 on, ``dbt``), requires Python 3.11 or later, and bundles its own adapters.
+
+Cosmos runs dbt Core 2.0 through the ``dbt`` binary, with ``InvocationMode.SUBPROCESS`` for rendering and execution.
+
+Why subprocess only
+~~~~~~~~~~~~~~~~~~~
+
+dbt Core 2.0 ships a Python ``dbt`` package, but not the dbt Core 1.x API that ``InvocationMode.DBT_RUNNER`` relies on:
+
+- ``dbt.version`` does not exist;
+- ``dbtRunner(callbacks=...)`` raises ``NotImplementedError``, so the event callbacks ``ExecutionMode.WATCHER`` uses in ``DBT_RUNNER`` mode are unavailable;
+- ``dbtRunner().invoke(["ls", "--output", "json"])`` returns node names instead of JSON records.
+
+Cosmos therefore treats dbt Core 2.0 as "no dbt runner available": ``InvocationMode`` auto-detection picks ``SUBPROCESS``, and an explicit ``InvocationMode.DBT_RUNNER`` fails with an error that points at ``SUBPROCESS``.
+
+Support
+~~~~~~~
+
+- :ref:`ExecutionMode.LOCAL <local-execution>` and :ref:`ExecutionMode.WATCHER <watcher-execution-mode>` with ``InvocationMode.SUBPROCESS``
+- ``LoadMode.DBT_LS`` with ``RenderConfig(invocation_mode=InvocationMode.SUBPROCESS)``
+- ``LoadMode.DBT_MANIFEST`` with a ``manifest.json`` written by dbt Core 2.0
+
+Not supported: ``InvocationMode.DBT_RUNNER`` and :ref:`ExecutionMode.AIRFLOW_ASYNC <async-execution-mode>`.
+
+How to use
+~~~~~~~~~~
+
+1. Install dbt Core 2.0 next to Airflow, or in its own virtualenv. Python 3.11 or later is required, and Postgres is an experimental adapter on the 2.0 engine (``DBT_ALLOW_EXPERIMENTAL_ADAPTERS=true``):
+
+   .. code-block:: bash
+
+       pip install "dbt-core>=2.0.0rc2,<3"
+
+2. Point ``RenderConfig`` and ``ExecutionConfig`` at the ``dbt`` binary and use ``InvocationMode.SUBPROCESS`` in both:
+
+   .. code-block:: python
+
+       from cosmos import DbtDag, ExecutionConfig, RenderConfig
+       from cosmos.constants import ExecutionMode, InvocationMode
+
+       DbtDag(
+           ...,
+           render_config=RenderConfig(
+               dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
+               invocation_mode=InvocationMode.SUBPROCESS,
+           ),
+           execution_config=ExecutionConfig(
+               execution_mode=ExecutionMode.WATCHER,
+               dbt_executable_path="/usr/local/airflow/dbt_venv/bin/dbt",
+               invocation_mode=InvocationMode.SUBPROCESS,
+           ),
+       )
+
+   ``RenderConfig.invocation_mode`` defaults to ``InvocationMode.DBT_RUNNER``; with dbt Core 2.0 installed in the same environment as Airflow, rendering falls back to a subprocess and logs that it did. Set ``SUBPROCESS`` explicitly to make the choice visible.
+
+Limitations
+~~~~~~~~~~~
+
+- dbt Core 2.0 is a release candidate at the time of writing (``2.0.0rc2``, September 2026); Cosmos tests against it in CI on duckdb.
+- The adapters are the ones bundled in the 2.0 engine; check `the dbt documentation <https://docs.getdbt.com/docs/supported-data-platforms>`_ for your platform.

--- a/docs/guides/index.rst
+++ b/docs/guides/index.rst
@@ -24,6 +24,7 @@ Make your dbt projects available to Airflow and install dbt into the environment
    :caption: Set up dbt with Airflow
 
    dbt_setup/dbt-fusion
+   dbt_setup/dbt-core-2
    dbt_setup/execution-modes-local-conflicts
 
 Connect to your dbt database

--- a/docs/policy/compatibility-policy.rst
+++ b/docs/policy/compatibility-policy.rst
@@ -48,7 +48,7 @@ dbt Core
 ++++++++
 
 - **Minimum required version**: dbt Core 1.8
-- **Supported versions**: 1.8, 1.9, 1.10, 1.11, 1.12, 2.0 (dbt Fusion)
+- **Supported versions**: 1.8, 1.9, 1.10, 1.11, 1.12, 2.0 (dbt Core, ``InvocationMode.SUBPROCESS`` only; see :ref:`dbt_core_2`), 2.0 (dbt Fusion)
 
 .. note::
 
@@ -84,6 +84,12 @@ into a plain Python image, then ``import dbt.cli.main`` — checked
      - OK
      - OK
      - OK
+   * - 2.0 (Core, ``2.0.0rc2``, checked 2026-09-10)
+     - fails
+     - OK
+     - OK
+     - OK
+     - not checked
    * - 2.0 (Fusion)
      - n/a
      - n/a
@@ -94,9 +100,12 @@ into a plain Python image, then ``import dbt.cli.main`` — checked
 - dbt Core 1.8–1.11 fail on Python 3.14 inside ``dbt_common``'s
   ``mashumaro`` dependency (e.g. ``mashumaro.exceptions.UnserializableField``),
   which hasn't caught up to Python 3.14's typing changes.
-- dbt Fusion (``2.0``) is **not** installed via ``pip install dbt-core==2.0``
-  — there is no such release on PyPI. Fusion ships as a separate
-  binary/installer; this table's pip-based check does not apply to it.
+- dbt Core 2.0 declares ``requires-python >= 3.11``, so the 3.10 install is
+  refused by pip. Its wheels are ``cp311-abi3``; 3.14 was not part of the
+  check.
+- dbt Fusion (``2.0``) is **not** installed via ``pip install dbt-core==2.0``;
+  Fusion ships as a separate binary/installer, and this table's pip-based
+  check does not apply to it.
 
 .. note::
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,8 @@ test-kubernetes = "sh scripts/test/integration-kubernetes.sh"
 test-kubernetes-setup = "sh scripts/test/kubernetes-setup.sh {matrix:dbt}"
 test-integration-dbtf-setup = 'sh scripts/test/integration-dbtf-setup.sh'
 test-integration-dbtf = 'sh scripts/test/integration-dbtf.sh'
+test-integration-dbt-core-2-setup = 'sh scripts/test/integration-dbtf-setup.sh'
+test-integration-dbt-core-2 = 'sh scripts/test/integration-dbt-core-2.sh'
 test-integration-dbt-1-8 = 'sh scripts/test/integration-dbt-1-8.sh'
 test-integration-dbt-async = 'sh scripts/test/integration-dbt-async.sh {matrix:dbt}'
 test-integration-dbt-loom = 'sh scripts/test/integration-dbt-loom.sh {matrix:dbt}'
@@ -212,7 +214,7 @@ type-check = "pre-commit run mypy --files cosmos/**/*"
 addopts = "--ignore-glob=**/dbt_packages/*"
 filterwarnings = ["ignore::DeprecationWarning"]
 minversion = "6.0"
-markers = ["integration", "perf", "dbtfusion"]
+markers = ["integration", "perf", "dbtfusion", "dbtcore2"]
 
 ######################################
 # DOCS

--- a/scripts/test/integration-dbt-core-2.sh
+++ b/scripts/test/integration-dbt-core-2.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+set -x
+set -e
+set -v
+
+pip freeze | grep airflow
+echo $AIRFLOW_HOME
+ls $AIRFLOW_HOME
+airflow db check
+rm -rf dbt/jaffle_shop/dbt_packages;
+
+# dbt-core 2.0 is the Rust engine; the wheel ships the `dbt` binary and a Python `dbt` package without the
+# 1.x API (no dbt.version, no dbtRunner callbacks), so Cosmos drives it through InvocationMode.SUBPROCESS.
+# Pinned to a release candidate until 2.0.0 is final; bump deliberately.
+uv pip install "dbt-core==2.0.0rc2"
+dbt --version
+
+pytest -vv \
+    tests/test_dbt_core_2.py \
+    --cov=cosmos \
+    --cov-report=term-missing \
+    --cov-report=xml \
+    --durations=0

--- a/scripts/test/integration-expensive.sh
+++ b/scripts/test/integration-expensive.sh
@@ -3,7 +3,7 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    -m 'integration and not dbtfusion' \
+    -m 'integration and not dbtfusion and not dbtcore2' \
     --ignore=tests/perf \
     --ignore=tests/test_example_k8s_dags.py \
     -k 'example_cosmos_python_models or example_virtualenv'

--- a/scripts/test/integration-kubernetes.sh
+++ b/scripts/test/integration-kubernetes.sh
@@ -18,6 +18,6 @@ pytest -vv \
     --cov=cosmos \
     --cov-report=term-missing \
     --cov-report=xml \
-    -m 'integration and not dbtfusion' \
+    -m 'integration and not dbtfusion and not dbtcore2' \
     tests/test_example_k8s_dags.py \
     tests/operators/test_watcher_kubernetes_integration.py

--- a/scripts/test/integration.sh
+++ b/scripts/test/integration.sh
@@ -27,7 +27,7 @@ pytest -vv \
     --durations=0 \
     --timeout=300 \
     --timeout-method=thread \
-    -m 'integration and not dbtfusion' \
+    -m 'integration and not dbtfusion and not dbtcore2' \
     --ignore=tests/perf \
     --ignore=tests/test_async_example_dag.py \
     --ignore=tests/test_example_k8s_dags.py \

--- a/scripts/test/unit.sh
+++ b/scripts/test/unit.sh
@@ -1,6 +1,6 @@
 pytest \
     -vv \
-    -m "not (integration or perf or dbtfusion)" \
+    -m "not (integration or perf or dbtfusion or dbtcore2)" \
     --ignore=tests/perf \
     --ignore=tests/test_example_dags.py \
     --ignore=tests/test_async_example_dag.py \

--- a/tests/dbt/test_runner.py
+++ b/tests/dbt/test_runner.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 import sys
@@ -59,6 +60,14 @@ def invalid_dbt_project_dir(valid_dbt_project_dir):
 @patch.dict(sys.modules, {"dbt.cli.main": None})
 def test_is_available_is_false():
     assert not dbt_runner.is_available()
+
+
+@patch.dict(sys.modules, {"dbt.cli.main": MagicMock(), "dbt.version": None})
+def test_is_available_is_false_without_dbt_version(caplog):
+    """dbt-core 2.x exposes dbtRunner but not dbt.version; Cosmos does not drive it in-process (#2993)."""
+    with caplog.at_level(logging.INFO):
+        assert not dbt_runner.is_available()
+    assert "Cosmos will invoke dbt as a subprocess" in caplog.text
 
 
 def test_cleanup_dbt_adapters_calls_reset_adapters_and_gc():

--- a/tests/operators/test_local.py
+++ b/tests/operators/test_local.py
@@ -375,10 +375,33 @@ def test_dbt_base_operator_run_dbt_runner_cannot_import():
         project_dir="my/dir",
         invocation_mode=InvocationMode.DBT_RUNNER,
     )
-    expected_error_message = "Could not import dbt core. Ensure that dbt-core >= v1.5 is installed and available in the environment where the operator is running."
+    expected_error_message = "Could not import dbt core. Ensure that dbt-core >= v1.5 and < 2.0 is installed"
     with patch.dict(sys.modules, {"dbt.cli.main": None}):
         with pytest.raises(CosmosDbtRunError, match=expected_error_message):
             dbt_base_operator.run_dbt_runner(command=["cmd"], env={}, cwd="some-project")
+
+
+def test_dbt_base_operator_discover_invocation_mode_without_dbt_version():
+    """dbt-core 2.x exposes dbtRunner but not dbt.version; discovery falls back to subprocess (#2993)."""
+    with patch.dict(sys.modules, {"dbt.cli.main": MagicMock(), "dbt.version": None}):
+        dbt_base_operator = ConcreteDbtLocalBaseOperator(
+            profile_config=profile_config, task_id="my-task", project_dir="my/dir"
+        )
+        dbt_base_operator._discover_invocation_mode()
+    assert dbt_base_operator.invocation_mode == InvocationMode.SUBPROCESS
+
+
+def test_generate_dbt_flags_raises_when_dbt_runner_is_unavailable(tmp_path):
+    """An explicit InvocationMode.DBT_RUNNER on dbt-core 2.x fails before importing dbt.version (#2993)."""
+    operator = ConcreteDbtLocalBaseOperator(
+        profile_config=profile_config,
+        task_id="test-task",
+        project_dir=tmp_path,
+        invocation_mode=InvocationMode.DBT_RUNNER,
+    )
+    with patch.dict(sys.modules, {"dbt.cli.main": MagicMock(), "dbt.version": None}):
+        with pytest.raises(CosmosDbtRunError, match="InvocationMode.SUBPROCESS"):
+            operator._generate_dbt_flags(str(tmp_path), tmp_path / "profiles.yml")
 
 
 @patch("cosmos.dbt.project.os.environ")

--- a/tests/test_dbt_core_2.py
+++ b/tests/test_dbt_core_2.py
@@ -1,0 +1,110 @@
+"""
+Run Cosmos against dbt-core 2.0 (the Rust engine) through ``InvocationMode.SUBPROCESS`` on duckdb.
+
+dbt-core 2.0 ships a Python ``dbt`` package without the 1.x API Cosmos drives in-process (no ``dbt.version``,
+no ``dbtRunner`` callbacks, ``ls`` results without JSON records), so both rendering and execution go through
+the ``dbt`` binary. See https://github.com/astronomer/astronomer-cosmos/issues/2993
+"""
+
+import os
+import shutil
+from datetime import datetime
+from pathlib import Path
+
+import pytest
+from airflow.utils.state import DagRunState
+
+from cosmos import DbtDag, ExecutionConfig, ProfileConfig, ProjectConfig, RenderConfig
+from cosmos.constants import ExecutionMode, InvocationMode
+
+DBT_PROJECT_PATH = Path(__file__).parent.parent / "dev/dags/dbt/jaffle_shop"
+
+project_config = ProjectConfig(dbt_project_path=DBT_PROJECT_PATH)
+
+
+def dbt_core_2_binary() -> str:
+    dbt_executable = shutil.which("dbt")
+    assert dbt_executable, "dbt-core 2.0 must be installed in the test environment"
+    return dbt_executable
+
+
+def duckdb_profile_config(tmp_path: Path) -> ProfileConfig:
+    # Every task runs dbt in its own copy of the project, so the duckdb file must live outside it.
+    profiles_yml = tmp_path / "profiles.yml"
+    profiles_yml.write_text(f"""duckdb_profile:
+  target: dev
+  outputs:
+    dev:
+      type: duckdb
+      path: {tmp_path / "jaffle_shop.duckdb"}
+      threads: 4
+""")
+    return ProfileConfig(profile_name="duckdb_profile", target_name="dev", profiles_yml_filepath=profiles_yml)
+
+
+@pytest.mark.parametrize(
+    "dag_id,execution_mode",
+    [
+        ("dbt_core_2_local_duckdb_dag", ExecutionMode.LOCAL),
+        ("dbt_core_2_watcher_duckdb_dag", ExecutionMode.WATCHER),
+    ],
+)
+@pytest.mark.integration
+@pytest.mark.dbtcore2
+def test_dbt_core_2(dag_id, execution_mode, tmp_path):
+    """
+    Run a DbtDag using dbt-core 2.0 with rendering and execution both in InvocationMode.SUBPROCESS.
+    Confirm it succeeds and has the expected amount of both:
+    - dbt resources
+    - Airflow tasks
+    And that the tasks are in the expected topological order.
+    """
+    dbt_executable_path = dbt_core_2_binary()
+
+    if os.getenv("CI"):
+        operator_args = {"trigger_rule": "all_success"}
+    else:
+        operator_args = {}
+
+    dbt_core_2_dag = DbtDag(
+        execution_config=ExecutionConfig(
+            execution_mode=execution_mode,
+            dbt_executable_path=dbt_executable_path,
+            invocation_mode=InvocationMode.SUBPROCESS,
+        ),
+        project_config=project_config,
+        profile_config=duckdb_profile_config(tmp_path),
+        render_config=RenderConfig(
+            dbt_executable_path=dbt_executable_path,
+            invocation_mode=InvocationMode.SUBPROCESS,
+        ),
+        start_date=datetime(2023, 1, 1),
+        dag_id=dag_id,
+        tags=["profiles"],
+        operator_args=operator_args,
+    )
+    outcome = dbt_core_2_dag.test()
+    assert outcome.state == DagRunState.SUCCESS
+
+    assert len(dbt_core_2_dag.dbt_graph.filtered_nodes) == 23
+
+    tasks_names = [task.task_id for task in dbt_core_2_dag.topological_sort()]
+    expected_task_names = [
+        "raw_customers_seed",
+        "raw_orders_seed",
+        "raw_payments_seed",
+        "stg_customers.run",
+        "stg_customers.test",
+        "stg_orders.run",
+        "stg_orders.test",
+        "stg_payments.run",
+        "stg_payments.test",
+        "customers.run",
+        "customers.test",
+        "orders.run",
+        "orders.test",
+    ]
+    if execution_mode == ExecutionMode.WATCHER:
+        expected_task_names.insert(0, "dbt_producer_watcher")
+
+    assert tasks_names == expected_task_names


### PR DESCRIPTION
## Description

dbt Core 2.0 (the Apache-2.0 Rust engine, `2.0.0rc2` on PyPI as `dbt-core` / `dbt-oss`; `pip install dbt` resolves to it from 2026-09-14) ships a Python `dbt` package that is not the 1.x API Cosmos drives in-process: `dbt.version` is gone, `dbtRunner(callbacks=...)` raises `NotImplementedError`, and `dbtRunner().invoke(["ls", "--output", "json"])` returns node names instead of JSON records. Today `dbt_runner.is_available()` only checks that `dbt.cli.main.dbtRunner` imports, so with dbt Core 2.0 installed next to Airflow the default configuration picks `InvocationMode.DBT_RUNNER` and every task fails with `ModuleNotFoundError: No module named 'dbt.version'` (`cosmos/operators/local.py`, `_generate_dbt_flags`). Both `ExecutionMode.LOCAL` and `ExecutionMode.WATCHER` already work when rendering and execution are forced to `InvocationMode.SUBPROCESS`.

Changes:

- `cosmos/dbt/runner.py`: `is_available()` now also requires `dbt.version`, the marker of the 1.x Python API. dbt Core 2.0 therefore counts as "no runner": `_discover_invocation_mode()` falls back to `SUBPROCESS` (with an info log saying why) and `DbtGraph.run_command` does the same for rendering. The unavailable-runner message lives in one place (`UNAVAILABLE_MESSAGE`) and names `InvocationMode.SUBPROCESS` as the mode for dbt-core 2.x.
- `cosmos/operators/local.py`: an explicit `InvocationMode.DBT_RUNNER` now fails in `_generate_dbt_flags` with that message, before the `dbt.version` import, instead of with the bare `ModuleNotFoundError`.
- CI: `Run-Integration-dbt-core-2-Tests`, a copy of the dbt Fusion job on duckdb (Python 3.11 / 3.12, Airflow 2.10 / 3.0, no warehouse secrets), running `tests/test_dbt_core_2.py`: the jaffle_shop project in `ExecutionMode.LOCAL` and `ExecutionMode.WATCHER`, rendering and executing through `SUBPROCESS`, same 23 nodes and task order as `tests/test_dbtf.py`. New `dbtcore2` marker, excluded from the unit and other integration scripts like `dbtfusion`. `dbt-core` is pinned to `2.0.0rc2` in `scripts/test/integration-dbt-core-2.sh`, to be bumped deliberately.
- The duckdb `profiles.yml` is written by the test into `tmp_path`, with an absolute database path, so every task's copy of the project reaches the same file and the jaffle_shop fixture (whose folder hash other tests pin) is untouched.
- Docs: `docs/guides/dbt_setup/dbt-core-2.rst` (what is supported, why subprocess only, how to configure), linked from the guides index; `compatibility-policy.rst` lists dbt Core 2.0 with its Python row (`requires-python >= 3.11`, checked on 3.11 / 3.12 / 3.13) and corrects the note that said no `dbt-core==2.0` exists on PyPI.
- Tests: `is_available()` is false when `dbt.cli.main` imports but `dbt.version` does not; discovery falls back to `SUBPROCESS` in that case; `_generate_dbt_flags` raises the new message on an explicit `DBT_RUNNER`.

Not in this PR, left to the maintainers as decided in #2993: putting dbt Core 2.0 into the regular hatch/CI matrix. The `"2.0"` label there currently means dbt Fusion (`pre-install-airflow.sh`, `tests.py*-2.0` envs), the Postgres-based integration suite cannot run on the 2.0 engine (Postgres is an experimental adapter there), and `dbt-core<2.0` pins in `dev/Dockerfile.*` and `require-dbt-version` in the dev projects exclude it. The dedicated job avoids all three while giving 2.0 coverage. `DBT_RUNNER` on 2.x can be revisited once upstream ships callbacks and JSON `ls` results through the Python API.

Related: #2860 (the alpha had no Python package at all), #2992 / #2997 (empty Dag with `DBT_RUNNER` rendering).

## Related Issue(s)

closes #2993

## Breaking Change?

No. On dbt-core 1.x nothing changes: `dbt.version` exists, so `is_available()` keeps returning true. On dbt-core 2.x the default configuration goes from every task failing to running through a subprocess; an explicit `InvocationMode.DBT_RUNNER` fails with an actionable message instead of an import error.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
