### PR TITLE
Add ExecutionMode.WATCHER_AWS_ECS

### DIFF
--- a/cosmos/airflow/graph.py
+++ b/cosmos/airflow/graph.py
@@ -212,6 +212,7 @@ _WATCHER_TO_FALLBACK_EXECUTION_MODE = {
     ExecutionMode.WATCHER: ExecutionMode.LOCAL,
     ExecutionMode.WATCHER_KUBERNETES: ExecutionMode.KUBERNETES,
     ExecutionMode.WATCHER_GCP_GKE: ExecutionMode.GCP_GKE,
+    ExecutionMode.WATCHER_AWS_ECS: ExecutionMode.AWS_ECS,
 }
 
 
@@ -1243,7 +1244,7 @@ def build_airflow_graph(
     if execution_mode == ExecutionMode.AIRFLOW_ASYNC:
         # This property is only relevant for the setup task, not the other tasks:
         virtualenv_dir = task_args.pop("virtualenv_dir", None)
-    elif execution_mode in (ExecutionMode.WATCHER, ExecutionMode.WATCHER_KUBERNETES, ExecutionMode.WATCHER_GCP_GKE):
+    elif execution_mode in _WATCHER_TO_FALLBACK_EXECUTION_MODE:
         setup_operator_args = getattr(execution_config, "setup_operator_args", None) or {}
         # We are intentionally creating the producer task ahead of the consumer tasks
         # Airflow priority weight is not being respected in multiple versions of the library, including 3.1

--- a/cosmos/constants.py
+++ b/cosmos/constants.py
@@ -125,6 +125,7 @@ class ExecutionMode(Enum):
     GCP_GKE = "gcp_gke"
     WATCHER_GCP_GKE = "watcher_gcp_gke"
     WATCHER_KUBERNETES = "watcher_kubernetes"
+    WATCHER_AWS_ECS = "watcher_aws_ecs"
 
 
 class InvocationMode(Enum):
@@ -236,5 +237,8 @@ TELEMETRY_TIMEOUT = 1.0
 _AIRFLOW3_MAJOR_VERSION = 3
 
 _K8s_WATCHER_MIN_K8S_PROVIDER_VERSION = Version("10.8.0")
+# First release with `AwsTaskLogFetcher._get_log_events(skip_token)` and the `_wait_for_task_ended` /
+# `_after_execution` seams of `EcsRunTaskOperator` that the ECS watcher producer overrides.
+_ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION = Version("8.3.0")
 _DBT_STARTUP_EVENTS_XCOM_KEY = "dbt_startup_events"
 _PRODUCER_CMD_FLAGS_XCOM_KEY = "producer_cmd_flags"

--- a/cosmos/operators/_k8s_common.py
+++ b/cosmos/operators/_k8s_common.py
@@ -15,7 +15,6 @@ from os import PathLike
 from typing import TYPE_CHECKING, Any, Protocol
 
 import kubernetes.client as k8s
-from airflow.exceptions import AirflowException
 from airflow.providers.cncf.kubernetes.backcompat.backwards_compat_converters import convert_env_vars
 from airflow.providers.cncf.kubernetes.callbacks import client_type
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
@@ -26,16 +25,7 @@ except ImportError:
     from airflow.utils.context import context_merge
 
 from cosmos.airflow._override import CosmosKubernetesPodManager
-from cosmos.airflow.compatibility import AirflowSkipException
 from cosmos.config import ProfileConfig
-from cosmos.constants import _PRODUCER_CMD_FLAGS_XCOM_KEY, PRODUCER_WATCHER_TASK_ID
-from cosmos.operators._watcher import safe_xcom_push
-from cosmos.operators._watcher.xcom import (
-    _compose_backup_callback,
-    _delete_xcom_backup_variable,
-    _init_xcom_backup,
-    _restore_xcom_from_variable,
-)
 
 if TYPE_CHECKING:  # pragma: no cover
     from pendulum import DateTime
@@ -376,19 +366,34 @@ def setup_warning_handler(
     return handler
 
 
-# Contract keys between operator and callback.
-CONTEXT_HOLDER_KEY = "context_holder"
-CONTEXT_KEY = "context"
+# Container-agnostic producer helpers live in ``cosmos.operators._watcher.producer``; they are
+# re-exported here for the K8s and GKE watcher modules and their tests.
+from cosmos.operators._watcher.producer import (  # noqa: E402  # noqa: E402, F401  # re-exported for the watcher unit tests
+    CONTEXT_HOLDER_KEY,
+    CONTEXT_KEY,
+    _populate_producer_model_outlet_uris,  # noqa: E402, F401
+    compose_watcher_backup_callbacks,
+    execute_watcher_producer,
+    finalize_watcher_producer,
+)
+from cosmos.operators._watcher.producer import init_watcher_producer as _init_watcher_producer  # noqa: E402
 
-
-# The K8s-based watcher producers (``DbtProducerWatcherKubernetesOperator``,
-# ``DbtProducerWatcherGcpGkeOperator``) share their per-execution state and the helpers below that
-# read/write it. ``init_watcher_producer`` seeds that state; the operator carries the following
-# contract (typed ``Any`` in the helpers, mirroring ``compose_watcher_backup_callbacks``, because
-# the state is populated dynamically rather than declared on the concrete operator classes):
-#   _tests_per_model, _test_results_per_model, _context_holder, _upstream_failure_skipped_ids,
-#   _should_generate_model_uris, _dataset_namespace, _model_outlet_uris, manifest_filepath,
-#   dbt_cmd_flags, profile_config, client, callbacks, log.
+__all__ = [
+    "CONTEXT_HOLDER_KEY",
+    "CONTEXT_KEY",
+    "DbtTestWarningHandler",
+    "WatcherK8sCallback",
+    "build_and_run_cmd",
+    "build_kube_args",
+    "build_watcher_pod_manager",
+    "compose_watcher_backup_callbacks",
+    "execute_watcher_producer",
+    "finalize_watcher_producer",
+    "init_k8s_operator",
+    "init_watcher_producer",
+    "inject_watcher_callback",
+    "setup_warning_handler",
+]
 
 
 class WatcherK8sCallback(KubernetesPodOperatorCallback):  # type: ignore[misc]
@@ -468,69 +473,15 @@ def inject_watcher_callback(kwargs: dict[str, Any]) -> None:
 
 
 def init_watcher_producer(operator: Any, kwargs: dict[str, Any]) -> str:
-    """Shared pre-``super().__init__`` setup for K8s-based watcher producers.
+    """K8s flavour of :func:`cosmos.operators._watcher.producer.init_watcher_producer`.
 
-    Seeds the per-execution state that ``build_watcher_pod_manager`` / ``execute_watcher_producer``
-    rely on, injects the log-parsing callback, and returns the resolved ``task_id`` for the caller
-    to forward to ``super().__init__``. Shared by ``DbtProducerWatcherKubernetesOperator`` and
-    ``DbtProducerWatcherGcpGkeOperator``.
-
-    :param operator: the producer instance being initialised.
-    :param kwargs: the operator's ``__init__`` kwargs; watcher-only keys are popped in place.
-    :returns: the resolved ``task_id``.
+    Seeds the shared producer state and appends ``WatcherK8sCallback`` to the pod callbacks, so the
+    pod manager parses dbt's JSON log lines as they stream. Shared by
+    ``DbtProducerWatcherKubernetesOperator`` and ``DbtProducerWatcherGcpGkeOperator``.
     """
-    task_id: str = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
-    operator._tests_per_model = kwargs.pop("tests_per_model", {})
-    operator._test_results_per_model = {}
-    # Whether the producer should compute per-model outlet URIs. The producer never emits datasets
-    # itself (the consumer sensors do), but it must build the URI map so each consumer can. Wired as
-    # an explicit flag by _add_watcher_producer_task.
-    operator._should_generate_model_uris = kwargs.pop("_should_generate_model_uris", kwargs.get("emit_datasets", True))
-    # manifest_filepath is threaded through task_args by cosmos.converter (from
-    # ProjectConfig.manifest_path). The pod's own target/manifest.json lives inside the container and
-    # is not reachable from the scheduler, so this scheduler-side manifest is the only practical
-    # source for the outlet URI map. Popped here because the K8s base operator (unlike the local one)
-    # doesn't accept it.
-    operator.manifest_filepath = kwargs.pop("manifest_filepath", "") or ""
-    # Mutable per-execution state shared by reference with the log-parsing callback via the pod
-    # manager's callback_extra_kwargs. execute() resolves the namespace and fills the URI map in
-    # place (never reassigns), so a pod_manager created earlier still observes the populated map.
-    operator._dataset_namespace = None
-    operator._model_outlet_uris = {}
-    # Mutable holder shared by reference with pod_manager's callback_extra_kwargs. execute() sets its
-    # "context" entry (the holder itself is never reassigned), so a pod_manager created before
-    # execute() still sees the live context.
-    operator._context_holder = {CONTEXT_KEY: None}
+    task_id = _init_watcher_producer(operator, kwargs)
     inject_watcher_callback(kwargs)
     return task_id
-
-
-def finalize_watcher_producer(operator: Any) -> None:
-    """Shared post-``super().__init__`` setup for K8s-based watcher producers.
-
-    Forces the dbt JSON log format the parser depends on, wires the XCom-backup flush onto the
-    producer's retry/failure callbacks, and seeds the upstream-failure tracking set. Must run after
-    ``super().__init__`` so ``compose_watcher_backup_callbacks`` can preserve a DAG-level
-    ``default_args`` callback (#2776).
-    """
-    operator.dbt_cmd_flags += ["--log-format", "json"]
-    compose_watcher_backup_callbacks(operator)
-    # Populated by the log parser when dbt emits SkippingDetails or LogSkipBecauseError for a node;
-    # subsequent "skipped" terminal events for those unique_ids are rewritten to "failed" so the
-    # consumer sensor fails on attempt 1 (instead of SKIPPED, which Airflow will not retry).
-    # Mirrors DbtProducerWatcherOperator._upstream_failure_skipped_ids; see #2698.
-    operator._upstream_failure_skipped_ids = set()
-
-
-def compose_watcher_backup_callbacks(operator: Any) -> None:
-    """Append the XCom backup flush to the producer's retry/failure callbacks.
-
-    A graceful failure with retries left is UP_FOR_RETRY (on_retry_callback), not
-    FAILED, so register on both. Must be called after ``super().__init__`` to preserve
-    a DAG-level ``default_args`` callback (#2776).
-    """
-    operator.on_retry_callback = _compose_backup_callback(getattr(operator, "on_retry_callback", None))
-    operator.on_failure_callback = _compose_backup_callback(getattr(operator, "on_failure_callback", None))
 
 
 def build_watcher_pod_manager(operator: Any) -> CosmosKubernetesPodManager:
@@ -554,93 +505,3 @@ def build_watcher_pod_manager(operator: Any) -> CosmosKubernetesPodManager:
             "should_generate_model_uris": operator._should_generate_model_uris,
         },
     )
-
-
-def _populate_producer_model_outlet_uris(operator: Any) -> None:
-    """Resolve the dataset namespace and fill ``operator._model_outlet_uris`` from the manifest.
-
-    Mirrors the SUBPROCESS producer, but reads ``ProjectConfig.manifest_path`` (threaded as
-    ``manifest_filepath``) instead of ``{project_dir}/target/manifest.json``: in K8s the pod's
-    manifest isn't reachable from the scheduler. The map is mutated in place (never reassigned)
-    so the reference held by the pod manager's ``callback_extra_kwargs`` stays valid.
-
-    Degrades to a no-op -- dbt still runs and statuses are still reported, but no datasets are
-    emitted -- when generation is disabled, no ``ProfileConfig`` is set, no namespace resolves,
-    or the manifest is unavailable.
-    """
-    operator._model_outlet_uris.clear()
-    operator._dataset_namespace = None
-    if not operator._should_generate_model_uris:
-        return
-    # get_dataset_namespace requires a ProfileConfig; some constructions (e.g. inline profiles
-    # via profiles_yml_filepath only) don't supply one, so dataset emission degrades to a no-op.
-    if operator.profile_config is None:
-        return
-
-    from cosmos.dataset import compute_model_outlet_uris, get_dataset_namespace
-
-    operator._dataset_namespace = get_dataset_namespace(operator.profile_config)
-    if not operator._dataset_namespace:
-        return
-    if not operator.manifest_filepath:
-        operator.log.warning(
-            "manifest_filepath not supplied to %s; per-model dataset emission is disabled for this run. "
-            "Pass ProjectConfig.manifest_path to enable it.",
-            type(operator).__name__,
-        )
-        return
-    # manifest_filepath is ProjectConfig.manifest_path, an Airflow ObjectStoragePath that may point
-    # at a remote manifest (s3://, gs://, ...). Pass it through unchanged -- wrapping it in Path()
-    # would mangle remote URIs (e.g. "s3://b/m.json" -> "s3:/b/m.json"). compute_model_outlet_uris
-    # reads it via ObjectStoragePath.open() and returns {} (logging) if it's missing or unreadable,
-    # so no local existence check is needed here.
-    operator._model_outlet_uris.update(
-        compute_model_outlet_uris(operator.manifest_filepath, operator._dataset_namespace)
-    )
-
-
-def execute_watcher_producer(operator: Any, context: Context, parent_execute: Callable[..., Any], **kwargs: Any) -> Any:
-    """Shared ``execute`` logic for K8s watcher producer operators.
-
-    On retry, restores any XCom backup and raises ``AirflowSkipException`` (the
-    producer does not support Airflow retries). On the first attempt, initialises
-    an XCom backup, exposes the execution context to the log-parsing callback, runs
-    the parent execute, and deletes the backup on success. On failure the producer's
-    on-failure/on-retry callback (see ``compose_watcher_backup_callbacks``) flushes
-    the backup so the next try can restore it.
-    """
-    task_instance = context.get("ti")
-    if task_instance is None:
-        raise AirflowException(f"{type(operator).__name__} expects a task instance in the execution context")
-
-    try_number = getattr(task_instance, "try_number", 1)
-
-    from cosmos import settings
-
-    reliable_retry = settings.enable_watcher_reliable_retry
-
-    if try_number > 1:
-        _restore_xcom_from_variable(context)
-        raise AirflowSkipException(
-            f"{type(operator).__name__} does not support Airflow retries. "
-            f"Detected attempt #{try_number}; skipping execution to avoid running a second dbt build."
-        )
-
-    _init_xcom_backup(context, persist=reliable_retry)
-
-    # Resolve the namespace and build the per-model outlet URI map before the pod runs, so the
-    # log-parsing callback can attach outlet URIs to each model's status XCom for the consumers.
-    _populate_producer_model_outlet_uris(operator)
-    operator._upstream_failure_skipped_ids.clear()
-    # Publish the context through the mutable holder shared by reference with the pod
-    # manager's callback_extra_kwargs, so the log-parsing callback sees the live context
-    # even if the pod manager (a cached_property) was created before this runs.
-    operator._context_holder[CONTEXT_KEY] = context
-
-    safe_xcom_push(task_instance=task_instance, key=_PRODUCER_CMD_FLAGS_XCOM_KEY, value=operator.add_cmd_flags())
-
-    # On failure parent_execute() raises and the on-failure callback flushes the backup.
-    return_value = parent_execute(context, **kwargs)
-    if reliable_retry:
-        _delete_xcom_backup_variable(context)
-    return return_value

--- a/cosmos/operators/_watcher/producer.py
+++ b/cosmos/operators/_watcher/producer.py
@@ -1,0 +1,201 @@
+"""Container-agnostic helpers shared by the watcher producer operators.
+
+The watcher producer runs one ``dbt build`` and publishes per-node statuses parsed from dbt's JSON
+log lines. How those lines are obtained depends on where the container runs (pod log stream, log
+service polling, ...) and lives with each flavour; the state the parser needs, the retry semantics
+and the XCom backup handling do not, and live here so a flavour can be added without importing
+another flavour's client libraries.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from typing import TYPE_CHECKING, Any
+
+from airflow.exceptions import AirflowException
+
+from cosmos.airflow.compatibility import AirflowSkipException
+from cosmos.constants import _PRODUCER_CMD_FLAGS_XCOM_KEY, PRODUCER_WATCHER_TASK_ID
+from cosmos.operators._watcher import safe_xcom_push
+from cosmos.operators._watcher.xcom import (
+    _compose_backup_callback,
+    _delete_xcom_backup_variable,
+    _init_xcom_backup,
+    _restore_xcom_from_variable,
+)
+
+if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context  # type: ignore[attr-defined]
+
+
+# Contract keys between operator and callback.
+CONTEXT_HOLDER_KEY = "context_holder"
+CONTEXT_KEY = "context"
+
+
+# The container-based watcher producers (``DbtProducerWatcherKubernetesOperator``,
+# ``DbtProducerWatcherGcpGkeOperator``) share their per-execution state and the helpers below that
+# read/write it. ``init_watcher_producer`` seeds that state; the operator carries the following
+# contract (typed ``Any`` in the helpers, mirroring ``compose_watcher_backup_callbacks``, because
+# the state is populated dynamically rather than declared on the concrete operator classes):
+#   _tests_per_model, _test_results_per_model, _context_holder, _upstream_failure_skipped_ids,
+#   _should_generate_model_uris, _dataset_namespace, _model_outlet_uris, manifest_filepath,
+#   dbt_cmd_flags, profile_config, log.
+
+
+def init_watcher_producer(operator: Any, kwargs: dict[str, Any]) -> str:
+    """Shared pre-``super().__init__`` setup for container-based watcher producers.
+
+    Seeds the per-execution state that ``execute_watcher_producer`` and the log-parsing hook of each
+    container flavour rely on, and returns the resolved ``task_id`` for the caller to forward to
+    ``super().__init__``. The Kubernetes flavours add their pod-log callback on top
+    (``cosmos.operators._k8s_common.init_watcher_producer``).
+
+    :param operator: the producer instance being initialised.
+    :param kwargs: the operator's ``__init__`` kwargs; watcher-only keys are popped in place.
+    :returns: the resolved ``task_id``.
+    """
+    task_id: str = kwargs.pop("task_id", PRODUCER_WATCHER_TASK_ID)
+    operator._tests_per_model = kwargs.pop("tests_per_model", {})
+    operator._test_results_per_model = {}
+    # Whether the producer should compute per-model outlet URIs. The producer never emits datasets
+    # itself (the consumer sensors do), but it must build the URI map so each consumer can. Wired as
+    # an explicit flag by _add_watcher_producer_task.
+    operator._should_generate_model_uris = kwargs.pop("_should_generate_model_uris", kwargs.get("emit_datasets", True))
+    # manifest_filepath is threaded through task_args by cosmos.converter (from
+    # ProjectConfig.manifest_path). The pod's own target/manifest.json lives inside the container and
+    # is not reachable from the scheduler, so this scheduler-side manifest is the only practical
+    # source for the outlet URI map. Popped here because the K8s base operator (unlike the local one)
+    # doesn't accept it.
+    operator.manifest_filepath = kwargs.pop("manifest_filepath", "") or ""
+    # Mutable per-execution state shared by reference with the log-parsing callback via the pod
+    # manager's callback_extra_kwargs. execute() resolves the namespace and fills the URI map in
+    # place (never reassigns), so a pod_manager created earlier still observes the populated map.
+    operator._dataset_namespace = None
+    operator._model_outlet_uris = {}
+    # Mutable holder shared by reference with pod_manager's callback_extra_kwargs. execute() sets its
+    # "context" entry (the holder itself is never reassigned), so a pod_manager created before
+    # execute() still sees the live context.
+    operator._context_holder = {CONTEXT_KEY: None}
+    return task_id
+
+
+def finalize_watcher_producer(operator: Any) -> None:
+    """Shared post-``super().__init__`` setup for container-based watcher producers.
+
+    Forces the dbt JSON log format the parser depends on, wires the XCom-backup flush onto the
+    producer's retry/failure callbacks, and seeds the upstream-failure tracking set. Must run after
+    ``super().__init__`` so ``compose_watcher_backup_callbacks`` can preserve a DAG-level
+    ``default_args`` callback (#2776).
+    """
+    operator.dbt_cmd_flags += ["--log-format", "json"]
+    compose_watcher_backup_callbacks(operator)
+    # Populated by the log parser when dbt emits SkippingDetails or LogSkipBecauseError for a node;
+    # subsequent "skipped" terminal events for those unique_ids are rewritten to "failed" so the
+    # consumer sensor fails on attempt 1 (instead of SKIPPED, which Airflow will not retry).
+    # Mirrors DbtProducerWatcherOperator._upstream_failure_skipped_ids; see #2698.
+    operator._upstream_failure_skipped_ids = set()
+
+
+def compose_watcher_backup_callbacks(operator: Any) -> None:
+    """Append the XCom backup flush to the producer's retry/failure callbacks.
+
+    A graceful failure with retries left is UP_FOR_RETRY (on_retry_callback), not
+    FAILED, so register on both. Must be called after ``super().__init__`` to preserve
+    a DAG-level ``default_args`` callback (#2776).
+    """
+    operator.on_retry_callback = _compose_backup_callback(getattr(operator, "on_retry_callback", None))
+    operator.on_failure_callback = _compose_backup_callback(getattr(operator, "on_failure_callback", None))
+
+
+def _populate_producer_model_outlet_uris(operator: Any) -> None:
+    """Resolve the dataset namespace and fill ``operator._model_outlet_uris`` from the manifest.
+
+    Mirrors the SUBPROCESS producer, but reads ``ProjectConfig.manifest_path`` (threaded as
+    ``manifest_filepath``) instead of ``{project_dir}/target/manifest.json``: in K8s the pod's
+    manifest isn't reachable from the scheduler. The map is mutated in place (never reassigned)
+    so the reference held by the pod manager's ``callback_extra_kwargs`` stays valid.
+
+    Degrades to a no-op -- dbt still runs and statuses are still reported, but no datasets are
+    emitted -- when generation is disabled, no ``ProfileConfig`` is set, no namespace resolves,
+    or the manifest is unavailable.
+    """
+    operator._model_outlet_uris.clear()
+    operator._dataset_namespace = None
+    if not operator._should_generate_model_uris:
+        return
+    # get_dataset_namespace requires a ProfileConfig; some constructions (e.g. inline profiles
+    # via profiles_yml_filepath only) don't supply one, so dataset emission degrades to a no-op.
+    if operator.profile_config is None:
+        return
+
+    from cosmos.dataset import compute_model_outlet_uris, get_dataset_namespace
+
+    operator._dataset_namespace = get_dataset_namespace(operator.profile_config)
+    if not operator._dataset_namespace:
+        return
+    if not operator.manifest_filepath:
+        operator.log.warning(
+            "manifest_filepath not supplied to %s; per-model dataset emission is disabled for this run. "
+            "Pass ProjectConfig.manifest_path to enable it.",
+            type(operator).__name__,
+        )
+        return
+    # manifest_filepath is ProjectConfig.manifest_path, an Airflow ObjectStoragePath that may point
+    # at a remote manifest (s3://, gs://, ...). Pass it through unchanged -- wrapping it in Path()
+    # would mangle remote URIs (e.g. "s3://b/m.json" -> "s3:/b/m.json"). compute_model_outlet_uris
+    # reads it via ObjectStoragePath.open() and returns {} (logging) if it's missing or unreadable,
+    # so no local existence check is needed here.
+    operator._model_outlet_uris.update(
+        compute_model_outlet_uris(operator.manifest_filepath, operator._dataset_namespace)
+    )
+
+
+def execute_watcher_producer(operator: Any, context: Context, parent_execute: Callable[..., Any], **kwargs: Any) -> Any:
+    """Shared ``execute`` logic for container-based watcher producer operators.
+
+    On retry, restores any XCom backup and raises ``AirflowSkipException`` (the
+    producer does not support Airflow retries). On the first attempt, initialises
+    an XCom backup, exposes the execution context to the log-parsing callback, runs
+    the parent execute, and deletes the backup on success. On failure the producer's
+    on-failure/on-retry callback (see ``compose_watcher_backup_callbacks``) flushes
+    the backup so the next try can restore it.
+    """
+    task_instance = context.get("ti")
+    if task_instance is None:
+        raise AirflowException(f"{type(operator).__name__} expects a task instance in the execution context")
+
+    try_number = getattr(task_instance, "try_number", 1)
+
+    from cosmos import settings
+
+    reliable_retry = settings.enable_watcher_reliable_retry
+
+    if try_number > 1:
+        _restore_xcom_from_variable(context)
+        raise AirflowSkipException(
+            f"{type(operator).__name__} does not support Airflow retries. "
+            f"Detected attempt #{try_number}; skipping execution to avoid running a second dbt build."
+        )
+
+    _init_xcom_backup(context, persist=reliable_retry)
+
+    # Resolve the namespace and build the per-model outlet URI map before the pod runs, so the
+    # log-parsing callback can attach outlet URIs to each model's status XCom for the consumers.
+    _populate_producer_model_outlet_uris(operator)
+    operator._upstream_failure_skipped_ids.clear()
+    # Publish the context through the mutable holder shared by reference with the pod
+    # manager's callback_extra_kwargs, so the log-parsing callback sees the live context
+    # even if the pod manager (a cached_property) was created before this runs.
+    operator._context_holder[CONTEXT_KEY] = context
+
+    safe_xcom_push(task_instance=task_instance, key=_PRODUCER_CMD_FLAGS_XCOM_KEY, value=operator.add_cmd_flags())
+
+    # On failure parent_execute() raises and the on-failure callback flushes the backup.
+    return_value = parent_execute(context, **kwargs)
+    if reliable_retry:
+        _delete_xcom_backup_variable(context)
+    return return_value

--- a/cosmos/operators/watcher_aws_ecs.py
+++ b/cosmos/operators/watcher_aws_ecs.py
@@ -1,0 +1,321 @@
+"""``ExecutionMode.WATCHER_AWS_ECS``: the watcher producer runs ``dbt build`` in an ECS task.
+
+The producer starts the task through ``EcsRunTaskOperator`` and reads dbt's JSON log lines from the
+task's CloudWatch stream while it runs, pushing one status XCom per node as the consumer sensors
+expect. The provider's log-fetcher thread only collects the CloudWatch events into a queue; parsing
+and XCom pushes happen on the operator's own thread, as they do for the Kubernetes producer.
+"""
+
+from __future__ import annotations
+
+import json
+import queue
+import time
+from datetime import timedelta
+from typing import TYPE_CHECKING, Any
+
+from airflow.exceptions import AirflowException
+from packaging.version import Version
+
+from cosmos.constants import _ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION
+from cosmos.dbt.graph import DbtNode
+from cosmos.exceptions import CosmosValueError
+from cosmos.log import get_logger
+from cosmos.operators._watcher.base import BaseConsumerSensor, store_dbt_resource_status_from_log
+from cosmos.operators._watcher.producer import (
+    CONTEXT_KEY,
+    execute_watcher_producer,
+    finalize_watcher_producer,
+    init_watcher_producer,
+)
+from cosmos.operators.aws_ecs import (
+    DbtBuildAwsEcsOperator,
+    DbtRunAwsEcsOperator,
+    DbtSourceAwsEcsOperator,
+)
+from cosmos.operators.base import DbtRunMixin, DbtSeedMixin, DbtSnapshotMixin
+
+if TYPE_CHECKING:  # pragma: no cover
+    try:
+        from airflow.sdk.definitions.context import Context
+    except ImportError:
+        from airflow.utils.context import Context  # type: ignore[attr-defined]
+
+try:
+    from airflow.providers.amazon import __version__ as amazon_provider_version
+    from airflow.providers.amazon.aws.hooks.logs import AwsLogsHook
+    from airflow.providers.amazon.aws.utils.task_log_fetcher import AwsTaskLogFetcher
+except ImportError:  # pragma: no cover
+    raise ImportError(
+        "Could not import the Amazon provider log fetcher. Ensure you've installed the Amazon Web Services "
+        "provider separately or with `pip install astronomer-cosmos[...,aws-ecs]`."
+    )
+
+if Version(amazon_provider_version) < _ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION:  # pragma: no cover
+    raise ImportError(
+        f"ExecutionMode.WATCHER_AWS_ECS requires apache-airflow-providers-amazon >= "
+        f"{_ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION}; found {amazon_provider_version}."
+    )
+
+logger = get_logger(__name__)
+
+# dbt's last JSON event of a run; once seen, no more log lines will arrive for this task.
+_COMMAND_COMPLETED_EVENT = "CommandCompleted"
+_DRAIN_POLL_SECONDS = 1.0
+_STOPPED = "STOPPED"
+
+
+def _is_command_completed(message: str) -> bool:
+    if _COMMAND_COMPLETED_EVENT not in message:
+        return False
+    try:
+        event = json.loads(message)
+    except json.JSONDecodeError:
+        return False
+    return isinstance(event, dict) and event.get("info", {}).get("name") == _COMMAND_COMPLETED_EVENT
+
+
+class WatcherEcsLogFetcher(AwsTaskLogFetcher):  # type: ignore[misc]
+    """Collects the dbt container's CloudWatch events for the producer to parse on its own thread.
+
+    ``AwsTaskLogFetcher.run`` sleeps ``fetch_interval`` before every poll and returns as soon as
+    ``stop()`` is called, so the events written between the last poll and the task's end are never
+    read; for the watcher those are the last ``NodeFinished`` events. This subclass queues every
+    event message for the producer and, after ``stop()``, keeps polling until dbt's
+    ``CommandCompleted`` event has been read or ``drain_timeout`` has elapsed.
+    """
+
+    def __init__(self, *, events: queue.SimpleQueue[str], drain_timeout: timedelta, **kwargs: Any) -> None:
+        super().__init__(**kwargs)
+        self.events = events
+        self.drain_timeout = drain_timeout
+        self.command_completed = False
+        self._continuation_token = AwsLogsHook.ContinuationToken()
+
+    def run(self) -> None:
+        while not self.is_stopped():
+            time.sleep(self.fetch_interval.total_seconds())
+            self.collect()
+        deadline = time.monotonic() + self.drain_timeout.total_seconds()
+        while not self.command_completed and time.monotonic() < deadline:
+            time.sleep(_DRAIN_POLL_SECONDS)
+            self.collect()
+        if not self.command_completed:
+            self.logger.warning(
+                "dbt's %s event was not read within %s after the ECS task stopped; consumers of nodes whose "
+                "status never arrived will fall back to running them on their own.",
+                _COMMAND_COMPLETED_EVENT,
+                self.drain_timeout,
+            )
+
+    def collect(self) -> None:
+        """Read the events available now, queue their messages and log them as the parent does."""
+        for event in self._get_log_events(self._continuation_token):
+            message = event["message"]
+            self.events.put(message)
+            if _is_command_completed(message):
+                self.command_completed = True
+            self.logger.info(self.event_to_str(event))
+
+
+class DbtProducerWatcherAwsEcsOperator(DbtBuildAwsEcsOperator):
+    """Runs ``dbt build`` in an ECS task and publishes per-node statuses read from CloudWatch.
+
+    Requires ``awslogs_group`` and ``awslogs_stream_prefix``: without the log stream there is no
+    source of node statuses and every consumer would wait for nothing. ``deferrable``, ``reattach``
+    and ``wait_for_completion=False`` are rejected: the log stream is only read on the synchronous
+    path, and the producer never re-attaches to a previous build (see ``execute_watcher_producer``).
+
+    :param awslogs_fetch_interval: how often CloudWatch is polled while the task runs; it bounds the
+        delay before a consumer can see its node's status. The provider default of 30 seconds is
+        meant for displaying logs, so this operator defaults to 5 seconds.
+    :param drain_timeout: how long to keep polling after the task stopped, waiting for dbt's
+        ``CommandCompleted`` event.
+    """
+
+    template_fields: tuple[str, ...] = tuple(DbtBuildAwsEcsOperator.template_fields)
+
+    def __init__(
+        self,
+        *args: Any,
+        awslogs_fetch_interval: timedelta = timedelta(seconds=5),
+        drain_timeout: timedelta = timedelta(seconds=60),
+        **kwargs: Any,
+    ) -> None:
+        if kwargs.get("deferrable"):
+            raise CosmosValueError(
+                "ExecutionMode.WATCHER_AWS_ECS does not support deferrable=True on the producer: node statuses "
+                "are read from the CloudWatch log stream while the task runs, which only happens on the "
+                "synchronous path."
+            )
+        if kwargs.get("wait_for_completion") is False:
+            raise CosmosValueError("ExecutionMode.WATCHER_AWS_ECS requires the producer to wait for completion.")
+        if kwargs.get("reattach"):
+            raise CosmosValueError(
+                "ExecutionMode.WATCHER_AWS_ECS does not support reattach=True: the producer never re-runs or "
+                "re-attaches to a dbt build; consumers fall back on their own on retry."
+            )
+        if not (kwargs.get("awslogs_group") and kwargs.get("awslogs_stream_prefix")):
+            raise CosmosValueError(
+                "ExecutionMode.WATCHER_AWS_ECS requires awslogs_group and awslogs_stream_prefix in operator_args: "
+                "node statuses are read from the dbt container's CloudWatch log stream."
+            )
+        task_id = init_watcher_producer(self, kwargs)
+        self._log_events: queue.SimpleQueue[str] = queue.SimpleQueue()
+        self.drain_timeout = drain_timeout
+        super().__init__(task_id=task_id, awslogs_fetch_interval=awslogs_fetch_interval, *args, **kwargs)
+        finalize_watcher_producer(self)
+
+    def _get_task_log_fetcher(self) -> WatcherEcsLogFetcher:
+        if not self.awslogs_group:
+            raise ValueError("must specify awslogs_group to fetch task logs")
+        return WatcherEcsLogFetcher(
+            events=self._log_events,
+            drain_timeout=self.drain_timeout,
+            aws_conn_id=self.aws_conn_id,
+            region_name=self.awslogs_region,
+            log_group=self.awslogs_group,
+            log_stream_name=self._get_logs_stream_name(),
+            fetch_interval=self.awslogs_fetch_interval,
+            logger=self.log,
+        )
+
+    def _process_log_events(self) -> None:
+        """Parse the queued dbt log lines and push node statuses; runs on the operator's thread."""
+        context = self._context_holder.get(CONTEXT_KEY)
+        extra_kwargs = {"context": context} if context else {}
+        while True:
+            try:
+                line = self._log_events.get_nowait()
+            except queue.Empty:
+                return
+            store_dbt_resource_status_from_log(
+                line,
+                extra_kwargs,
+                tests_per_model=self._tests_per_model,
+                test_results_per_model=self._test_results_per_model,
+                model_outlet_uris=self._model_outlet_uris,
+                should_generate_model_uris=self._should_generate_model_uris,
+                upstream_failure_skipped_ids=self._upstream_failure_skipped_ids,
+            )
+
+    def _wait_for_task_ended(self) -> None:
+        """Poll the task status, parsing the queued log lines between polls.
+
+        Replaces the provider's blocking ``tasks_stopped`` waiter so the lines collected by the
+        fetcher thread are parsed here, on the operator's thread, while the build is running.
+        """
+        if not self.client or not self.arn:
+            return
+        for _ in range(self.waiter_max_attempts):
+            self._process_log_events()
+            tasks = self.client.describe_tasks(cluster=self.cluster, tasks=[self.arn]).get("tasks") or []
+            if not tasks:
+                raise AirflowException(f"ECS task {self.arn} was not found in cluster {self.cluster}")
+            if tasks[0].get("lastStatus") == _STOPPED:
+                return
+            time.sleep(self.waiter_delay)
+        raise AirflowException(
+            f"ECS task {self.arn} did not stop within {self.waiter_max_attempts} polls of {self.waiter_delay}s"
+        )
+
+    def _after_execution(self) -> None:
+        # Runs after ``EcsRunTaskOperator.execute`` has stopped and joined the fetcher: the drained
+        # tail of the log stream is still in the queue.
+        self._process_log_events()
+        super()._after_execution()
+
+    def execute(self, context: Context, **kwargs: Any) -> Any:
+        # Bind before passing, because bare super() doesn't work inside lambdas or when called outside this method.
+        parent_execute = super().execute
+        return execute_watcher_producer(self, context, parent_execute, **kwargs)
+
+
+class DbtConsumerWatcherAwsEcsSensor(BaseConsumerSensor, DbtRunAwsEcsOperator):
+    """Consumer sensor for ``ExecutionMode.WATCHER_AWS_ECS``.
+
+    Polls the producer's per-node status XCom and, on successful model completion, emits one
+    Airflow Asset per outlet URI the producer computed from the manifest. On retry, or when the
+    producer finished without reporting this node, runs ``dbt run --select <model>`` in an ECS task
+    through ``DbtRunAwsEcsOperator``.
+    """
+
+    template_fields: tuple[str, ...] = BaseConsumerSensor.template_fields + tuple(DbtRunAwsEcsOperator.template_fields)
+
+
+# This Operator does not seem to make sense for this particular execution mode, since build is executed by the producer task.
+# That said, it is important to raise an exception if users attempt to use TestBehavior.BUILD, until we have a better experience.
+class DbtBuildWatcherAwsEcsOperator:
+    def __init__(self, *args: Any, **kwargs: Any):
+        raise NotImplementedError(
+            "`ExecutionMode.WATCHER_AWS_ECS` does not expose a DbtBuild operator, since the build command is executed by the producer task."
+        )
+
+
+class DbtSeedWatcherAwsEcsOperator(DbtSeedMixin, DbtConsumerWatcherAwsEcsSensor):
+    """
+    Watches for the progress of dbt seed execution, run by the producer task (DbtProducerWatcherAwsEcsOperator).
+    """
+
+    template_fields: tuple[str, ...] = DbtConsumerWatcherAwsEcsSensor.template_fields + DbtSeedMixin.template_fields  # type: ignore[operator]
+
+
+class DbtSnapshotWatcherAwsEcsOperator(DbtSnapshotMixin, DbtConsumerWatcherAwsEcsSensor):
+    """
+    Watches for the progress of dbt snapshot execution, run by the producer task (DbtProducerWatcherAwsEcsOperator).
+    """
+
+    template_fields: tuple[str, ...] = DbtConsumerWatcherAwsEcsSensor.template_fields
+
+
+class DbtSourceWatcherAwsEcsOperator(DbtSourceAwsEcsOperator):
+    """
+    Executes a dbt source freshness command, synchronously, as ExecutionMode.AWS_ECS.
+    """
+
+    template_fields: tuple[str, ...] = tuple(DbtSourceAwsEcsOperator.template_fields)
+
+
+class DbtRunWatcherAwsEcsOperator(DbtConsumerWatcherAwsEcsSensor):
+    """
+    Watches for the progress of dbt model execution, run by the producer task (DbtProducerWatcherAwsEcsOperator).
+    """
+
+    template_fields: tuple[str, ...] = DbtConsumerWatcherAwsEcsSensor.template_fields + DbtRunMixin.template_fields  # type: ignore[operator]
+
+
+class DbtTestWatcherAwsEcsOperator(DbtConsumerWatcherAwsEcsSensor):
+    """Sensor that watches the aggregated test status for a dbt model in WATCHER_AWS_ECS execution mode.
+
+    The producer collects individual test results as they finish and, once every test for a model has
+    reported, pushes a single aggregated XCom (``"pass"`` or ``"fail"``) under
+    ``get_tests_status_xcom_key(model_uid)``. On manual clear or Airflow-level retry the sensor falls
+    back to an ECS task running ``dbt test --select <model>``.
+    """
+
+    template_fields: tuple[str, ...] = DbtConsumerWatcherAwsEcsSensor.template_fields
+
+    # See DbtTestWatcherOperator for the reasoning behind hardcoding base_cmd
+    # rather than inheriting from DbtTestMixin.
+    base_cmd = ["test"]
+
+    @property
+    def is_test_sensor(self) -> bool:
+        return True
+
+    def _fallback_to_non_watcher_run(self, try_number: int, context: Context) -> bool:
+        """Run ``dbt test --select <model>`` in an ECS task for this model.
+
+        Producer flags are intentionally not forwarded because some of them (e.g. ``--full-refresh``)
+        are not valid for ``dbt test``.
+        """
+        logger.info(
+            "Running tests for model '%s' from project '%s' (try %s)",
+            self.model_unique_id,
+            self.project_dir,
+            try_number,
+        )
+        model_selector = DbtNode.get_resource_name_from_unique_id(self.model_unique_id)
+        self.build_and_run_cmd(context, cmd_flags=["--select", model_selector])
+        logger.info("dbt test completed successfully for model '%s'", self.model_unique_id)
+        return True

--- a/docs/guides/run_dbt/container/index.rst
+++ b/docs/guides/run_dbt/container/index.rst
@@ -8,6 +8,7 @@ Run dbt in a container
    docker
    kubernetes
    watcher-kubernetes-execution-mode
+   watcher-aws-ecs-execution-mode
    aws-container-run-job
    aws-eks
    azure-container-instance

--- a/docs/guides/run_dbt/container/watcher-aws-ecs-execution-mode.rst
+++ b/docs/guides/run_dbt/container/watcher-aws-ecs-execution-mode.rst
@@ -1,0 +1,119 @@
+.. _watcher-aws-ecs-execution-mode:
+
+Watcher AWS ECS execution mode
+==============================
+
+.. versionadded:: 1.16.0
+
+.. note::
+   ``ExecutionMode.WATCHER_AWS_ECS`` is experimental.
+
+``ExecutionMode.WATCHER_AWS_ECS`` combines the **speed of the** :ref:`watcher-execution-mode` **with the isolation of** :ref:`aws-container-run-job`.
+
+This execution mode is for users who:
+
+- Run dbt in ECS tasks today (``ExecutionMode.AWS_ECS``) and want one ``dbt build`` per Dag run instead of one container per node
+- Run the ``ExecutionMode.WATCHER`` producer on an `Apache Airflow® <https://airflow.apache.org/>`_ worker whose memory is shared with other tasks, as on Amazon MWAA, and want the dbt process out of the worker
+
+Background
+~~~~~~~~~~
+
+The :ref:`watcher-execution-mode` runs dbt as a single command while keeping model-level tasks in Airflow: a producer task runs ``dbt build`` and publishes the status of every node as dbt reports it; one consumer sensor per node waits for its status.
+
+With ``ExecutionMode.WATCHER`` the producer runs dbt as a subprocess of the Airflow worker. With ``ExecutionMode.WATCHER_AWS_ECS`` the producer starts an ECS task, as ``ExecutionMode.AWS_ECS`` does, and reads dbt's JSON log lines from the task's CloudWatch log stream while it runs. The consumer sensors are unchanged.
+
+For the watcher concept itself, refer to :ref:`watcher-execution-mode`.
+
+How to use
+~~~~~~~~~~
+
+Users of ``ExecutionMode.AWS_ECS`` replace the ``execution_mode`` and add the CloudWatch log arguments:
+
+.. code-block:: python
+
+    from cosmos import DbtDag
+    from cosmos.config import ExecutionConfig
+    from cosmos.constants import ExecutionMode
+
+    dag = DbtDag(
+        dag_id="jaffle_shop_watcher_aws_ecs",
+        # ... other DAG parameters ...
+        execution_config=ExecutionConfig(
+            execution_mode=ExecutionMode.WATCHER_AWS_ECS,
+            dbt_project_path="dags/dbt/jaffle_shop",
+        ),
+        operator_args={
+            "cluster": "dbt-cluster",
+            "task_definition": "dbt-task",
+            "container_name": "dbt",
+            "awslogs_group": "/ecs/dbt",
+            "awslogs_stream_prefix": "ecs/dbt",
+            "awslogs_region": "eu-west-1",
+        },
+    )
+
+**Key differences from** ``ExecutionMode.AWS_ECS``:
+
+- The producer task runs the entire ``dbt build`` command in a single ECS task
+- Consumer tasks (sensors) watch for the completion of their corresponding dbt models
+- ``awslogs_group`` and ``awslogs_stream_prefix`` are mandatory: node statuses are read from that log stream
+
+For the ECS task definition, IAM permissions and profile setup, refer to :ref:`aws-container-run-job`.
+
+How statuses reach the consumers
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+ECS has no streaming log API, so the producer polls CloudWatch: every ``awslogs_fetch_interval`` (default 5 seconds for this producer; the provider default of 30 seconds is meant for displaying logs) it reads the new events of the task's log stream, parses each dbt JSON line and pushes the node statuses. After the task stops, it keeps polling until dbt's final ``CommandCompleted`` event has been read, or ``drain_timeout`` (default 60 seconds) has elapsed, so the last ``NodeFinished`` events are not lost.
+
+The delay between a node finishing in dbt and its consumer seeing the status is therefore bounded by ``awslogs_fetch_interval`` plus the consumer's own ``poke_interval``.
+
+Both arguments are set through ``operator_args``:
+
+.. code-block:: python
+
+    from datetime import timedelta
+
+    operator_args = {
+        # ... ECS and CloudWatch arguments ...
+        "awslogs_fetch_interval": timedelta(seconds=10),
+        "drain_timeout": timedelta(seconds=120),
+    }
+
+Test behavior
+~~~~~~~~~~~~~
+
+By default, ``ExecutionMode.WATCHER_AWS_ECS`` runs tests alongside models via the ``dbt build`` command executed by the producer task (``DbtProducerWatcherAwsEcsOperator``).
+
+``TestBehavior.AFTER_EACH`` (the default) renders each model's tests as a ``DbtTestWatcherAwsEcsOperator``, a ``DbtConsumerWatcherAwsEcsSensor`` subclass that waits for the aggregated test status of its model; on retry it runs ``dbt test --select <model>`` in an ECS task.
+
+``TestBehavior.AFTER_ALL`` renders a single ``DbtTestAwsEcsOperator`` that runs ``dbt test`` in a dedicated ECS task after all models complete.
+
+``TestBehavior.NONE`` disables test tasks.
+
+``TestBehavior.BUILD`` is not exposed: the build command is already executed by the producer task.
+
+Known limitations
+~~~~~~~~~~~~~~~~~
+
+Amazon provider version
++++++++++++++++++++++++
+
+Requires ``apache-airflow-providers-amazon >= 8.3.0``, the first release whose ``EcsRunTaskOperator`` and ``AwsTaskLogFetcher`` expose the hooks this producer builds on.
+
+Producer arguments
+++++++++++++++++++
+
+- ``deferrable=True`` is rejected for the producer: the log stream is only read on the synchronous path, and the deferred path of ``EcsRunTaskOperator`` waits for the task without reading its logs. The producer holds a worker slot for the duration of the build, occupied by the CloudWatch polling, not by dbt. Consumer sensors defer as in the other watcher modes.
+- ``reattach=True`` and ``wait_for_completion=False`` are rejected: the producer never re-runs or re-attaches to a dbt build. On retry it restores the statuses it had published and skips; consumers whose status is missing fall back to running their node in an ECS task.
+
+Log delivery
+++++++++++++
+
+- The ``awslogs`` log driver of the dbt container must run in its default ``blocking`` mode. In ``non-blocking`` mode the driver drops lines under back-pressure, and a dropped ``NodeFinished`` line means a consumer that only fails when the producer has finished.
+- The Airflow connection used for ``aws_conn_id`` needs ``logs:GetLogEvents`` on the log group, in addition to the ECS permissions ``ExecutionMode.AWS_ECS`` already requires.
+- Lines the CloudWatch agent splits (events above 256 KB) are not parseable as JSON and are skipped; node status events are far below that limit.
+
+Other inherited limitations
++++++++++++++++++++++++++++
+
+The limitations of :ref:`watcher-execution-mode` and :ref:`aws-container-run-job` apply.

--- a/docs/guides/run_dbt/execution-modes.rst
+++ b/docs/guides/run_dbt/execution-modes.rst
@@ -144,6 +144,7 @@ You can also execute dbt commands in a container. Choosing these kinds of execut
 - :ref:`kubernetes <kubernetes>`: Run ``dbt`` commands within Kubernetes Pods managed by Cosmos.
 - :ref:`watcher_kubernetes <watcher-kubernetes-execution-mode>`: (Stable since Cosmos 1.15.0) Combines the speed of the watcher execution mode with the isolation of Kubernetes.
 - :ref:`aws_ecs <aws-container-run-job>`: Run ``dbt`` commands in containers via AWS ECS.
+- :ref:`watcher_aws_ecs <watcher-aws-ecs-execution-mode>`: (experimental) Combines the speed of the watcher execution mode with the isolation of AWS ECS.
 - :ref:`aws_eks <aws-eks>`: Run ``dbt`` commands via Kubernetes Pods in AWS EKS.
 - :ref:`azure_container_instance <azure-container-instance>`: Run ``dbt`` commands in Azure Container Instances.
 - :ref:`gcp_cloud_run_job <gcp-cloud-run-job>`: Run ``dbt`` commands via a container managed by GCP Cloud Run Job.
@@ -269,6 +270,10 @@ The type of execution mode that you choose directly affects how fast your Cosmos
      - No
    * - AWS ECS
      - Slow
+     - High
+     - No
+   * - Watcher AWS ECS
+     - Fast
      - High
      - No
    * - AWS_EKS

--- a/tests/operators/test_k8s_common.py
+++ b/tests/operators/test_k8s_common.py
@@ -438,8 +438,8 @@ def test_pod_manager_passes_extra_kwargs_only_to_marked_callbacks():
     ),
 )
 @patch("cosmos.settings.enable_watcher_reliable_retry", True)
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 def test_execute_watcher_producer(mock_init, mock_delete, extra_kwargs: dict):
     ti = MagicMock()
     ti.try_number = 1
@@ -454,7 +454,7 @@ def test_execute_watcher_producer(mock_init, mock_delete, extra_kwargs: dict):
     mock_delete.assert_called_once_with(context)
 
 
-@patch("cosmos.operators._k8s_common._restore_xcom_from_variable")
+@patch("cosmos.operators._watcher.producer._restore_xcom_from_variable")
 def test_execute_watcher_producer_skips_retry(mock_restore):
     from airflow.exceptions import AirflowSkipException
 
@@ -471,8 +471,8 @@ def test_execute_watcher_producer_skips_retry(mock_restore):
 
 
 @patch("cosmos.settings.enable_watcher_reliable_retry", True)
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 def test_execute_watcher_producer_keeps_backup_on_failure(mock_init, mock_delete):
     """On failure the backup Variable is kept (not deleted) for the retry; the on-failure
     callback (see ``compose_watcher_backup_callbacks``) performs the flush, not ``execute``."""
@@ -489,8 +489,8 @@ def test_execute_watcher_producer_keeps_backup_on_failure(mock_init, mock_delete
 
 
 @patch("cosmos.settings.enable_watcher_reliable_retry", False)
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 def test_execute_watcher_producer_in_memory_mode_skips_variable_backup(mock_init, mock_delete):
     """With enable_watcher_reliable_retry=False the producer keeps the buffer in memory only (#2776)."""
     ti = MagicMock()
@@ -512,8 +512,8 @@ def test_execute_watcher_producer_raises_when_ti_missing():
         execute_watcher_producer(MagicMock(), {"ti": None}, MagicMock())
 
 
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 def test_execute_watcher_producer_sets_context_before_parent_execute(mock_init, mock_delete):
     """The context holder (read by build_watcher_pod_manager) is populated before parent_execute runs."""
     operator = MagicMock()
@@ -532,8 +532,8 @@ def test_execute_watcher_producer_sets_context_before_parent_execute(mock_init, 
     operator._upstream_failure_skipped_ids.clear.assert_called_once_with()
 
 
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 def test_execute_watcher_producer_publishes_own_cmd_flags_to_xcom(mock_init, mock_delete):
     """The producer must publish its own rendered ``add_cmd_flags()`` so consumer fallback runs can
     reuse it instead of re-deriving flags from a possibly different consumer operator_args.

--- a/tests/operators/test_watcher_aws_ecs.py
+++ b/tests/operators/test_watcher_aws_ecs.py
@@ -1,0 +1,377 @@
+import json
+import queue
+from datetime import timedelta
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+from airflow.exceptions import AirflowException, AirflowSkipException
+from airflow.providers.amazon import __version__ as amazon_provider_version
+from packaging.version import Version
+
+from cosmos.airflow.graph import _WATCHER_TO_FALLBACK_EXECUTION_MODE, calculate_operator_class
+from cosmos.constants import (
+    _ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION,
+    PRODUCER_WATCHER_TASK_ID,
+    ExecutionMode,
+)
+from cosmos.exceptions import CosmosValueError
+
+if Version(amazon_provider_version) < _ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION:
+    pytest.skip(
+        f"Watcher AWS ECS depends on apache-airflow-providers-amazon >= {_ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION}. "
+        f"Current version: {amazon_provider_version}",
+        allow_module_level=True,
+    )
+else:
+    from cosmos.operators._watcher.producer import CONTEXT_KEY
+    from cosmos.operators.watcher_aws_ecs import (
+        DbtBuildWatcherAwsEcsOperator,
+        DbtConsumerWatcherAwsEcsSensor,
+        DbtProducerWatcherAwsEcsOperator,
+        DbtTestWatcherAwsEcsOperator,
+        WatcherEcsLogFetcher,
+    )
+
+ECS_KWARGS = {
+    "cluster": "dbt-cluster",
+    "task_definition": "dbt-task:3",
+    "awslogs_group": "/ecs/dbt",
+    "awslogs_stream_prefix": "ecs/dbt",
+    "project_dir": "dags/dbt/jaffle_shop",
+    "profile_config": None,
+}
+
+
+def node_finished(unique_id: str, status: str = "success") -> str:
+    return json.dumps(
+        {
+            "data": {"node_info": {"unique_id": unique_id, "node_status": status, "resource_type": "model"}},
+            "info": {"name": "NodeFinished", "level": "debug", "msg": ""},
+        }
+    )
+
+
+COMMAND_COMPLETED = json.dumps({"data": {}, "info": {"name": "CommandCompleted", "level": "info", "msg": ""}})
+
+
+def make_producer(**overrides):
+    return DbtProducerWatcherAwsEcsOperator(**{**ECS_KWARGS, **overrides})
+
+
+# ---------------------------------------------------------------------------
+# graph wiring
+# ---------------------------------------------------------------------------
+
+
+def test_operator_classes_resolve_from_the_execution_mode():
+    assert (
+        calculate_operator_class(ExecutionMode.WATCHER_AWS_ECS, "DbtRun")
+        == "cosmos.operators.watcher_aws_ecs.DbtRunWatcherAwsEcsOperator"
+    )
+    assert (
+        calculate_operator_class(ExecutionMode.WATCHER_AWS_ECS, "DbtProducer")
+        == "cosmos.operators.watcher_aws_ecs.DbtProducerWatcherAwsEcsOperator"
+    )
+
+
+def test_after_all_tests_fall_back_to_plain_ecs():
+    assert _WATCHER_TO_FALLBACK_EXECUTION_MODE[ExecutionMode.WATCHER_AWS_ECS] == ExecutionMode.AWS_ECS
+
+
+# ---------------------------------------------------------------------------
+# producer construction
+# ---------------------------------------------------------------------------
+
+
+def test_producer_default_task_id_matches_watcher_task_id():
+    assert make_producer().task_id == PRODUCER_WATCHER_TASK_ID
+
+
+def test_producer_honours_explicit_task_id():
+    assert make_producer(task_id="custom_producer").task_id == "custom_producer"
+
+
+def test_producer_forces_json_log_format_and_default_fetch_interval():
+    op = make_producer()
+    assert op.dbt_cmd_flags[-2:] == ["--log-format", "json"]
+    assert op.awslogs_fetch_interval == timedelta(seconds=5)
+    assert op.drain_timeout == timedelta(seconds=60)
+
+
+@pytest.mark.parametrize(
+    "overrides,match",
+    [
+        ({"deferrable": True}, "does not support deferrable=True"),
+        ({"wait_for_completion": False}, "requires the producer to wait for completion"),
+        ({"reattach": True}, "does not support reattach=True"),
+        ({"awslogs_group": None}, "requires awslogs_group and awslogs_stream_prefix"),
+        ({"awslogs_stream_prefix": None}, "requires awslogs_group and awslogs_stream_prefix"),
+    ],
+)
+def test_producer_rejects_unsupported_arguments(overrides, match):
+    with pytest.raises(CosmosValueError, match=match):
+        make_producer(**overrides)
+
+
+def test_producer_stores_tests_per_model():
+    tests_per_model = {"model.pkg.orders": ["test.pkg.t1", "test.pkg.t2"]}
+    op = make_producer(tests_per_model=tests_per_model)
+    assert op._tests_per_model is tests_per_model
+    assert op._test_results_per_model == {}
+
+
+def test_producer_log_fetcher_is_bound_to_the_operator_state():
+    op = make_producer()
+    op.arn = "arn:aws:ecs:eu-west-1:123456789012:task/dbt-cluster/abcdef"
+    fetcher = op._get_task_log_fetcher()
+    assert isinstance(fetcher, WatcherEcsLogFetcher)
+    assert fetcher.events is op._log_events
+    assert fetcher.drain_timeout == op.drain_timeout
+    assert fetcher.log_group == "/ecs/dbt"
+    assert fetcher.log_stream_name == "ecs/dbt/abcdef"
+    assert fetcher.fetch_interval == timedelta(seconds=5)
+
+
+# ---------------------------------------------------------------------------
+# log fetcher
+# ---------------------------------------------------------------------------
+
+
+def make_fetcher(**overrides):
+    kwargs = {
+        "events": queue.SimpleQueue(),
+        "drain_timeout": timedelta(seconds=3),
+        "log_group": "/ecs/dbt",
+        "log_stream_name": "ecs/dbt/abcdef",
+        "fetch_interval": timedelta(seconds=0),
+        "logger": MagicMock(),
+        "aws_conn_id": None,
+    }
+    kwargs.update(overrides)
+    return WatcherEcsLogFetcher(**kwargs)
+
+
+def test_fetcher_collect_queues_messages_and_detects_command_completed():
+    fetcher = make_fetcher()
+    events = [
+        {"timestamp": 1_700_000_000_000, "message": node_finished("model.pkg.a")},
+        {"timestamp": 1_700_000_001_000, "message": COMMAND_COMPLETED},
+    ]
+    with patch.object(fetcher, "_get_log_events", return_value=iter(events)) as mock_get:
+        fetcher.collect()
+
+    mock_get.assert_called_once_with(fetcher._continuation_token)
+    assert fetcher.events.get_nowait() == node_finished("model.pkg.a")
+    assert fetcher.events.get_nowait() == COMMAND_COMPLETED
+    assert fetcher.command_completed is True
+    assert fetcher.logger.info.call_count == 2
+
+
+def test_fetcher_ignores_non_json_and_other_events_for_completion():
+    fetcher = make_fetcher()
+    events = [
+        {"timestamp": 1, "message": "plain text mentioning CommandCompleted"},
+        {"timestamp": 2, "message": node_finished("model.pkg.a")},
+    ]
+    with patch.object(fetcher, "_get_log_events", return_value=iter(events)):
+        fetcher.collect()
+    assert fetcher.command_completed is False
+    assert fetcher.events.qsize() == 2
+
+
+@patch("cosmos.operators.watcher_aws_ecs.time.sleep")
+def test_fetcher_drains_after_stop_until_command_completed(mock_sleep):
+    """After stop(), the events written since the last poll are still read (the provider's loop drops them)."""
+    fetcher = make_fetcher()
+    fetcher.stop()
+    tail = [
+        iter([]),  # first drain poll: CloudWatch has not ingested the tail yet
+        iter(
+            [
+                {"timestamp": 1, "message": node_finished("model.pkg.last")},
+                {"timestamp": 2, "message": COMMAND_COMPLETED},
+            ]
+        ),
+    ]
+    with patch.object(fetcher, "_get_log_events", side_effect=tail) as mock_get:
+        fetcher.run()
+
+    assert mock_get.call_count == 2
+    assert fetcher.command_completed is True
+    assert fetcher.events.qsize() == 2
+
+
+@patch("cosmos.operators.watcher_aws_ecs.time.monotonic", side_effect=[0.0, 0.0, 10.0])
+@patch("cosmos.operators.watcher_aws_ecs.time.sleep")
+def test_fetcher_drain_gives_up_after_the_timeout(mock_sleep, mock_monotonic):
+    fetcher = make_fetcher(drain_timeout=timedelta(seconds=5))
+    fetcher.stop()
+    with patch.object(fetcher, "_get_log_events", return_value=iter([])):
+        fetcher.run()
+
+    assert fetcher.command_completed is False
+    fetcher.logger.warning.assert_called_once()
+    assert "CommandCompleted" in fetcher.logger.warning.call_args[0][1]
+
+
+# ---------------------------------------------------------------------------
+# producer execution
+# ---------------------------------------------------------------------------
+
+
+@patch("cosmos.operators.watcher_aws_ecs.store_dbt_resource_status_from_log")
+def test_process_log_events_parses_the_queue_with_the_execution_context(mock_store):
+    op = make_producer(tests_per_model={"model.pkg.a": ["test.pkg.t"]})
+    context = {"ti": MagicMock()}
+    op._context_holder[CONTEXT_KEY] = context
+    op._log_events.put(node_finished("model.pkg.a"))
+    op._log_events.put(node_finished("model.pkg.b"))
+
+    op._process_log_events()
+
+    assert mock_store.call_count == 2
+    first = mock_store.call_args_list[0]
+    assert first.args == (node_finished("model.pkg.a"), {"context": context})
+    assert first.kwargs["tests_per_model"] is op._tests_per_model
+    assert first.kwargs["test_results_per_model"] is op._test_results_per_model
+    assert first.kwargs["model_outlet_uris"] is op._model_outlet_uris
+    assert first.kwargs["upstream_failure_skipped_ids"] is op._upstream_failure_skipped_ids
+    assert op._log_events.empty()
+
+
+@patch("cosmos.operators.watcher_aws_ecs.time.sleep")
+@patch("cosmos.operators.watcher_aws_ecs.DbtProducerWatcherAwsEcsOperator.client", new_callable=lambda: MagicMock())
+def test_wait_for_task_ended_parses_between_status_polls(mock_client, mock_sleep):
+    op = make_producer(waiter_delay=7, waiter_max_attempts=5)
+    op.arn = "arn:aws:ecs:eu-west-1:123456789012:task/dbt-cluster/abcdef"
+    mock_client.describe_tasks.side_effect = [
+        {"tasks": [{"lastStatus": "RUNNING"}]},
+        {"tasks": [{"lastStatus": "STOPPED"}]},
+    ]
+    with patch.object(op, "_process_log_events") as mock_process:
+        op._wait_for_task_ended()
+
+    assert mock_process.call_count == 2
+    mock_client.describe_tasks.assert_called_with(cluster="dbt-cluster", tasks=[op.arn])
+    mock_sleep.assert_called_once_with(7)
+
+
+@patch("cosmos.operators.watcher_aws_ecs.time.sleep")
+@patch("cosmos.operators.watcher_aws_ecs.DbtProducerWatcherAwsEcsOperator.client", new_callable=lambda: MagicMock())
+def test_wait_for_task_ended_fails_when_the_task_never_stops(mock_client, mock_sleep):
+    op = make_producer(waiter_delay=1, waiter_max_attempts=2)
+    op.arn = "arn:aws:ecs:eu-west-1:123456789012:task/dbt-cluster/abcdef"
+    mock_client.describe_tasks.return_value = {"tasks": [{"lastStatus": "RUNNING"}]}
+    with patch.object(op, "_process_log_events"), pytest.raises(AirflowException, match="did not stop within 2 polls"):
+        op._wait_for_task_ended()
+
+
+@patch("cosmos.operators.watcher_aws_ecs.DbtProducerWatcherAwsEcsOperator.client", new_callable=lambda: MagicMock())
+def test_wait_for_task_ended_fails_when_the_task_is_missing(mock_client):
+    op = make_producer()
+    op.arn = "arn:aws:ecs:eu-west-1:123456789012:task/dbt-cluster/abcdef"
+    mock_client.describe_tasks.return_value = {"tasks": [], "failures": [{"reason": "MISSING"}]}
+    with patch.object(op, "_process_log_events"), pytest.raises(AirflowException, match="was not found"):
+        op._wait_for_task_ended()
+
+
+@patch("cosmos.operators.aws_ecs.EcsRunTaskOperator._after_execution")
+def test_after_execution_parses_the_drained_tail_before_checking_success(mock_parent_after):
+    op = make_producer()
+    order = []
+    mock_parent_after.side_effect = lambda: order.append("check_success")
+    with patch.object(op, "_process_log_events", side_effect=lambda: order.append("process")):
+        op._after_execution()
+    assert order == ["process", "check_success"]
+
+
+@patch("cosmos.operators._watcher.producer._restore_xcom_from_variable")
+@patch("cosmos.operators.aws_ecs.DbtAwsEcsBaseOperator.build_and_run_cmd")
+def test_producer_skips_retry_attempt(mock_build_and_run, mock_restore):
+    op = make_producer()
+    ti = MagicMock()
+    ti.try_number = 2
+    context = {"ti": ti, "run_id": "test_run"}
+    with pytest.raises(AirflowSkipException, match="does not support Airflow retries"):
+        op.execute(context=context)
+    mock_restore.assert_called_once_with(context)
+    mock_build_and_run.assert_not_called()
+
+
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
+@patch("cosmos.operators.aws_ecs.DbtAwsEcsBaseOperator.build_and_run_cmd")
+def test_producer_first_attempt_exposes_context_and_runs_the_build(mock_build_and_run, mock_init, mock_delete):
+    op = make_producer()
+    ti = MagicMock()
+    ti.try_number = 1
+    context = {"ti": ti, "run_id": "test_run"}
+
+    op.execute(context=context)
+
+    assert op._context_holder[CONTEXT_KEY] is context
+    mock_init.assert_called_once()
+    mock_build_and_run.assert_called_once()
+    ti.xcom_push.assert_has_calls([call(key="producer_cmd_flags", value=op.add_cmd_flags())])
+
+
+# ---------------------------------------------------------------------------
+# consumers
+# ---------------------------------------------------------------------------
+
+
+def make_sensor(sensor_class=DbtConsumerWatcherAwsEcsSensor, **kwargs):
+    kwargs["extra_context"] = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
+    sensor = sensor_class(
+        task_id="model.my_model",
+        cluster="dbt-cluster",
+        task_definition="dbt-task:3",
+        project_dir="/tmp/project",
+        profile_config=None,
+        deferrable=False,
+        **kwargs,
+    )
+    sensor._get_producer_task_status = MagicMock(return_value=None)
+    return sensor
+
+
+def make_context(ti_mock, *, run_id: str = "test-run"):
+    return {"ti": ti_mock, "run_id": run_id, "task_instance": MagicMock(map_index=0)}
+
+
+@patch("cosmos.operators._watcher.base.BaseConsumerSensor._log_startup_events")
+def test_consumer_first_execution_polls_the_producer_xcom(mock_startup_events):
+    sensor = make_sensor()
+    ti = MagicMock()
+    ti.try_number = 1
+    ti.xcom_pull.return_value = {"status": "success", "outlet_uris": []}
+    assert sensor.poke(make_context(ti)) is True
+    ti.xcom_pull.assert_called()
+
+
+@patch("cosmos.operators.aws_ecs.DbtAwsEcsBaseOperator.build_and_run_cmd")
+def test_consumer_retry_runs_the_model_in_an_ecs_task(mock_build_and_run_cmd):
+    sensor = make_sensor()
+    sensor._get_producer_task_status.return_value = "success"
+    ti = MagicMock()
+    ti.try_number = 2
+    ti.xcom_pull.return_value = None
+    ti.task.dag.get_task.return_value.add_cmd_flags.return_value = ["--threads", "2"]
+    assert sensor.poke(make_context(ti)) is True
+    mock_build_and_run_cmd.assert_called_once()
+    assert mock_build_and_run_cmd.call_args.kwargs["cmd_flags"][-2:] == ["--select", "stg_orders"]
+
+
+@patch("cosmos.operators.aws_ecs.DbtAwsEcsBaseOperator.build_and_run_cmd")
+def test_test_sensor_retry_runs_dbt_test_for_the_model(mock_build_and_run_cmd):
+    sensor = make_sensor(DbtTestWatcherAwsEcsOperator)
+    assert sensor.is_test_sensor is True
+    assert sensor.base_cmd == ["test"]
+    context = make_context(MagicMock())
+    assert sensor._fallback_to_non_watcher_run(try_number=2, context=context) is True
+    mock_build_and_run_cmd.assert_called_once_with(context, cmd_flags=["--select", "stg_orders"])
+
+
+def test_dbt_build_watcher_aws_ecs_operator_raises_not_implemented_error():
+    with pytest.raises(NotImplementedError, match="does not expose a DbtBuild operator"):
+        DbtBuildWatcherAwsEcsOperator()

--- a/tests/operators/test_watcher_gcp_gke_unit.py
+++ b/tests/operators/test_watcher_gcp_gke_unit.py
@@ -57,7 +57,7 @@ def test_retries_not_forced_to_zero():
     assert op.retries == 5
 
 
-@patch("cosmos.operators._k8s_common._restore_xcom_from_variable")
+@patch("cosmos.operators._watcher.producer._restore_xcom_from_variable")
 @patch("cosmos.operators.gcp_gke.DbtBuildGcpGkeOperator.execute")
 def test_skips_retry_attempt(mock_execute, mock_restore):
     """Smoke-test that the GCP GKE producer delegates to ``execute_watcher_producer``.
@@ -232,8 +232,8 @@ def test_producer_pod_manager_wires_callback_extra_kwargs(mock_manager_cls):
     assert extra[CONTEXT_HOLDER_KEY] is op._context_holder
 
 
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 @patch("cosmos.operators.gcp_gke.DbtBuildGcpGkeOperator.execute")
 def test_pod_manager_created_before_execute_sees_execution_context(mock_execute, mock_init, mock_delete):
     """pod_manager accessed before execute() must not hold a stale context=None (#2543 follow-up).

--- a/tests/operators/test_watcher_kubernetes_unit.py
+++ b/tests/operators/test_watcher_kubernetes_unit.py
@@ -114,7 +114,7 @@ def test_producer_honours_explicit_task_id():
     assert op.task_id == "custom_producer"
 
 
-@patch("cosmos.operators._k8s_common._restore_xcom_from_variable")
+@patch("cosmos.operators._watcher.producer._restore_xcom_from_variable")
 @patch("cosmos.operators.kubernetes.DbtBuildKubernetesOperator.execute")
 def test_skips_retry_attempt(mock_execute, mock_restore):
     """Smoke-test that the K8s producer delegates to ``execute_watcher_producer``.
@@ -280,8 +280,8 @@ def test_producer_pod_manager_wires_callback_extra_kwargs(mock_manager_cls):
     assert extra[CONTEXT_HOLDER_KEY] is op._context_holder
 
 
-@patch("cosmos.operators._k8s_common._delete_xcom_backup_variable")
-@patch("cosmos.operators._k8s_common._init_xcom_backup")
+@patch("cosmos.operators._watcher.producer._delete_xcom_backup_variable")
+@patch("cosmos.operators._watcher.producer._init_xcom_backup")
 @patch("cosmos.operators.kubernetes.DbtBuildKubernetesOperator.execute")
 def test_pod_manager_created_before_execute_sees_execution_context(mock_execute, mock_init, mock_delete):
     """pod_manager accessed before execute() must not hold a stale context=None (#2543 follow-up).


### PR DESCRIPTION
## Description

Adds `ExecutionMode.WATCHER_AWS_ECS`: the watcher producer runs one `dbt build` in an ECS task and publishes per-node statuses read from the task's CloudWatch log stream; the consumer sensors are the existing ones. Same contract as `WATCHER_KUBERNETES`, on ECS. Motivation and the MWAA failure it addresses are in #2988.

Built on #2999, which moves the container-agnostic producer helpers out of `_k8s_common` so this module imports without the Kubernetes stack. Until #2999 merges this diff includes its commit; I'll rebase once it lands.

### How it works

`EcsRunTaskOperator.execute` (non-deferrable path, `awslogs_group` + `awslogs_stream_prefix` set) starts an `AwsTaskLogFetcher` thread through `_get_task_log_fetcher()`, waits for the task, then stops and joins the fetcher. The producer overrides three seams of that flow, all present since `apache-airflow-providers-amazon` 8.3.0 (`_ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION`, checked at import):

- `_get_task_log_fetcher()` returns `WatcherEcsLogFetcher`, a subclass that queues every CloudWatch event message instead of only logging it. Its `run()` also fixes a gap that matters here: the provider loop is `while not stopped: sleep; fetch`, so after the task stops the events written since the last poll — the last `NodeFinished` lines — are never read. The subclass keeps polling after `stop()` until dbt's `CommandCompleted` event is read or `drain_timeout` (default 60 s) elapses, and logs a warning if it gives up.
- `_wait_for_task_ended()` polls `describe_tasks` with the operator's `waiter_delay` / `waiter_max_attempts` and parses the queued lines between polls, so `store_dbt_resource_status_from_log` and every XCom push run on the operator's thread, as they do for the Kubernetes producer (the fetcher thread does I/O only).
- `_after_execution()` parses the drained tail before the provider's `_check_success_task()`.

Status latency for a consumer is bounded by `awslogs_fetch_interval` (default 5 s for this producer; the provider's 30 s is meant for displaying logs) plus the consumer's `poke_interval`.

`execute()` delegates to the shared `execute_watcher_producer`: no retries of the build, XCom backup restored and the attempt skipped on `try_number > 1`, backup flushed from the `on_retry` / `on_failure` callbacks.

### Rejected arguments

`awslogs_group` and `awslogs_stream_prefix` are required (no log stream, no statuses); `deferrable=True`, `reattach=True` and `wait_for_completion=False` raise `CosmosValueError` with the reason. Deferrable is not offered in this PR: the provider's deferred path (`TaskDoneTrigger`) yields once, at task completion, and does not re-enter the operator on an interval the way `KubernetesPodTrigger` does with `logging_interval`; a Cosmos trigger with that shape is a follow-up I intend to open after this one.

### Files

- `cosmos/operators/watcher_aws_ecs.py`: `WatcherEcsLogFetcher`, `DbtProducerWatcherAwsEcsOperator`, `DbtConsumerWatcherAwsEcsSensor` and the seed / snapshot / run / test / source / build operators, mirroring `watcher_kubernetes.py` (test sensor falls back to `dbt test --select <model>` in an ECS task; `DbtBuildWatcherAwsEcsOperator` raises).
- `cosmos/constants.py`: `ExecutionMode.WATCHER_AWS_ECS`, `_ECS_WATCHER_MIN_AMAZON_PROVIDER_VERSION`.
- `cosmos/airflow/graph.py`: the mode in `_WATCHER_TO_FALLBACK_EXECUTION_MODE` (→ `AWS_ECS` for `AFTER_ALL` tests); the producer-creation branch now keys off that map instead of a hard-coded tuple.
- `tests/operators/test_watcher_aws_ecs.py`: 27 tests, all mocked — operator class resolution and fallback map; producer defaults and rejected arguments; fetcher bound to the operator state; `collect()` queues messages and detects `CommandCompleted` (JSON only); drain after `stop()` reads the tail and gives up on timeout; queued lines parsed with the execution context and the producer state; `_wait_for_task_ended` parses between status polls and fails on a missing or never-stopping task; `_after_execution` order; retry skip and first-attempt flow; consumer first poke, retry fallback to an ECS `dbt run --select`, test sensor fallback; build operator raises.
- Docs: `docs/guides/run_dbt/container/watcher-aws-ecs-execution-mode.rst` (how it works, test behaviour, provider version, rejected arguments, `awslogs` driver in `blocking` mode, IAM), listed in the container index, the execution-modes list and the comparison table.

### Verification

Unit suite and the new tests green locally; docs build clean. Cosmos CI has no ECS cluster, so an end-to-end run against a real cluster is pending; I'll report the result in this PR before asking for review.

## Related Issue(s)

closes #2988

## Breaking Change?

No. New execution mode; existing modes untouched apart from the refactor in #2999.

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works

🤖 Generated with Claude Code (https://claude.com/claude-code)
