### PR TITLE
Fall back consumer retries when producer is up for retry

### DIFF
--- a/cosmos/operators/_watcher/base.py
+++ b/cosmos/operators/_watcher/base.py
@@ -737,11 +737,19 @@ class BaseConsumerSensor(BaseSensorOperator):
                 self._override_rtif(context)
 
     def _handle_retry(self, try_number: int, producer_task_state: str | None, context: Context) -> bool | None:
-        """Handle sensor retry by checking whether the producer is still active.
+        """Handle sensor retry by checking whether the producer can still deliver a node result.
 
-        Returns the fallback result if the producer has terminated, or None if
-        the sensor should continue polling (producer still active).
+        Returns the fallback result if the producer has terminated or is only
+        waiting on its own retry, or None if the sensor should continue polling
+        (producer still active on its current attempt).
         """
+        if producer_task_state == ProducerTaskState.UP_FOR_RETRY:
+            # The producer self-skips on any retry attempt (see
+            # DbtProducerWatcherOperator.execute), so its next attempt can
+            # never publish a new node result. Fall back now instead of
+            # re-poking the producer's stale XCom until this sensor's own
+            # retries are exhausted.
+            return self._fallback_to_non_watcher_run(try_number, context)
         if is_producer_task_terminated(producer_task_state):
             # Producer finished — this is either an automatic retry after
             # the producer completed or a manual task clear from the UI.

--- a/cosmos/operators/_watcher/state.py
+++ b/cosmos/operators/_watcher/state.py
@@ -62,6 +62,7 @@ class ProducerTaskState(str, Enum):
     SUCCESS = "success"
     FAILED = "failed"
     SKIPPED = "skipped"
+    UP_FOR_RETRY = "up_for_retry"
     UPSTREAM_FAILED = "upstream_failed"
     REMOVED = "removed"
 

--- a/tests/operators/_watcher/test_state.py
+++ b/tests/operators/_watcher/test_state.py
@@ -101,7 +101,9 @@ class TestProducerTaskTerminated:
     def test_terminal_states(self, state: str):
         assert is_producer_task_terminated(state) is True
 
-    @pytest.mark.parametrize("state", ["running", "deferred", "queued", "scheduled", "up_for_reschedule", None, ""])
+    @pytest.mark.parametrize(
+        "state", ["running", "deferred", "queued", "scheduled", "up_for_reschedule", "up_for_retry", None, ""]
+    )
     def test_non_terminal_states(self, state: str | None):
         assert is_producer_task_terminated(state) is False
 

--- a/tests/operators/_watcher/test_watcher_base.py
+++ b/tests/operators/_watcher/test_watcher_base.py
@@ -276,6 +276,78 @@ class TestHandleNoDbtNodeStatus:
         assert sensor.poke_retry_number == 1
 
 
+class TestHandleRetry:
+    """Tests for BaseConsumerSensor._handle_retry."""
+
+    def _make_sensor(self):
+        class SubclassBaseConsumerSensor(BaseConsumerSensor, DbtRunLocalOperator):
+            something_to_be_implemented = True
+
+        extra_context = {"dbt_node_config": {"unique_id": "model.jaffle_shop.stg_orders"}}
+        sensor = SubclassBaseConsumerSensor(
+            task_id="test_sensor",
+            producer_task_id="dbt_run_local",
+            profile_config=None,
+            project_dir="/tmp/sample_project",
+            extra_context=extra_context,
+        )
+        return sensor
+
+    @patch("cosmos.operators._watcher.base.BaseConsumerSensor._fallback_to_non_watcher_run", return_value=True)
+    def test_producer_up_for_retry_falls_back(self, mock_fallback):
+        """A producer waiting on its own retry will self-skip on that retry,
+        so the sensor must fall back immediately instead of burning its own
+        retries re-poking the producer's stale XCom."""
+        sensor = self._make_sensor()
+        context = MagicMock()
+
+        result = sensor._handle_retry(try_number=2, producer_task_state="up_for_retry", context=context)
+
+        assert result is True
+        mock_fallback.assert_called_once_with(2, context)
+
+    def test_poke_retry_while_producer_up_for_retry_falls_back(self):
+        """Full poke flow for #3001: a retried sensor must fall back without
+        ever re-reading the failed attempt's stale node status."""
+        sensor = self._make_sensor()
+        mock_ti = Mock()
+        mock_ti.try_number = 2
+        context = {"ti": mock_ti, "run_id": "run_123"}
+
+        with (
+            patch.object(sensor, "_get_producer_task_status", return_value="up_for_retry"),
+            patch.object(sensor, "_fallback_to_non_watcher_run", return_value=True) as mock_fallback,
+            patch.object(sensor, "_get_node_status") as mock_node_status,
+            patch.object(sensor, "_log_startup_events"),
+        ):
+            assert sensor.poke(context) is True
+
+        mock_fallback.assert_called_once_with(2, context)
+        mock_node_status.assert_not_called()
+
+    @patch("cosmos.operators._watcher.base.BaseConsumerSensor._fallback_to_non_watcher_run", return_value=True)
+    @pytest.mark.parametrize("state", ["success", "failed", "skipped", "upstream_failed", "removed"])
+    def test_terminated_producer_falls_back(self, mock_fallback, state):
+        sensor = self._make_sensor()
+        context = MagicMock()
+
+        result = sensor._handle_retry(try_number=2, producer_task_state=state, context=context)
+
+        assert result is True
+        mock_fallback.assert_called_once_with(2, context)
+
+    @patch("cosmos.operators._watcher.base.BaseConsumerSensor._fallback_to_non_watcher_run", return_value=True)
+    @pytest.mark.parametrize("state", ["running", "queued", "scheduled", "deferred", "up_for_reschedule", None])
+    def test_active_producer_keeps_polling(self, mock_fallback, state):
+        sensor = self._make_sensor()
+        context = MagicMock()
+
+        result = sensor._handle_retry(try_number=2, producer_task_state=state, context=context)
+
+        assert result is None
+        mock_fallback.assert_not_called()
+
+
 class TestBaseConsumerSensorEmitDatasets:
     """Tests for the dataset-emission logic hoisted into BaseConsumerSensor and shared by every
     ExecutionMode.WATCHER* consumer (SUBPROCESS, Kubernetes, GCP GKE)."""


### PR DESCRIPTION
## Description

Hit this on a WATCHER pipeline where one model flakes out under warehouse load. The producer fails, goes `up_for_retry`, and the consumers are supposed to pick up the failed models with a standalone dbt run scoped to that model (`_fallback_to_non_watcher_run`). The fallback only kicks in once the producer hits a terminal state though, and `up_for_retry` isn't terminal.

So while the producer sits in `up_for_retry` waiting for the scheduler to pick up its retry, every consumer retry that fires in that window goes through `_handle_retry`, sees a non-terminal state, and falls through to `poke()`, which re-reads the stale XCom status from the failed attempt and raises the same error again. Each of those cycles burns a retry with no actual work. On a busy scheduler I watched a consumer exhaust its whole retry budget before the producer's skip ever executed, so the model never got retried at all.

The key bit is the producer's retry can never help here. `DbtProducerWatcherOperator.execute()` self-skips for any `try_number > 1` by design, so waiting for that skip to run gains nothing — it just delays (or starves) the one thing that's actually supposed to happen, a real `dbt run` for the model that failed.

The change makes `_handle_retry` treat `up_for_retry` the same as a terminated producer and go straight to `_fallback_to_non_watcher_run`. Also added `UP_FOR_RETRY` to `ProducerTaskState` so the comparison isn't a bare string. States like `running`/`queued`/`scheduled`/`deferred` are untouched — consumers still keep polling a producer that's actively working on its current attempt.

Not 100% sure there isn't a scenario where waiting for the skip matters, but I can't think of one: the skip attempt only restores the backup XCom and exits, it never produces a new node result.

## Related Issue(s)

closes #3001

## Breaking Change?

No

## Checklist

- [x] I have made corresponding changes to the documentation (if required)
- [x] I have added tests that prove my fix is effective or that my feature works
